### PR TITLE
Add provisioning profile create/regenerate tools & UI

### DIFF
--- a/src/MauiSherpa.Core/Interfaces.cs
+++ b/src/MauiSherpa.Core/Interfaces.cs
@@ -235,11 +235,23 @@ public interface IAppleConnectService
     
     // Provisioning Profiles
     Task<IReadOnlyList<AppleProfile>> GetProfilesAsync();
+    Task<AppleProfile> CreateProfileAsync(AppleProfileCreateRequest request);
     Task<byte[]> DownloadProfileAsync(string id);
     Task DeleteProfileAsync(string id);
     Task<string> InstallProfileAsync(string id);
     Task<int> InstallProfilesAsync(IEnumerable<string> ids, IProgress<string>? progress = null);
 }
+
+/// <summary>
+/// Request to create a new Apple provisioning profile
+/// </summary>
+public record AppleProfileCreateRequest(
+    string Name,
+    string ProfileType,              // e.g., "IOS_APP_DEVELOPMENT", "IOS_APP_STORE"
+    string BundleIdResourceId,       // App Store Connect resource ID (not the identifier)
+    IReadOnlyList<string> CertificateIds,
+    IReadOnlyList<string>? DeviceIds // null or empty for App Store profiles
+);
 
 /// <summary>
 /// Result of creating a new Apple certificate

--- a/src/MauiSherpa/Components/CopilotOverlay.razor
+++ b/src/MauiSherpa/Components/CopilotOverlay.razor
@@ -1,6 +1,7 @@
 @using MauiSherpa.Core.Interfaces
 @inject ICopilotContextService ContextService
 @inject ICopilotService CopilotService
+@inject IThemeService ThemeService
 @inject ILoggingService Logger
 @implements IDisposable
 
@@ -14,7 +15,7 @@
 @* Overlay *@
 @if (isOpen)
 {
-    <div class="copilot-overlay-backdrop" @onclick="CloseOverlay">
+    <div class="copilot-overlay-backdrop @(ThemeService.IsDarkMode ? "theme-dark" : "theme-light")" @onclick="CloseOverlay">
         <div class="copilot-overlay @(isClosing ? "closing" : "")" @onclick:stopPropagation="true">
             <div class="overlay-header">
                 <div class="header-title">
@@ -211,8 +212,8 @@
     }
     
     /* Dark mode */
