### PR TITLE
Fix Windows publish per official MAUI docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -310,17 +310,16 @@ jobs:
           dotnet publish src/MauiSherpa/MauiSherpa.csproj `
             -f net10.0-windows10.0.19041.0 `
             -c Release `
+            -p:RuntimeIdentifierOverride=win-x64 `
             -p:WindowsPackageType=None `
-            -p:SelfContained=true `
-            -p:PublishTrimmed=false `
+            -p:WindowsAppSDKSelfContained=true `
             -p:AppVersion=${{ steps.version.outputs.app_version }} `
             -p:AppCommitSha=${{ steps.version.outputs.commit_sha }}
 
       - name: Create ZIP archive
         run: |
-          $publishDir = "src/MauiSherpa/bin/Release/net10.0-windows10.0.19041.0/win10-x64/publish"
+          $publishDir = "src/MauiSherpa/bin/Release/net10.0-windows10.0.19041.0/win-x64/publish"
           if (-not (Test-Path $publishDir)) {
-            # Fallback: find the publish output
             $publishDir = Get-ChildItem -Path "src/MauiSherpa/bin/Release" -Filter "publish" -Recurse -Directory | Select-Object -First 1 -ExpandProperty FullName
           }
           New-Item -ItemType Directory -Force -Path ./artifacts | Out-Null

--- a/src/MauiSherpa/MauiSherpa.csproj
+++ b/src/MauiSherpa/MauiSherpa.csproj
@@ -34,6 +34,11 @@
     <CodeSignEntitlements>Platforms/MacCatalyst/Entitlements.Debug.plist</CodeSignEntitlements>
   </PropertyGroup>
 
+  <!-- Workaround for WindowsAppSDK Issue #3337 -->
+  <PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows' and '$(RuntimeIdentifierOverride)' != ''">
+    <RuntimeIdentifier>$(RuntimeIdentifierOverride)</RuntimeIdentifier>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Blazorise.Icons.FontAwesome" Version="1.7.2" />
     <PackageReference Include="Microsoft.AspNetCore.Components.QuickGrid" Version="10.0.1" />


### PR DESCRIPTION
Fixes the Windows publish command to follow the [official .NET MAUI unpackaged deployment docs](https://learn.microsoft.com/en-us/dotnet/maui/windows/deployment/publish-unpackaged-cli?view=net-maui-10.0):

- Add `RuntimeIdentifierOverride` property group to csproj (workaround for [WindowsAppSDK #3337](https://github.com/microsoft/WindowsAppSDK/issues/3337))
- Use `-p:RuntimeIdentifierOverride=win-x64` (not `win10-x64`, which is no longer supported in .NET 10)
- Use `-p:WindowsAppSDKSelfContained=true` (the correct property for self-contained Windows App SDK apps)
- Fix expected publish output path to `win-x64/publish`