### PR TITLE
Implement file open picker for Browse button in Add Apple Identity di alog

### DIFF
--- a/src/MauiSherpa/Pages/Settings.razor
+++ b/src/MauiSherpa/Pages/Settings.razor
@@ -525,7 +525,7 @@
                     @if (p8InputMode == "file")
                     {
                         <div class="file-input-group">
-                            <input type="text" @bind="identityP8Path" placeholder="Path to .p8 file" readonly />
+                            <input type="text" value="@identityP8Path" placeholder="Path to .p8 file" readonly />
                             <button class="btn btn-secondary" @onclick="BrowseP8File">
                                 <i class="fas fa-folder-open"></i> Browse...
                             </button>
@@ -1490,6 +1490,7 @@
         {
             identityP8Path = path;
             identityP8Content = await FileSystem.ReadFileAsync(path) ?? "";
+            await InvokeAsync(StateHasChanged);
         }
     }
 

--- a/src/MauiSherpa/Services/DialogService.cs
+++ b/src/MauiSherpa/Services/DialogService.cs
@@ -71,8 +71,10 @@ public class DialogService : IDialogService
         }
         else
         {
-            // TODO: Implement file open picker
-            return null;
+            var extensions = filters?
+                .Select(f => f.TrimStart('*'))
+                .ToArray();
+            return await PickOpenFileAsync(title, extensions);
         }
 #else
         return await Task.FromResult<string?>(null);
@@ -151,11 +153,11 @@ public class DialogService : IDialogService
             var picker = new UIDocumentPickerViewController(types.ToArray(), false);
             picker.AllowsMultipleSelection = false;
 
-            picker.DidPickDocument += (sender, e) =>
+            picker.DidPickDocumentAtUrls += (sender, e) =>
             {
-                var url = e.Url;
-                if (url != null)
+                if (e.Urls?.Length > 0)
                 {
+                    var url = e.Urls[0];
                     url.StartAccessingSecurityScopedResource();
                     tcs.TrySetResult(url.Path);
                 }


### PR DESCRIPTION
The Browse button for selecting a .p8 Private Key file in the Apple Identity settings dialog was non-functional due to three issues:

1. ShowFileDialogAsync had an unimplemented TODO for the file-open case on Mac Catalyst that just returned null. Implemented it by delegating to the existing PickOpenFileAsync method.

2. PickOpenFileAsync used the DidPickDocument delegate which does not fire on Mac Catalyst. Changed to DidPickDocumentAtUrls (matching the working PickFolderAsync pattern) so the callback actually resolves.

3. The path textbox used @bind on a readonly input which doesn't re-render on programmatic changes. Switched to value= binding and added InvokeAsync(StateHasChanged) after the native picker returns.

Fixes #14