### PR TITLE
Add Device Inspector UI and services

### DIFF
--- a/src/MauiSherpa.Core/Interfaces.cs
+++ b/src/MauiSherpa.Core/Interfaces.cs
@@ -126,6 +126,40 @@ public interface IAdbDeviceWatcherService : IDisposable
     event Action<IReadOnlyList<DeviceInfo>>? DevicesChanged;
 }
 
+public record DeviceFileEntry(
+    string Name,
+    string FullPath,
+    bool IsDirectory,
+    long Size,
+    string? Permissions,
+    DateTimeOffset? Modified);
+
+public interface IDeviceFileService
+{
+    Task<IReadOnlyList<DeviceFileEntry>> ListAsync(string serial, string path, CancellationToken ct = default);
+    Task PullAsync(string serial, string remotePath, string localPath, IProgress<string>? progress = null, CancellationToken ct = default);
+    Task PushAsync(string serial, string localPath, string remotePath, IProgress<string>? progress = null, CancellationToken ct = default);
+    Task DeleteAsync(string serial, string remotePath, CancellationToken ct = default);
+}
+
+public interface IDeviceShellService : IDisposable
+{
+    bool IsRunning { get; }
+    string? ActiveSerial { get; }
+    Task StartAsync(string serial, CancellationToken ct = default);
+    Task SendCommandAsync(string command, CancellationToken ct = default);
+    void Stop();
+    IAsyncEnumerable<string> OutputStreamAsync(CancellationToken ct = default);
+}
+
+public interface IScreenCaptureService
+{
+    bool IsRecording { get; }
+    Task<byte[]> CaptureScreenshotAsync(string serial, CancellationToken ct = default);
+    Task StartRecordingAsync(string serial, int maxSeconds = 180, CancellationToken ct = default);
+    Task<byte[]?> StopRecordingAsync(CancellationToken ct = default);
+}
+
 
 
 public interface IAndroidSdkSettingsService

