### PR TITLE
Add Logcat viewer and ADB device watcher

### DIFF
--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "redth.mauidevflow.cli": {
-      "version": "0.4.1",
+      "version": "0.5.0",
       "commands": [
         "maui-devflow"
       ],

--- a/src/MauiSherpa.Core/Interfaces.cs
+++ b/src/MauiSherpa.Core/Interfaces.cs
@@ -1,3 +1,5 @@
+using MauiSherpa.Core.Services;
+
 namespace MauiSherpa.Core.Interfaces;
 
 public interface IAlertService
@@ -103,6 +105,28 @@ public interface IAndroidSdkService
     // Path change notification
     event Action? SdkPathChanged;
 }
+
+public interface ILogcatService : IDisposable
+{
+    bool IsRunning { get; }
+    IReadOnlyList<LogcatEntry> Entries { get; }
+    Task StartAsync(string serial, CancellationToken ct = default);
+    void Stop();
+    void Clear();
+    IAsyncEnumerable<LogcatEntry> StreamAsync(CancellationToken ct = default);
+    event Action? OnCleared;
+}
+
+public interface IAdbDeviceWatcherService : IDisposable
+{
+    IReadOnlyList<DeviceInfo> Devices { get; }
+    bool IsWatching { get; }
+    Task StartAsync();
+    void Stop();
+    event Action<IReadOnlyList<DeviceInfo>>? DevicesChanged;
+}
+
+
 
 public interface IAndroidSdkSettingsService
 {

--- a/src/MauiSherpa.Core/MauiSherpa.Core.csproj
+++ b/src/MauiSherpa.Core/MauiSherpa.Core.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="AndroidSdk" Version="0.26.0" />
+    <PackageReference Include="AndroidSdk.Adbd" Version="0.26.0" />
     <PackageReference Include="AppStoreConnectClient" Version="0.2.18" />
     <PackageReference Include="AWSSDK.SecretsManager" Version="4.0.4.6" />
     <PackageReference Include="Azure.Identity" Version="1.13.2" />

--- a/src/MauiSherpa.Core/Services/AdbDeviceWatcherService.cs
+++ b/src/MauiSherpa.Core/Services/AdbDeviceWatcherService.cs
@@ -1,0 +1,184 @@
+using AndroidSdk;
+using MauiSherpa.Core.Interfaces;
+
+namespace MauiSherpa.Core.Services;
+
+/// <summary>
+/// Watches for ADB device connect/disconnect events using the ADB daemon protocol
+/// (host:track-devices-l). Fires DevicesChanged when the set of connected devices changes.
+/// </summary>
+public class AdbDeviceWatcherService : IAdbDeviceWatcherService
+{
+    private readonly IAndroidSdkService _sdkService;
+    private readonly ILoggingService _logger;
+    private readonly object _lock = new();
+    private List<DeviceInfo> _devices = new();
+    private CancellationTokenSource? _cts;
+    private Task? _watchTask;
+    private AdbdClient? _client;
+
+    public IReadOnlyList<DeviceInfo> Devices
+    {
+        get { lock (_lock) return _devices.ToList().AsReadOnly(); }
+    }
+
+    public bool IsWatching => _watchTask is { IsCompleted: false };
+
+    public event Action<IReadOnlyList<DeviceInfo>>? DevicesChanged;
+
+    public AdbDeviceWatcherService(IAndroidSdkService sdkService, ILoggingService logger)
+    {
+        _sdkService = sdkService;
+        _logger = logger;
+    }
+
+    public async Task StartAsync()
+    {
+        if (IsWatching) return;
+
+        _cts = new CancellationTokenSource();
+
+        var sdkPath = _sdkService.SdkPath;
+        if (string.IsNullOrEmpty(sdkPath))
+        {
+            // Try to detect SDK ourselves
+            await _sdkService.DetectSdkAsync();
+            sdkPath = _sdkService.SdkPath;
+        }
+
+        if (!string.IsNullOrEmpty(sdkPath))
+        {
+            _watchTask = WatchLoopAsync(sdkPath, _cts.Token);
+            _logger.LogInformation("ADB device watcher started.");
+        }
+        else
+        {
+            // SDK still not found — listen for it to become available later
+            _logger.LogInformation("ADB device watcher waiting for SDK path...");
+            _sdkService.SdkPathChanged += OnSdkPathAvailable;
+        }
+    }
+
+    private void OnSdkPathAvailable()
+    {
+        _sdkService.SdkPathChanged -= OnSdkPathAvailable;
+
+        var sdkPath = _sdkService.SdkPath;
+        if (string.IsNullOrEmpty(sdkPath) || _cts == null) return;
+
+        _logger.LogInformation("SDK path detected, starting ADB device watcher.");
+        _watchTask = WatchLoopAsync(sdkPath, _cts.Token);
+    }
+
+    public void Stop()
+    {
+        _sdkService.SdkPathChanged -= OnSdkPathAvailable;
+        _cts?.Cancel();
+        _client?.Disconnect();
+        _cts?.Dispose();
+        _cts = null;
+        _client = null;
+        _logger.LogInformation("ADB device watcher stopped.");
+    }
+
+    private async Task WatchLoopAsync(string sdkPath, CancellationToken ct)
+    {
+        // Do an initial device list fetch so we have devices immediately
+        await RefreshDeviceListAsync(sdkPath, ct);
+
+        // Retry loop in case the ADB connection drops
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                _client = new AdbdClient(sdkPath);
+
+                // WatchDevicesAsync fires per-device per-update, but the upstream
+                // parsing of multi-device messages is unreliable (splits all whitespace).
+                // We use it only as a change notification trigger, then fetch the full
+                // list via a separate ListDevicesAsync call.
+                await _client.WatchDevicesAsync(ct, async _ =>
+                {
+                    await RefreshDeviceListAsync(sdkPath, ct);
+                });
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning($"ADB device watcher error: {ex.Message}. Reconnecting in 5s...");
+                _client?.Disconnect();
+                _client = null;
+
+                try { await Task.Delay(5000, ct); }
+                catch (OperationCanceledException) { break; }
+            }
+        }
+    }
+
+    // Debounce: the watcher fires multiple callbacks per update (one per device line).
+    // We only want to fetch the full list once per batch.
+    private int _refreshPending = 0;
+
+    private async Task RefreshDeviceListAsync(string sdkPath, CancellationToken ct)
+    {
+        // If a refresh is already pending, skip
+        if (Interlocked.Exchange(ref _refreshPending, 1) == 1)
+            return;
+
+        // Small delay to let all per-device callbacks arrive before we query
+        try { await Task.Delay(250, ct); }
+        catch (OperationCanceledException) { Interlocked.Exchange(ref _refreshPending, 0); return; }
+
+        try
+        {
+            var listClient = new AdbdClient(sdkPath);
+            var adbDevices = await listClient.ListDevicesAsync(ct);
+            listClient.Disconnect();
+
+            var newList = adbDevices
+                .Select(d => new DeviceInfo(
+                    d.Serial,
+                    "device",
+                    d.Model?.Replace('_', ' '),
+                    d.Serial.StartsWith("emulator-")))
+                .ToList();
+
+            lock (_lock)
+            {
+                var changed = HasChanged(_devices, newList);
+                _devices = newList;
+
+                if (changed)
+                {
+                    _logger.LogInformation($"ADB devices changed: {newList.Count} device(s) connected.");
+                    DevicesChanged?.Invoke(newList.AsReadOnly());
+                }
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning($"Failed to refresh device list: {ex.Message}");
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _refreshPending, 0);
+        }
+    }
+
+    private static bool HasChanged(List<DeviceInfo> old, List<DeviceInfo> current)
+    {
+        if (old.Count != current.Count) return true;
+        var oldSerials = old.Select(d => d.Serial).OrderBy(s => s).ToList();
+        var newSerials = current.Select(d => d.Serial).OrderBy(s => s).ToList();
+        return !oldSerials.SequenceEqual(newSerials);
+    }
+
+    public void Dispose()
+    {
+        Stop();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/src/MauiSherpa.Core/Services/LogcatParser.cs
+++ b/src/MauiSherpa.Core/Services/LogcatParser.cs
@@ -1,0 +1,82 @@
+using System.Text.RegularExpressions;
+
+namespace MauiSherpa.Core.Services;
+
+/// <summary>
+/// Parses adb logcat output in threadtime format into structured LogcatEntry records.
+/// Format: MM-DD HH:MM:SS.mmm  PID  TID  LEVEL  TAG: MESSAGE
+/// </summary>
+public static partial class LogcatParser
+{
+    // Regex for threadtime format: "01-01 12:00:01.234  1234  5678 I ActivityManager: Start proc"
+    [GeneratedRegex(@"^(\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2}\.\d{3})\s+(\d+)\s+(\d+)\s+([VDIWEFA])\s+(.+?):\s(.*)$")]
+    private static partial Regex ThreadtimeRegex();
+
+    public static LogcatEntry? Parse(string line)
+    {
+        if (string.IsNullOrEmpty(line))
+            return null;
+
+        var match = ThreadtimeRegex().Match(line);
+        if (!match.Success)
+            return null;
+
+        var level = match.Groups[4].Value[0] switch
+        {
+            'V' => LogcatLevel.Verbose,
+            'D' => LogcatLevel.Debug,
+            'I' => LogcatLevel.Info,
+            'W' => LogcatLevel.Warning,
+            'E' => LogcatLevel.Error,
+            'F' or 'A' => LogcatLevel.Fatal,
+            _ => LogcatLevel.Verbose,
+        };
+
+        return new LogcatEntry(
+            Timestamp: match.Groups[1].Value,
+            Pid: int.Parse(match.Groups[2].Value),
+            Tid: int.Parse(match.Groups[3].Value),
+            Level: level,
+            Tag: match.Groups[5].Value.Trim(),
+            Message: match.Groups[6].Value,
+            RawLine: line
+        );
+    }
+
+    /// <summary>
+    /// Creates a continuation entry for lines that don't match threadtime format
+    /// (e.g. multi-line stack traces). Inherits metadata from the previous entry.
+    /// </summary>
+    public static LogcatEntry CreateContinuation(string line, LogcatEntry? previous)
+    {
+        return new LogcatEntry(
+            Timestamp: previous?.Timestamp ?? "",
+            Pid: previous?.Pid ?? 0,
+            Tid: previous?.Tid ?? 0,
+            Level: previous?.Level ?? LogcatLevel.Verbose,
+            Tag: previous?.Tag ?? "",
+            Message: line,
+            RawLine: line
+        );
+    }
+}
+
+public enum LogcatLevel
+{
+    Verbose = 0,
+    Debug = 1,
+    Info = 2,
+    Warning = 3,
+    Error = 4,
+    Fatal = 5
+}
+
+public record LogcatEntry(
+    string Timestamp,
+    int Pid,
+    int Tid,
+    LogcatLevel Level,
+    string Tag,
+    string Message,
+    string RawLine
+);

--- a/src/MauiSherpa.Core/Services/LogcatService.cs
+++ b/src/MauiSherpa.Core/Services/LogcatService.cs
@@ -1,0 +1,176 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Threading.Channels;
+using MauiSherpa.Core.Interfaces;
+
+namespace MauiSherpa.Core.Services;
+
+public class LogcatService : ILogcatService
+{
+    private const int MaxEntries = 50_000;
+
+    private readonly IAndroidSdkService _sdkService;
+    private readonly ILoggingService _logger;
+    private readonly List<LogcatEntry> _entries = new();
+    private readonly object _lock = new();
+    private Process? _process;
+    private CancellationTokenSource? _cts;
+    private LogcatEntry? _lastEntry;
+    private Channel<LogcatEntry>? _channel;
+
+    public bool IsRunning => _process is { HasExited: false };
+    public IReadOnlyList<LogcatEntry> Entries
+    {
+        get { lock (_lock) return _entries.ToList().AsReadOnly(); }
+    }
+
+    public event Action? OnCleared;
+
+    public LogcatService(IAndroidSdkService sdkService, ILoggingService logger)
+    {
+        _sdkService = sdkService;
+        _logger = logger;
+    }
+
+    public Task StartAsync(string serial, CancellationToken ct = default)
+    {
+        if (IsRunning)
+            Stop();
+
+        var sdkPath = _sdkService.SdkPath;
+        if (string.IsNullOrEmpty(sdkPath))
+            throw new InvalidOperationException("Android SDK path is not configured.");
+
+        var adbPath = Path.Combine(sdkPath, "platform-tools", "adb");
+        if (!File.Exists(adbPath))
+            throw new FileNotFoundException("adb not found.", adbPath);
+
+        _cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        _channel = Channel.CreateUnbounded<LogcatEntry>(new UnboundedChannelOptions
+        {
+            SingleWriter = true,
+            SingleReader = false,
+        });
+
+        _process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = adbPath,
+                Arguments = $"-s {serial} logcat -v threadtime",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+            },
+            EnableRaisingEvents = true,
+        };
+
+        _process.Start();
+        _logger.LogInformation($"Logcat started for device {serial} (PID: {_process.Id})");
+
+        _ = Task.Run(() => ReadOutputAsync(_process, _cts.Token), _cts.Token);
+
+        return Task.CompletedTask;
+    }
+
+    public void Stop()
+    {
+        _cts?.Cancel();
+        _channel?.Writer.TryComplete();
+
+        if (_process is { HasExited: false })
+        {
+            try
+            {
+                _process.Kill(entireProcessTree: true);
+                _logger.LogInformation("Logcat process stopped.");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning($"Failed to kill logcat process: {ex.Message}");
+            }
+        }
+
+        _process?.Dispose();
+        _process = null;
+        _cts?.Dispose();
+        _cts = null;
+    }
+
+    public void Clear()
+    {
+        lock (_lock)
+        {
+            _entries.Clear();
+            _lastEntry = null;
+        }
+        OnCleared?.Invoke();
+    }
+
+    public async IAsyncEnumerable<LogcatEntry> StreamAsync(
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+    {
+        if (_channel == null)
+            yield break;
+
+        await foreach (var entry in _channel.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+        {
+            yield return entry;
+        }
+    }
+
+    public void Dispose()
+    {
+        Stop();
+        GC.SuppressFinalize(this);
+    }
+
+    private async Task ReadOutputAsync(Process process, CancellationToken ct)
+    {
+        try
+        {
+            var reader = process.StandardOutput;
+
+            while (!ct.IsCancellationRequested && !reader.EndOfStream)
+            {
+                var line = await reader.ReadLineAsync(ct).ConfigureAwait(false);
+                if (line == null)
+                    break;
+
+                var entry = LogcatParser.Parse(line);
+
+                if (entry == null && !string.IsNullOrWhiteSpace(line))
+                {
+                    entry = LogcatParser.CreateContinuation(line, _lastEntry);
+                }
+
+                if (entry == null)
+                    continue;
+
+                lock (_lock)
+                {
+                    if (_entries.Count >= MaxEntries)
+                        _entries.RemoveAt(0);
+
+                    _entries.Add(entry);
+                    _lastEntry = entry;
+                }
+
+                _channel?.Writer.TryWrite(entry);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected on stop
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"Error reading logcat output: {ex.Message}", ex);
+        }
+        finally
+        {
+            _channel?.Writer.TryComplete();
+        }
+    }
+}

--- a/src/MauiSherpa/Components/LogcatContent.razor
+++ b/src/MauiSherpa/Components/LogcatContent.razor
@@ -1,0 +1,810 @@
+@using MauiSherpa.Core.Interfaces
+@using MauiSherpa.Core.Services
+@using MauiSherpa.Services
+@inject ILogcatService LogcatService
+@inject IAdbDeviceWatcherService DeviceWatcher
+@inject LogcatPanelService PanelService
+@inject IAlertService AlertService
+@inject ILoggingService Logger
+@inject IJSRuntime JS
+@implements IDisposable
+
+<div class="logcat-page">
+    <div class="logcat-toolbar">
+        <div class="toolbar-left">
+            <div class="device-selector" @onclick="FocusDeviceSelect">
+                <i class="fab fa-android device-selector-icon"></i>
+                <select class="device-select" @ref="deviceSelectRef" value="@Serial" @onchange="OnDeviceChanged">
+                    @foreach (var d in connectedDevices)
+                    {
+                        <option value="@d.Serial" selected="@(d.Serial == Serial)">@(d.Model ?? d.Serial)</option>
+                    }
+                </select>
+            </div>
+            @if (LogcatService.IsRunning)
+            {
+                <button class="btn btn-sm btn-danger" @onclick="StopLogcat">
+                    <i class="fas fa-stop"></i> Stop
+                </button>
+            }
+            else
+            {
+                <button class="btn btn-sm btn-success" @onclick="StartLogcat">
+                    <i class="fas fa-play"></i> Start
+                </button>
+            }
+            <button class="btn btn-sm btn-secondary" @onclick="ClearLogcat">
+                <i class="fas fa-trash-alt"></i> Clear
+            </button>
+            <button class="btn btn-sm @(isPaused ? "btn-warning" : "btn-secondary")" @onclick="TogglePause">
+                <i class="fas @(isPaused ? "fa-play" : "fa-pause")"></i> @(isPaused ? "Resume" : "Pause")
+            </button>
+            <button class="btn btn-sm @(autoScroll ? "btn-primary" : "btn-secondary")" @onclick="ToggleAutoScroll">
+                <i class="fas fa-arrow-down"></i> Auto-scroll
+            </button>
+        </div>
+        <div class="toolbar-right">
+            @if (LogcatService.IsRunning)
+            {
+                <span class="streaming-dot @(isPaused ? "paused" : "")"></span>
+            }
+        </div>
+    </div>
+
+    <div class="logcat-filters">
+        <div class="filter-group">
+            <label>Level</label>
+            <select @bind="filterLevel" @bind:after="ApplyFilters">
+                <option value="">All</option>
+                <option value="Verbose">V - Verbose</option>
+                <option value="Debug">D - Debug</option>
+                <option value="Info">I - Info</option>
+                <option value="Warning">W - Warning</option>
+                <option value="Error">E - Error</option>
+                <option value="Fatal">F - Fatal</option>
+            </select>
+        </div>
+        <div class="filter-group filter-grow">
+            <label>Tag</label>
+            <input type="text" placeholder="Filter by tag..." @bind="filterTag" @bind:event="oninput" @bind:after="DebouncedApplyFilters" />
+        </div>
+        <div class="filter-group">
+            <label>PID</label>
+            <input type="text" placeholder="PID" @bind="filterPid" @bind:event="oninput" @bind:after="DebouncedApplyFilters" class="input-pid" />
+        </div>
+        <div class="filter-group filter-grow">
+            <label>Search</label>
+            <input type="text" placeholder="Search messages..." @bind="filterText" @bind:event="oninput" @bind:after="DebouncedApplyFilters" />
+        </div>
+        @if (HasActiveFilters)
+        {
+            <button class="btn btn-sm btn-ghost" @onclick="ClearFilters">
+                <i class="fas fa-times"></i> Clear
+            </button>
+        }
+    </div>
+
+    <div class="logcat-grid-container">
+        <div class="logcat-grid">
+            <div class="grid-header">
+                <div class="col-time" style="width:@(colWidths[0])px">Time<span class="col-resizer" @onpointerdown="@(e => StartColResize(e, 0))"></span></div>
+                <div class="col-level" style="width:@(colWidths[1])px">Lvl<span class="col-resizer" @onpointerdown="@(e => StartColResize(e, 1))"></span></div>
+                <div class="col-pid" style="width:@(colWidths[2])px">PID<span class="col-resizer" @onpointerdown="@(e => StartColResize(e, 2))"></span></div>
+                <div class="col-tid" style="width:@(colWidths[3])px">TID<span class="col-resizer" @onpointerdown="@(e => StartColResize(e, 3))"></span></div>
+                <div class="col-tag" style="width:@(colWidths[4])px">Tag<span class="col-resizer" @onpointerdown="@(e => StartColResize(e, 4))"></span></div>
+                <div class="col-message">Message</div>
+            </div>
+            <div class="grid-body" @ref="gridBody" @onscroll="OnScroll">
+                <div style="height:@(filteredCount * RowHeight)px;position:relative;">
+                    <div style="position:absolute;top:@(visibleStart * RowHeight)px;left:0;right:0;">
+                        @for (int i = visibleStart; i < visibleEnd; i++)
+                        {
+                            var entry = filteredEntries[i];
+                            <div class="grid-row @GetLevelClass(entry.Level)">
+                                <div class="col-time" style="width:@(colWidths[0])px">@FormatTimestamp(entry.Timestamp)</div>
+                                <div class="col-level" style="width:@(colWidths[1])px"><span class="level-badge @GetLevelBadgeClass(entry.Level)">@GetLevelChar(entry.Level)</span></div>
+                                <div class="col-pid" style="width:@(colWidths[2])px">@entry.Pid</div>
+                                <div class="col-tid" style="width:@(colWidths[3])px">@entry.Tid</div>
+                                <div class="col-tag" style="width:@(colWidths[4])px" title="@entry.Tag">@entry.Tag</div>
+                                <div class="col-message" title="@entry.Message">@entry.Message</div>
+                            </div>
+                        }
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<style>
+    .logcat-page {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        gap: 0;
+    }
+
+    .logcat-toolbar {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 6px 8px;
+        background: var(--bg-secondary);
+        border-bottom: 1px solid var(--border-color);
+        flex-shrink: 0;
+    }
+    .toolbar-left {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+    }
+    .toolbar-right {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+    }
+
+    .device-selector {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        background: var(--bg-tertiary);
+        padding: 2px 8px 2px 10px;
+        border-radius: 20px;
+        border: 1px solid var(--border-color);
+        cursor: pointer;
+        transition: border-color 0.15s;
+    }
+    .device-selector:focus-within {
+        border-color: var(--accent-primary, #4299e1);
+    }
+    .device-selector-icon {
+        color: #3ddc84;
+        font-size: 13px;
+        flex-shrink: 0;
+        pointer-events: none;
+    }
+    .device-select {
+        background: transparent;
+        border: none;
+        color: var(--text-primary);
+        font-size: 12px;
+        font-weight: 600;
+        font-family: 'Consolas', 'Monaco', monospace;
+        cursor: pointer;
+        outline: none;
+        padding: 2px 0;
+        max-width: 180px;
+        -webkit-appearance: none;
+        appearance: none;
+    }
+    .device-select:focus {
+        outline: none;
+        box-shadow: none;
+    }
+    .device-select option {
+        background: var(--bg-secondary);
+        color: var(--text-primary);
+    }
+
+    .streaming-dot {
+        display: inline-block;
+        width: 8px;
+        height: 8px;
+        background: #48bb78;
+        border-radius: 50%;
+        margin-left: 6px;
+        animation: pulse 1.5s ease-in-out infinite;
+    }
+    .streaming-dot.paused {
+        background: #ed8936;
+        animation: none;
+    }
+
+    @@keyframes pulse {
+        0%, 100% { opacity: 1; }
+        50% { opacity: 0.3; }
+    }
+
+    /* Filter bar */
+    .logcat-filters {
+        display: flex;
+        align-items: flex-end;
+        gap: 8px;
+        padding: 5px 8px;
+        background: var(--bg-secondary);
+        border-bottom: 1px solid var(--border-color);
+        flex-shrink: 0;
+    }
+    .filter-group {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+    }
+    .filter-group label {
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        color: var(--text-muted);
+        font-weight: 600;
+    }
+    .filter-grow { flex: 1; }
+    .filter-group input, .filter-group select {
+        background: var(--bg-tertiary);
+        border: 1px solid var(--border-color);
+        color: var(--text-primary);
+        padding: 4px 8px;
+        border-radius: 4px;
+        font-size: 12px;
+        font-family: 'Consolas', 'Monaco', monospace;
+    }
+    .filter-group input:focus, .filter-group select:focus {
+        outline: none;
+        border-color: var(--accent-primary);
+    }
+    .input-pid { width: 70px; }
+
+    /* Grid */
+    .logcat-grid-container {
+        flex: 1;
+        overflow: hidden;
+        background: var(--bg-primary, #1a1a2e);
+    }
+    .logcat-grid {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
+        font-size: 12px;
+    }
+    .grid-header {
+        display: flex;
+        padding: 4px 0;
+        background: var(--bg-tertiary);
+        border-bottom: 2px solid var(--border-color);
+        font-weight: 700;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        color: var(--text-secondary);
+        flex-shrink: 0;
+    }
+    .grid-header > div {
+        position: relative;
+        padding: 0 6px;
+        flex-shrink: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+    .grid-header > .col-message { flex: 1; flex-shrink: 1; }
+    .col-resizer {
+        position: absolute;
+        top: 0;
+        right: -3px;
+        width: 7px;
+        height: 100%;
+        cursor: col-resize;
+        z-index: 5;
+    }
+    .col-resizer:hover, .col-resizer:active {
+        background: var(--accent-primary, #4299e1);
+        opacity: 0.4;
+        border-radius: 2px;
+    }
+    .grid-body {
+        flex: 1;
+        overflow-y: auto;
+        overflow-x: hidden;
+    }
+    .grid-row {
+        display: flex;
+        height: 22px;
+        line-height: 22px;
+        box-sizing: border-box;
+    }
+    .grid-row > div {
+        padding: 0 6px;
+        flex-shrink: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+    .grid-row > .col-message { flex: 1; flex-shrink: 1; }
+    .grid-row:hover {
+        background: rgba(255,255,255,0.05) !important;
+    }
+
+    /* Column colors */
+    .col-time { color: var(--text-muted); }
+    .col-level { text-align: center; }
+    .col-pid { color: var(--text-secondary); }
+    .col-tid { color: var(--text-secondary); }
+    .col-tag { color: var(--text-primary); font-weight: 500; }
+    .col-message { color: var(--text-primary); }
+
+    /* Level badges */
+    .level-badge {
+        display: inline-block;
+        width: 20px;
+        height: 18px;
+        line-height: 18px;
+        text-align: center;
+        border-radius: 3px;
+        font-weight: 700;
+        font-size: 11px;
+    }
+    .level-v { background: #4a5568; color: #a0aec0; }
+    .level-d { background: #2b6cb0; color: #bee3f8; }
+    .level-i { background: #276749; color: #c6f6d5; }
+    .level-w { background: #975a16; color: #fefcbf; }
+    .level-e { background: #9b2c2c; color: #fed7d7; }
+    .level-f { background: #702459; color: #fed7e2; }
+
+    /* Row level tinting */
+    .row-verbose { }
+    .row-debug { }
+    .row-info { }
+    .row-warning { background: rgba(237, 137, 54, 0.06); }
+    .row-error { background: rgba(245, 101, 101, 0.10); }
+    .row-fatal { background: rgba(183, 62, 137, 0.12); }
+
+    /* Buttons */
+    .btn { padding: 6px 14px; border: none; border-radius: 5px; font-size: 12px; cursor: pointer; display: inline-flex; align-items: center; gap: 5px; transition: all 0.15s; }
+    .btn i { font-size: 11px; }
+    .btn-sm { padding: 4px 8px; font-size: 11px; }
+    .btn-primary { background: var(--accent-primary); color: white; }
+    .btn-secondary { background: var(--bg-tertiary); color: var(--text-secondary); border: 1px solid var(--border-color); }
+    .btn-success { background: #48bb78; color: white; }
+    .btn-danger { background: #f56565; color: white; }
+    .btn-warning { background: #ed8936; color: white; }
+    .btn-ghost { background: transparent; color: var(--text-muted); }
+    .btn:hover:not(:disabled) { filter: brightness(1.1); }
+    .btn:disabled { opacity: 0.5; cursor: not-allowed; }
+</style>
+
+@code {
+    [Parameter] public string Serial { get; set; } = "";
+
+    private ElementReference gridBody;
+    private ElementReference deviceSelectRef;
+    private List<DeviceInfo> connectedDevices = new();
+
+    private List<LogcatEntry> filteredEntries = new();
+    private int filteredCount;
+    private int totalCount;
+    private bool isPaused;
+    private bool autoScroll = true;
+
+    // Virtualization
+    private const int RowHeight = 22;
+    private const int OverscanRows = 10;
+    private int visibleStart;
+    private int visibleEnd;
+    private double scrollTop;
+    private double viewportHeight;
+
+    // Column widths (px) — Time, Lvl, PID, TID, Tag; Message is 1fr
+    private double[] colWidths = [90, 36, 56, 56, 160];
+    private const int ColCount = 5; // resizable columns (Message excluded)
+
+    // Column resize state
+    private bool isColResizing;
+    private int resizeColIndex;
+    private double colResizeStartX;
+    private double colResizeStartWidth;
+    private DotNetObjectReference<LogcatContent>? colResizeSelfRef;
+
+    // Filters
+    private string filterLevel = "";
+    private string filterTag = "";
+    private string filterPid = "";
+    private string filterText = "";
+
+    private bool HasActiveFilters => !string.IsNullOrEmpty(filterLevel) || !string.IsNullOrEmpty(filterTag)
+        || !string.IsNullOrEmpty(filterPid) || !string.IsNullOrEmpty(filterText);
+
+    // Stream
+    private CancellationTokenSource? _streamCts;
+    private CancellationTokenSource? _filterDebounce;
+
+    protected override async Task OnInitializedAsync()
+    {
+        LogcatService.OnCleared += OnLogcatCleared;
+        PanelService.DeviceChanged += OnDeviceSwitched;
+        DeviceWatcher.DevicesChanged += OnWatcherDevicesChanged;
+        connectedDevices = DeviceWatcher.Devices.ToList();
+        if (connectedDevices.Count == 0)
+            connectedDevices = new() { new DeviceInfo(Serial, "device", null, false) };
+        await StartLogcat();
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            colResizeSelfRef = DotNetObjectReference.Create(this);
+            await JS.InvokeVoidAsync("eval", @"
+                window.__logcatColResize = {
+                    onMove: null, onUp: null,
+                    start: function(dotnetRef) {
+                        this.onMove = (e) => { e.preventDefault(); dotnetRef.invokeMethodAsync('OnColResizeMoveJS', e.clientX); };
+                        this.onUp = () => { dotnetRef.invokeMethodAsync('OnColResizeUpJS'); window.__logcatColResize.stop(); };
+                        document.addEventListener('pointermove', this.onMove);
+                        document.addEventListener('pointerup', this.onUp);
+                    },
+                    stop: function() {
+                        if (this.onMove) document.removeEventListener('pointermove', this.onMove);
+                        if (this.onUp) document.removeEventListener('pointerup', this.onUp);
+                        this.onMove = null; this.onUp = null;
+                    }
+                };
+            ");
+            await UpdateViewportHeight();
+        }
+    }
+
+    private async Task UpdateViewportHeight()
+    {
+        try
+        {
+            viewportHeight = await JS.InvokeAsync<double>("eval", "(function(){ var el = document.querySelector('.grid-body'); return el ? el.clientHeight : 400; })()");
+            RecalcVisibleRange();
+        }
+        catch { viewportHeight = 400; }
+    }
+
+    private void RecalcVisibleRange()
+    {
+        var count = filteredCount;
+        if (count == 0)
+        {
+            visibleStart = 0;
+            visibleEnd = 0;
+            return;
+        }
+
+        int firstVisible = Math.Max(0, (int)(scrollTop / RowHeight) - OverscanRows);
+        int visibleRows = (int)Math.Ceiling(viewportHeight / RowHeight) + OverscanRows * 2;
+        visibleStart = firstVisible;
+        visibleEnd = Math.Min(count, firstVisible + visibleRows);
+    }
+
+    private void OnScroll(EventArgs e)
+    {
+        _ = InvokeAsync(async () =>
+        {
+            try
+            {
+                var dims = await JS.InvokeAsync<double[]>("eval", "(function(){ var el = document.querySelector('.grid-body'); return el ? [el.scrollTop, el.clientHeight] : [0, 400]; })()");
+                scrollTop = dims[0];
+                if (dims[1] > 0) viewportHeight = dims[1];
+                var maxScroll = filteredCount * RowHeight - viewportHeight;
+                if (maxScroll > 0 && scrollTop < maxScroll - RowHeight * 2)
+                    autoScroll = false;
+                RecalcVisibleRange();
+                StateHasChanged();
+            }
+            catch { }
+        });
+    }
+
+    private async Task StartLogcat()
+    {
+        try
+        {
+            _streamCts?.Cancel();
+            _streamCts = new CancellationTokenSource();
+            await LogcatService.StartAsync(Serial);
+            _ = ConsumeStreamAsync(_streamCts.Token);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError($"Failed to start logcat: {ex.Message}", ex);
+            await AlertService.ShowAlertAsync("Error", $"Failed to start logcat: {ex.Message}");
+        }
+    }
+
+    private async Task ConsumeStreamAsync(CancellationToken ct)
+    {
+        const int batchIntervalMs = 150;
+        var lastFlush = Environment.TickCount64;
+        var viewportChecked = false;
+
+        try
+        {
+            await foreach (var entry in LogcatService.StreamAsync(ct))
+            {
+                if (isPaused)
+                {
+                    continue;
+                }
+
+                var now = Environment.TickCount64;
+                if (now - lastFlush >= batchIntervalMs)
+                {
+                    lastFlush = now;
+
+                    // Re-check viewport height periodically until it stabilizes
+                    if (!viewportChecked || viewportHeight <= 400)
+                    {
+                        await UpdateViewportHeight();
+                        if (viewportHeight > 400) viewportChecked = true;
+                    }
+
+                    await InvokeAsync(() =>
+                    {
+                        ApplyFilters();
+                        if (autoScroll)
+                            ScrollToBottom();
+                        StateHasChanged();
+                    });
+                }
+            }
+        }
+        catch (OperationCanceledException) { }
+
+        // Final flush
+        await InvokeAsync(() =>
+        {
+            ApplyFilters();
+            StateHasChanged();
+        });
+    }
+
+    private void StopLogcat()
+    {
+        _streamCts?.Cancel();
+        LogcatService.Stop();
+        InvokeAsync(StateHasChanged);
+    }
+
+    private void ClearLogcat()
+    {
+        LogcatService.Clear();
+    }
+
+    private void TogglePause()
+    {
+        isPaused = !isPaused;
+        if (!isPaused)
+        {
+            ApplyFilters();
+            ScrollToBottom();
+            StateHasChanged();
+        }
+    }
+
+    private void ToggleAutoScroll()
+    {
+        autoScroll = !autoScroll;
+        if (autoScroll)
+            ScrollToBottom();
+    }
+
+    private void OnLogcatCleared()
+    {
+        InvokeAsync(() =>
+        {
+            filteredEntries.Clear();
+            filteredCount = 0;
+            totalCount = 0;
+            scrollTop = 0;
+            RecalcVisibleRange();
+            StateHasChanged();
+        });
+    }
+
+    private void ScrollToBottom()
+    {
+        scrollTop = Math.Max(0, filteredCount * RowHeight - viewportHeight);
+        RecalcVisibleRange();
+        _ = InvokeAsync(async () =>
+        {
+            try
+            {
+                await JS.InvokeVoidAsync("eval", "(function(){ var el = document.querySelector('.grid-body'); if(el) el.scrollTop = el.scrollHeight; })()");
+            }
+            catch { }
+        });
+    }
+
+    private void ApplyFilters()
+    {
+        var entries = LogcatService.Entries;
+        totalCount = entries.Count;
+
+        LogcatLevel? minLevel = filterLevel switch
+        {
+            "Verbose" => LogcatLevel.Verbose,
+            "Debug" => LogcatLevel.Debug,
+            "Info" => LogcatLevel.Info,
+            "Warning" => LogcatLevel.Warning,
+            "Error" => LogcatLevel.Error,
+            "Fatal" => LogcatLevel.Fatal,
+            _ => null
+        };
+
+        int? pidFilter = int.TryParse(filterPid, out var p) ? p : null;
+        var tagFilter = filterTag?.Trim();
+        var textFilter = filterText?.Trim();
+
+        IEnumerable<LogcatEntry> query = entries;
+
+        if (minLevel.HasValue)
+            query = query.Where(e => e.Level >= minLevel.Value);
+        if (pidFilter.HasValue)
+            query = query.Where(e => e.Pid == pidFilter.Value);
+        if (!string.IsNullOrEmpty(tagFilter))
+            query = query.Where(e => e.Tag.Contains(tagFilter, StringComparison.OrdinalIgnoreCase));
+        if (!string.IsNullOrEmpty(textFilter))
+            query = query.Where(e => e.Message.Contains(textFilter, StringComparison.OrdinalIgnoreCase)
+                || e.Tag.Contains(textFilter, StringComparison.OrdinalIgnoreCase));
+
+        filteredEntries = query.ToList();
+        filteredCount = filteredEntries.Count;
+        RecalcVisibleRange();
+    }
+
+    private async Task DebouncedApplyFilters()
+    {
+        _filterDebounce?.Cancel();
+        _filterDebounce = new CancellationTokenSource();
+        var token = _filterDebounce.Token;
+
+        try
+        {
+            await Task.Delay(300, token);
+            ApplyFilters();
+            StateHasChanged();
+        }
+        catch (TaskCanceledException) { }
+    }
+
+    private void ClearFilters()
+    {
+        filterLevel = "";
+        filterTag = "";
+        filterPid = "";
+        filterText = "";
+        ApplyFilters();
+    }
+
+    private static string GetLevelChar(LogcatLevel level) => level switch
+    {
+        LogcatLevel.Verbose => "V",
+        LogcatLevel.Debug => "D",
+        LogcatLevel.Info => "I",
+        LogcatLevel.Warning => "W",
+        LogcatLevel.Error => "E",
+        LogcatLevel.Fatal => "F",
+        _ => "?"
+    };
+
+    private static string GetLevelBadgeClass(LogcatLevel level) => level switch
+    {
+        LogcatLevel.Verbose => "level-v",
+        LogcatLevel.Debug => "level-d",
+        LogcatLevel.Info => "level-i",
+        LogcatLevel.Warning => "level-w",
+        LogcatLevel.Error => "level-e",
+        LogcatLevel.Fatal => "level-f",
+        _ => "level-v"
+    };
+
+    private static string GetLevelClass(LogcatLevel level) => level switch
+    {
+        LogcatLevel.Verbose => "row-verbose",
+        LogcatLevel.Debug => "row-debug",
+        LogcatLevel.Info => "row-info",
+        LogcatLevel.Warning => "row-warning",
+        LogcatLevel.Error => "row-error",
+        LogcatLevel.Fatal => "row-fatal",
+        _ => ""
+    };
+
+    // Timestamp: strip "MM-DD " prefix, show only "HH:MM:SS.mmm"
+    private static string FormatTimestamp(string ts)
+    {
+        // Timestamps are "MM-DD HH:MM:SS.mmm" — find the space after date
+        var spaceIdx = ts.IndexOf(' ');
+        return spaceIdx >= 0 ? ts[(spaceIdx + 1)..] : ts;
+    }
+
+    // Column resize
+    private async void StartColResize(PointerEventArgs e, int colIndex)
+    {
+        isColResizing = true;
+        resizeColIndex = colIndex;
+        colResizeStartX = e.ClientX;
+        colResizeStartWidth = colWidths[colIndex];
+        if (colResizeSelfRef != null)
+            await JS.InvokeVoidAsync("window.__logcatColResize.start", colResizeSelfRef);
+    }
+
+    [JSInvokable]
+    public void OnColResizeMoveJS(double clientX)
+    {
+        if (!isColResizing) return;
+        var delta = clientX - colResizeStartX;
+        var newWidth = Math.Max(24, colResizeStartWidth + delta);
+        colWidths[resizeColIndex] = newWidth;
+        InvokeAsync(StateHasChanged);
+    }
+
+    [JSInvokable]
+    public void OnColResizeUpJS()
+    {
+        isColResizing = false;
+        InvokeAsync(StateHasChanged);
+    }
+
+    // Device watcher integration
+    private async Task FocusDeviceSelect()
+    {
+        // Blur then re-focus to allow reopening the dropdown even when already focused
+        await JS.InvokeVoidAsync("eval", "(function(){ var el = document.querySelector('.device-select'); if(el){ el.blur(); el.focus(); el.click(); } })()");
+    }
+
+    private void OnWatcherDevicesChanged(IReadOnlyList<DeviceInfo> newDevices)
+    {
+        InvokeAsync(() =>
+        {
+            connectedDevices = newDevices.ToList();
+
+            // If active device disconnected, stop logcat
+            if (!string.IsNullOrEmpty(Serial) && !newDevices.Any(d => d.Serial == Serial))
+            {
+                _streamCts?.Cancel();
+                LogcatService.Stop();
+                isPaused = true; // Show paused state
+            }
+
+            StateHasChanged();
+        });
+    }
+
+    private async Task OnDeviceChanged(ChangeEventArgs e)
+    {
+        var newSerial = e.Value?.ToString();
+        if (string.IsNullOrEmpty(newSerial) || newSerial == Serial) return;
+        PanelService.SwitchDevice(newSerial, connectedDevices.FirstOrDefault(d => d.Serial == newSerial)?.Model);
+    }
+
+    private void OnDeviceSwitched(string newSerial)
+    {
+        _ = InvokeAsync(async () =>
+        {
+            // Stop current stream and clean up
+            _streamCts?.Cancel();
+            LogcatService.Stop();
+            LogcatService.Clear();
+
+            // Reset UI state
+            Serial = newSerial;
+            filteredEntries.Clear();
+            filteredCount = 0;
+            totalCount = 0;
+            scrollTop = 0;
+            isPaused = false;
+            autoScroll = true;
+            RecalcVisibleRange();
+            StateHasChanged();
+
+            // Start new stream
+            await StartLogcat();
+        });
+    }
+
+    public void Dispose()
+    {
+        _streamCts?.Cancel();
+        _streamCts?.Dispose();
+        LogcatService.OnCleared -= OnLogcatCleared;
+        PanelService.DeviceChanged -= OnDeviceSwitched;
+        DeviceWatcher.DevicesChanged -= OnWatcherDevicesChanged;
+        _filterDebounce?.Dispose();
+        colResizeSelfRef?.Dispose();
+        LogcatService.Stop();
+    }
+}

--- a/src/MauiSherpa/Components/LogcatPanel.razor
+++ b/src/MauiSherpa/Components/LogcatPanel.razor
@@ -1,0 +1,463 @@
+@using MauiSherpa.Services
+@inject LogcatPanelService PanelService
+@inject IJSRuntime JS
+@implements IDisposable
+
+@if (PanelService.IsOpen)
+{
+    @if (PanelService.IsMinimized)
+    {
+        <div class="logcat-collapsed" @onclick="PanelService.Restore">
+            <i class="fab fa-android collapsed-icon"></i>
+            <span class="collapsed-label">Logcat</span>
+            <span class="collapsed-serial">@PanelService.ActiveSerial</span>
+            <i class="fas fa-chevron-up collapsed-expand"></i>
+        </div>
+    }
+    else
+    {
+        <div class="logcat-dialog @(isMaximized ? "maximized" : "")" @ref="dialogRef"
+             style="left:@(posX)px;top:@(posY)px;width:@(width)px;height:@(height)px;">
+            @if (!isMaximized)
+            {
+                <!-- Resize handles -->
+                <div class="resize-handle resize-n" @onpointerdown="@(e => StartResize(e, ResizeEdge.N))"></div>
+                <div class="resize-handle resize-s" @onpointerdown="@(e => StartResize(e, ResizeEdge.S))"></div>
+                <div class="resize-handle resize-e" @onpointerdown="@(e => StartResize(e, ResizeEdge.E))"></div>
+                <div class="resize-handle resize-w" @onpointerdown="@(e => StartResize(e, ResizeEdge.W))"></div>
+                <div class="resize-handle resize-ne" @onpointerdown="@(e => StartResize(e, ResizeEdge.NE))"></div>
+                <div class="resize-handle resize-nw" @onpointerdown="@(e => StartResize(e, ResizeEdge.NW))"></div>
+                <div class="resize-handle resize-se" @onpointerdown="@(e => StartResize(e, ResizeEdge.SE))"></div>
+                <div class="resize-handle resize-sw" @onpointerdown="@(e => StartResize(e, ResizeEdge.SW))"></div>
+            }
+
+            <div class="dialog-titlebar" @onpointerdown="StartDrag">
+                <div class="dialog-title">
+                    <i class="fab fa-android title-android-icon"></i>
+                    <span class="title-text">Logcat</span>
+                </div>
+                <div class="dialog-actions" @onpointerdown:stopPropagation="true">
+                    <button class="dialog-btn" @onclick="PanelService.Minimize" @onclick:stopPropagation="true" title="Minimize">
+                        <i class="fas fa-minus"></i>
+                    </button>
+                    <button class="dialog-btn" @onclick="ToggleMaximize" @onclick:stopPropagation="true" title="@(isMaximized ? "Restore" : "Maximize")">
+                        <i class="fas @(isMaximized ? "fa-compress" : "fa-expand")"></i>
+                    </button>
+                    <button class="dialog-btn dialog-btn-close" @onclick="OnClose" @onclick:stopPropagation="true" title="Close">
+                        <i class="fas fa-times"></i>
+                    </button>
+                </div>
+            </div>
+            <div class="dialog-body">
+                <LogcatContent Serial="@(PanelService.ActiveSerial!)" />
+            </div>
+        </div>
+    }
+}
+
+<style>
+    /* ── Floating dialog ── */
+    .logcat-dialog {
+        position: fixed;
+        min-width: 520px;
+        min-height: 300px;
+        background: var(--bg-secondary, #ffffff);
+        border: 1px solid var(--border-color, #e2e8f0);
+        border-radius: 10px;
+        display: flex;
+        flex-direction: column;
+        z-index: 10002;
+        box-shadow: 0 8px 32px rgba(0,0,0,0.18), 0 2px 8px rgba(0,0,0,0.08);
+        animation: dialogIn 0.2s ease-out;
+    }
+
+    .logcat-dialog.maximized {
+        border-radius: 0;
+        box-shadow: none;
+    }
+    .logcat-dialog.maximized .dialog-titlebar {
+        border-radius: 0;
+    }
+    .logcat-dialog.maximized .dialog-body {
+        border-radius: 0;
+    }
+
+    @@keyframes dialogIn {
+        from { opacity: 0; transform: scale(0.95) translateY(12px); }
+        to   { opacity: 1; transform: scale(1) translateY(0); }
+    }
+
+    /* ── Titlebar ── */
+    .dialog-titlebar {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 7px 10px 7px 14px;
+        background: var(--bg-tertiary, #edf2f7);
+        border-bottom: 1px solid var(--border-color, #e2e8f0);
+        flex-shrink: 0;
+        cursor: grab;
+        user-select: none;
+        border-radius: 10px 10px 0 0;
+        overflow: hidden;
+    }
+    .dialog-titlebar:active { cursor: grabbing; }
+
+    .dialog-title {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-size: 13px;
+        font-weight: 600;
+        color: var(--text-primary);
+        overflow: hidden;
+    }
+    .title-android-icon {
+        color: #3ddc84;
+        font-size: 15px;
+        flex-shrink: 0;
+    }
+    .title-text {
+        flex-shrink: 0;
+    }
+    .title-serial {
+        font-family: 'Consolas', 'Monaco', monospace;
+        font-size: 11px;
+        font-weight: 400;
+        color: var(--text-muted);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .dialog-actions {
+        display: flex;
+        gap: 2px;
+        flex-shrink: 0;
+    }
+    .dialog-btn {
+        background: none;
+        border: none;
+        color: var(--text-secondary);
+        cursor: pointer;
+        padding: 4px 8px;
+        border-radius: 5px;
+        font-size: 12px;
+        transition: all 0.12s;
+        line-height: 1;
+    }
+    .dialog-btn:hover {
+        background: var(--bg-secondary);
+        color: var(--text-primary);
+    }
+    .dialog-btn-close:hover {
+        background: #f56565;
+        color: white;
+    }
+
+    /* ── Body ── */
+    .logcat-dialog .dialog-body {
+        flex: 1;
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
+        padding: 0 !important;
+        border-radius: 0 0 10px 10px;
+    }
+    .logcat-dialog .dialog-body .logcat-page {
+        height: 100% !important;
+    }
+
+    /* ── Resize handles ── */
+    .resize-handle { position: absolute; z-index: 10; touch-action: none; }
+    .resize-handle:hover { background: var(--accent-primary, #4299e1); opacity: 0.35; }
+    .resize-n  { top: 0;     left: 14px;  right: 14px; height: 5px; cursor: n-resize; }
+    .resize-s  { bottom: 0;  left: 14px;  right: 14px; height: 5px; cursor: s-resize; }
+    .resize-e  { top: 14px;  right: 0;    bottom: 14px; width: 5px; cursor: e-resize; }
+    .resize-w  { top: 14px;  left: 0;     bottom: 14px; width: 5px; cursor: w-resize; }
+    .resize-ne { top: 0;     right: 0;    width: 14px; height: 14px; cursor: ne-resize; }
+    .resize-nw { top: 0;     left: 0;     width: 14px; height: 14px; cursor: nw-resize; }
+    .resize-se { bottom: 0;  right: 0;    width: 14px; height: 14px; cursor: se-resize; }
+    .resize-sw { bottom: 0;  left: 0;     width: 14px; height: 14px; cursor: sw-resize; }
+    .resize-se::after {
+        content: '';
+        position: absolute;
+        bottom: 3px;
+        right: 3px;
+        width: 8px;
+        height: 8px;
+        border-right: 2px solid var(--text-muted, #888);
+        border-bottom: 2px solid var(--text-muted, #888);
+        opacity: 0.5;
+    }
+
+    /* ── Collapsed bar ── */
+    .logcat-collapsed {
+        position: fixed;
+        bottom: 0;
+        left: 250px; /* sidebar width */
+        right: 0;
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        background: var(--bg-tertiary, #edf2f7);
+        border-top: 1px solid var(--border-color, #e2e8f0);
+        padding: 6px 16px;
+        cursor: pointer;
+        z-index: 10002;
+        user-select: none;
+        transition: background 0.15s;
+    }
+    .logcat-collapsed:hover {
+        background: var(--bg-secondary, #ffffff);
+    }
+    .collapsed-icon {
+        color: #3ddc84;
+        font-size: 15px;
+    }
+    .collapsed-label {
+        font-size: 13px;
+        font-weight: 600;
+        color: var(--text-primary);
+    }
+    .collapsed-serial {
+        font-family: 'Consolas', 'Monaco', monospace;
+        font-size: 12px;
+        color: var(--text-muted);
+        flex: 1;
+    }
+    .collapsed-expand {
+        color: var(--text-secondary);
+        font-size: 11px;
+        transition: transform 0.15s;
+    }
+    .logcat-collapsed:hover .collapsed-expand {
+        transform: translateY(-2px);
+        color: var(--accent-primary);
+    }
+</style>
+
+@code {
+    private ElementReference dialogRef;
+
+    // Position & size
+    private double posX = 280;
+    private double posY = 120;
+    private double width = 800;
+    private double height = 480;
+
+    private const double MinWidth = 520;
+    private const double MinHeight = 300;
+
+    // Maximize state
+    private bool isMaximized;
+    private double restorePosX, restorePosY, restoreWidth, restoreHeight;
+    private const double SidebarWidth = 250;
+
+    // Drag state
+    private bool isDragging;
+    private double dragStartMouseX, dragStartMouseY;
+    private double dragStartPosX, dragStartPosY;
+
+    // Resize state
+    private bool isResizing;
+    private ResizeEdge resizeEdge;
+    private double resizeStartMouseX, resizeStartMouseY;
+    private double resizeStartX, resizeStartY, resizeStartW, resizeStartH;
+
+    private DotNetObjectReference<LogcatPanel>? selfRef;
+
+    private enum ResizeEdge { N, S, E, W, NE, NW, SE, SW }
+
+    protected override void OnInitialized()
+    {
+        PanelService.StateChanged += OnStateChanged;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            selfRef = DotNetObjectReference.Create(this);
+            await JS.InvokeVoidAsync("eval", @"
+                window.__logcatDrag = {
+                    ref: null,
+                    onMove: null,
+                    onUp: null,
+                    start: function(dotnetRef) {
+                        this.ref = dotnetRef;
+                        this.onMove = (e) => { e.preventDefault(); dotnetRef.invokeMethodAsync('OnPointerMoveJS', e.clientX, e.clientY); };
+                        this.onUp = (e) => { dotnetRef.invokeMethodAsync('OnPointerUpJS'); window.__logcatDrag.stop(); };
+                        document.addEventListener('pointermove', this.onMove);
+                        document.addEventListener('pointerup', this.onUp);
+                    },
+                    stop: function() {
+                        if (this.onMove) document.removeEventListener('pointermove', this.onMove);
+                        if (this.onUp) document.removeEventListener('pointerup', this.onUp);
+                        this.onMove = null; this.onUp = null;
+                    }
+                };
+            ");
+        }
+    }
+
+    private async void StartDrag(PointerEventArgs e)
+    {
+        if (isMaximized)
+        {
+            // Un-maximize on drag, position dialog so cursor is centered on restored titlebar
+            posX = e.ClientX - restoreWidth / 2;
+            posY = e.ClientY - 15;
+            width = restoreWidth;
+            height = restoreHeight;
+            isMaximized = false;
+        }
+        isDragging = true;
+        isResizing = false;
+        dragStartMouseX = e.ClientX;
+        dragStartMouseY = e.ClientY;
+        dragStartPosX = posX;
+        dragStartPosY = posY;
+        if (selfRef != null)
+            await JS.InvokeVoidAsync("window.__logcatDrag.start", selfRef);
+    }
+
+    private async void StartResize(PointerEventArgs e, ResizeEdge edge)
+    {
+        isResizing = true;
+        isDragging = false;
+        resizeEdge = edge;
+        resizeStartMouseX = e.ClientX;
+        resizeStartMouseY = e.ClientY;
+        resizeStartX = posX;
+        resizeStartY = posY;
+        resizeStartW = width;
+        resizeStartH = height;
+        if (selfRef != null)
+            await JS.InvokeVoidAsync("window.__logcatDrag.start", selfRef);
+    }
+
+    [JSInvokable]
+    public void OnPointerMoveJS(double clientX, double clientY)
+    {
+        if (isDragging)
+        {
+            posX = dragStartPosX + (clientX - dragStartMouseX);
+            posY = dragStartPosY + (clientY - dragStartMouseY);
+            // Clamp so titlebar stays on screen
+            posX = Math.Max(-width + 100, posX);
+            posY = Math.Max(0, posY);
+            InvokeAsync(StateHasChanged);
+        }
+        else if (isResizing)
+        {
+            double dx = clientX - resizeStartMouseX;
+            double dy = clientY - resizeStartMouseY;
+            ApplyResize(dx, dy);
+            InvokeAsync(StateHasChanged);
+        }
+    }
+
+    [JSInvokable]
+    public void OnPointerUpJS()
+    {
+        isDragging = false;
+        isResizing = false;
+        InvokeAsync(StateHasChanged);
+    }
+
+    private void ApplyResize(double dx, double dy)
+    {
+        switch (resizeEdge)
+        {
+            case ResizeEdge.SE:
+                width = Math.Max(MinWidth, resizeStartW + dx);
+                height = Math.Max(MinHeight, resizeStartH + dy);
+                break;
+            case ResizeEdge.S:
+                height = Math.Max(MinHeight, resizeStartH + dy);
+                break;
+            case ResizeEdge.E:
+                width = Math.Max(MinWidth, resizeStartW + dx);
+                break;
+            case ResizeEdge.NE:
+                width = Math.Max(MinWidth, resizeStartW + dx);
+                var newH_ne = resizeStartH - dy;
+                if (newH_ne >= MinHeight) { height = newH_ne; posY = resizeStartY + dy; }
+                break;
+            case ResizeEdge.N:
+                var newH_n = resizeStartH - dy;
+                if (newH_n >= MinHeight) { height = newH_n; posY = resizeStartY + dy; }
+                break;
+            case ResizeEdge.NW:
+                var newW_nw = resizeStartW - dx;
+                var newH_nw = resizeStartH - dy;
+                if (newW_nw >= MinWidth) { width = newW_nw; posX = resizeStartX + dx; }
+                if (newH_nw >= MinHeight) { height = newH_nw; posY = resizeStartY + dy; }
+                break;
+            case ResizeEdge.W:
+                var newW_w = resizeStartW - dx;
+                if (newW_w >= MinWidth) { width = newW_w; posX = resizeStartX + dx; }
+                break;
+            case ResizeEdge.SW:
+                var newW_sw = resizeStartW - dx;
+                if (newW_sw >= MinWidth) { width = newW_sw; posX = resizeStartX + dx; }
+                height = Math.Max(MinHeight, resizeStartH + dy);
+                break;
+        }
+    }
+
+    private void OnClose()
+    {
+        isMaximized = false;
+        PanelService.Close();
+    }
+
+    private async Task ToggleMaximize()
+    {
+        if (isMaximized)
+        {
+            posX = restorePosX;
+            posY = restorePosY;
+            width = restoreWidth;
+            height = restoreHeight;
+            isMaximized = false;
+        }
+        else
+        {
+            restorePosX = posX;
+            restorePosY = posY;
+            restoreWidth = width;
+            restoreHeight = height;
+
+            try
+            {
+                var vpWidth = await JS.InvokeAsync<double>("eval", "window.innerWidth");
+                var vpHeight = await JS.InvokeAsync<double>("eval", "window.innerHeight");
+                posX = SidebarWidth;
+                posY = 0;
+                width = vpWidth - SidebarWidth;
+                height = vpHeight;
+            }
+            catch
+            {
+                posX = SidebarWidth;
+                posY = 0;
+                width = 1200;
+                height = 800;
+            }
+            isMaximized = true;
+        }
+    }
+
+    private void OnStateChanged()
+    {
+        InvokeAsync(StateHasChanged);
+    }
+
+    public void Dispose()
+    {
+        PanelService.StateChanged -= OnStateChanged;
+        selfRef?.Dispose();
+    }
+}

--- a/src/MauiSherpa/Components/MainLayout.razor
+++ b/src/MauiSherpa/Components/MainLayout.razor
@@ -3,6 +3,7 @@
 @inject IThemeService ThemeService
 @inject ISplashService SplashService
 @inject ISettingsMigrationService MigrationService
+@inject IAdbDeviceWatcherService DeviceWatcher
 @inject ILoggingService Logger
 @inject IJSRuntime JS
 @implements IDisposable
@@ -80,6 +81,9 @@
 <!-- Global Toast Notifications -->
 <MauiSherpa.Components.ToastContainer />
 
+<!-- Global Logcat Panel -->
+<MauiSherpa.Components.LogcatPanel />
+
 @code {
     private string ThemeClass => ThemeService.IsDarkMode ? "theme-dark" : "theme-light";
 
@@ -100,6 +104,9 @@
             
             // Run settings migration in background
             _ = RunMigrationAsync();
+
+            // Start watching for ADB device changes
+            _ = DeviceWatcher.StartAsync();
         }
     }
 

--- a/src/MauiSherpa/MauiProgram.cs
+++ b/src/MauiSherpa/MauiProgram.cs
@@ -61,6 +61,9 @@ public static class MauiProgram
         // Core services
         builder.Services.AddSingleton<IAndroidSdkService, AndroidSdkService>();
         builder.Services.AddSingleton<IAndroidSdkSettingsService, AndroidSdkSettingsService>();
+        builder.Services.AddSingleton<ILogcatService, LogcatService>();
+        builder.Services.AddSingleton<IAdbDeviceWatcherService, AdbDeviceWatcherService>();
+        builder.Services.AddSingleton<LogcatPanelService>();
         builder.Services.AddSingleton<IDoctorService, DoctorService>();
         builder.Services.AddSingleton<ICopilotToolsService, CopilotToolsService>();
         builder.Services.AddSingleton<ICopilotService, CopilotService>();

--- a/src/MauiSherpa/MauiSherpa.csproj
+++ b/src/MauiSherpa/MauiSherpa.csproj
@@ -35,13 +35,14 @@
 
   <ItemGroup>
     <PackageReference Include="Blazorise.Icons.FontAwesome" Version="1.7.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.QuickGrid" Version="10.0.1" />
     <PackageReference Include="Markdig" Version="0.44.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="10.0.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
     <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
-    <PackageReference Include="Redth.MauiDevFlow.Agent" Version="0.4.1" />
-    <PackageReference Include="Redth.MauiDevFlow.Blazor" Version="0.4.1" />
+    <PackageReference Include="Redth.MauiDevFlow.Agent" Version="0.5.0" />
+    <PackageReference Include="Redth.MauiDevFlow.Blazor" Version="0.5.0" />
     <PackageReference Include="Shiny.Mediator.Caching.MicrosoftMemoryCache" Version="6.1.1" />
     <PackageReference Include="Shiny.Mediator.Maui" Version="6.1.1" />
   </ItemGroup>

--- a/src/MauiSherpa/Pages/Devices.razor
+++ b/src/MauiSherpa/Pages/Devices.razor
@@ -6,9 +6,11 @@
 @inject IMediator Mediator
 @inject IAndroidSdkService SdkService
 @inject IAndroidSdkSettingsService SdkSettings
+@inject IAdbDeviceWatcherService DeviceWatcher
 @inject IAlertService AlertService
 @inject IDialogService DialogService
 @inject IFileSystemService FileSystem
+@inject LogcatPanelService LogcatPanel
 @inject BlazorToastService ToastService
 @implements IDisposable
 
@@ -89,6 +91,9 @@
                     </div>
                 </div>
                 <div class="device-actions">
+                    <button class="btn btn-info btn-sm" @onclick="@(() => LogcatPanel.Open(device.Serial, device.Model ?? device.Serial))">
+                        <i class="fas fa-scroll"></i> Logcat
+                    </button>
                     @if (device.IsEmulator)
                     {
                         <button class="btn btn-danger btn-sm" @onclick="@(() => StopEmulator(device.Serial))" disabled="@isLoading">
@@ -188,6 +193,15 @@
     .btn-danger {
         background-color: #f56565;
         color: white;
+    }
+
+    .btn-info {
+        background-color: var(--accent-primary);
+        color: white;
+    }
+
+    .btn-info:hover:not(:disabled) {
+        background-color: #3182ce;
     }
 
     .btn-danger:hover:not(:disabled) {
@@ -328,10 +342,30 @@
     {
         // Subscribe to SDK path changes from Settings
         SdkService.SdkPathChanged += OnSdkPathChanged;
+        DeviceWatcher.DevicesChanged += OnDevicesChanged;
         
         // Initialize SDK settings (loads stored custom path if any)
         await SdkSettings.InitializeAsync();
-        await RefreshDevices();
+
+        // Use watcher's cached devices if available, otherwise fetch
+        var cached = DeviceWatcher.Devices;
+        if (cached.Count > 0)
+        {
+            devices = cached.ToList();
+        }
+        else
+        {
+            await RefreshDevices();
+        }
+    }
+
+    private void OnDevicesChanged(IReadOnlyList<DeviceInfo> newDevices)
+    {
+        InvokeAsync(() =>
+        {
+            devices = newDevices.ToList();
+            StateHasChanged();
+        });
     }
 
     private void OnSdkPathChanged()
@@ -401,5 +435,6 @@
     public void Dispose()
     {
         SdkService.SdkPathChanged -= OnSdkPathChanged;
+        DeviceWatcher.DevicesChanged -= OnDevicesChanged;
     }
 }

--- a/src/MauiSherpa/Services/LogcatPanelService.cs
+++ b/src/MauiSherpa/Services/LogcatPanelService.cs
@@ -1,0 +1,54 @@
+namespace MauiSherpa.Services;
+
+public class LogcatPanelService
+{
+    public bool IsOpen { get; private set; }
+    public bool IsMinimized { get; private set; }
+    public string? ActiveSerial { get; private set; }
+    public string? ActiveDeviceName { get; private set; }
+
+    public event Action? StateChanged;
+    public event Action<string>? DeviceChanged;
+
+    public void Open(string serial, string? deviceName = null)
+    {
+        var switchingDevice = IsOpen && ActiveSerial != serial;
+        ActiveSerial = serial;
+        ActiveDeviceName = deviceName ?? serial;
+        IsOpen = true;
+        IsMinimized = false;
+        StateChanged?.Invoke();
+        if (switchingDevice)
+            DeviceChanged?.Invoke(serial);
+    }
+
+    public void SwitchDevice(string serial, string? deviceName = null)
+    {
+        if (ActiveSerial == serial) return;
+        ActiveSerial = serial;
+        ActiveDeviceName = deviceName ?? serial;
+        StateChanged?.Invoke();
+        DeviceChanged?.Invoke(serial);
+    }
+
+    public void Minimize()
+    {
+        IsMinimized = true;
+        StateChanged?.Invoke();
+    }
+
+    public void Restore()
+    {
+        IsMinimized = false;
+        StateChanged?.Invoke();
+    }
+
+    public void Close()
+    {
+        IsOpen = false;
+        IsMinimized = false;
+        ActiveSerial = null;
+        ActiveDeviceName = null;
+        StateChanged?.Invoke();
+    }
+}


### PR DESCRIPTION
Introduce full-featured logcat support and ADB device watching.

- Add ILogcatService and IAdbDeviceWatcherService to core interfaces.
- Implement LogcatService (starts adb logcat, streams/parses entries, stores entries, supports clear/streaming/dispose).
- Add LogcatParser to parse threadtime-formatted logcat lines and produce LogcatEntry records.
- Implement AdbDeviceWatcherService using AndroidSdk.Adbd to watch/list devices and emit DevicesChanged events (with debounce/reconnect logic).
- Add UI components LogcatContent.razor and LogcatPanel.razor for an embeddable/resizable logcat panel with filtering, virtualization, pause/auto-scroll, device selection and drag/resize behaviors.
- Add (and register) LogcatPanelService (new service file) and integrate device watcher/logcat UI in app (DI and UI updates in MauiProgram/MainLayout/Pages).
- Add AndroidSdk.Adbd package reference and bump redth.mauidevflow.cli tool to 0.5.0.

These changes enable live device detection and interactive log viewing within the app.