### PR TITLE
Add 'Open in Finder/Explorer' action

### DIFF
--- a/src/MauiSherpa/Pages/AppleSimulators.razor
+++ b/src/MauiSherpa/Pages/AppleSimulators.razor
@@ -12,6 +12,7 @@
 @inject BlazorToastService ToastService
 @inject SimInspectorService SimInspector
 @inject IPhysicalDeviceService PhysicalDeviceService
+@inject IPlatformService Platform
 
 <h1><i class="fas fa-tablet-screen-button"></i> iOS Devices</h1>
 
@@ -223,6 +224,10 @@ else
                         @if (openDropdownId == sim.Udid)
                         {
                             <div class="sim-dropdown-menu">
+                                <button class="sim-dropdown-item" @onclick="@(() => { CloseDropdown(); OpenSimulatorDirectory(sim); })">
+                                    <i class="fas fa-folder-open"></i> Open in @(Platform.IsMacCatalyst ? "Finder" : "Explorer")
+                                </button>
+                                <div class="sim-dropdown-divider"></div>
                                 <button class="sim-dropdown-item" @onclick="@(() => { CloseDropdown(); CloneSimulator(sim); })" disabled="@(isLoading || isBooting)">
                                     <i class="fas fa-clone"></i> Clone
                                 </button>
@@ -1053,6 +1058,12 @@ else
     {
         await DialogService.CopyToClipboardAsync(text);
         await AlertService.ShowToastAsync("Copied to clipboard");
+    }
+
+    private void OpenSimulatorDirectory(SimulatorDevice sim)
+    {
+        var path = SimulatorService.GetSimulatorDataPath(sim.Udid);
+        FileSystem.RevealInFileManager(path);
     }
 
     private void ToggleDropdown(string udid)


### PR DESCRIPTION
Inject IPlatformService and add an "Open in Finder/Explorer" button to the simulator dropdown. The new button closes the dropdown then calls OpenSimulatorDirectory, which resolves the simulator data path via SimulatorService.GetSimulatorDataPath and reveals it using FileSystem.RevealInFileManager. Uses Platform.IsMacCatalyst to choose the label (Finder vs Explorer) and adds a divider before the existing Clone action.