--- a/src/MauiSherpa.Core/Services/DeviceFileService.cs
+++ b/src/MauiSherpa.Core/Services/DeviceFileService.cs
@@ -1,0 +1,160 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Text.RegularExpressions;
+using MauiSherpa.Core.Interfaces;
+
+namespace MauiSherpa.Core.Services;
+
+public class DeviceFileService : IDeviceFileService
+{
+    private readonly IAndroidSdkService _sdkService;
+    private readonly ILoggingService _logger;
+
+    public DeviceFileService(IAndroidSdkService sdkService, ILoggingService logger)
+    {
+        _sdkService = sdkService;
+        _logger = logger;
+    }
+
+    public async Task<IReadOnlyList<DeviceFileEntry>> ListAsync(string serial, string path, CancellationToken ct = default)
+    {
+        // Always append trailing / so ls lists directory contents (not the symlink itself)
+        var listPath = path.TrimEnd('/') + "/";
+        var output = await RunAdbAsync(serial, $"shell ls -la \"{listPath}\"", ct);
+        if (string.IsNullOrEmpty(output))
+            return Array.Empty<DeviceFileEntry>();
+
+        var entries = new List<DeviceFileEntry>();
+        var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        foreach (var line in lines)
+        {
+            var entry = ParseLsLine(line.Trim(), path);
+            if (entry != null && entry.Name != "." && entry.Name != "..")
+                entries.Add(entry);
+        }
+
+        return entries
+            .OrderByDescending(e => e.IsDirectory)
+            .ThenBy(e => e.Name, StringComparer.OrdinalIgnoreCase)
+            .ToList()
+            .AsReadOnly();
+    }
+
+    public async Task PullAsync(string serial, string remotePath, string localPath, IProgress<string>? progress = null, CancellationToken ct = default)
+    {
+        progress?.Report($"Pulling {Path.GetFileName(remotePath)}...");
+        await RunAdbAsync(serial, $"pull \"{remotePath}\" \"{localPath}\"", ct);
+        progress?.Report("Done.");
+    }
+
+    public async Task PushAsync(string serial, string localPath, string remotePath, IProgress<string>? progress = null, CancellationToken ct = default)
+    {
+        progress?.Report($"Pushing {Path.GetFileName(localPath)}...");
+        await RunAdbAsync(serial, $"push \"{localPath}\" \"{remotePath}\"", ct);
+        progress?.Report("Done.");
+    }
+
+    public async Task DeleteAsync(string serial, string remotePath, CancellationToken ct = default)
+    {
+        await RunAdbAsync(serial, $"shell rm -rf \"{remotePath}\"", ct);
+    }
+
+    private async Task<string> RunAdbAsync(string serial, string arguments, CancellationToken ct)
+    {
+        var adbPath = GetAdbPath();
+        if (adbPath == null) return string.Empty;
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = adbPath,
+            Arguments = $"-s {serial} {arguments}",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        using var process = Process.Start(psi);
+        if (process == null) return string.Empty;
+
+        var output = await process.StandardOutput.ReadToEndAsync(ct);
+        await process.WaitForExitAsync(ct);
+        return output;
+    }
+
+    private string? GetAdbPath()
+    {
+        var sdkPath = _sdkService.SdkPath;
+        if (string.IsNullOrEmpty(sdkPath)) return null;
+        return Path.Combine(sdkPath, "platform-tools", "adb");
+    }
+
+    // Parse a line from `ls -la` output
+    // Format: drwxrwxr-x  2 root root  4096 2024-01-15 10:30 dirname
+    // Also handles: drwxrws--x 78 media_rw ext_data_rw 8192 2026-01-08 10:33 data
+    private static readonly Regex LsRegex = new(
+        @"^([drwxlsStT\-]{10})\s+\d+\s+\S+\s+\S+\s+(\d+)\s+(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2})\s+(.+)$",
+        RegexOptions.Compiled);
+
+    // Fallback for lines with ? permissions (no read access)
+    // e.g.: d?????????   ? ?      ?             ?                ? data_mirror
+    private static readonly Regex LsFallbackRegex = new(
+        @"^([dl\-\?]{1}[\?rwxsStT\-]{9})\s+.*\s(\S+?)(\s*->\s*\S+)?$",
+        RegexOptions.Compiled);
+
+    private static DeviceFileEntry? ParseLsLine(string line, string parentPath)
+    {
+        // Skip "total N" header line
+        if (line.StartsWith("total ", StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        var match = LsRegex.Match(line);
+        if (match.Success)
+        {
+            var perms = match.Groups[1].Value;
+            var size = long.TryParse(match.Groups[2].Value, out var s) ? s : 0;
+            var dateStr = match.Groups[3].Value;
+            var name = match.Groups[4].Value;
+
+            // Handle symlinks: name -> target
+            var isSymlink = perms.StartsWith('l');
+            if (isSymlink)
+            {
+                var arrowIdx = name.IndexOf(" -> ", StringComparison.Ordinal);
+                if (arrowIdx > 0)
+                    name = name[..arrowIdx];
+            }
+
+            // Directories start with 'd'; symlinks need special handling
+            var isDir = perms.StartsWith('d');
+            // For symlinks, check if size is small (typical for dir symlinks)
+            // We can't reliably tell if a symlink points to a dir without stat
+            if (isSymlink)
+                isDir = true; // Treat symlinks as navigable (user can click to try)
+
+            DateTimeOffset? modified = null;
+            if (DateTimeOffset.TryParseExact(dateStr, "yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture, DateTimeStyles.None, out var dt))
+                modified = dt;
+
+            var fullPath = parentPath.TrimEnd('/') + "/" + name;
+            return new DeviceFileEntry(name, fullPath, isDir, size, perms, modified);
+        }
+
+        // Fallback: parse lines with ? characters (no access)
+        var fallback = LsFallbackRegex.Match(line);
+        if (fallback.Success)
+        {
+            var perms = fallback.Groups[1].Value;
+            var name = fallback.Groups[2].Value;
+
+            if (name == "." || name == ".." || name == "?") return null;
+
+            var isDir = perms[0] == 'd' || perms[0] == 'l';
+            var fullPath = parentPath.TrimEnd('/') + "/" + name;
+            return new DeviceFileEntry(name, fullPath, isDir, 0, perms, null);
+        }
+
+        return null;
+    }
+}

--- a/src/MauiSherpa.Core/Services/DeviceShellService.cs
+++ b/src/MauiSherpa.Core/Services/DeviceShellService.cs
@@ -1,0 +1,148 @@
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+using MauiSherpa.Core.Interfaces;
+
+namespace MauiSherpa.Core.Services;
+
+public class DeviceShellService : IDeviceShellService
+{
+    private readonly IAndroidSdkService _sdkService;
+    private readonly ILoggingService _logger;
+    private Process? _process;
+    private Channel<string>? _channel;
+    private CancellationTokenSource? _readCts;
+
+    public bool IsRunning => _process is { HasExited: false };
+    public string? ActiveSerial { get; private set; }
+
+    public DeviceShellService(IAndroidSdkService sdkService, ILoggingService logger)
+    {
+        _sdkService = sdkService;
+        _logger = logger;
+    }
+
+    public Task StartAsync(string serial, CancellationToken ct = default)
+    {
+        Stop();
+
+        var adbPath = GetAdbPath();
+        if (adbPath == null)
+            throw new InvalidOperationException("Android SDK not found");
+
+        ActiveSerial = serial;
+        _channel = Channel.CreateUnbounded<string>(new UnboundedChannelOptions { SingleReader = true });
+        _readCts = new CancellationTokenSource();
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = adbPath,
+            Arguments = $"-s {serial} shell",
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            // Prevent encoding issues with binary/control chars
+            StandardOutputEncoding = System.Text.Encoding.UTF8,
+            StandardErrorEncoding = System.Text.Encoding.UTF8
+        };
+        // Set TERM so adb shell allocates a proper PTY
+        psi.Environment["TERM"] = "xterm-256color";
+
+        _process = Process.Start(psi);
+        if (_process == null)
+            throw new InvalidOperationException("Failed to start adb shell process");
+
+        _logger.LogInformation($"Shell started for device {serial} (PID: {_process.Id})");
+
+        // Read stdout char-by-char for real-time output (prompts, partial lines)
+        _ = ReadStreamCharsAsync(_process.StandardOutput, _readCts.Token);
+        _ = ReadStreamCharsAsync(_process.StandardError, _readCts.Token);
+
+        return Task.CompletedTask;
+    }
+
+    public async Task SendCommandAsync(string command, CancellationToken ct = default)
+    {
+        if (_process is not { HasExited: false })
+            throw new InvalidOperationException("Shell not running");
+
+        await _process.StandardInput.WriteLineAsync(command.AsMemory(), ct);
+        await _process.StandardInput.FlushAsync(ct);
+    }
+
+    public async IAsyncEnumerable<string> OutputStreamAsync([EnumeratorCancellation] CancellationToken ct = default)
+    {
+        if (_channel == null) yield break;
+
+        await foreach (var chunk in _channel.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+        {
+            yield return chunk;
+        }
+    }
+
+    public void Stop()
+    {
+        _readCts?.Cancel();
+        _channel?.Writer.TryComplete();
+
+        if (_process is { HasExited: false })
+        {
+            try
+            {
+                _process.StandardInput.Close();
+                if (!_process.WaitForExit(2000))
+                    _process.Kill();
+            }
+            catch { }
+        }
+
+        if (ActiveSerial != null)
+            _logger.LogInformation($"Shell stopped for device {ActiveSerial}");
+
+        _process?.Dispose();
+        _process = null;
+        _readCts?.Dispose();
+        _readCts = null;
+        _channel = null;
+        ActiveSerial = null;
+    }
+
+    private async Task ReadStreamCharsAsync(System.IO.StreamReader reader, CancellationToken ct)
+    {
+        var buffer = new char[1024];
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                var count = await reader.ReadAsync(buffer.AsMemory(), ct);
+                if (count == 0) break; // stream closed
+                var chunk = new string(buffer, 0, count);
+                _channel?.Writer.TryWrite(chunk);
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch (Exception ex)
+        {
+            _logger.LogWarning($"Shell read error: {ex.Message}");
+        }
+        finally
+        {
+            _channel?.Writer.TryComplete();
+        }
+    }
+
+    private string? GetAdbPath()
+    {
+        var sdkPath = _sdkService.SdkPath;
+        if (string.IsNullOrEmpty(sdkPath)) return null;
+        return System.IO.Path.Combine(sdkPath, "platform-tools", "adb");
+    }
+
+    public void Dispose()
+    {
+        Stop();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/src/MauiSherpa.Core/Services/ScreenCaptureService.cs
+++ b/src/MauiSherpa.Core/Services/ScreenCaptureService.cs
@@ -1,0 +1,151 @@
+using System.Diagnostics;
+using MauiSherpa.Core.Interfaces;
+
+namespace MauiSherpa.Core.Services;
+
+public class ScreenCaptureService : IScreenCaptureService
+{
+    private readonly IAndroidSdkService _sdkService;
+    private readonly ILoggingService _logger;
+    private Process? _recordProcess;
+    private string? _recordingSerial;
+    private string? _remoteRecordPath;
+
+    public bool IsRecording => _recordProcess is { HasExited: false };
+
+    public ScreenCaptureService(IAndroidSdkService sdkService, ILoggingService logger)
+    {
+        _sdkService = sdkService;
+        _logger = logger;
+    }
+
+    public async Task<byte[]> CaptureScreenshotAsync(string serial, CancellationToken ct = default)
+    {
+        var adbPath = GetAdbPath() ?? throw new InvalidOperationException("Android SDK not found");
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = adbPath,
+            Arguments = $"-s {serial} exec-out screencap -p",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        using var process = Process.Start(psi) ?? throw new InvalidOperationException("Failed to start screencap");
+
+        using var ms = new MemoryStream();
+        await process.StandardOutput.BaseStream.CopyToAsync(ms, ct);
+        await process.WaitForExitAsync(ct);
+
+        var data = ms.ToArray();
+        _logger.LogInformation($"Screenshot captured from {serial}: {data.Length} bytes");
+        return data;
+    }
+
+    public Task StartRecordingAsync(string serial, int maxSeconds = 180, CancellationToken ct = default)
+    {
+        if (IsRecording)
+            throw new InvalidOperationException("Already recording");
+
+        var adbPath = GetAdbPath() ?? throw new InvalidOperationException("Android SDK not found");
+
+        _recordingSerial = serial;
+        _remoteRecordPath = $"/sdcard/screenrecord-{DateTimeOffset.UtcNow:yyyyMMddHHmmss}.mp4";
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = adbPath,
+            Arguments = $"-s {serial} shell screenrecord --time-limit {maxSeconds} {_remoteRecordPath}",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        _recordProcess = Process.Start(psi);
+        if (_recordProcess == null)
+            throw new InvalidOperationException("Failed to start screenrecord");
+
+        _logger.LogInformation($"Recording started on {serial} (PID: {_recordProcess.Id}, max {maxSeconds}s)");
+        return Task.CompletedTask;
+    }
+
+    public async Task<byte[]?> StopRecordingAsync(CancellationToken ct = default)
+    {
+        if (_recordProcess == null || _recordingSerial == null || _remoteRecordPath == null)
+            return null;
+
+        // Send interrupt to stop recording gracefully
+        if (!_recordProcess.HasExited)
+        {
+            try { _recordProcess.Kill(); } catch { }
+            try { await _recordProcess.WaitForExitAsync(ct); } catch { }
+        }
+
+        _recordProcess.Dispose();
+        _recordProcess = null;
+
+        // Wait briefly for file to finalize on device
+        await Task.Delay(500, ct);
+
+        // Pull the file
+        var adbPath = GetAdbPath();
+        if (adbPath == null) return null;
+
+        var localPath = Path.Combine(Path.GetTempPath(), Path.GetFileName(_remoteRecordPath));
+
+        var pullPsi = new ProcessStartInfo
+        {
+            FileName = adbPath,
+            Arguments = $"-s {_recordingSerial} pull {_remoteRecordPath} \"{localPath}\"",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        using (var pullProcess = Process.Start(pullPsi))
+        {
+            if (pullProcess != null)
+                await pullProcess.WaitForExitAsync(ct);
+        }
+
+        // Clean up remote file
+        var rmPsi = new ProcessStartInfo
+        {
+            FileName = adbPath,
+            Arguments = $"-s {_recordingSerial} shell rm {_remoteRecordPath}",
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        using (var rmProcess = Process.Start(rmPsi))
+        {
+            if (rmProcess != null)
+                await rmProcess.WaitForExitAsync(ct);
+        }
+
+        var serial = _recordingSerial;
+        _recordingSerial = null;
+        _remoteRecordPath = null;
+
+        if (File.Exists(localPath))
+        {
+            var data = await File.ReadAllBytesAsync(localPath, ct);
+            File.Delete(localPath);
+            _logger.LogInformation($"Recording stopped on {serial}: {data.Length} bytes");
+            return data;
+        }
+
+        _logger.LogWarning($"Recording file not found after pull from {serial}");
+        return null;
+    }
+
+    private string? GetAdbPath()
+    {
+        var sdkPath = _sdkService.SdkPath;
+        if (string.IsNullOrEmpty(sdkPath)) return null;
+        return Path.Combine(sdkPath, "platform-tools", "adb");
+    }
+}

--- a/src/MauiSherpa/Components/FileExplorerTab.razor
+++ b/src/MauiSherpa/Components/FileExplorerTab.razor
@@ -1,0 +1,331 @@
+@using MauiSherpa.Core.Interfaces
+@using MauiSherpa.Services
+@inject IDeviceFileService FileService
+@inject DeviceInspectorService Inspector
+@inject IDialogService DialogService
+@inject IJSRuntime JS
+@implements IDisposable
+
+<div class="file-explorer">
+    <div class="file-toolbar">
+        <div class="breadcrumb">
+            @foreach (var crumb in GetBreadcrumbs())
+            {
+                <button class="breadcrumb-item" @onclick="@(() => NavigateTo(crumb.Path))">@crumb.Name</button>
+                @if (crumb.Path != currentPath)
+                {
+                    <span class="breadcrumb-separator">/</span>
+                }
+            }
+        </div>
+        <div class="file-toolbar-actions">
+            <button class="btn btn-sm btn-secondary" @onclick="UploadFileAsync" disabled="@isLoading" title="Upload file to current folder">
+                <i class="fas fa-upload"></i>
+            </button>
+            <button class="btn btn-sm btn-secondary" @onclick="RefreshAsync" disabled="@isLoading">
+                <i class="fas fa-sync-alt @(isLoading ? "fa-spin" : "")"></i>
+            </button>
+            <button class="btn btn-sm btn-secondary" @onclick="NavigateUp" disabled="@(currentPath == "/")">
+                <i class="fas fa-level-up-alt"></i>
+            </button>
+        </div>
+    </div>
+
+    <div class="file-list">
+        @if (isLoading)
+        {
+            <div class="file-loading">
+                <i class="fas fa-spinner fa-spin"></i> Loading...
+            </div>
+        }
+        else if (entries.Count == 0)
+        {
+            <div class="file-empty">
+                <i class="fas fa-folder-open"></i>
+                <span>Empty directory</span>
+            </div>
+        }
+        else
+        {
+            <div class="file-header">
+                <span class="file-col-icon"></span>
+                <span class="file-col-name">Name</span>
+                <span class="file-col-size">Size</span>
+                <span class="file-col-perms">Permissions</span>
+                <span class="file-col-date">Modified</span>
+                <span class="file-col-actions"></span>
+            </div>
+            <div class="file-scroll">
+                @foreach (var entry in entries)
+                {
+                    <div class="file-row @(entry.IsDirectory ? "file-row-dir" : "")" @ondblclick="@(() => { if (entry.IsDirectory) NavigateTo(entry.FullPath); })">
+                        <span class="file-col-icon">
+                            <i class="fas @(entry.IsDirectory ? "fa-folder" : GetFileIcon(entry.Name))"></i>
+                        </span>
+                        <span class="file-col-name" title="@entry.FullPath">
+                            @if (entry.IsDirectory)
+                            {
+                                <a href="javascript:void(0)" @onclick="@(() => NavigateTo(entry.FullPath))">@entry.Name</a>
+                            }
+                            else
+                            {
+                                @entry.Name
+                            }
+                        </span>
+                        <span class="file-col-size">@(entry.IsDirectory ? "—" : FormatSize(entry.Size))</span>
+                        <span class="file-col-perms">@entry.Permissions</span>
+                        <span class="file-col-date">@(entry.Modified?.ToString("MM-dd HH:mm") ?? "—")</span>
+                        <span class="file-col-actions">
+                            @if (!entry.IsDirectory)
+                            {
+                                <button class="btn-file-action" @onclick="@(() => DownloadFileAsync(entry))" title="Download">
+                                    <i class="fas fa-download"></i>
+                                </button>
+                            }
+                            <button class="btn-file-action btn-file-delete" @onclick="@(() => DeleteAsync(entry))" title="Delete">
+                                <i class="fas fa-trash-alt"></i>
+                            </button>
+                        </span>
+                    </div>
+                }
+            </div>
+        }
+    </div>
+</div>
+
+<style>
+    .file-explorer {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        font-size: 12px;
+    }
+    .file-toolbar {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 4px 8px;
+        background: var(--bg-tertiary, #edf2f7);
+        border-bottom: 1px solid var(--border-color, #e2e8f0);
+        gap: 8px;
+        flex-shrink: 0;
+    }
+    .breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 2px;
+        overflow-x: auto;
+        flex: 1;
+    }
+    .breadcrumb-item {
+        background: none;
+        border: none;
+        padding: 2px 4px;
+        border-radius: 4px;
+        color: var(--accent-primary, #4299e1);
+        cursor: pointer;
+        font-size: 12px;
+        font-family: 'Consolas', 'Monaco', monospace;
+        white-space: nowrap;
+    }
+    .breadcrumb-item:hover { background: var(--bg-secondary); }
+    .breadcrumb-separator { color: var(--text-muted); font-size: 10px; }
+    .file-toolbar-actions { display: flex; gap: 4px; flex-shrink: 0; }
+
+    .file-list { flex: 1; overflow: hidden; display: flex; flex-direction: column; }
+    .file-header {
+        display: flex;
+        align-items: center;
+        padding: 4px 8px;
+        font-weight: 600;
+        font-size: 11px;
+        color: var(--text-secondary);
+        border-bottom: 1px solid var(--border-color, #e2e8f0);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        flex-shrink: 0;
+    }
+    .file-scroll { flex: 1; overflow-y: auto; }
+    .file-row {
+        display: flex;
+        align-items: center;
+        padding: 3px 8px;
+        border-bottom: 1px solid var(--border-subtle, rgba(0,0,0,0.04));
+        transition: background 0.1s;
+    }
+    .file-row:hover { background: var(--bg-tertiary, #f7fafc); }
+    .file-row-dir { font-weight: 500; }
+    .file-col-icon { width: 28px; text-align: center; flex-shrink: 0; }
+    .file-row-dir .file-col-icon { color: #eab308; }
+    .file-col-name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .file-col-name a { color: var(--accent-primary, #4299e1); text-decoration: none; }
+    .file-col-name a:hover { text-decoration: underline; }
+    .file-col-size { width: 70px; text-align: right; color: var(--text-muted); flex-shrink: 0; padding-right: 12px; }
+    .file-col-perms { width: 90px; font-family: 'Consolas', 'Monaco', monospace; font-size: 11px; color: var(--text-muted); flex-shrink: 0; }
+    .file-col-date { width: 90px; color: var(--text-muted); flex-shrink: 0; }
+    .file-col-actions { width: 56px; display: flex; gap: 4px; justify-content: flex-end; flex-shrink: 0; }
+    .btn-file-action {
+        background: none; border: none; color: var(--text-muted); cursor: pointer;
+        padding: 2px 4px; border-radius: 4px; font-size: 11px;
+    }
+    .btn-file-action:hover { background: var(--bg-secondary); color: var(--text-primary); }
+    .btn-file-delete:hover { color: #f56565; }
+
+    .file-loading, .file-empty {
+        display: flex; align-items: center; justify-content: center; gap: 8px;
+        padding: 32px; color: var(--text-muted); font-size: 13px;
+    }
+</style>
+
+@code {
+    [Parameter] public string Serial { get; set; } = "";
+
+    private string currentPath = "/sdcard";
+    private List<DeviceFileEntry> entries = new();
+    private bool isLoading;
+
+    protected override async Task OnInitializedAsync()
+    {
+        Inspector.DeviceChanged += OnDeviceChanged;
+        await RefreshAsync();
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (!string.IsNullOrEmpty(Serial))
+            await RefreshAsync();
+    }
+
+    private async Task RefreshAsync()
+    {
+        if (string.IsNullOrEmpty(Serial)) return;
+        isLoading = true;
+        StateHasChanged();
+
+        try
+        {
+            var result = await FileService.ListAsync(Serial, currentPath);
+            entries = result.ToList();
+        }
+        catch
+        {
+            entries = new();
+        }
+        finally
+        {
+            isLoading = false;
+            StateHasChanged();
+        }
+    }
+
+    private async void NavigateTo(string path)
+    {
+        currentPath = path;
+        await RefreshAsync();
+    }
+
+    private async void NavigateUp()
+    {
+        if (currentPath == "/") return;
+        var parent = currentPath.LastIndexOf('/');
+        currentPath = parent <= 0 ? "/" : currentPath[..parent];
+        await RefreshAsync();
+    }
+
+    private record Breadcrumb(string Name, string Path);
+
+    private List<Breadcrumb> GetBreadcrumbs()
+    {
+        var crumbs = new List<Breadcrumb> { new("/", "/") };
+        if (currentPath == "/") return crumbs;
+
+        var parts = currentPath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        var path = "";
+        foreach (var part in parts)
+        {
+            path += "/" + part;
+            crumbs.Add(new(part, path));
+        }
+        return crumbs;
+    }
+
+    private async Task DownloadFileAsync(DeviceFileEntry entry)
+    {
+        var ext = System.IO.Path.GetExtension(entry.Name)?.TrimStart('.') ?? "";
+        var savePath = await DialogService.PickSaveFileAsync("Save File", entry.Name, ext);
+        if (string.IsNullOrEmpty(savePath)) return;
+        await FileService.PullAsync(Serial, entry.FullPath, savePath);
+    }
+
+    private async Task DeleteAsync(DeviceFileEntry entry)
+    {
+        // Simple confirmation via alert service
+        await FileService.DeleteAsync(Serial, entry.FullPath);
+        await RefreshAsync();
+    }
+
+    private async Task UploadFileAsync()
+    {
+        if (string.IsNullOrEmpty(Serial)) return;
+
+        var localPath = await DialogService.PickOpenFileAsync("Select file to upload");
+        if (string.IsNullOrEmpty(localPath)) return;
+
+        var fileName = System.IO.Path.GetFileName(localPath);
+        var remotePath = currentPath.TrimEnd('/') + "/" + fileName;
+
+        isLoading = true;
+        StateHasChanged();
+
+        try
+        {
+            await FileService.PushAsync(Serial, localPath, remotePath);
+            await RefreshAsync();
+        }
+        catch
+        {
+            isLoading = false;
+            StateHasChanged();
+        }
+    }
+
+    private void OnDeviceChanged(string newSerial)
+    {
+        InvokeAsync(() =>
+        {
+            currentPath = "/sdcard";
+            _ = RefreshAsync();
+        });
+    }
+
+    private static string FormatSize(long bytes)
+    {
+        if (bytes < 1024) return $"{bytes} B";
+        if (bytes < 1024 * 1024) return $"{bytes / 1024.0:F1} KB";
+        if (bytes < 1024 * 1024 * 1024) return $"{bytes / (1024.0 * 1024):F1} MB";
+        return $"{bytes / (1024.0 * 1024 * 1024):F1} GB";
+    }
+
+    private static string GetFileIcon(string name)
+    {
+        var ext = System.IO.Path.GetExtension(name)?.ToLowerInvariant();
+        return ext switch
+        {
+            ".apk" => "fa-cube",
+            ".jpg" or ".jpeg" or ".png" or ".gif" or ".webp" or ".bmp" => "fa-image",
+            ".mp4" or ".mkv" or ".avi" or ".mov" => "fa-film",
+            ".mp3" or ".wav" or ".ogg" or ".flac" => "fa-music",
+            ".txt" or ".log" or ".md" => "fa-file-alt",
+            ".xml" or ".json" or ".yaml" or ".yml" => "fa-file-code",
+            ".zip" or ".tar" or ".gz" or ".7z" => "fa-file-archive",
+            ".pdf" => "fa-file-pdf",
+            ".db" or ".sqlite" => "fa-database",
+            _ => "fa-file"
+        };
+    }
+
+    public void Dispose()
+    {
+        Inspector.DeviceChanged -= OnDeviceChanged;
+    }
+}

--- a/src/MauiSherpa/Components/LogcatContent.razor
+++ b/src/MauiSherpa/Components/LogcatContent.razor
@@ -3,7 +3,7 @@
 @using MauiSherpa.Services
 @inject ILogcatService LogcatService
 @inject IAdbDeviceWatcherService DeviceWatcher
-@inject LogcatPanelService PanelService
+@inject DeviceInspectorService PanelService
 @inject IAlertService AlertService
 @inject ILoggingService Logger
 @inject IJSRuntime JS
@@ -12,15 +12,6 @@
 <div class="logcat-page">
     <div class="logcat-toolbar">
         <div class="toolbar-left">
-            <div class="device-selector" @onclick="FocusDeviceSelect">
-                <i class="fab fa-android device-selector-icon"></i>
-                <select class="device-select" @ref="deviceSelectRef" value="@Serial" @onchange="OnDeviceChanged">
-                    @foreach (var d in connectedDevices)
-                    {
-                        <option value="@d.Serial" selected="@(d.Serial == Serial)">@(d.Model ?? d.Serial)</option>
-                    }
-                </select>
-            </div>
             @if (LogcatService.IsRunning)
             {
                 <button class="btn btn-sm btn-danger" @onclick="StopLogcat">

--- a/src/MauiSherpa/Components/LogcatPanel.razor
+++ b/src/MauiSherpa/Components/LogcatPanel.razor
@@ -1,5 +1,7 @@
 @using MauiSherpa.Services
-@inject LogcatPanelService PanelService
+@using MauiSherpa.Core.Interfaces
+@inject DeviceInspectorService PanelService
+@inject IAdbDeviceWatcherService DeviceWatcher
 @inject IJSRuntime JS
 @implements IDisposable
 
@@ -9,7 +11,7 @@
     {
         <div class="logcat-collapsed" @onclick="PanelService.Restore">
             <i class="fab fa-android collapsed-icon"></i>
-            <span class="collapsed-label">Logcat</span>
+            <span class="collapsed-label">@(PanelService.ActiveDeviceName ?? "Device")</span>
             <span class="collapsed-serial">@PanelService.ActiveSerial</span>
             <i class="fas fa-chevron-up collapsed-expand"></i>
         </div>
@@ -34,7 +36,7 @@
             <div class="dialog-titlebar" @onpointerdown="StartDrag">
                 <div class="dialog-title">
                     <i class="fab fa-android title-android-icon"></i>
-                    <span class="title-text">Logcat</span>
+                    <span class="title-text">Device Inspector</span>
                 </div>
                 <div class="dialog-actions" @onpointerdown:stopPropagation="true">
                     <button class="dialog-btn" @onclick="PanelService.Minimize" @onclick:stopPropagation="true" title="Minimize">
@@ -48,8 +50,53 @@
                     </button>
                 </div>
             </div>
+
+            <div class="inspector-tabstrip">
+                <div class="inspector-tabs">
+                    <button class="inspector-tab @(PanelService.ActiveTab == InspectorTab.Logcat ? "active" : "")"
+                            @onclick="@(() => PanelService.SetTab(InspectorTab.Logcat))">
+                        <i class="fas fa-scroll"></i> Logcat
+                    </button>
+                    <button class="inspector-tab @(PanelService.ActiveTab == InspectorTab.Files ? "active" : "")"
+                            @onclick="@(() => PanelService.SetTab(InspectorTab.Files))">
+                        <i class="fas fa-folder-open"></i> Files
+                    </button>
+                    <button class="inspector-tab @(PanelService.ActiveTab == InspectorTab.Shell ? "active" : "")"
+                            @onclick="@(() => PanelService.SetTab(InspectorTab.Shell))">
+                        <i class="fas fa-terminal"></i> Shell
+                    </button>
+                    <button class="inspector-tab @(PanelService.ActiveTab == InspectorTab.Capture ? "active" : "")"
+                            @onclick="@(() => PanelService.SetTab(InspectorTab.Capture))">
+                        <i class="fas fa-camera"></i> Capture
+                    </button>
+                </div>
+                <div class="inspector-device-selector">
+                    <i class="fab fa-android inspector-device-icon"></i>
+                    <select class="inspector-device-select" @ref="deviceSelectRef" value="@PanelService.ActiveSerial" @onchange="OnDeviceChanged">
+                        @foreach (var d in connectedDevices)
+                        {
+                            <option value="@d.Serial" selected="@(d.Serial == PanelService.ActiveSerial)">@(d.Model ?? d.Serial)</option>
+                        }
+                    </select>
+                </div>
+            </div>
+
             <div class="dialog-body">
-                <LogcatContent Serial="@(PanelService.ActiveSerial!)" />
+                @switch (PanelService.ActiveTab)
+                {
+                    case InspectorTab.Logcat:
+                        <LogcatContent Serial="@(PanelService.ActiveSerial!)" />
+                        break;
+                    case InspectorTab.Files:
+                        <FileExplorerTab Serial="@(PanelService.ActiveSerial!)" />
+                        break;
+                    case InspectorTab.Shell:
+                        <ShellTab Serial="@(PanelService.ActiveSerial!)" />
+                        break;
+                    case InspectorTab.Capture:
+                        <ScreenCaptureTab Serial="@(PanelService.ActiveSerial!)" />
+                        break;
+                }
             </div>
         </div>
     }
@@ -168,17 +215,108 @@
         height: 100% !important;
     }
 
+    /* ── Tab strip ── */
+    .inspector-tabstrip {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0 8px;
+        background: var(--bg-tertiary, #edf2f7);
+        border-bottom: 1px solid var(--border-color, #e2e8f0);
+        flex-shrink: 0;
+        gap: 8px;
+    }
+    .inspector-tabs {
+        display: flex;
+        gap: 0;
+        position: relative;
+        z-index: 1;
+    }
+    .inspector-tab {
+        background: none;
+        border: none;
+        padding: 6px 12px;
+        font-size: 12px;
+        font-weight: 500;
+        color: var(--text-secondary);
+        cursor: pointer;
+        border-bottom: 2px solid transparent;
+        transition: all 0.15s;
+        display: flex;
+        align-items: center;
+        gap: 5px;
+        white-space: nowrap;
+    }
+    .inspector-tab:hover {
+        color: var(--text-primary);
+        background: var(--bg-secondary);
+    }
+    .inspector-tab.active {
+        color: var(--accent-primary, #4299e1);
+        border-bottom-color: var(--accent-primary, #4299e1);
+        font-weight: 600;
+    }
+    .inspector-tab i {
+        font-size: 11px;
+    }
+
+    /* ── Panel-level device selector ── */
+    .inspector-device-selector {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        padding: 3px 8px;
+        border-radius: 6px;
+        border: 1px solid var(--border-color, #e2e8f0);
+        background: var(--bg-secondary, #fff);
+        cursor: pointer;
+        transition: border-color 0.15s, box-shadow 0.15s;
+        position: relative;
+        overflow: hidden;
+        flex-shrink: 0;
+    }
+    .inspector-device-selector:hover {
+        border-color: var(--accent-primary, #4299e1);
+    }
+    .inspector-device-selector:focus-within {
+        border-color: var(--accent-primary, #4299e1);
+        box-shadow: 0 0 0 2px rgba(66, 153, 225, 0.3);
+    }
+    .inspector-device-icon {
+        color: #3ddc84;
+        font-size: 12px;
+        flex-shrink: 0;
+    }
+    .inspector-device-select {
+        border: none;
+        outline: none !important;
+        -webkit-focus-ring-color: transparent;
+        background: transparent;
+        font-size: 12px;
+        font-family: 'Consolas', 'Monaco', monospace;
+        color: var(--text-primary);
+        cursor: pointer;
+        -webkit-appearance: none;
+        appearance: none;
+        padding-right: 2px;
+        max-width: 180px;
+    }
+    .inspector-device-select:focus {
+        outline: none !important;
+        box-shadow: none !important;
+    }
+
     /* ── Resize handles ── */
     .resize-handle { position: absolute; z-index: 10; touch-action: none; }
     .resize-handle:hover { background: var(--accent-primary, #4299e1); opacity: 0.35; }
-    .resize-n  { top: 0;     left: 14px;  right: 14px; height: 5px; cursor: n-resize; }
-    .resize-s  { bottom: 0;  left: 14px;  right: 14px; height: 5px; cursor: s-resize; }
-    .resize-e  { top: 14px;  right: 0;    bottom: 14px; width: 5px; cursor: e-resize; }
-    .resize-w  { top: 14px;  left: 0;     bottom: 14px; width: 5px; cursor: w-resize; }
-    .resize-ne { top: 0;     right: 0;    width: 14px; height: 14px; cursor: ne-resize; }
-    .resize-nw { top: 0;     left: 0;     width: 14px; height: 14px; cursor: nw-resize; }
-    .resize-se { bottom: 0;  right: 0;    width: 14px; height: 14px; cursor: se-resize; }
-    .resize-sw { bottom: 0;  left: 0;     width: 14px; height: 14px; cursor: sw-resize; }
+    .resize-n  { top: 0;     left: 14px;  right: 14px; height: 5px; cursor: n-resize; border-radius: 3px; }
+    .resize-s  { bottom: 0;  left: 14px;  right: 14px; height: 5px; cursor: s-resize; border-radius: 3px; }
+    .resize-e  { top: 14px;  right: 0;    bottom: 14px; width: 5px; cursor: e-resize; border-radius: 3px; }
+    .resize-w  { top: 14px;  left: 0;     bottom: 14px; width: 5px; cursor: w-resize; border-radius: 3px; }
+    .resize-ne { top: 0;     right: 0;    width: 14px; height: 14px; cursor: ne-resize; border-radius: 0 6px 0 6px; }
+    .resize-nw { top: 0;     left: 0;     width: 14px; height: 14px; cursor: nw-resize; border-radius: 6px 0 6px 0; }
+    .resize-se { bottom: 0;  right: 0;    width: 14px; height: 14px; cursor: se-resize; border-radius: 6px 0 6px 0; }
+    .resize-sw { bottom: 0;  left: 0;     width: 14px; height: 14px; cursor: sw-resize; border-radius: 0 6px 0 6px; }
     .resize-se::after {
         content: '';
         position: absolute;
@@ -239,6 +377,8 @@
 
 @code {
     private ElementReference dialogRef;
+    private ElementReference deviceSelectRef;
+    private List<DeviceInfo> connectedDevices = new();
 
     // Position & size
     private double posX = 280;
@@ -272,6 +412,8 @@
     protected override void OnInitialized()
     {
         PanelService.StateChanged += OnStateChanged;
+        DeviceWatcher.DevicesChanged += OnWatcherDevicesChanged;
+        connectedDevices = DeviceWatcher.Devices.ToList();
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -455,9 +597,31 @@
         InvokeAsync(StateHasChanged);
     }
 
+    private void OnWatcherDevicesChanged(IReadOnlyList<DeviceInfo> newDevices)
+    {
+        InvokeAsync(() =>
+        {
+            connectedDevices = newDevices.ToList();
+            StateHasChanged();
+        });
+    }
+
+    private void OnDeviceChanged(ChangeEventArgs e)
+    {
+        var newSerial = e.Value?.ToString();
+        if (string.IsNullOrEmpty(newSerial) || newSerial == PanelService.ActiveSerial) return;
+        PanelService.SwitchDevice(newSerial, connectedDevices.FirstOrDefault(d => d.Serial == newSerial)?.Model);
+    }
+
+    private async Task FocusDeviceSelect()
+    {
+        await JS.InvokeVoidAsync("eval", "(function(){ var el = document.querySelector('.inspector-device-select'); if(el){ el.blur(); el.focus(); el.click(); } })()");
+    }
+
     public void Dispose()
     {
         PanelService.StateChanged -= OnStateChanged;
+        DeviceWatcher.DevicesChanged -= OnWatcherDevicesChanged;
         selfRef?.Dispose();
     }
 }

--- a/src/MauiSherpa/Components/ScreenCaptureTab.razor
+++ b/src/MauiSherpa/Components/ScreenCaptureTab.razor
@@ -1,0 +1,254 @@
+@using MauiSherpa.Core.Interfaces
+@using MauiSherpa.Services
+@inject IScreenCaptureService CaptureService
+@inject DeviceInspectorService Inspector
+@inject IDialogService DialogService
+@implements IDisposable
+
+<div class="capture-tab">
+    <div class="capture-toolbar">
+        <button class="btn btn-sm btn-primary" @onclick="TakeScreenshot" disabled="@isCapturing">
+            <i class="fas @(isCapturing ? "fa-spinner fa-spin" : "fa-camera")"></i> Screenshot
+        </button>
+        @if (CaptureService.IsRecording)
+        {
+            <button class="btn btn-sm btn-danger" @onclick="StopRecording">
+                <i class="fas fa-stop"></i> Stop Recording (@FormatDuration(recordingElapsed))
+            </button>
+        }
+        else
+        {
+            <button class="btn btn-sm btn-secondary" @onclick="StartRecording" disabled="@isCapturing">
+                <i class="fas fa-video"></i> Record
+            </button>
+        }
+    </div>
+
+    <div class="capture-content">
+        @if (captures.Count == 0 && !isCapturing)
+        {
+            <div class="capture-empty">
+                <i class="fas fa-camera-retro"></i>
+                <span>Take a screenshot or start recording</span>
+            </div>
+        }
+        else
+        {
+            <div class="capture-gallery">
+                @foreach (var capture in captures.AsEnumerable().Reverse())
+                {
+                    <div class="capture-card">
+                        <div class="capture-preview">
+                            @if (capture.IsVideo)
+                            {
+                                <div class="capture-video-placeholder">
+                                    <i class="fas fa-film"></i>
+                                    <span>Video (@FormatSize(capture.Data.Length))</span>
+                                </div>
+                            }
+                            else
+                            {
+                                <img src="data:image/png;base64,@Convert.ToBase64String(capture.Data)" alt="Screenshot" />
+                            }
+                        </div>
+                        <div class="capture-info">
+                            <span class="capture-time">@capture.Timestamp.ToString("HH:mm:ss")</span>
+                            <span class="capture-size">@FormatSize(capture.Data.Length)</span>
+                            <button class="btn-capture-save" @onclick="@(() => SaveCaptureAsync(capture))" title="Save">
+                                <i class="fas fa-download"></i>
+                            </button>
+                        </div>
+                    </div>
+                }
+            </div>
+        }
+    </div>
+</div>
+
+<style>
+    .capture-tab {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        font-size: 12px;
+    }
+    .capture-toolbar {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 6px 8px;
+        background: var(--bg-tertiary, #edf2f7);
+        border-bottom: 1px solid var(--border-color, #e2e8f0);
+        flex-shrink: 0;
+    }
+    .capture-content { flex: 1; overflow-y: auto; padding: 8px; }
+    .capture-empty {
+        display: flex; flex-direction: column; align-items: center;
+        justify-content: center; gap: 12px; padding: 48px;
+        color: var(--text-muted); font-size: 14px;
+    }
+    .capture-empty i { font-size: 36px; opacity: 0.4; }
+
+    .capture-gallery {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+    }
+    .capture-card {
+        border: 1px solid var(--border-color, #e2e8f0);
+        border-radius: 8px;
+        overflow: hidden;
+        background: var(--bg-secondary, #fff);
+    }
+    .capture-preview {
+        max-height: 300px;
+        overflow: hidden;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: #f0f0f0;
+    }
+    .capture-preview img {
+        max-width: 100%;
+        max-height: 300px;
+        object-fit: contain;
+    }
+    .capture-video-placeholder {
+        padding: 24px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 8px;
+        color: var(--text-muted);
+    }
+    .capture-video-placeholder i { font-size: 28px; }
+    .capture-info {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 6px 8px;
+        font-size: 11px;
+        color: var(--text-secondary);
+    }
+    .capture-time { font-family: 'Consolas', monospace; }
+    .capture-size { flex: 1; }
+    .btn-capture-save {
+        background: none; border: none; color: var(--text-muted);
+        cursor: pointer; padding: 2px 6px; border-radius: 4px;
+    }
+    .btn-capture-save:hover { background: var(--bg-tertiary); color: var(--accent-primary); }
+</style>
+
+@code {
+    [Parameter] public string Serial { get; set; } = "";
+
+    private bool isCapturing;
+    private TimeSpan recordingElapsed;
+    private System.Threading.Timer? _recordTimer;
+    private DateTimeOffset _recordStart;
+    private List<CaptureItem> captures = new();
+
+    private record CaptureItem(byte[] Data, bool IsVideo, DateTimeOffset Timestamp);
+
+    protected override void OnInitialized()
+    {
+        Inspector.DeviceChanged += OnDeviceChanged;
+    }
+
+    private async Task TakeScreenshot()
+    {
+        if (string.IsNullOrEmpty(Serial)) return;
+        isCapturing = true;
+        StateHasChanged();
+
+        try
+        {
+            var data = await CaptureService.CaptureScreenshotAsync(Serial);
+            if (data.Length > 0)
+                captures.Add(new CaptureItem(data, false, DateTimeOffset.Now));
+        }
+        catch { }
+        finally
+        {
+            isCapturing = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task StartRecording()
+    {
+        if (string.IsNullOrEmpty(Serial)) return;
+        isCapturing = true;
+        StateHasChanged();
+
+        try
+        {
+            await CaptureService.StartRecordingAsync(Serial);
+            _recordStart = DateTimeOffset.Now;
+            _recordTimer = new System.Threading.Timer(_ =>
+            {
+                recordingElapsed = DateTimeOffset.Now - _recordStart;
+                InvokeAsync(StateHasChanged);
+            }, null, 0, 1000);
+        }
+        catch { }
+        finally
+        {
+            isCapturing = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task StopRecording()
+    {
+        _recordTimer?.Dispose();
+        _recordTimer = null;
+
+        try
+        {
+            var data = await CaptureService.StopRecordingAsync();
+            if (data != null && data.Length > 0)
+                captures.Add(new CaptureItem(data, true, DateTimeOffset.Now));
+        }
+        catch { }
+        finally
+        {
+            recordingElapsed = TimeSpan.Zero;
+            StateHasChanged();
+        }
+    }
+
+    private async Task SaveCaptureAsync(CaptureItem capture)
+    {
+        var ext = capture.IsVideo ? "mp4" : "png";
+        var name = $"capture-{capture.Timestamp:yyyyMMdd-HHmmss}.{ext}";
+        var savePath = await DialogService.PickSaveFileAsync("Save Capture", name, ext);
+        if (string.IsNullOrEmpty(savePath)) return;
+        await System.IO.File.WriteAllBytesAsync(savePath, capture.Data);
+    }
+
+    private void OnDeviceChanged(string newSerial)
+    {
+        InvokeAsync(() =>
+        {
+            captures.Clear();
+            StateHasChanged();
+        });
+    }
+
+    private static string FormatDuration(TimeSpan ts) =>
+        ts.Hours > 0 ? ts.ToString(@"h\:mm\:ss") : ts.ToString(@"m\:ss");
+
+    private static string FormatSize(long bytes)
+    {
+        if (bytes < 1024) return $"{bytes} B";
+        if (bytes < 1024 * 1024) return $"{bytes / 1024.0:F1} KB";
+        return $"{bytes / (1024.0 * 1024):F1} MB";
+    }
+
+    public void Dispose()
+    {
+        Inspector.DeviceChanged -= OnDeviceChanged;
+        _recordTimer?.Dispose();
+    }
+}

--- a/src/MauiSherpa/Components/ShellTab.razor
+++ b/src/MauiSherpa/Components/ShellTab.razor
@@ -1,0 +1,171 @@
+@using MauiSherpa.Core.Interfaces
+@using MauiSherpa.Services
+@inject IDeviceShellService ShellService
+@inject DeviceInspectorService Inspector
+@inject IJSRuntime JS
+@implements IDisposable
+
+<div class="shell-tab">
+    <div class="shell-toolbar">
+        <button class="btn btn-sm btn-secondary" @onclick="ClearTerminal" title="Clear">
+            <i class="fas fa-trash-alt"></i> Clear
+        </button>
+        <button class="btn btn-sm btn-secondary" @onclick="RestartShell" title="Restart shell">
+            <i class="fas fa-redo"></i> Restart
+        </button>
+        @if (!ShellService.IsRunning)
+        {
+            <span class="shell-status disconnected"><i class="fas fa-circle"></i> Disconnected</span>
+        }
+        else
+        {
+            <span class="shell-status connected"><i class="fas fa-circle"></i> Connected</span>
+        }
+    </div>
+    <div id="@terminalId" class="shell-terminal-container"></div>
+</div>
+
+<style>
+    .shell-tab {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+    }
+    .shell-toolbar {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 4px 8px;
+        background: var(--bg-tertiary, #edf2f7);
+        border-bottom: 1px solid var(--border-color, #e2e8f0);
+        flex-shrink: 0;
+    }
+    .shell-status {
+        font-size: 11px;
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        margin-left: auto;
+    }
+    .shell-status.connected { color: #3ddc84; }
+    .shell-status.connected i { font-size: 7px; }
+    .shell-status.disconnected { color: #f56565; }
+    .shell-status.disconnected i { font-size: 7px; }
+    .shell-terminal-container {
+        flex: 1;
+        overflow: hidden;
+        background: #1a1a2e;
+        padding: 8px;
+    }
+</style>
+
+@code {
+    [Parameter] public string Serial { get; set; } = "";
+
+    private string terminalId = $"shell-term-{Guid.NewGuid():N}";
+    private DotNetObjectReference<ShellTab>? selfRef;
+    private CancellationTokenSource? _streamCts;
+    private bool _initialized;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            selfRef = DotNetObjectReference.Create(this);
+            await JS.InvokeVoidAsync("terminalInterop.initializeInteractive", terminalId, selfRef);
+            _initialized = true;
+            Inspector.DeviceChanged += OnDeviceChanged;
+            await StartShellAsync();
+        }
+    }
+
+    private async Task StartShellAsync()
+    {
+        if (string.IsNullOrEmpty(Serial)) return;
+
+        _streamCts?.Cancel();
+        ShellService.Stop();
+
+        try
+        {
+            await ShellService.StartAsync(Serial);
+            StateHasChanged();
+            _streamCts = new CancellationTokenSource();
+            _ = ConsumeOutputAsync(_streamCts.Token);
+        }
+        catch (Exception ex)
+        {
+            if (_initialized)
+                await JS.InvokeVoidAsync("terminalInterop.writeRaw", terminalId, $"\x1b[31mError: {ex.Message}\x1b[0m\r\n");
+            StateHasChanged();
+        }
+    }
+
+    private async Task ConsumeOutputAsync(CancellationToken ct)
+    {
+        try
+        {
+            await foreach (var chunk in ShellService.OutputStreamAsync(ct))
+            {
+                await JS.InvokeVoidAsync("terminalInterop.writeRaw", terminalId, chunk);
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch (Exception ex)
+        {
+            try { await JS.InvokeVoidAsync("terminalInterop.writeRaw", terminalId, $"\r\n\x1b[31mShell disconnected: {ex.Message}\x1b[0m\r\n"); }
+            catch { }
+        }
+
+        await InvokeAsync(StateHasChanged);
+    }
+
+    [JSInvokable]
+    public async Task OnTerminalData(string command)
+    {
+        if (!ShellService.IsRunning) return;
+
+        try
+        {
+            await ShellService.SendCommandAsync(command);
+            // Small delay to let output arrive, then write prompt
+            await Task.Delay(150);
+            if (_initialized)
+                await JS.InvokeVoidAsync("terminalInterop.writePrompt", terminalId);
+        }
+        catch { }
+    }
+
+    private async Task ClearTerminal()
+    {
+        if (_initialized)
+            await JS.InvokeVoidAsync("terminalInterop.clear", terminalId);
+    }
+
+    private async Task RestartShell()
+    {
+        if (_initialized)
+            await JS.InvokeVoidAsync("terminalInterop.clear", terminalId);
+        await StartShellAsync();
+    }
+
+    private void OnDeviceChanged(string newSerial)
+    {
+        InvokeAsync(async () =>
+        {
+            if (_initialized)
+                await JS.InvokeVoidAsync("terminalInterop.clear", terminalId);
+            await StartShellAsync();
+        });
+    }
+
+    public void Dispose()
+    {
+        Inspector.DeviceChanged -= OnDeviceChanged;
+        _streamCts?.Cancel();
+        _streamCts?.Dispose();
+        ShellService.Stop();
+        try { JS.InvokeVoidAsync("terminalInterop.dispose", terminalId); } catch { }
+        selfRef?.Dispose();
+    }
+}

--- a/src/MauiSherpa/MauiProgram.cs
+++ b/src/MauiSherpa/MauiProgram.cs
@@ -63,7 +63,10 @@ public static class MauiProgram
         builder.Services.AddSingleton<IAndroidSdkSettingsService, AndroidSdkSettingsService>();
         builder.Services.AddSingleton<ILogcatService, LogcatService>();
         builder.Services.AddSingleton<IAdbDeviceWatcherService, AdbDeviceWatcherService>();
-        builder.Services.AddSingleton<LogcatPanelService>();
+        builder.Services.AddSingleton<IDeviceFileService, DeviceFileService>();
+        builder.Services.AddSingleton<IDeviceShellService, DeviceShellService>();
+        builder.Services.AddSingleton<IScreenCaptureService, ScreenCaptureService>();
+        builder.Services.AddSingleton<DeviceInspectorService>();
         builder.Services.AddSingleton<IDoctorService, DoctorService>();
         builder.Services.AddSingleton<ICopilotToolsService, CopilotToolsService>();
         builder.Services.AddSingleton<ICopilotService, CopilotService>();

--- a/src/MauiSherpa/Pages/Devices.razor
+++ b/src/MauiSherpa/Pages/Devices.razor
@@ -10,7 +10,7 @@
 @inject IAlertService AlertService
 @inject IDialogService DialogService
 @inject IFileSystemService FileSystem
-@inject LogcatPanelService LogcatPanel
+@inject DeviceInspectorService DeviceInspector
 @inject BlazorToastService ToastService
 @implements IDisposable
 
@@ -91,8 +91,11 @@
                     </div>
                 </div>
                 <div class="device-actions">
-                    <button class="btn btn-info btn-sm" @onclick="@(() => LogcatPanel.Open(device.Serial, device.Model ?? device.Serial))">
+                    <button class="btn btn-info btn-sm" @onclick="@(() => DeviceInspector.Open(device.Serial, device.Model ?? device.Serial))">
                         <i class="fas fa-scroll"></i> Logcat
+                    </button>
+                    <button class="btn btn-secondary btn-sm" @onclick="@(() => DeviceInspector.Open(device.Serial, device.Model ?? device.Serial, InspectorTab.Files))">
+                        <i class="fas fa-folder-open"></i> Inspect
                     </button>
                     @if (device.IsEmulator)
                     {

--- a/src/MauiSherpa/Services/LogcatPanelService.cs
+++ b/src/MauiSherpa/Services/LogcatPanelService.cs
@@ -1,20 +1,24 @@
 namespace MauiSherpa.Services;
 
-public class LogcatPanelService
+public enum InspectorTab { Logcat, Files, Shell, Capture }
+
+public class DeviceInspectorService
 {
     public bool IsOpen { get; private set; }
     public bool IsMinimized { get; private set; }
     public string? ActiveSerial { get; private set; }
     public string? ActiveDeviceName { get; private set; }
+    public InspectorTab ActiveTab { get; private set; } = InspectorTab.Logcat;
 
     public event Action? StateChanged;
     public event Action<string>? DeviceChanged;
 
-    public void Open(string serial, string? deviceName = null)
+    public void Open(string serial, string? deviceName = null, InspectorTab tab = InspectorTab.Logcat)
     {
         var switchingDevice = IsOpen && ActiveSerial != serial;
         ActiveSerial = serial;
         ActiveDeviceName = deviceName ?? serial;
+        ActiveTab = tab;
         IsOpen = true;
         IsMinimized = false;
         StateChanged?.Invoke();
@@ -29,6 +33,13 @@ public class LogcatPanelService
         ActiveDeviceName = deviceName ?? serial;
         StateChanged?.Invoke();
         DeviceChanged?.Invoke(serial);
+    }
+
+    public void SetTab(InspectorTab tab)
+    {
+        if (ActiveTab == tab) return;
+        ActiveTab = tab;
+        StateChanged?.Invoke();
     }
 
     public void Minimize()


### PR DESCRIPTION
Introduce a Device Inspector feature: add core interfaces (DeviceFileEntry, IDeviceFileService, IDeviceShellService, IScreenCaptureService) and implementations (DeviceFileService, DeviceShellService, ScreenCaptureService) to list/pull/push/delete files, run an interactive shell, and capture/record the device screen. Add Blazor components FileExplorerTab, ShellTab and ScreenCaptureTab and update LogcatPanel to host an inspector tab strip with device selection, routing between Logcat/Files/Shell/Capture, and related UI/styling. Wire up device watcher and inspector interactions (device switching, event handling) and update LogcatContent to use the inspector service. Also include supporting changes to terminal JS and panel services to enable interactive terminal streaming and device selection handling.