### PR TITLE
Fix: dotnet not found when fixing workloads from Doctor page

### DIFF
--- a/src/MauiSherpa.Core/Interfaces.cs
+++ b/src/MauiSherpa.Core/Interfaces.cs
@@ -1085,6 +1085,12 @@ public interface IDoctorService
     /// Installs or updates workloads to a specific workload set version.
     /// </summary>
     Task<bool> UpdateWorkloadsAsync(string workloadSetVersion, IProgress<string>? progress = null);
+
+    /// <summary>
+    /// Resolves the full path to the dotnet executable.
+    /// GUI apps on macOS don't inherit the user's shell PATH, so bare "dotnet" won't resolve.
+    /// </summary>
+    string GetDotNetExecutablePath();
 }
 
 // ============================================================================

--- a/src/MauiSherpa/Pages/Doctor.razor
+++ b/src/MauiSherpa/Pages/Doctor.razor
@@ -885,10 +885,11 @@ else
 
         if (dep.Category == DependencyCategory.Workload && !string.IsNullOrEmpty(dep.FixAction))
         {
-            // e.g., "dotnet workload install maui"
+            // e.g., "dotnet workload install maui" — resolve full dotnet path for GUI apps
             var parts = dep.FixAction.Split(' ', 2);
+            var command = parts[0] == "dotnet" ? DoctorService.GetDotNetExecutablePath() : parts[0];
             request = new ProcessRequest(
-                Command: parts[0],
+                Command: command,
                 Arguments: parts.Length > 1 ? parts[1].Split(' ') : Array.Empty<string>(),
                 RequiresElevation: true,
                 ElevationPrompt: $"Install {dep.Name}",
@@ -1010,9 +1011,10 @@ else
     {
         if (version == report?.InstalledWorkloadSetVersion) return;
 
-        // Build the workload update command
+        // Build the workload update command using full path (GUI apps may not have dotnet on PATH)
+        var dotnetPath = DoctorService.GetDotNetExecutablePath();
         var request = new ProcessRequest(
-            Command: "dotnet",
+            Command: dotnetPath,
             Arguments: new[] { "workload", "update", "--version", version },
             RequiresElevation: true,
             ElevationPrompt: "Install .NET Workloads",


### PR DESCRIPTION
## Problem

On macOS, GUI apps launched from Finder or Dock don't inherit the user's shell PATH environment. When the Doctor page tries to fix a workload version mismatch, it spawns a process with bare `dotnet` as the command, which fails because `/usr/local/share/dotnet` isn't on PATH in the app's process context.

This shows up as a "command not found" error in the CLI popup modal (see #61).

## Fix

- Added `ResolveDotNetExecutable()` helper to `DoctorService` that uses the existing `LocalSdkService.GetDotNetSdkPath()` to resolve the full path (e.g. `/usr/local/share/dotnet/dotnet`), with a fallback to bare `dotnet` if the SDK path can't be determined
- Exposed it via `IDoctorService.GetDotNetExecutablePath()` so `Doctor.razor` can use it for `ProcessRequest` commands
- Fixed all three code paths that spawn dotnet processes:
  - `DoctorService.UpdateWorkloadsAsync()` — internal process execution
  - `Doctor.razor UpdateToVersion()` — workload version update modal
  - `Doctor.razor FixDependency()` — general workload fix action splitting

Fixes #61