### PR TITLE
Fix incorrect App Store Connect API Keys URL in Apple Identities settings

### DIFF
--- a/src/MauiSherpa/Pages/Settings.razor
+++ b/src/MauiSherpa/Pages/Settings.razor
@@ -105,7 +105,7 @@
     <h2><i class="fab fa-apple"></i> Apple Identities</h2>
     <p class="section-description">
         Configure App Store Connect API credentials for managing Apple Developer resources.
-        <a href="https://appstoreconnect.apple.com/access/api" target="_blank">Get API keys</a>
+        <a href="https://appstoreconnect.apple.com/access/integrations/api" target="_blank">Get API keys</a>
     </p>
     
     <div class="settings-container">


### PR DESCRIPTION
The 'Get API keys' link on the Settings page under Apple Identities was pointing to https://appstoreconnect.apple.com/access/api which no longer exists. Updated the URL to the correct location at https://appstoreconnect.apple.com/access/integrations/api.

Fixes #15