-    :root.dark .copilot-overlay {
-        background: var(--card-bg, #2d3748);
+    :global(.theme-dark) .copilot-overlay {
+        background: var(--card-bg);
     }
 </style>
 

--- a/src/MauiSherpa/Components/CreateProfileDialog.razor
+++ b/src/MauiSherpa/Components/CreateProfileDialog.razor
@@ -1,0 +1,1159 @@
+@using MauiSherpa.Core.Interfaces
+@using MauiSherpa.Services
+@inject IAppleConnectService AppleService
+@inject IAppleIdentityStateService IdentityState
+@inject IAlertService AlertService
+@inject ILoggingService Logger
+
+@if (IsVisible)
+{
+    <div class="dialog-overlay" @onclick="HandleOverlayClick">
+        <div class="dialog" @onclick:stopPropagation="true">
+            <div class="dialog-header">
+                <h2><i class="fas fa-plus-circle"></i> Create Provisioning Profile</h2>
+                <button class="close-btn" @onclick="Close"><i class="fas fa-times"></i></button>
+            </div>
+
+            <!-- Step Indicator -->
+            <div class="step-indicator">
+                <div class="step @(currentStep >= 1 ? "active" : "") @(currentStep > 1 ? "completed" : "")">
+                    <div class="step-number">@(currentStep > 1 ? "✓" : "1")</div>
+                    <div class="step-label">Type</div>
+                </div>
+                <div class="step-line @(currentStep > 1 ? "active" : "")"></div>
+                <div class="step @(currentStep >= 2 ? "active" : "") @(currentStep > 2 ? "completed" : "")">
+                    <div class="step-number">@(currentStep > 2 ? "✓" : "2")</div>
+                    <div class="step-label">Bundle ID</div>
+                </div>
+                <div class="step-line @(currentStep > 2 ? "active" : "")"></div>
+                <div class="step @(currentStep >= 3 ? "active" : "") @(currentStep > 3 ? "completed" : "")">
+                    <div class="step-number">@(currentStep > 3 ? "✓" : "3")</div>
+                    <div class="step-label">Certificates</div>
+                </div>
+                <div class="step-line @(currentStep > 3 ? "active" : "")"></div>
+                <div class="step @(currentStep >= 4 ? "active" : "") @(currentStep > 4 ? "completed" : "")">
+                    <div class="step-number">@(currentStep > 4 ? "✓" : "4")</div>
+                    <div class="step-label">@(RequiresDevices ? "Devices" : "Name")</div>
+                </div>
+                @if (RequiresDevices)
+                {
+                    <div class="step-line @(currentStep > 4 ? "active" : "")"></div>
+                    <div class="step @(currentStep >= 5 ? "active" : "")">
+                        <div class="step-number">5</div>
+                        <div class="step-label">Name</div>
+                    </div>
+                }
+            </div>
+
+            <div class="dialog-body">
+                @if (isLoadingData)
+                {
+                    <div class="loading-state">
+                        <i class="fas fa-spinner fa-spin"></i>
+                        <span>Loading data...</span>
+                    </div>
+                }
+                else if (!string.IsNullOrEmpty(errorMessage))
+                {
+                    <div class="error-message">
+                        <i class="fas fa-exclamation-circle"></i>
+                        @errorMessage
+                    </div>
+                }
+                else
+                {
+                    @switch (currentStep)
+                    {
+                        case 1:
+                            <Step1ProfileType />
+                            break;
+                        case 2:
+                            <Step2BundleId />
+                            break;
+                        case 3:
+                            <Step3Certificates />
+                            break;
+                        case 4:
+                            @if (RequiresDevices)
+                            {
+                                <Step4Devices />
+                            }
+                            else
+                            {
+                                <Step5Name />
+                            }
+                            break;
+                        case 5:
+                            <Step5Name />
+                            break;
+                    }
+                }
+            </div>
+
+            <div class="dialog-footer">
+                @if (currentStep > 1)
+                {
+                    <button class="btn btn-secondary" @onclick="PreviousStep" disabled="@isCreating">
+                        <i class="fas fa-arrow-left"></i> Back
+                    </button>
+                }
+                <div class="spacer"></div>
+                <button class="btn btn-outline" @onclick="Close" disabled="@isCreating">Cancel</button>
+                @if (IsLastStep)
+                {
+                    <button class="btn btn-primary" @onclick="CreateProfile" disabled="@(!CanCreate || isCreating)">
+                        @if (isCreating)
+                        {
+                            <i class="fas fa-spinner fa-spin"></i>
+                            <span>Creating...</span>
+                        }
+                        else
+                        {
+                            <i class="fas fa-plus"></i>
+                            <span>Create Profile</span>
+                        }
+                    </button>
+                }
+                else
+                {
+                    <button class="btn btn-primary" @onclick="NextStep" disabled="@(!CanProceed)">
+                        Next <i class="fas fa-arrow-right"></i>
+                    </button>
+                }
+            </div>
+        </div>
+    </div>
+}
+
+@* Step 1: Profile Type Selection *@
+@{ void Step1ProfileType() {
+    <div class="step-content">
+        <h3>Select Profile Type</h3>
+        <p class="step-description">Choose the type of provisioning profile you want to create.</p>
+
+        <div class="profile-type-groups">
+            @foreach (var group in ProfileTypeGroups)
+            {
+                <div class="platform-group">
+                    <div class="platform-header">
+                        <i class="@group.Icon"></i> @group.Platform
+                    </div>
+                    <div class="type-options">
+                        @foreach (var type in group.Types)
+                        {
+                            <label class="type-option @(selectedProfileType == type.Value ? "selected" : "")">
+                                <input type="radio" name="profileType" value="@type.Value" 
+                                       checked="@(selectedProfileType == type.Value)"
+                                       @onchange="@(() => SelectProfileType(type.Value))" />
+                                <div class="type-content">
+                                    <div class="type-name">@type.Name</div>
+                                    <div class="type-description">@type.Description</div>
+                                </div>
+                            </label>
+                        }
+                    </div>
+                </div>
+            }
+        </div>
+    </div>
+}}
+
+@* Step 2: Bundle ID Selection *@
+@{ void Step2BundleId() {
+    <div class="step-content">
+        <h3>Select Bundle ID</h3>
+        <p class="step-description">Choose the App ID for this profile.</p>
+
+        <div class="search-box">
+            <i class="fas fa-search"></i>
+            <input type="text" @bind="bundleIdSearch" @bind:event="oninput" placeholder="Search bundle IDs..." />
+        </div>
+
+        <div class="selection-list">
+            @foreach (var bundleId in FilteredBundleIds)
+            {
+                <label class="selection-item @(selectedBundleId == bundleId.Id ? "selected" : "")">
+                    <input type="radio" name="bundleId" value="@bundleId.Id"
+                           checked="@(selectedBundleId == bundleId.Id)"
+                           @onchange="@(() => SelectBundleId(bundleId))" />
+                    <div class="item-content">
+                        <div class="item-name">@bundleId.Name</div>
+                        <div class="item-detail">@bundleId.Identifier</div>
+                        <span class="badge">@bundleId.Platform</span>
+                    </div>
+                </label>
+            }
+            @if (!FilteredBundleIds.Any())
+            {
+                <div class="empty-list">
+                    <i class="fas fa-inbox"></i>
+                    <span>No bundle IDs found</span>
+                </div>
+            }
+        </div>
+    </div>
+}}
+
+@* Step 3: Certificate Selection *@
+@{ void Step3Certificates() {
+    <div class="step-content">
+        <h3>Select Certificate(s)</h3>
+        <p class="step-description">
+            Choose the @(IsDevelopmentProfile ? "development" : "distribution") certificate(s) to include in this profile.
+        </p>
+
+        <div class="selection-list">
+            @foreach (var cert in FilteredCertificates)
+            {
+                var isSelected = selectedCertificateIds.Contains(cert.Id);
+                <label class="selection-item checkbox @(isSelected ? "selected" : "")">
+                    <input type="checkbox" value="@cert.Id"
+                           checked="@isSelected"
+                           @onchange="@(e => ToggleCertificate(cert.Id, (bool)(e.Value ?? false)))" />
+                    <div class="item-content">
+                        <div class="item-name">@cert.Name</div>
+                        <div class="item-detail">
+                            <span>@cert.SerialNumber</span>
+                            <span>Expires: @cert.ExpirationDate.ToString("MMM dd, yyyy")</span>
+                        </div>
+                        <span class="badge">@FormatCertType(cert.CertificateType)</span>
+                    </div>
+                </label>
+            }
+            @if (!FilteredCertificates.Any())
+            {
+                <div class="empty-list">
+                    <i class="fas fa-certificate"></i>
+                    <span>No compatible @(IsDevelopmentProfile ? "development" : "distribution") certificates found</span>
+                </div>
+            }
+        </div>
+        
+        @if (selectedCertificateIds.Any())
+        {
+            <div class="selection-summary">
+                <i class="fas fa-check-circle"></i> @selectedCertificateIds.Count certificate(s) selected
+            </div>
+        }
+    </div>
+}}
+
+@* Step 4: Device Selection (only for dev/adhoc) *@
+@{ void Step4Devices() {
+    <div class="step-content">
+        <h3>Select Devices</h3>
+        <p class="step-description">
+            Choose the devices to include in this @(selectedProfileType?.Contains("ADHOC") == true ? "ad hoc" : "development") profile.
+        </p>
+
+        <div class="device-toolbar">
+            <label class="select-all-checkbox">
+                <input type="checkbox" 
+                       checked="@(selectedDeviceIds.Count == FilteredDevices.Count() && FilteredDevices.Any())"
+                       @onchange="ToggleAllDevices" />
+                <span>Select All (@FilteredDevices.Count())</span>
+            </label>
+            <div class="search-box small">
+                <i class="fas fa-search"></i>
+                <input type="text" @bind="deviceSearch" @bind:event="oninput" placeholder="Search devices..." />
+            </div>
+        </div>
+
+        <div class="selection-list devices">
+            @foreach (var device in FilteredDevices)
+            {
+                var isSelected = selectedDeviceIds.Contains(device.Id);
+                var isDisabled = device.Status != "ENABLED";
+                <label class="selection-item checkbox @(isSelected ? "selected" : "") @(isDisabled ? "disabled" : "")">
+                    <input type="checkbox" value="@device.Id"
+                           checked="@isSelected"
+                           disabled="@isDisabled"
+                           @onchange="@(e => ToggleDevice(device.Id, (bool)(e.Value ?? false)))" />
+                    <div class="item-content">
+                        <div class="item-name">
+                            <i class="@GetDeviceIcon(device.DeviceClass)"></i>
+                            @device.Name
+                        </div>
+                        <div class="item-detail">@device.Udid</div>
+                        @if (isDisabled)
+                        {
+                            <span class="badge badge-warning">Disabled</span>
+                        }
+                    </div>
+                </label>
+            }
+            @if (!FilteredDevices.Any())
+            {
+                <div class="empty-list">
+                    <i class="fas fa-mobile-alt"></i>
+                    <span>No compatible devices found for @GetPlatformFromProfileType()</span>
+                </div>
+            }
+        </div>
+
+        @if (selectedDeviceIds.Any())
+        {
+            <div class="selection-summary">
+                <i class="fas fa-check-circle"></i> @selectedDeviceIds.Count device(s) selected
+            </div>
+        }
+        else
+        {
+            <div class="selection-summary warning">
+                <i class="fas fa-exclamation-triangle"></i> At least 1 device is required
+            </div>
+        }
+    </div>
+}}
+
+@* Step 5: Profile Name *@
+@{ void Step5Name() {
+    <div class="step-content">
+        <h3>Profile Name</h3>
+        <p class="step-description">Enter a name for your provisioning profile.</p>
+
+        <div class="form-group">
+            <label>Profile Name</label>
+            <input type="text" @bind="profileName" @bind:event="oninput" placeholder="My App Development" class="form-input" />
+            @if (!string.IsNullOrEmpty(suggestedName) && profileName != suggestedName)
+            {
+                <button class="btn-suggestion" @onclick="@(() => profileName = suggestedName)">
+                    <i class="fas fa-lightbulb"></i> Use suggested: @suggestedName
+                </button>
+            }
+        </div>
+
+        <div class="summary-section">
+            <h4>Profile Summary</h4>
+            <div class="summary-grid">
+                <div class="summary-item">
+                    <span class="summary-label">Type</span>
+                    <span class="summary-value">@FormatProfileTypeDisplay(selectedProfileType)</span>
+                </div>
+                <div class="summary-item">
+                    <span class="summary-label">Bundle ID</span>
+                    <span class="summary-value">@(bundleIds.FirstOrDefault(b => b.Id == selectedBundleId)?.Identifier ?? "-")</span>
+                </div>
+                <div class="summary-item">
+                    <span class="summary-label">Certificates</span>
+                    <span class="summary-value">@selectedCertificateIds.Count selected</span>
+                </div>
+                @if (RequiresDevices)
+                {
+                    <div class="summary-item">
+                        <span class="summary-label">Devices</span>
+                        <span class="summary-value">@selectedDeviceIds.Count selected</span>
+                    </div>
+                }
+            </div>
+        </div>
+    </div>
+}}
+
+<style>
+    .dialog-overlay {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background: rgba(0, 0, 0, 0.6);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 10000;
+        backdrop-filter: blur(2px);
+    }
+
+    .dialog {
+        background: var(--card-bg, white);
+        border-radius: 12px;
+        width: 90%;
+        max-width: 700px;
+        max-height: 85vh;
+        display: flex;
+        flex-direction: column;
+        box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+    }
+
+    .dialog-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 16px 24px;
+        border-bottom: 1px solid var(--border-color, #e2e8f0);
+    }
+
+    .dialog-header h2 {
+        margin: 0;
+        font-size: 18px;
+        font-weight: 600;
+        color: var(--text-primary, #1a202c);
+        display: flex;
+        align-items: center;
+        gap: 10px;
+    }
+
+    .dialog-header h2 i { color: #8b5cf6; }
+
+    .close-btn {
+        background: none;
+        border: none;
+        font-size: 18px;
+        color: var(--text-muted, #a0aec0);
+        cursor: pointer;
+        padding: 4px 8px;
+    }
+
+    .close-btn:hover { color: var(--text-secondary, #4a5568); }
+
+    /* Step Indicator */
+    .step-indicator {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 20px 24px;
+        background: var(--bg-secondary, #f7fafc);
+        border-bottom: 1px solid var(--border-color, #e2e8f0);
+        gap: 8px;
+    }
+
+    .step {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 4px;
+    }
+
+    .step-number {
+        width: 28px;
+        height: 28px;
+        border-radius: 50%;
+        background: var(--border-color, #e2e8f0);
+        color: var(--text-muted, #a0aec0);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 12px;
+        font-weight: 600;
+    }
+
+    .step.active .step-number {
+        background: #8b5cf6;
+        color: white;
+    }
+
+    .step.completed .step-number {
+        background: #48bb78;
+        color: white;
+    }
+
+    .step-label {
+        font-size: 11px;
+        color: var(--text-muted, #a0aec0);
+        white-space: nowrap;
+    }
+
+    .step.active .step-label { color: #8b5cf6; font-weight: 500; }
+    .step.completed .step-label { color: #48bb78; }
+
+    .step-line {
+        width: 40px;
+        height: 2px;
+        background: var(--border-color, #e2e8f0);
+        margin-bottom: 20px;
+    }
+
+    .step-line.active { background: #48bb78; }
+
+    .dialog-body {
+        flex: 1;
+        padding: 24px;
+        overflow-y: auto;
+    }
+
+    .step-content h3 {
+        margin: 0 0 4px 0;
+        font-size: 16px;
+        color: var(--text-primary, #1a202c);
+    }
+
+    .step-description {
+        margin: 0 0 20px 0;
+        font-size: 13px;
+        color: var(--text-muted, #718096);
+    }
+
+    /* Profile Type Groups */
+    .profile-type-groups {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+    }
+
+    .platform-group {
+        border: 1px solid var(--border-color, #e2e8f0);
+        border-radius: 8px;
+        overflow: hidden;
+    }
+
+    .platform-header {
+        padding: 10px 14px;
+        background: var(--bg-secondary, #f7fafc);
+        font-weight: 600;
+        font-size: 13px;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        color: var(--text-secondary, #4a5568);
+    }
+
+    .type-options {
+        display: flex;
+        flex-direction: column;
+    }
+
+    .type-option {
+        display: flex;
+        align-items: flex-start;
+        gap: 12px;
+        padding: 12px 14px;
+        border-bottom: 1px solid var(--border-color, #e2e8f0);
+        cursor: pointer;
+        transition: background 0.15s;
+    }
+
+    .type-option:last-child { border-bottom: none; }
+    .type-option:hover { background: var(--bg-hover, #f7fafc); }
+    .type-option.selected { background: #faf5ff; }
+
+    .type-option input[type="radio"] {
+        margin-top: 2px;
+        accent-color: #8b5cf6;
+    }
+
+    .type-content { flex: 1; }
+    .type-name { font-weight: 500; font-size: 14px; color: var(--text-primary, #1a202c); }
+    .type-description { font-size: 12px; color: var(--text-muted, #718096); margin-top: 2px; }
+
+    /* Search Box */
+    .search-box {
+        position: relative;
+        margin-bottom: 16px;
+    }
+
+    .search-box i {
+        position: absolute;
+        left: 12px;
+        top: 50%;
+        transform: translateY(-50%);
+        color: var(--text-muted, #a0aec0);
+        font-size: 14px;
+    }
+
+    .search-box input {
+        width: 100%;
+        padding: 10px 12px 10px 36px;
+        border: 1px solid var(--border-color, #e2e8f0);
+        border-radius: 6px;
+        font-size: 14px;
+        box-sizing: border-box;
+    }
+
+    .search-box input:focus {
+        outline: none;
+        border-color: #8b5cf6;
+        box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.15);
+    }
+
+    .search-box.small { margin-bottom: 0; }
+    .search-box.small input { padding: 6px 10px 6px 32px; font-size: 13px; }
+    .search-box.small i { font-size: 12px; left: 10px; }
+
+    /* Selection List */
+    .selection-list {
+        border: 1px solid var(--border-color, #e2e8f0);
+        border-radius: 8px;
+        max-height: 280px;
+        overflow-y: auto;
+    }
+
+    .selection-list.devices { max-height: 240px; }
+
+    .selection-item {
+        display: flex;
+        align-items: flex-start;
+        gap: 12px;
+        padding: 12px 14px;
+        border-bottom: 1px solid var(--border-color, #e2e8f0);
+        cursor: pointer;
+        transition: background 0.15s;
+    }
+
+    .selection-item:last-child { border-bottom: none; }
+    .selection-item:hover { background: var(--bg-hover, #f7fafc); }
+    .selection-item.selected { background: #faf5ff; }
+    .selection-item.disabled { opacity: 0.5; cursor: not-allowed; }
+
+    .selection-item input { margin-top: 2px; accent-color: #8b5cf6; }
+
+    .item-content { flex: 1; min-width: 0; }
+    .item-name { 
+        font-weight: 500; 
+        font-size: 14px; 
+        color: var(--text-primary, #1a202c);
+        display: flex;
+        align-items: center;
+        gap: 8px;
+    }
+    .item-detail { 
+        font-size: 12px; 
+        color: var(--text-muted, #718096); 
+        margin-top: 2px;
+        display: flex;
+        gap: 12px;
+        font-family: monospace;
+    }
+
+    .badge {
+        display: inline-block;
+        padding: 2px 8px;
+        border-radius: 10px;
+        font-size: 11px;
+        font-weight: 500;
+        background: #e2e8f0;
+        color: #4a5568;
+        margin-top: 4px;
+    }
+
+    .badge-warning { background: #fef3c7; color: #92400e; }
+
+    .empty-list {
+        padding: 40px 20px;
+        text-align: center;
+        color: var(--text-muted, #a0aec0);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 8px;
+    }
+
+    .empty-list i { font-size: 24px; }
+
+    .selection-summary {
+        margin-top: 12px;
+        padding: 8px 12px;
+        background: #f0fff4;
+        border-radius: 6px;
+        font-size: 13px;
+        color: #276749;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+    }
+
+    .selection-summary.warning {
+        background: #fffbeb;
+        color: #92400e;
+    }
+
+    /* Device Toolbar */
+    .device-toolbar {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 12px;
+        gap: 12px;
+    }
+
+    .select-all-checkbox {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-size: 13px;
+        cursor: pointer;
+    }
+
+    .select-all-checkbox input { accent-color: #8b5cf6; }
+
+    /* Form Elements */
+    .form-group {
+        margin-bottom: 20px;
+    }
+
+    .form-group label {
+        display: block;
+        font-size: 13px;
+        font-weight: 500;
+        color: var(--text-secondary, #4a5568);
+        margin-bottom: 6px;
+    }
+
+    .form-input {
+        width: 100%;
+        padding: 10px 14px;
+        border: 1px solid var(--border-color, #e2e8f0);
+        border-radius: 6px;
+        font-size: 14px;
+        box-sizing: border-box;
+    }
+
+    .form-input:focus {
+        outline: none;
+        border-color: #8b5cf6;
+        box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.15);
+    }
+
+    .btn-suggestion {
+        margin-top: 8px;
+        padding: 6px 12px;
+        background: #faf5ff;
+        border: 1px dashed #8b5cf6;
+        border-radius: 6px;
+        font-size: 12px;
+        color: #6b46c1;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        gap: 6px;
+    }
+
+    .btn-suggestion:hover { background: #ede9fe; }
+
+    /* Summary Section */
+    .summary-section {
+        margin-top: 24px;
+        padding: 16px;
+        background: var(--bg-secondary, #f7fafc);
+        border-radius: 8px;
+    }
+
+    .summary-section h4 {
+        margin: 0 0 12px 0;
+        font-size: 14px;
+        color: var(--text-secondary, #4a5568);
+    }
+
+    .summary-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 12px;
+    }
+
+    .summary-item {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+    }
+
+    .summary-label {
+        font-size: 11px;
+        color: var(--text-muted, #a0aec0);
+        text-transform: uppercase;
+    }
+
+    .summary-value {
+        font-size: 13px;
+        font-weight: 500;
+        color: var(--text-primary, #1a202c);
+    }
+
+    /* Dialog Footer */
+    .dialog-footer {
+        display: flex;
+        align-items: center;
+        padding: 16px 24px;
+        border-top: 1px solid var(--border-color, #e2e8f0);
+        gap: 12px;
+    }
+
+    .spacer { flex: 1; }
+
+    .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 10px 20px;
+        border: none;
+        border-radius: 6px;
+        font-size: 14px;
+        font-weight: 500;
+        cursor: pointer;
+        transition: all 0.2s;
+    }
+
+    .btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+    .btn-primary { background: #8b5cf6; color: white; }
+    .btn-primary:hover:not(:disabled) { background: #7c3aed; }
+
+    .btn-secondary { background: #a0aec0; color: white; }
+    .btn-secondary:hover:not(:disabled) { background: #718096; }
+
+    .btn-outline {
+        background: none;
+        border: 1px solid var(--border-color, #e2e8f0);
+        color: var(--text-secondary, #4a5568);
+    }
+    .btn-outline:hover:not(:disabled) { background: var(--bg-hover, #f7fafc); }
+
+    /* Loading & Error States */
+    .loading-state {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        padding: 40px;
+        gap: 12px;
+        color: var(--text-muted, #a0aec0);
+    }
+
+    .loading-state i { font-size: 24px; color: #8b5cf6; }
+
+    .error-message {
+        padding: 12px 16px;
+        background: #fff5f5;
+        border: 1px solid #fc8181;
+        border-radius: 6px;
+        color: #c53030;
+        display: flex;
+        align-items: center;
+        gap: 10px;
+    }
+</style>
+
+@code {
+    [Parameter] public bool IsVisible { get; set; }
+    [Parameter] public EventCallback<bool> IsVisibleChanged { get; set; }
+    [Parameter] public EventCallback<AppleProfile> OnProfileCreated { get; set; }
+
+    // Wizard state
+    private int currentStep = 1;
+    private bool isLoadingData = false;
+    private bool isCreating = false;
+    private string errorMessage = "";
+
+    // Data
+    private List<AppleBundleId> bundleIds = new();
+    private List<AppleCertificate> certificates = new();
+    private List<AppleDevice> devices = new();
+
+    // Selections
+    private string? selectedProfileType;
+    private string? selectedBundleId;
+    private HashSet<string> selectedCertificateIds = new();
+    private HashSet<string> selectedDeviceIds = new();
+    private string profileName = "";
+
+    // Search filters
+    private string bundleIdSearch = "";
+    private string deviceSearch = "";
+
+    // Computed properties
+    private bool RequiresDevices => selectedProfileType?.Contains("DEVELOPMENT") == true || 
+                                    selectedProfileType?.Contains("ADHOC") == true;
+    private bool IsDevelopmentProfile => selectedProfileType?.Contains("DEVELOPMENT") == true;
+    private int TotalSteps => RequiresDevices ? 5 : 4;
+    private bool IsLastStep => currentStep == TotalSteps || (!RequiresDevices && currentStep == 4);
+
+    private string suggestedName => GenerateSuggestedName();
+
+    private bool CanProceed => currentStep switch
+    {
+        1 => !string.IsNullOrEmpty(selectedProfileType),
+        2 => !string.IsNullOrEmpty(selectedBundleId),
+        3 => selectedCertificateIds.Any(),
+        4 => RequiresDevices ? selectedDeviceIds.Any() : !string.IsNullOrEmpty(profileName),
+        _ => false
+    };
+
+    private bool CanCreate => !string.IsNullOrEmpty(profileName) &&
+                              !string.IsNullOrEmpty(selectedProfileType) &&
+                              !string.IsNullOrEmpty(selectedBundleId) &&
+                              selectedCertificateIds.Any() &&
+                              (!RequiresDevices || selectedDeviceIds.Any());
+
+    // Profile type definitions
+    private static readonly List<ProfileTypeGroup> ProfileTypeGroups = new()
+    {
+        new("iOS", "fab fa-apple", new[]
+        {
+            new ProfileTypeInfo("IOS_APP_DEVELOPMENT", "Development", "Run app on registered devices during development"),
+            new ProfileTypeInfo("IOS_APP_ADHOC", "Ad Hoc", "Distribute to a limited number of registered devices"),
+            new ProfileTypeInfo("IOS_APP_STORE", "App Store", "Submit to the App Store or TestFlight")
+        }),
+        new("macOS", "fas fa-laptop", new[]
+        {
+            new ProfileTypeInfo("MAC_APP_DEVELOPMENT", "Development", "Run app on registered Macs during development"),
+            new ProfileTypeInfo("MAC_APP_STORE", "Mac App Store", "Submit to the Mac App Store"),
+            new ProfileTypeInfo("MAC_APP_DIRECT", "Direct Distribution", "Distribute outside the Mac App Store (notarized)")
+        }),
+        new("Mac Catalyst", "fas fa-layer-group", new[]
+        {
+            new ProfileTypeInfo("MAC_CATALYST_APP_DEVELOPMENT", "Development", "Run iPad app on Mac during development"),
+            new ProfileTypeInfo("MAC_CATALYST_APP_STORE", "Mac App Store", "Submit iPad app to Mac App Store"),
+            new ProfileTypeInfo("MAC_CATALYST_APP_DIRECT", "Direct Distribution", "Distribute iPad app outside Mac App Store")
+        })
+    };
+
+    private IEnumerable<AppleBundleId> FilteredBundleIds => bundleIds
+        .Where(b => string.IsNullOrEmpty(bundleIdSearch) || 
+                    b.Name.Contains(bundleIdSearch, StringComparison.OrdinalIgnoreCase) ||
+                    b.Identifier.Contains(bundleIdSearch, StringComparison.OrdinalIgnoreCase))
+        .OrderBy(b => b.Name);
+
+    private IEnumerable<AppleCertificate> FilteredCertificates => certificates
+        .Where(c => IsCertificateCompatible(c.CertificateType))
+        .Where(c => c.ExpirationDate > DateTime.UtcNow)
+        .OrderBy(c => c.Name);
+
+    private IEnumerable<AppleDevice> FilteredDevices => devices
+        .Where(d => IsDeviceCompatible(d.Platform, d.DeviceClass))
+        .Where(d => string.IsNullOrEmpty(deviceSearch) ||
+                    d.Name.Contains(deviceSearch, StringComparison.OrdinalIgnoreCase) ||
+                    d.Udid.Contains(deviceSearch, StringComparison.OrdinalIgnoreCase))
+        .OrderByDescending(d => d.Status == "ENABLED")
+        .ThenBy(d => d.Name);
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (IsVisible && bundleIds.Count == 0)
+        {
+            await LoadDataAsync();
+        }
+    }
+
+    private async Task LoadDataAsync()
+    {
+        if (IdentityState.SelectedIdentity == null) return;
+        
+        isLoadingData = true;
+        errorMessage = "";
+        try
+        {
+            var bundleTask = AppleService.GetBundleIdsAsync();
+            var certTask = AppleService.GetCertificatesAsync();
+            var deviceTask = AppleService.GetDevicesAsync();
+
+            await Task.WhenAll(bundleTask, certTask, deviceTask);
+
+            bundleIds = (await bundleTask).ToList();
+            certificates = (await certTask).ToList();
+            devices = (await deviceTask).ToList();
+        }
+        catch (Exception ex)
+        {
+            errorMessage = $"Failed to load data: {ex.Message}";
+            Logger.LogError(errorMessage, ex);
+        }
+        finally
+        {
+            isLoadingData = false;
+        }
+    }
+
+    private void SelectProfileType(string type)
+    {
+        selectedProfileType = type;
+        // Clear certificate selection when type changes (compatibility may change)
+        selectedCertificateIds.Clear();
+    }
+
+    private void SelectBundleId(AppleBundleId bundle)
+    {
+        selectedBundleId = bundle.Id;
+        // Auto-suggest name based on bundle
+        if (string.IsNullOrEmpty(profileName))
+        {
+            profileName = suggestedName;
+        }
+    }
+
+    private void ToggleCertificate(string id, bool selected)
+    {
+        if (selected)
+            selectedCertificateIds.Add(id);
+        else
+            selectedCertificateIds.Remove(id);
+    }
+
+    private void ToggleDevice(string id, bool selected)
+    {
+        if (selected)
+            selectedDeviceIds.Add(id);
+        else
+            selectedDeviceIds.Remove(id);
+    }
+
+    private void ToggleAllDevices(ChangeEventArgs e)
+    {
+        var selectAll = (bool)(e.Value ?? false);
+        selectedDeviceIds.Clear();
+        if (selectAll)
+        {
+            foreach (var device in FilteredDevices.Where(d => d.Status == "ENABLED"))
+            {
+                selectedDeviceIds.Add(device.Id);
+            }
+        }
+    }
+
+    private bool IsCertificateCompatible(string certType)
+    {
+        if (string.IsNullOrEmpty(selectedProfileType)) return true;
+
+        var isDev = IsDevelopmentProfile;
+        var certTypeLower = certType.ToUpperInvariant();
+
+        return isDev
+            ? certTypeLower.Contains("DEVELOPMENT")
+            : certTypeLower.Contains("DISTRIBUTION") || certTypeLower.Contains("STORE");
+    }
+
+    private bool IsDeviceCompatible(string devicePlatform, string deviceClass)
+    {
+        if (string.IsNullOrEmpty(selectedProfileType)) return true;
+
+        if (selectedProfileType.StartsWith("IOS_") || selectedProfileType.StartsWith("MAC_CATALYST_"))
+        {
+            return devicePlatform == "IOS" || deviceClass is "IPHONE" or "IPAD" or "IPOD";
+        }
+        if (selectedProfileType.StartsWith("MAC_APP_"))
+        {
+            return devicePlatform == "MAC_OS" || deviceClass == "MAC";
+        }
+        return true;
+    }
+
+    private string GetPlatformFromProfileType() => selectedProfileType switch
+    {
+        var t when t?.StartsWith("IOS_") == true => "iOS",
+        var t when t?.StartsWith("MAC_CATALYST_") == true => "iOS (Mac Catalyst)",
+        var t when t?.StartsWith("MAC_") == true => "macOS",
+        _ => "this platform"
+    };
+
+    private string GetDeviceIcon(string deviceClass) => deviceClass?.ToUpperInvariant() switch
+    {
+        "IPHONE" => "fas fa-mobile-alt",
+        "IPAD" => "fas fa-tablet-alt",
+        "MAC" => "fas fa-laptop",
+        "APPLE_TV" => "fas fa-tv",
+        "APPLE_WATCH" => "fas fa-clock",
+        _ => "fas fa-microchip"
+    };
+
+    private string FormatCertType(string certType) => certType.Replace("_", " ");
+
+    private string FormatProfileTypeDisplay(string? profileType) => profileType switch
+    {
+        "IOS_APP_DEVELOPMENT" => "iOS Development",
+        "IOS_APP_ADHOC" => "iOS Ad Hoc",
+        "IOS_APP_STORE" => "iOS App Store",
+        "MAC_APP_DEVELOPMENT" => "macOS Development",
+        "MAC_APP_STORE" => "Mac App Store",
+        "MAC_APP_DIRECT" => "macOS Direct Distribution",
+        "MAC_CATALYST_APP_DEVELOPMENT" => "Mac Catalyst Development",
+        "MAC_CATALYST_APP_STORE" => "Mac Catalyst App Store",
+        "MAC_CATALYST_APP_DIRECT" => "Mac Catalyst Direct",
+        _ => profileType ?? "-"
+    };
+
+    private string GenerateSuggestedName()
+    {
+        var bundle = bundleIds.FirstOrDefault(b => b.Id == selectedBundleId);
+        if (bundle == null || string.IsNullOrEmpty(selectedProfileType)) return "";
+
+        var suffix = selectedProfileType switch
+        {
+            var t when t.Contains("DEVELOPMENT") => "Development",
+            var t when t.Contains("ADHOC") => "Ad Hoc",
+            var t when t.Contains("STORE") => "App Store",
+            var t when t.Contains("DIRECT") => "Direct",
+            _ => ""
+        };
+
+        return $"{bundle.Name} {suffix}";
+    }
+
+    private void NextStep()
+    {
+        if (CanProceed && currentStep < TotalSteps)
+        {
+            currentStep++;
+            // Auto-fill name when reaching last step
+            if (IsLastStep && string.IsNullOrEmpty(profileName))
+            {
+                profileName = suggestedName;
+            }
+        }
+    }
+
+    private void PreviousStep()
+    {
+        if (currentStep > 1)
+            currentStep--;
+    }
+
+    private async Task CreateProfile()
+    {
+        if (!CanCreate) return;
+
+        isCreating = true;
+        errorMessage = "";
+        try
+        {
+            var request = new AppleProfileCreateRequest(
+                profileName,
+                selectedProfileType!,
+                selectedBundleId!,
+                selectedCertificateIds.ToList(),
+                RequiresDevices ? selectedDeviceIds.ToList() : null
+            );
+
+            var profile = await AppleService.CreateProfileAsync(request);
+            
+            await AlertService.ShowToastAsync($"Profile '{profile.Name}' created successfully!");
+            await OnProfileCreated.InvokeAsync(profile);
+            await Close();
+        }
+        catch (Exception ex)
+        {
+            errorMessage = $"Failed to create profile: {ex.Message}";
+            Logger.LogError(errorMessage, ex);
+        }
+        finally
+        {
+            isCreating = false;
+        }
+    }
+
+    private async Task Close()
+    {
+        // Reset state
+        currentStep = 1;
+        selectedProfileType = null;
+        selectedBundleId = null;
+        selectedCertificateIds.Clear();
+        selectedDeviceIds.Clear();
+        profileName = "";
+        bundleIdSearch = "";
+        deviceSearch = "";
+        errorMessage = "";
+
+        IsVisible = false;
+        await IsVisibleChanged.InvokeAsync(false);
+    }
+
+    private void HandleOverlayClick()
+    {
+        if (!isCreating)
+        {
+            _ = Close();
+        }
+    }
+
+    // Helper types
+    private record ProfileTypeGroup(string Platform, string Icon, ProfileTypeInfo[] Types);
+    private record ProfileTypeInfo(string Value, string Name, string Description);
+}

--- a/src/MauiSherpa/Components/EditProfileDialog.razor
+++ b/src/MauiSherpa/Components/EditProfileDialog.razor
@@ -1,0 +1,739 @@
+@using MauiSherpa.Core.Interfaces
+@using MauiSherpa.Services
+@inject IAppleConnectService AppleService
+@inject IAppleIdentityStateService IdentityState
+@inject IAlertService AlertService
+@inject ILoggingService Logger
+
+@if (IsVisible && Profile != null)
+{
+    <div class="dialog-overlay" @onclick="HandleOverlayClick">
+        <div class="dialog" @onclick:stopPropagation="true">
+            <div class="dialog-header">
+                <h2><i class="fas fa-edit"></i> Edit Profile</h2>
+                <button class="close-btn" @onclick="Close"><i class="fas fa-times"></i></button>
+            </div>
+
+            <div class="dialog-body">
+                @if (isLoading)
+                {
+                    <div class="loading-state">
+                        <i class="fas fa-spinner fa-spin"></i>
+                        <span>Loading profile data...</span>
+                    </div>
+                }
+                else if (!string.IsNullOrEmpty(errorMessage))
+                {
+                    <div class="error-message">
+                        <i class="fas fa-exclamation-circle"></i>
+                        @errorMessage
+                    </div>
+                }
+                else
+                {
+                    <div class="warning-banner">
+                        <i class="fas fa-exclamation-triangle"></i>
+                        <div>
+                            <strong>This will delete and recreate the profile.</strong>
+                            <p>The profile UUID will change. You may need to update your Xcode project settings.</p>
+                        </div>
+                    </div>
+
+                    <div class="profile-info">
+                        <h3>Profile Details</h3>
+                        <div class="info-grid">
+                            <div class="info-item">
+                                <span class="info-label">Name</span>
+                                <span class="info-value">@Profile.Name</span>
+                            </div>
+                            <div class="info-item">
+                                <span class="info-label">Type</span>
+                                <span class="info-value">@FormatProfileType(Profile.ProfileType)</span>
+                            </div>
+                            <div class="info-item">
+                                <span class="info-label">Bundle ID</span>
+                                <span class="info-value">@(selectedBundle?.Identifier ?? Profile.BundleId ?? "Unknown")</span>
+                            </div>
+                            <div class="info-item">
+                                <span class="info-label">Current Expiration</span>
+                                <span class="info-value @(Profile.ExpirationDate < DateTime.UtcNow ? "expired" : "")">
+                                    @Profile.ExpirationDate.ToString("MMM dd, yyyy")
+                                    @if (Profile.ExpirationDate < DateTime.UtcNow) { <span class="badge-expired">Expired</span> }
+                                </span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Certificates Section -->
+                    <div class="selection-section">
+                        <h3>Certificates</h3>
+                        <p class="section-description">
+                            Select @(IsDevelopmentProfile ? "development" : "distribution") certificates to include.
+                        </p>
+                        
+                        <div class="selection-list">
+                            @foreach (var cert in FilteredCertificates)
+                            {
+                                var isSelected = selectedCertificateIds.Contains(cert.Id);
+                                <label class="selection-item @(isSelected ? "selected" : "")">
+                                    <input type="checkbox" 
+                                           checked="@isSelected"
+                                           @onchange="@(e => ToggleCertificate(cert.Id, (bool)(e.Value ?? false)))" />
+                                    <div class="item-content">
+                                        <div class="item-name">@cert.Name</div>
+                                        <div class="item-detail">
+                                            <span>@cert.SerialNumber</span>
+                                            <span>Expires: @cert.ExpirationDate.ToString("MMM dd, yyyy")</span>
+                                        </div>
+                                    </div>
+                                </label>
+                            }
+                            @if (!FilteredCertificates.Any())
+                            {
+                                <div class="empty-list">
+                                    <i class="fas fa-certificate"></i>
+                                    <span>No compatible certificates found</span>
+                                </div>
+                            }
+                        </div>
+                        
+                        @if (selectedCertificateIds.Any())
+                        {
+                            <div class="selection-summary">
+                                <i class="fas fa-check-circle"></i> @selectedCertificateIds.Count certificate(s) selected
+                            </div>
+                        }
+                    </div>
+
+                    <!-- Devices Section (only for dev/adhoc) -->
+                    @if (RequiresDevices)
+                    {
+                        <div class="selection-section">
+                            <h3>Devices</h3>
+                            <p class="section-description">
+                                Select devices to include in this profile.
+                            </p>
+
+                            <div class="device-toolbar">
+                                <label class="select-all-checkbox">
+                                    <input type="checkbox" 
+                                           checked="@(selectedDeviceIds.Count == EnabledDevices.Count() && EnabledDevices.Any())"
+                                           @onchange="ToggleAllDevices" />
+                                    <span>Select All (@EnabledDevices.Count())</span>
+                                </label>
+                            </div>
+
+                            <div class="selection-list devices">
+                                @foreach (var device in FilteredDevices)
+                                {
+                                    var isSelected = selectedDeviceIds.Contains(device.Id);
+                                    var isDisabled = device.Status != "ENABLED";
+                                    <label class="selection-item @(isSelected ? "selected" : "") @(isDisabled ? "disabled" : "")">
+                                        <input type="checkbox"
+                                               checked="@isSelected"
+                                               disabled="@isDisabled"
+                                               @onchange="@(e => ToggleDevice(device.Id, (bool)(e.Value ?? false)))" />
+                                        <div class="item-content">
+                                            <div class="item-name">
+                                                <i class="@GetDeviceIcon(device.DeviceClass)"></i>
+                                                @device.Name
+                                            </div>
+                                            <div class="item-detail">@device.Udid</div>
+                                            @if (isDisabled)
+                                            {
+                                                <span class="badge badge-warning">Disabled</span>
+                                            }
+                                        </div>
+                                    </label>
+                                }
+                                @if (!FilteredDevices.Any())
+                                {
+                                    <div class="empty-list">
+                                        <i class="fas fa-mobile-alt"></i>
+                                        <span>No compatible devices found</span>
+                                    </div>
+                                }
+                            </div>
+
+                            @if (selectedDeviceIds.Any())
+                            {
+                                <div class="selection-summary">
+                                    <i class="fas fa-check-circle"></i> @selectedDeviceIds.Count device(s) selected
+                                </div>
+                            }
+                            else
+                            {
+                                <div class="selection-summary warning">
+                                    <i class="fas fa-exclamation-triangle"></i> At least 1 device is required
+                                </div>
+                            }
+                        </div>
+                    }
+                }
+            </div>
+
+            <div class="dialog-footer">
+                <button class="btn btn-outline" @onclick="Close" disabled="@isRegenerating">Cancel</button>
+                <button class="btn btn-primary" @onclick="RegenerateProfile" disabled="@(!CanRegenerate || isRegenerating)">
+                    @if (isRegenerating)
+                    {
+                        <i class="fas fa-spinner fa-spin"></i>
+                        <span>Regenerating...</span>
+                    }
+                    else
+                    {
+                        <i class="fas fa-sync-alt"></i>
+                        <span>Regenerate Profile</span>
+                    }
+                </button>
+            </div>
+        </div>
+    </div>
+}
+
+<style>
+    .dialog-overlay {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background: rgba(0, 0, 0, 0.6);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 10000;
+        backdrop-filter: blur(2px);
+    }
+
+    .dialog {
+        background: var(--card-bg, white);
+        border-radius: 12px;
+        width: 90%;
+        max-width: 600px;
+        max-height: 85vh;
+        display: flex;
+        flex-direction: column;
+        box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+    }
+
+    .dialog-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 16px 24px;
+        border-bottom: 1px solid var(--border-color, #e2e8f0);
+    }
+
+    .dialog-header h2 {
+        margin: 0;
+        font-size: 18px;
+        font-weight: 600;
+        color: var(--text-primary, #1a202c);
+        display: flex;
+        align-items: center;
+        gap: 10px;
+    }
+
+    .dialog-header h2 i { color: #8b5cf6; }
+
+    .close-btn {
+        background: none;
+        border: none;
+        font-size: 18px;
+        color: var(--text-muted, #a0aec0);
+        cursor: pointer;
+        padding: 4px 8px;
+    }
+
+    .close-btn:hover { color: var(--text-secondary, #4a5568); }
+
+    .dialog-body {
+        flex: 1;
+        padding: 24px;
+        overflow-y: auto;
+    }
+
+    .warning-banner {
+        display: flex;
+        gap: 12px;
+        padding: 16px;
+        background: var(--status-warning-bg);
+        border: 1px solid var(--accent-warning);
+        border-radius: 8px;
+        margin-bottom: 20px;
+    }
+
+    .warning-banner i {
+        color: var(--accent-warning);
+        font-size: 20px;
+        flex-shrink: 0;
+        margin-top: 2px;
+    }
+
+    .warning-banner strong {
+        color: var(--status-warning-text);
+        display: block;
+        margin-bottom: 4px;
+    }
+
+    .warning-banner p {
+        margin: 0;
+        font-size: 13px;
+        color: var(--status-warning-text);
+    }
+
+    .profile-info {
+        margin-bottom: 24px;
+    }
+
+    .profile-info h3 {
+        font-size: 14px;
+        font-weight: 600;
+        color: var(--text-secondary, #4a5568);
+        margin: 0 0 12px 0;
+    }
+
+    .info-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 12px;
+    }
+
+    .info-item {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+    }
+
+    .info-label {
+        font-size: 11px;
+        color: var(--text-muted, #a0aec0);
+        text-transform: uppercase;
+    }
+
+    .info-value {
+        font-size: 13px;
+        font-weight: 500;
+        color: var(--text-primary, #1a202c);
+    }
+
+    .info-value.expired { color: #dc2626; }
+
+    .badge-expired {
+        display: inline-block;
+        padding: 2px 6px;
+        background: var(--status-error-bg);
+        color: var(--status-error-text);
+        border-radius: 4px;
+        font-size: 10px;
+        font-weight: 500;
+        margin-left: 8px;
+    }
+
+    .selection-section {
+        margin-bottom: 20px;
+    }
+
+    .selection-section h3 {
+        font-size: 14px;
+        font-weight: 600;
+        color: var(--text-secondary, #4a5568);
+        margin: 0 0 4px 0;
+    }
+
+    .section-description {
+        font-size: 13px;
+        color: var(--text-muted, #718096);
+        margin: 0 0 12px 0;
+    }
+
+    .selection-list {
+        border: 1px solid var(--border-color, #e2e8f0);
+        border-radius: 8px;
+        max-height: 200px;
+        overflow-y: auto;
+        background: var(--input-bg, white);
+    }
+
+    .selection-list.devices { max-height: 180px; }
+
+    .selection-item {
+        display: flex;
+        align-items: flex-start;
+        gap: 12px;
+        padding: 12px 14px;
+        border-bottom: 1px solid var(--border-color, #e2e8f0);
+        cursor: pointer;
+        transition: background 0.15s;
+        background: var(--input-bg, white);
+    }
+
+    .selection-item:last-child { border-bottom: none; }
+    .selection-item:hover { background: var(--hover-bg, #f7fafc); }
+    .selection-item.selected { background: var(--accent-bg, #faf5ff); }
+    .selection-item.disabled { opacity: 0.5; cursor: not-allowed; }
+
+    .selection-item input { margin-top: 2px; accent-color: #8b5cf6; }
+
+    .item-content { flex: 1; min-width: 0; }
+    .item-name { 
+        font-weight: 500; 
+        font-size: 14px; 
+        color: var(--text-primary, #1a202c);
+        display: flex;
+        align-items: center;
+        gap: 8px;
+    }
+    .item-detail { 
+        font-size: 12px; 
+        color: var(--text-muted, #718096); 
+        margin-top: 2px;
+        display: flex;
+        gap: 12px;
+        font-family: monospace;
+    }
+
+    .badge { 
+        display: inline-block;
+        padding: 2px 8px;
+        border-radius: 10px;
+        font-size: 11px;
+        font-weight: 500;
+        margin-top: 4px;
+    }
+
+    .badge-warning { background: var(--status-warning-bg); color: var(--status-warning-text); }
+
+    .empty-list {
+        padding: 30px 20px;
+        text-align: center;
+        color: var(--text-muted);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 8px;
+    }
+
+    .empty-list i { font-size: 20px; }
+
+    .selection-summary {
+        margin-top: 8px;
+        padding: 8px 12px;
+        background: var(--status-success-bg);
+        border-radius: 6px;
+        font-size: 13px;
+        color: var(--status-success-text);
+        display: flex;
+        align-items: center;
+        gap: 8px;
+    }
+
+    .selection-summary.warning {
+        background: var(--status-warning-bg);
+        color: var(--status-warning-text);
+    }
+
+    .device-toolbar {
+        margin-bottom: 8px;
+    }
+
+    .select-all-checkbox {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-size: 13px;
+        cursor: pointer;
+        color: var(--text-secondary);
+    }
+
+    .select-all-checkbox input { accent-color: #8b5cf6; }
+
+    .dialog-footer {
+        display: flex;
+        justify-content: flex-end;
+        padding: 16px 24px;
+        border-top: 1px solid var(--border-color, #e2e8f0);
+        gap: 12px;
+    }
+
+    .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 10px 20px;
+        border: none;
+        border-radius: 6px;
+        font-size: 14px;
+        font-weight: 500;
+        cursor: pointer;
+        transition: all 0.2s;
+    }
+
+    .btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+    .btn-primary { background: #ed8936; color: white; }
+    .btn-primary:hover:not(:disabled) { background: #dd6b20; }
+
+    .btn-outline {
+        background: none;
+        border: 1px solid var(--border-color, #e2e8f0);
+        color: var(--text-secondary, #4a5568);
+    }
+    .btn-outline:hover:not(:disabled) { background: var(--bg-hover, #f7fafc); }
+
+    .loading-state {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        padding: 40px;
+        gap: 12px;
+        color: var(--text-muted, #a0aec0);
+    }
+
+    .loading-state i { font-size: 24px; color: #ed8936; }
+
+    .error-message {
+        padding: 12px 16px;
+        background: var(--status-error-bg);
+        border: 1px solid var(--accent-danger);
+        border-radius: 6px;
+        color: var(--status-error-text);
+        display: flex;
+        align-items: center;
+        gap: 10px;
+    }
+</style>
+
+@code {
+    [Parameter] public bool IsVisible { get; set; }
+    [Parameter] public EventCallback<bool> IsVisibleChanged { get; set; }
+    [Parameter] public AppleProfile? Profile { get; set; }
+    [Parameter] public EventCallback<AppleProfile> OnProfileRegenerated { get; set; }
+
+    // State
+    private bool isLoading = false;
+    private bool isRegenerating = false;
+    private string errorMessage = "";
+
+    // Data
+    private List<AppleBundleId> bundleIds = new();
+    private List<AppleCertificate> certificates = new();
+    private List<AppleDevice> devices = new();
+    private AppleBundleId? selectedBundle;
+
+    // Selections
+    private HashSet<string> selectedCertificateIds = new();
+    private HashSet<string> selectedDeviceIds = new();
+
+    // Computed
+    private bool RequiresDevices => Profile?.ProfileType?.Contains("DEVELOPMENT") == true || 
+                                    Profile?.ProfileType?.Contains("ADHOC") == true;
+    private bool IsDevelopmentProfile => Profile?.ProfileType?.Contains("DEVELOPMENT") == true;
+
+    private bool CanRegenerate => selectedCertificateIds.Any() &&
+                                  (!RequiresDevices || selectedDeviceIds.Any()) &&
+                                  selectedBundle != null;
+
+    private IEnumerable<AppleCertificate> FilteredCertificates => certificates
+        .Where(c => IsCertificateCompatible(c.CertificateType))
+        .Where(c => c.ExpirationDate > DateTime.UtcNow)
+        .OrderBy(c => c.Name);
+
+    private IEnumerable<AppleDevice> FilteredDevices => devices
+        .Where(d => IsDeviceCompatible(d.Platform, d.DeviceClass))
+        .OrderByDescending(d => d.Status == "ENABLED")
+        .ThenBy(d => d.Name);
+
+    private IEnumerable<AppleDevice> EnabledDevices => FilteredDevices.Where(d => d.Status == "ENABLED");
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (IsVisible && Profile != null && bundleIds.Count == 0)
+        {
+            await LoadDataAsync();
+        }
+    }
+
+    private async Task LoadDataAsync()
+    {
+        if (IdentityState.SelectedIdentity == null || Profile == null) return;
+
+        isLoading = true;
+        errorMessage = "";
+        try
+        {
+            var bundleTask = AppleService.GetBundleIdsAsync();
+            var certTask = AppleService.GetCertificatesAsync();
+            var deviceTask = AppleService.GetDevicesAsync();
+
+            await Task.WhenAll(bundleTask, certTask, deviceTask);
+
+            bundleIds = (await bundleTask).ToList();
+            certificates = (await certTask).ToList();
+            devices = (await deviceTask).ToList();
+
+            // Find matching bundle ID
+            selectedBundle = bundleIds.FirstOrDefault(b =>
+                !string.IsNullOrEmpty(Profile.BundleId) && 
+                b.Identifier.Equals(Profile.BundleId, StringComparison.OrdinalIgnoreCase));
+
+            // Pre-select all compatible certificates
+            selectedCertificateIds = FilteredCertificates.Select(c => c.Id).ToHashSet();
+
+            // Pre-select all enabled devices (for dev/adhoc)
+            if (RequiresDevices)
+            {
+                selectedDeviceIds = EnabledDevices.Select(d => d.Id).ToHashSet();
+            }
+        }
+        catch (Exception ex)
+        {
+            errorMessage = $"Failed to load data: {ex.Message}";
+            Logger.LogError(errorMessage, ex);
+        }
+        finally
+        {
+            isLoading = false;
+        }
+    }
+
+    private void ToggleCertificate(string id, bool selected)
+    {
+        if (selected)
+            selectedCertificateIds.Add(id);
+        else
+            selectedCertificateIds.Remove(id);
+    }
+
+    private void ToggleDevice(string id, bool selected)
+    {
+        if (selected)
+            selectedDeviceIds.Add(id);
+        else
+            selectedDeviceIds.Remove(id);
+    }
+
+    private void ToggleAllDevices(ChangeEventArgs e)
+    {
+        var selectAll = (bool)(e.Value ?? false);
+        selectedDeviceIds.Clear();
+        if (selectAll)
+        {
+            foreach (var device in EnabledDevices)
+            {
+                selectedDeviceIds.Add(device.Id);
+            }
+        }
+    }
+
+    private bool IsCertificateCompatible(string certType)
+    {
+        if (Profile == null) return true;
+        var certTypeLower = certType.ToUpperInvariant();
+        return IsDevelopmentProfile
+            ? certTypeLower.Contains("DEVELOPMENT")
+            : certTypeLower.Contains("DISTRIBUTION") || certTypeLower.Contains("STORE");
+    }
+
+    private bool IsDeviceCompatible(string devicePlatform, string deviceClass)
+    {
+        if (Profile == null) return true;
+        var profileType = Profile.ProfileType;
+
+        if (profileType.StartsWith("IOS_") || profileType.StartsWith("MAC_CATALYST_"))
+        {
+            return devicePlatform == "IOS" || deviceClass is "IPHONE" or "IPAD" or "IPOD";
+        }
+        if (profileType.StartsWith("MAC_APP_"))
+        {
+            return devicePlatform == "MAC_OS" || deviceClass == "MAC";
+        }
+        return true;
+    }
+
+    private string GetDeviceIcon(string deviceClass) => deviceClass?.ToUpperInvariant() switch
+    {
+        "IPHONE" => "fas fa-mobile-alt",
+        "IPAD" => "fas fa-tablet-alt",
+        "MAC" => "fas fa-laptop",
+        "APPLE_TV" => "fas fa-tv",
+        "APPLE_WATCH" => "fas fa-clock",
+        _ => "fas fa-microchip"
+    };
+
+    private string FormatProfileType(string profileType) => profileType switch
+    {
+        "IOS_APP_DEVELOPMENT" => "iOS Development",
+        "IOS_APP_ADHOC" => "iOS Ad Hoc",
+        "IOS_APP_STORE" => "iOS App Store",
+        "MAC_APP_DEVELOPMENT" => "macOS Development",
+        "MAC_APP_STORE" => "Mac App Store",
+        "MAC_APP_DIRECT" => "macOS Direct Distribution",
+        "MAC_CATALYST_APP_DEVELOPMENT" => "Mac Catalyst Development",
+        "MAC_CATALYST_APP_STORE" => "Mac Catalyst App Store",
+        "MAC_CATALYST_APP_DIRECT" => "Mac Catalyst Direct",
+        _ => profileType.Replace("_", " ")
+    };
+
+    private async Task RegenerateProfile()
+    {
+        if (Profile == null || selectedBundle == null || !CanRegenerate) return;
+
+        isRegenerating = true;
+        errorMessage = "";
+        try
+        {
+            // Delete the old profile
+            await AppleService.DeleteProfileAsync(Profile.Id);
+            Logger.LogInformation($"Deleted old profile: {Profile.Name}");
+
+            // Create the new profile
+            var request = new AppleProfileCreateRequest(
+                Profile.Name,
+                Profile.ProfileType,
+                selectedBundle.Id,
+                selectedCertificateIds.ToList(),
+                RequiresDevices ? selectedDeviceIds.ToList() : null);
+
+            var newProfile = await AppleService.CreateProfileAsync(request);
+            
+            await AlertService.ShowToastAsync($"Profile '{newProfile.Name}' regenerated successfully!");
+            await OnProfileRegenerated.InvokeAsync(newProfile);
+            await Close();
+        }
+        catch (Exception ex)
+        {
+            errorMessage = $"Failed to regenerate profile: {ex.Message}";
+            Logger.LogError(errorMessage, ex);
+        }
+        finally
+        {
+            isRegenerating = false;
+        }
+    }
+
+    private async Task Close()
+    {
+        // Reset state
+        bundleIds.Clear();
+        certificates.Clear();
+        devices.Clear();
+        selectedCertificateIds.Clear();
+        selectedDeviceIds.Clear();
+        selectedBundle = null;
+        errorMessage = "";
+
+        IsVisible = false;
+        await IsVisibleChanged.InvokeAsync(false);
+    }
+
+    private void HandleOverlayClick()
+    {
+        if (!isRegenerating)
+        {
+            _ = Close();
+        }
+    }
+}

--- a/src/MauiSherpa/Components/MainLayout.razor
+++ b/src/MauiSherpa/Components/MainLayout.razor
@@ -199,6 +199,7 @@
         --input-bg: #ffffff;
         --input-border: #e2e8f0;
         --hover-bg: #f7fafc;
+        --accent-bg: #faf5ff;
     }
 
     /* Dark theme */
@@ -215,6 +216,7 @@
         --input-bg: #2d3748;
         --input-border: #4a5568;
         --hover-bg: #4a5568;
+        --accent-bg: #312e81;
     }
 
     .theme-dark .sidebar {

--- a/src/MauiSherpa/Pages/Copilot.razor
+++ b/src/MauiSherpa/Pages/Copilot.razor
@@ -147,28 +147,32 @@ else
     else
     {
         <div class="chat-layout">
-            <!-- Suggested Prompts (shown when no messages) -->
-            @if (messages.Count == 0 && !isBusy)
-            {
-                <div class="suggestions-section">
-                    <p class="suggestions-hint"><i class="fas fa-lightbulb"></i> Try asking:</p>
-                    <div class="suggestions-grid">
-                        @foreach (var suggestion in suggestedPrompts)
-                        {
-                        <button class="suggestion-bubble" @onclick="@(() => UseSuggestion(suggestion))">
-                            <span class="bubble-text">"@suggestion.Prompt"</span>
-                            <i class="fas fa-arrow-right bubble-arrow"></i>
-                        </button>
-                    }
-                </div>
-            </div>
-        }
-
         <!-- Chat Messages -->
-        <div class="chat-container @(messages.Count == 0 && !isBusy ? "with-suggestions" : "")">
-            @if (messages.Count > 0 || isBusy)
-            {
+        <div class="chat-container">
             <div class="chat-messages" @ref="chatMessagesRef" @onscroll="OnChatScroll">
+                @* Show suggestions as first item - collapsible *@
+                <div class="suggestions-bubble @(suggestionsCollapsed ? "collapsed" : "")">
+                    <button class="suggestions-header" @onclick="ToggleSuggestionsCollapsed">
+                        <div class="suggestions-header-content">
+                            <i class="fas fa-lightbulb"></i>
+                            <span>Copilot Suggestions</span>
+                            </div>
+                            <i class="fas @(suggestionsCollapsed ? "fa-chevron-down" : "fa-chevron-up") collapse-icon"></i>
+                        </button>
+                        @if (!suggestionsCollapsed)
+                        {
+                            <p class="suggestions-intro">Hi! I can help you manage your development environment. Try one of these:</p>
+                            <div class="suggestions-grid">
+                                @foreach (var suggestion in suggestedPrompts)
+                                {
+                                    <button class="suggestion-bubble" @onclick="@(() => UseSuggestion(suggestion))">
+                                        <span class="bubble-text">"@suggestion.Prompt"</span>
+                                        <i class="fas fa-arrow-right bubble-arrow"></i>
+                                    </button>
+                                }
+                            </div>
+                        }
+                    </div>
                 @foreach (var msg in messages.ToList())
                 {
                     @if (msg.MessageType == CopilotMessageType.Reasoning)
@@ -302,7 +306,6 @@ else
                     </div>
                 }
             </div>
-            }
 
             <div class="chat-input-area">
                 @{
@@ -774,6 +777,62 @@ else
         margin-bottom: 16px;
     }
 
+    .suggestions-bubble {
+        align-self: flex-start;
+        max-width: 90%;
+        background: var(--bg-tertiary);
+        border: 1px solid var(--border-color);
+        border-radius: 12px;
+        padding: 16px;
+        flex-shrink: 0;
+    }
+
+    .suggestions-bubble.collapsed {
+        padding: 8px 16px;
+    }
+
+    .suggestions-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        width: 100%;
+        background: none;
+        border: none;
+        cursor: pointer;
+        padding: 0;
+        font-size: 12px;
+        font-weight: 600;
+        color: var(--text-muted);
+    }
+
+    .suggestions-bubble:not(.collapsed) .suggestions-header {
+        margin-bottom: 12px;
+    }
+
+    .suggestions-header-content {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+    }
+
+    .suggestions-header-content i {
+        color: #8b5cf6;
+    }
+
+    .suggestions-header .collapse-icon {
+        font-size: 10px;
+        color: var(--text-muted);
+        transition: transform 0.2s;
+        margin-left: 12px;
+    }
+
+    .suggestions-intro {
+        font-size: 14px;
+        color: var(--text-primary);
+        margin: 0 0 16px 0;
+        line-height: 1.5;
+    }
+
     .suggestions-hint {
         font-size: 13px;
         color: var(--text-muted);
@@ -798,8 +857,8 @@ else
         align-items: flex-start;
         gap: 8px;
         padding: 10px 14px;
-        background: linear-gradient(135deg, #f0f4ff 0%, #e8ecff 100%);
-        border: 1px solid #c7d2fe;
+        background: var(--suggestion-bg, linear-gradient(135deg, #f0f4ff 0%, #e8ecff 100%));
+        border: 1px solid var(--suggestion-border, #c7d2fe);
         border-radius: 18px;
         cursor: pointer;
         text-align: left;
@@ -808,15 +867,15 @@ else
     }
 
     .suggestion-bubble:hover {
-        background: linear-gradient(135deg, #e8ecff 0%, #ddd6fe 100%);
-        border-color: #a5b4fc;
+        background: var(--suggestion-bg-hover, linear-gradient(135deg, #e8ecff 0%, #ddd6fe 100%));
+        border-color: var(--suggestion-border-hover, #a5b4fc);
         transform: translateY(-1px);
         box-shadow: 0 2px 8px rgba(99, 102, 241, 0.15);
     }
 
     .bubble-text {
         font-size: 13px;
-        color: #4338ca;
+        color: var(--suggestion-text, #4338ca);
         font-style: italic;
         line-height: 1.4;
         word-wrap: break-word;
@@ -824,7 +883,7 @@ else
 
     .bubble-arrow {
         font-size: 11px;
-        color: #6366f1;
+        color: var(--suggestion-arrow, #6366f1);
         opacity: 0;
         transition: opacity 0.2s, transform 0.2s;
         flex-shrink: 0;
@@ -844,12 +903,6 @@ else
         border-radius: 12px;
         overflow: hidden;
         box-shadow: var(--card-shadow-lg);
-    }
-
-    .chat-container.with-suggestions {
-        height: auto;
-        min-height: unset;
-        max-height: none;
     }
 
     .chat-messages {
@@ -974,13 +1027,6 @@ else
         font-style: italic;
         opacity: 0.6;
     }
-    
-    /* Dark mode usage info */
-    :root.dark .usage-info {
-        color: #a5b4fc;
-        background: linear-gradient(135deg, rgba(99, 102, 241, 0.12) 0%, rgba(139, 92, 246, 0.12) 100%);
-        border-color: rgba(99, 102, 241, 0.25);
-    }
 
     .intent-indicator {
         display: flex;
@@ -1004,11 +1050,16 @@ else
         align-items: center;
         gap: 8px;
         padding: 8px 12px;
-        background: #fef3c7;
-        color: #92400e;
+        background: var(--tool-indicator-bg, linear-gradient(135deg, rgba(99, 102, 241, 0.15) 0%, rgba(139, 92, 246, 0.1) 100%));
+        color: var(--tool-indicator-text, #6366f1);
+        border: 1px solid var(--tool-indicator-border, rgba(99, 102, 241, 0.3));
         border-radius: 6px;
         font-size: 13px;
         margin-bottom: 12px;
+    }
+
+    .tool-indicator i {
+        color: var(--tool-indicator-icon, #8b5cf6);
     }
 
     .chat-input {
@@ -1133,8 +1184,7 @@ else
         margin-bottom: 8px;
         overflow: hidden;
         max-width: 90%;
-        flex-shrink: 0; /* Prevent shrinking */
-    }
+        flex-shrink: 0;
     }
 
     .tool-card.running {
@@ -1711,6 +1761,136 @@ else
     :global(.theme-dark) .debug-log.log-inf .log-level { color: #60a5fa; }
     :global(.theme-dark) .debug-log.log-wrn .log-level { color: #fbbf24; }
     :global(.theme-dark) .debug-log.log-err .log-level { color: #f87171; }
+
+    /* Comprehensive Dark Mode Styles */
+    :global(.theme-dark) .suggestion-bubble {
+        background: linear-gradient(135deg, rgba(99, 102, 241, 0.2) 0%, rgba(139, 92, 246, 0.2) 100%);
+        border-color: rgba(139, 92, 246, 0.4);
+    }
+
+    :global(.theme-dark) .suggestion-bubble:hover {
+        background: linear-gradient(135deg, rgba(99, 102, 241, 0.3) 0%, rgba(139, 92, 246, 0.3) 100%);
+        border-color: rgba(139, 92, 246, 0.6);
+    }
+
+    :global(.theme-dark) .bubble-text {
+        color: #c4b5fd;
+    }
+
+    :global(.theme-dark) .bubble-arrow {
+        color: #a78bfa;
+    }
+
+    :global(.theme-dark) .suggestions-hint {
+        color: #e2e8f0;
+    }
+
+    :global(.theme-dark) .assistant-message {
+        background: var(--bg-tertiary);
+        border-color: var(--border-color);
+    }
+
+    :global(.theme-dark) .usage-info {
+        background: linear-gradient(135deg, rgba(99, 102, 241, 0.15) 0%, rgba(139, 92, 246, 0.15) 100%);
+    }
+
+    :global(.theme-dark) .usage-label {
+        color: #a78bfa;
+    }
+
+    :global(.theme-dark) .usage-value {
+        color: #e2e8f0;
+    }
+
+    :global(.theme-dark) .tool-call {
+        background: linear-gradient(135deg, rgba(139, 92, 246, 0.12) 0%, rgba(99, 102, 241, 0.12) 100%);
+        border-color: rgba(139, 92, 246, 0.3);
+    }
+
+    :global(.theme-dark) .tool-name {
+        color: #c4b5fd;
+    }
+
+    :global(.theme-dark) .tool-status {
+        color: #a0aec0;
+    }
+
+    :global(.theme-dark) .input-area {
+        background: var(--card-bg);
+        border-color: var(--border-color);
+    }
+
+    :global(.theme-dark) .message-input {
+        background: var(--bg-tertiary);
+        color: var(--text-primary);
+        border-color: var(--border-color);
+    }
+
+    :global(.theme-dark) .message-input::placeholder {
+        color: var(--text-muted);
+    }
+
+    :global(.theme-dark) .message-input:focus {
+        border-color: #8b5cf6;
+        box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.2);
+    }
+
+    :global(.theme-dark) .permission-request {
+        background: linear-gradient(135deg, rgba(251, 191, 36, 0.15) 0%, rgba(245, 158, 11, 0.1) 100%);
+        border-color: rgba(251, 191, 36, 0.4);
+    }
+
+    :global(.theme-dark) .permission-header span {
+        color: #fcd34d;
+    }
+
+    :global(.theme-dark) .permission-message {
+        color: #e2e8f0;
+    }
+
+    :global(.theme-dark) .permission-tool {
+        color: #fbbf24;
+    }
+
+    :global(.theme-dark) .expand-permission-btn {
+        color: #fbbf24;
+    }
+
+    :global(.theme-dark) .permission-details {
+        background: rgba(0, 0, 0, 0.2);
+    }
+
+    :global(.theme-dark) .perm-label {
+        color: #a0aec0;
+    }
+
+    :global(.theme-dark) .perm-value {
+        color: #e2e8f0;
+    }
+
+    :global(.theme-dark) .intent-indicator {
+        background: linear-gradient(135deg, rgba(99, 102, 241, 0.15), rgba(139, 92, 246, 0.15));
+    }
+
+    :global(.theme-dark) .intent-text {
+        color: #c4b5fd;
+    }
+
+    :global(.theme-dark) .welcome-message {
+        color: var(--text-muted);
+    }
+
+    :global(.theme-dark) .empty-state-icon {
+        color: #6366f1;
+    }
+
+    :global(.theme-dark) .empty-state-text {
+        color: var(--text-muted);
+    }
+
+    :global(.theme-dark) .chat-container {
+        background: var(--card-bg);
+    }
 </style>
 
 <script suppress-error="BL9992">
@@ -1763,6 +1943,7 @@ else
     private CopilotAvailability? availability;
     private bool isConnecting = false;
     private bool isBusy = false;
+    private bool suggestionsCollapsed = false;
     private string userInput = "";
     private string currentResponse = "";
     private string currentTool = "";
@@ -2029,6 +2210,8 @@ else
 
     private async Task UseSuggestion(SuggestedPrompt suggestion)
     {
+        suggestionsCollapsed = true;
+        
         if (!CopilotService.IsConnected)
         {
             await Connect();
@@ -2042,6 +2225,8 @@ else
     private async Task SendMessage()
     {
         if (string.IsNullOrWhiteSpace(userInput) || isBusy) return;
+        
+        suggestionsCollapsed = true;
 
         var message = userInput.Trim();
         userInput = "";
@@ -2322,6 +2507,12 @@ else
     }
     
     // UI helper methods
+    private void ToggleSuggestionsCollapsed()
+    {
+        suggestionsCollapsed = !suggestionsCollapsed;
+        StateHasChanged();
+    }
+    
     private void ToggleMessageCollapse(CopilotChatMessage msg)
     {
         msg.IsCollapsed = !msg.IsCollapsed;

--- a/src/MauiSherpa/Pages/ProvisioningProfiles.razor
+++ b/src/MauiSherpa/Pages/ProvisioningProfiles.razor
@@ -19,6 +19,9 @@
 @if (IdentityState.SelectedIdentity != null)
 {
     <div class="toolbar">
+        <button class="btn btn-purple" @onclick="ShowCreateDialog" disabled="@isLoading">
+            <i class="fas fa-plus"></i> Create Profile
+        </button>
         <button class="btn btn-primary" @onclick="@(() => RefreshData(forceRefresh: true))" disabled="@isLoading">
             <i class="fas fa-sync-alt"></i> @(isLoading ? "Loading..." : "Refresh")
         </button>
@@ -89,7 +92,19 @@
             <div class="empty-state">
                 <div class="empty-icon"><i class="fas fa-file-alt"></i></div>
                 <div class="empty-title">@(profiles.Count == 0 ? "No provisioning profiles found" : "No profiles match filters")</div>
-                <div class="empty-description">@(profiles.Count == 0 ? "Create profiles in Xcode or Apple Developer Portal" : "Try adjusting your search or filters")</div>
+                <div class="empty-description">
+                    @if (profiles.Count == 0)
+                    {
+                        <span>Create a new profile to get started</span>
+                        <button class="btn btn-purple btn-empty-cta" @onclick="ShowCreateDialog">
+                            <i class="fas fa-plus"></i> Create Profile
+                        </button>
+                    }
+                    else
+                    {
+                        <span>Try adjusting your search or filters</span>
+                    }
+                </div>
             </div>
         }
         else
@@ -138,6 +153,9 @@
                         </div>
                     </div>
                     <div class="profile-actions">
+                        <button class="btn btn-secondary btn-sm" @onclick="@(() => ShowEditDialog(profile))" disabled="@isLoading" title="Edit profile certificates and devices">
+                            <i class="fas fa-edit"></i> Edit
+                        </button>
                         <div class="btn-group">
                             <button class="btn btn-secondary btn-sm" @onclick="@(() => DownloadProfile(profile))" disabled="@isLoading" title="Download to file">
                                 <i class="fas fa-download"></i> Download
@@ -164,11 +182,20 @@
     </div>
 }
 
+<CreateProfileDialog @bind-IsVisible="showCreateDialog" OnProfileCreated="OnProfileCreated" />
+<EditProfileDialog @bind-IsVisible="showEditDialog" Profile="selectedProfileForEdit" OnProfileRegenerated="OnProfileRegenerated" />
+
 <style>
     h1 { margin-bottom: 20px; font-size: 28px; color: var(--text-primary); }
 
     .toolbar { margin-bottom: 16px; display: flex; gap: 12px; }
     .error-bar { background: var(--status-error-bg); color: var(--status-error-text); padding: 12px 16px; border-radius: 6px; margin-bottom: 16px; }
+
+    .btn-purple { background: #8b5cf6; color: white; }
+    .btn-purple:hover:not(:disabled) { background: #7c3aed; }
+
+    .btn-warning { background: #ed8936; color: white; }
+    .btn-warning:hover:not(:disabled) { background: #dd6b20; }
 
     /* Filter Section Styles */
     .filter-section {
@@ -187,6 +214,7 @@
         position: relative;
         flex: 1;
         min-width: 200px;
+        margin: 0 !important;
     }
 
     .search-box input {
@@ -196,6 +224,8 @@
         border-radius: 6px;
         font-size: 14px;
         box-sizing: border-box;
+        background: var(--input-bg);
+        color: var(--text-primary);
     }
 
     .search-box input:focus {
@@ -207,10 +237,21 @@
     .search-icon {
         position: absolute;
         left: 12px;
-        top: 50%;
-        transform: translateY(-50%);
+        top: 0;
+        bottom: 0;
+        display: flex;
+        align-items: center;
         font-size: 14px;
         opacity: 0.5;
+        color: var(--text-muted);
+        pointer-events: none;
+    }
+
+    .search-icon i {
+        position: static !important;
+        left: auto !important;
+        top: auto !important;
+        transform: none !important;
     }
 
     .clear-btn {
@@ -245,6 +286,7 @@
         border-radius: 6px;
         font-size: 13px;
         background: var(--card-bg);
+        color: var(--text-primary);
         cursor: pointer;
         min-width: 120px;
     }
@@ -303,18 +345,28 @@
         display: inline-flex;
     }
 
+    .btn-group .btn {
+        border-radius: 0;
+    }
+
     .btn-group .btn:first-child {
+        border-top-left-radius: 6px;
+        border-bottom-left-radius: 6px;
         border-top-right-radius: 0;
         border-bottom-right-radius: 0;
     }
 
-    .btn-dropdown {
-        border-top-left-radius: 0;
-        border-bottom-left-radius: 0;
+    .btn-group .btn:last-of-type {
         border-top-right-radius: 6px;
         border-bottom-right-radius: 6px;
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
+    }
+
+    .btn-dropdown {
         padding: 6px 8px;
-        border-left: 1px solid rgba(255,255,255,0.3);
+        border-left: 1px solid rgba(255,255,255,0.2);
+        margin-left: -1px;
     }
 
     .dropdown-menu {
@@ -410,7 +462,8 @@
     .empty-icon { font-size: 48px; margin-bottom: 16px; color: #a0aec0; }
     .empty-icon i { font-size: 48px; }
     .empty-title { font-size: 18px; font-weight: 600; color: var(--text-primary); margin-bottom: 8px; }
-    .empty-description { color: var(--text-muted); font-size: 14px; }
+    .empty-description { color: var(--text-muted); font-size: 14px; display: flex; flex-direction: column; align-items: center; gap: 16px; }
+    .btn-empty-cta { margin-top: 8px; }
 </style>
 
 @code {
@@ -418,12 +471,17 @@
     private bool isLoading = false;
     private string errorMessage = "";
     private string? openDropdown = null;
+    private bool showCreateDialog = false;
     
     // Filter state
     private string searchQuery = "";
     private string filterState = "";
     private string filterType = "";
     private string filterPlatform = "";
+
+    // Edit dialog state
+    private bool showEditDialog = false;
+    private AppleProfile? selectedProfileForEdit = null;
 
     private bool HasActiveFilters => !string.IsNullOrEmpty(searchQuery) || 
                                       !string.IsNullOrEmpty(filterState) || 
@@ -439,6 +497,30 @@
     private void ToggleDropdown(string id)
     {
         openDropdown = openDropdown == id ? null : id;
+    }
+
+    private void ShowCreateDialog()
+    {
+        showCreateDialog = true;
+    }
+
+    private void ShowEditDialog(AppleProfile profile)
+    {
+        selectedProfileForEdit = profile;
+        showEditDialog = true;
+    }
+
+    private async Task OnProfileCreated(AppleProfile profile)
+    {
+        // Refresh the list to show the new profile
+        await RefreshData(forceRefresh: true);
+    }
+
+    private async Task OnProfileRegenerated(AppleProfile profile)
+    {
+        // Refresh the list to show the regenerated profile
+        selectedProfileForEdit = null;
+        await RefreshData(forceRefresh: true);
     }
 
     private IEnumerable<AppleProfile> FilteredProfiles => profiles

--- a/src/MauiSherpa/wwwroot/css/app.css
+++ b/src/MauiSherpa/wwwroot/css/app.css
@@ -48,6 +48,7 @@
     --accent-danger-hover: #c53030;
     --accent-purple: #9f7aea;
     --accent-indigo: #667eea;
+    --accent-bg: #faf5ff;
     
     /* Specific UI elements */
     --progress-bar-bg: #ebf8ff;
@@ -55,6 +56,20 @@
     --sdk-item-bg: #f7fafc;
     --sdk-item-installed-bg: #f0fff4;
     --modal-overlay: rgba(0, 0, 0, 0.5);
+    
+    /* Copilot suggestions */
+    --suggestion-bg: linear-gradient(135deg, #f0f4ff 0%, #e8ecff 100%);
+    --suggestion-bg-hover: linear-gradient(135deg, #e8ecff 0%, #ddd6fe 100%);
+    --suggestion-border: #c7d2fe;
+    --suggestion-border-hover: #a5b4fc;
+    --suggestion-text: #4338ca;
+    --suggestion-arrow: #6366f1;
+    
+    /* Copilot tool indicator */
+    --tool-indicator-bg: linear-gradient(135deg, rgba(99, 102, 241, 0.12) 0%, rgba(139, 92, 246, 0.08) 100%);
+    --tool-indicator-text: #5b21b6;
+    --tool-indicator-border: rgba(99, 102, 241, 0.25);
+    --tool-indicator-icon: #7c3aed;
 }
 
 /* Dark theme variable overrides */
@@ -105,6 +120,7 @@
     --accent-danger-hover: #f56565;
     --accent-purple: #b794f4;
     --accent-indigo: #7f9cf5;
+    --accent-bg: #312e81;
     
     /* Specific UI elements */
     --progress-bar-bg: #2a4365;
@@ -112,6 +128,20 @@
     --sdk-item-bg: #374151;
     --sdk-item-installed-bg: #276749;
     --modal-overlay: rgba(0, 0, 0, 0.7);
+    
+    /* Copilot suggestions - dark mode */
+    --suggestion-bg: linear-gradient(135deg, rgba(99, 102, 241, 0.2) 0%, rgba(139, 92, 246, 0.2) 100%);
+    --suggestion-bg-hover: linear-gradient(135deg, rgba(99, 102, 241, 0.3) 0%, rgba(139, 92, 246, 0.3) 100%);
+    --suggestion-border: rgba(139, 92, 246, 0.4);
+    --suggestion-border-hover: rgba(139, 92, 246, 0.6);
+    --suggestion-text: #c4b5fd;
+    --suggestion-arrow: #a78bfa;
+    
+    /* Copilot tool indicator - dark mode */
+    --tool-indicator-bg: linear-gradient(135deg, rgba(99, 102, 241, 0.2) 0%, rgba(139, 92, 246, 0.15) 100%);
+    --tool-indicator-text: #c4b5fd;
+    --tool-indicator-border: rgba(139, 92, 246, 0.4);
+    --tool-indicator-icon: #a78bfa;
 }
 
 /* Global styles using CSS variables */
@@ -678,4 +708,147 @@ pre {
 /* Available versions label */
 .available-versions .label {
     color: var(--text-muted);
+}
+
+/* Dialog styles - for modal dialogs like EditProfileDialog, CreateProfileDialog */
+.dialog-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: var(--modal-overlay);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 10000;
+    backdrop-filter: blur(2px);
+}
+
+.dialog {
+    background: var(--card-bg);
+    border-radius: 12px;
+    width: 90%;
+    max-width: 600px;
+    max-height: 85vh;
+    display: flex;
+    flex-direction: column;
+    box-shadow: var(--card-shadow-lg);
+    border: 1px solid var(--border-color);
+}
+
+.dialog-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 16px 24px;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.dialog-header h2 {
+    margin: 0;
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.dialog-body {
+    flex: 1;
+    padding: 24px;
+    overflow-y: auto;
+}
+
+.dialog-footer {
+    display: flex;
+    justify-content: flex-end;
+    padding: 16px 24px;
+    border-top: 1px solid var(--border-color);
+    gap: 12px;
+}
+
+/* Selection lists for dialogs */
+.selection-list {
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    background: var(--input-bg);
+    overflow-y: auto;
+}
+
+.selection-item {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 12px 14px;
+    border-bottom: 1px solid var(--border-color);
+    cursor: pointer;
+    transition: background 0.15s;
+    background: var(--input-bg);
+}
+
+.selection-item:last-child {
+    border-bottom: none;
+}
+
+.selection-item:hover {
+    background: var(--bg-hover);
+}
+
+.selection-item.selected {
+    background: var(--accent-bg, #faf5ff);
+}
+
+.theme-dark .selection-item.selected {
+    background: #312e81;
+}
+
+.selection-item .item-name {
+    font-weight: 500;
+    font-size: 14px;
+    color: var(--text-primary);
+}
+
+.selection-item .item-detail {
+    font-size: 12px;
+    color: var(--text-muted);
+    margin-top: 2px;
+}
+
+/* Warning banner for dialogs */
+.warning-banner {
+    display: flex;
+    gap: 12px;
+    padding: 16px;
+    background: var(--status-warning-bg);
+    border: 1px solid var(--accent-warning);
+    border-radius: 8px;
+    margin-bottom: 20px;
+}
+
+.warning-banner i {
+    color: var(--accent-warning);
+    font-size: 20px;
+    flex-shrink: 0;
+}
+
+.warning-banner strong,
+.warning-banner p {
+    color: var(--status-warning-text);
+}
+
+/* Selection summary */
+.selection-summary {
+    margin-top: 8px;
+    padding: 8px 12px;
+    background: var(--status-success-bg);
+    border-radius: 6px;
+    font-size: 13px;
+    color: var(--status-success-text);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.selection-summary.warning {
+    background: var(--status-warning-bg);
+    color: var(--status-warning-text);
 }


### PR DESCRIPTION
Introduce full support for creating and regenerating Apple provisioning profiles. Adds AppleProfileCreateRequest to the core API and implements CreateProfileAsync in AppleConnectService. Extends CopilotToolsService with tools: get_profile_types, create_provisioning_profile and regenerate_provisioning_profile (validation, bundle/certificate/device resolution, error handling, JSON results). Adds a CreateProfileDialog UI (wizard for type, bundle ID, certificates, devices, name) and an EditProfileDialog, updates Copilot overlay to respect theme, and tweaks related pages and app CSS to integrate the new flow.