### PR TITLE
Add Push Projects feature and backup support

### DIFF
--- a/src/MauiSherpa.Core/Services/PushProjectService.cs
+++ b/src/MauiSherpa.Core/Services/PushProjectService.cs
@@ -1,0 +1,233 @@
+using System.Text.Json;
+using MauiSherpa.Core.Interfaces;
+
+namespace MauiSherpa.Core.Services;
+
+public class PushProjectService : IPushProjectService
+{
+    private readonly IFileSystemService _fileSystem;
+    private readonly IEncryptedSettingsService _settingsService;
+    private readonly ILoggingService _logger;
+    private readonly string _storagePath;
+    private List<PushProject>? _projects;
+    private const int MaxHistoryEntries = 50;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    public event Action? OnProjectsChanged;
+
+    public PushProjectService(
+        IFileSystemService fileSystem,
+        IEncryptedSettingsService settingsService,
+        ILoggingService logger)
+    {
+        _fileSystem = fileSystem;
+        _settingsService = settingsService;
+        _logger = logger;
+        _storagePath = Path.Combine(
+            AppDataPath.GetAppDataDirectory(),
+            "push-projects.json");
+    }
+
+    public async Task<IReadOnlyList<PushProject>> GetProjectsAsync(PushProjectPlatform? platform = null)
+    {
+        await LoadProjectsAsync();
+        var results = platform.HasValue
+            ? _projects!.Where(p => p.Platform == platform.Value).ToList()
+            : _projects!.ToList();
+        return results.OrderByDescending(p => p.LastModified).ToList().AsReadOnly();
+    }
+
+    public async Task<PushProject?> GetProjectAsync(string id)
+    {
+        await LoadProjectsAsync();
+        return _projects!.FirstOrDefault(p => p.Id == id);
+    }
+
+    public async Task SaveProjectAsync(PushProject project)
+    {
+        await LoadProjectsAsync();
+        var index = _projects!.FindIndex(p => p.Id == project.Id);
+        var updated = project with { LastModified = DateTime.UtcNow };
+
+        if (index >= 0)
+            _projects[index] = updated;
+        else
+            _projects.Add(updated);
+
+        await PersistProjectsAsync();
+        OnProjectsChanged?.Invoke();
+    }
+
+    public async Task DeleteProjectAsync(string id)
+    {
+        await LoadProjectsAsync();
+        _projects!.RemoveAll(p => p.Id == id);
+        await PersistProjectsAsync();
+        OnProjectsChanged?.Invoke();
+    }
+
+    public async Task<PushProject> DuplicateProjectAsync(string id)
+    {
+        await LoadProjectsAsync();
+        var source = _projects!.FirstOrDefault(p => p.Id == id)
+            ?? throw new InvalidOperationException($"Project {id} not found");
+
+        var copy = source with
+        {
+            Id = Guid.NewGuid().ToString(),
+            Name = source.Name + " (Copy)",
+            History = new List<PushSendHistoryEntry>(),
+            CreatedAt = DateTime.UtcNow,
+            LastModified = DateTime.UtcNow
+        };
+
+        _projects.Add(copy);
+        await PersistProjectsAsync();
+        OnProjectsChanged?.Invoke();
+        return copy;
+    }
+
+    public async Task AddHistoryEntryAsync(string projectId, PushSendHistoryEntry entry)
+    {
+        await LoadProjectsAsync();
+        var project = _projects!.FirstOrDefault(p => p.Id == projectId);
+        if (project == null) return;
+
+        var history = new List<PushSendHistoryEntry> { entry };
+        history.AddRange(project.History);
+        if (history.Count > MaxHistoryEntries)
+            history = history.Take(MaxHistoryEntries).ToList();
+
+        var index = _projects.FindIndex(p => p.Id == projectId);
+        _projects[index] = project with { History = history, LastModified = DateTime.UtcNow };
+        await PersistProjectsAsync();
+        OnProjectsChanged?.Invoke();
+    }
+
+    public async Task ClearHistoryAsync(string projectId)
+    {
+        await LoadProjectsAsync();
+        var project = _projects!.FirstOrDefault(p => p.Id == projectId);
+        if (project == null) return;
+
+        var index = _projects.FindIndex(p => p.Id == projectId);
+        _projects[index] = project with { History = new List<PushSendHistoryEntry>(), LastModified = DateTime.UtcNow };
+        await PersistProjectsAsync();
+        OnProjectsChanged?.Invoke();
+    }
+
+    public async Task<PushProject?> MigrateFromLegacyAsync()
+    {
+        try
+        {
+            await LoadProjectsAsync();
+
+            // Only migrate if no APNs projects exist yet
+            if (_projects!.Any(p => p.Platform == PushProjectPlatform.Apns))
+                return null;
+
+            var settings = await _settingsService.GetSettingsAsync();
+            var legacy = settings.PushTesting;
+
+            // Check if legacy settings have non-default values
+            var defaultSettings = new PushTestingSettings();
+            if (legacy.AuthMode == defaultSettings.AuthMode &&
+                legacy.SelectedIdentityId == defaultSettings.SelectedIdentityId &&
+                legacy.P8FilePath == defaultSettings.P8FilePath &&
+                legacy.TeamId == defaultSettings.TeamId &&
+                legacy.BundleId == defaultSettings.BundleId &&
+                legacy.DeviceToken == defaultSettings.DeviceToken &&
+                legacy.JsonPayload == defaultSettings.JsonPayload)
+            {
+                return null;
+            }
+
+            var project = new PushProject
+            {
+                Id = Guid.NewGuid().ToString(),
+                Name = "Migrated APNs Config",
+                Platform = PushProjectPlatform.Apns,
+                ApnsConfig = new ApnsPushProjectConfig
+                {
+                    AuthMode = legacy.AuthMode,
+                    SelectedIdentityId = legacy.SelectedIdentityId,
+                    P8FilePath = legacy.P8FilePath,
+                    P8KeyId = legacy.P8KeyId,
+                    TeamId = legacy.TeamId,
+                    PushType = legacy.PushType,
+                    Priority = legacy.Priority,
+                    CollapseId = legacy.CollapseId,
+                    NotificationId = legacy.NotificationId,
+                    ExpirationSeconds = legacy.ExpirationSeconds,
+                    BundleId = legacy.BundleId,
+                    DeviceToken = legacy.DeviceToken,
+                    JsonPayload = legacy.JsonPayload,
+                    UseSandbox = legacy.UseSandbox
+                },
+                CreatedAt = DateTime.UtcNow,
+                LastModified = DateTime.UtcNow
+            };
+
+            _projects.Add(project);
+            await PersistProjectsAsync();
+
+            // Clear legacy settings
+            await _settingsService.UpdateSettingsAsync(s => s with { PushTesting = new PushTestingSettings() });
+
+            _logger.LogInformation("Migrated legacy APNs push settings to push project");
+            OnProjectsChanged?.Invoke();
+            return project;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"Failed to migrate legacy push settings: {ex.Message}", ex);
+            return null;
+        }
+    }
+
+    private async Task LoadProjectsAsync()
+    {
+        if (_projects != null) return;
+
+        try
+        {
+            if (await _fileSystem.FileExistsAsync(_storagePath))
+            {
+                var json = await _fileSystem.ReadFileAsync(_storagePath);
+                if (!string.IsNullOrEmpty(json))
+                {
+                    _projects = JsonSerializer.Deserialize<List<PushProject>>(json, JsonOptions) ?? new();
+                    return;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"Failed to load push projects: {ex.Message}", ex);
+        }
+
+        _projects = new List<PushProject>();
+    }
+
+    private async Task PersistProjectsAsync()
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(_storagePath)!;
+            if (!await _fileSystem.DirectoryExistsAsync(dir))
+                await _fileSystem.CreateDirectoryAsync(dir);
+
+            var json = JsonSerializer.Serialize(_projects, JsonOptions);
+            await _fileSystem.WriteFileAsync(_storagePath, json);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"Failed to persist push projects: {ex.Message}", ex);
+        }
+    }
+}

--- a/src/MauiSherpa.MacOS/MacOSMauiProgram.cs
+++ b/src/MauiSherpa.MacOS/MacOSMauiProgram.cs
@@ -107,6 +107,7 @@ public static class MacOSMauiProgram
         builder.Services.AddSingleton<IAppleConnectService, AppleConnectService>();
         builder.Services.AddSingleton<IAppleRootCertService, AppleRootCertService>();
         builder.Services.AddSingleton<IApnsPushService, ApnsPushService>();
+        builder.Services.AddSingleton<IPushProjectService, PushProjectService>();
         builder.Services.AddSingleton<ILocalCertificateService>(sp =>
         {
             var logger = sp.GetRequiredService<ILoggingService>();

--- a/src/MauiSherpa.MacOS/MauiSherpa.MacOS.csproj
+++ b/src/MauiSherpa.MacOS/MauiSherpa.MacOS.csproj
@@ -26,9 +26,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Platform.Maui.MacOS" Version="0.2.0-beta.11" />
-    <PackageReference Include="Platform.Maui.MacOS.BlazorWebView" Version="0.2.0-beta.11" />
-    <PackageReference Include="Platform.Maui.MacOS.Essentials" Version="0.2.0-beta.11" />
+    <PackageReference Include="Platform.Maui.MacOS" Version="0.2.0-beta.12" />
+    <PackageReference Include="Platform.Maui.MacOS.BlazorWebView" Version="0.2.0-beta.12" />
+    <PackageReference Include="Platform.Maui.MacOS.Essentials" Version="0.2.0-beta.12" />
     <PackageReference Include="Blazorise.Icons.FontAwesome" Version="1.7.2" />
     <PackageReference Include="Microsoft.AspNetCore.Components.QuickGrid" Version="10.0.1" />
     <PackageReference Include="Markdig" Version="0.44.0" />

--- a/src/MauiSherpa/Components/PushProjectBar.razor
+++ b/src/MauiSherpa/Components/PushProjectBar.razor
@@ -1,0 +1,380 @@
+@using MauiSherpa.Core.Interfaces
+@using MauiSherpa.Services
+@inject IPushProjectService ProjectService
+@inject IAlertService AlertService
+@inject BlazorToastService ToastService
+@implements IDisposable
+
+<div class="project-bar">
+    <div class="project-bar-row">
+        <div class="project-selector">
+            <label><i class="fas fa-folder-open"></i> Project:</label>
+            <select value="@selectedProjectId" @onchange="OnProjectDropdownChanged">
+                <option value="__new__">+ New Project</option>
+                @foreach (var project in projects)
+                {
+                    <option value="@project.Id">@project.Name</option>
+                }
+            </select>
+        </div>
+
+        <div class="project-name-group">
+            <input type="text" class="project-name-input" placeholder="Project name"
+                   value="@projectName"
+                   @oninput="OnNameInput" />
+        </div>
+
+        <div class="project-actions">
+            <button class="btn btn-sm @(IsDirty ? "btn-save-dirty" : "btn-save")" @onclick="HandleSave" title="Save project">
+                <i class="fas fa-save"></i> Save
+            </button>
+            <button class="btn btn-sm btn-ghost" @onclick="HandleDuplicate" disabled="@(ActiveProject == null)" title="Duplicate project">
+                <i class="fas fa-copy"></i>
+            </button>
+            <button class="btn btn-sm btn-ghost btn-danger-ghost" @onclick="HandleDelete" disabled="@(ActiveProject == null)" title="Delete project">
+                <i class="fas fa-trash-alt"></i>
+            </button>
+        </div>
+    </div>
+
+    @if (showDescription)
+    {
+        <div class="project-description-row">
+            <input type="text" class="project-description-input" placeholder="Description (optional)"
+                   value="@projectDescription"
+                   @oninput="OnDescriptionInput" />
+        </div>
+    }
+
+    <button class="description-toggle" @onclick="() => showDescription = !showDescription">
+        <i class="fas @(showDescription ? "fa-chevron-up" : "fa-chevron-down")"></i>
+        @(showDescription ? "Hide description" : "Description")
+    </button>
+</div>
+
+<style>
+    .project-bar {
+        background: var(--bg-tertiary);
+        border: 1px solid var(--border-color);
+        border-radius: 10px;
+        padding: 0.75rem 1rem;
+        margin-bottom: 1rem;
+    }
+
+    .project-bar-row {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+    }
+
+    .project-selector {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        flex-shrink: 0;
+    }
+
+    .project-selector label {
+        font-weight: 500;
+        font-size: 0.8125rem;
+        color: var(--text-secondary);
+        white-space: nowrap;
+        display: flex;
+        align-items: center;
+        gap: 0.375rem;
+    }
+
+    .project-selector select {
+        max-width: 220px;
+        padding: 0.375rem 0.625rem;
+        border: 1px solid var(--border-color);
+        border-radius: 6px;
+        font-size: 0.8125rem;
+        background: var(--card-bg);
+        color: var(--text-primary);
+    }
+
+    .project-selector select:focus {
+        outline: none;
+        border-color: var(--accent-primary);
+    }
+
+    .project-name-group {
+        flex: 1;
+        min-width: 150px;
+    }
+
+    .project-name-input {
+        width: 100%;
+        padding: 0.375rem 0.625rem;
+        border: 1px solid var(--border-color);
+        border-radius: 6px;
+        font-size: 0.8125rem;
+        background: var(--card-bg);
+        color: var(--text-primary);
+        box-sizing: border-box;
+    }
+
+    .project-name-input:focus {
+        outline: none;
+        border-color: var(--accent-primary);
+    }
+
+    .project-actions {
+        display: flex;
+        gap: 0.25rem;
+        flex-shrink: 0;
+    }
+
+    .project-description-row {
+        margin-top: 0.5rem;
+    }
+
+    .project-description-input {
+        width: 100%;
+        padding: 0.375rem 0.625rem;
+        border: 1px solid var(--border-color);
+        border-radius: 6px;
+        font-size: 0.8125rem;
+        background: var(--card-bg);
+        color: var(--text-primary);
+        box-sizing: border-box;
+    }
+
+    .project-description-input:focus {
+        outline: none;
+        border-color: var(--accent-primary);
+    }
+
+    .description-toggle {
+        background: none;
+        border: none;
+        color: var(--text-muted);
+        font-size: 0.6875rem;
+        cursor: pointer;
+        padding: 0.25rem 0;
+        display: flex;
+        align-items: center;
+        gap: 0.25rem;
+        margin-top: 0.25rem;
+    }
+
+    .description-toggle:hover {
+        color: var(--text-secondary);
+    }
+
+    .btn-sm {
+        padding: 0.3rem 0.625rem;
+        font-size: 0.75rem;
+        border: none;
+        border-radius: 5px;
+        cursor: pointer;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.25rem;
+        transition: all 0.15s ease;
+    }
+
+    .btn-sm:disabled {
+        opacity: 0.4;
+        cursor: not-allowed;
+    }
+
+    .btn-save {
+        background: var(--bg-hover);
+        color: var(--text-secondary);
+    }
+
+    .btn-save:hover:not(:disabled) {
+        background: var(--accent-primary);
+        color: white;
+    }
+
+    .btn-save-dirty {
+        background: var(--accent-primary);
+        color: white;
+        animation: pulse-save 2s ease-in-out infinite;
+    }
+
+    @@keyframes pulse-save {
+        0%, 100% { box-shadow: 0 0 0 0 rgba(66, 153, 225, 0.4); }
+        50% { box-shadow: 0 0 0 4px rgba(66, 153, 225, 0); }
+    }
+
+    .btn-ghost {
+        background: transparent;
+        color: var(--text-secondary);
+    }
+
+    .btn-ghost:hover:not(:disabled) {
+        background: var(--bg-hover);
+        color: var(--text-primary);
+    }
+
+    .btn-danger-ghost:hover:not(:disabled) {
+        background: rgba(239, 68, 68, 0.1);
+        color: var(--danger, #ef4444);
+    }
+</style>
+
+@code {
+    [Parameter] public PushProjectPlatform Platform { get; set; }
+    [Parameter] public PushProject? ActiveProject { get; set; }
+    [Parameter] public EventCallback<PushProject?> ActiveProjectChanged { get; set; }
+    [Parameter] public EventCallback OnSaveRequested { get; set; }
+    [Parameter] public bool IsDirty { get; set; }
+
+    private List<PushProject> projects = new();
+    private string selectedProjectId = "__new__";
+    private string projectName = "";
+    private string projectDescription = "";
+    private bool showDescription;
+
+    protected override async Task OnInitializedAsync()
+    {
+        ProjectService.OnProjectsChanged += OnProjectsChanged;
+        await LoadProjects();
+    }
+
+    protected override void OnParametersSet()
+    {
+        if (ActiveProject != null)
+        {
+            selectedProjectId = ActiveProject.Id;
+            projectName = ActiveProject.Name;
+            projectDescription = ActiveProject.Description ?? "";
+            if (!string.IsNullOrEmpty(projectDescription))
+                showDescription = true;
+        }
+        else
+        {
+            selectedProjectId = "__new__";
+            if (string.IsNullOrEmpty(projectName))
+                projectName = "Untitled";
+        }
+    }
+
+    private async Task LoadProjects()
+    {
+        projects = (await ProjectService.GetProjectsAsync(Platform)).ToList();
+    }
+
+    private async Task OnProjectDropdownChanged(ChangeEventArgs e)
+    {
+        var value = e.Value?.ToString() ?? "__new__";
+
+        if (IsDirty)
+        {
+            var discard = await AlertService.ShowConfirmAsync(
+                "Unsaved Changes",
+                "You have unsaved changes. Discard them?",
+                "Discard", "Cancel");
+            if (!discard) return;
+        }
+
+        if (value == "__new__")
+        {
+            await ActiveProjectChanged.InvokeAsync(null);
+            projectName = "Untitled";
+            projectDescription = "";
+        }
+        else
+        {
+            var project = projects.FirstOrDefault(p => p.Id == value);
+            if (project != null)
+            {
+                await ActiveProjectChanged.InvokeAsync(project);
+                projectName = project.Name;
+                projectDescription = project.Description ?? "";
+            }
+        }
+    }
+
+    private void OnNameInput(ChangeEventArgs e)
+    {
+        projectName = e.Value?.ToString() ?? "";
+    }
+
+    private void OnDescriptionInput(ChangeEventArgs e)
+    {
+        projectDescription = e.Value?.ToString() ?? "";
+    }
+
+    public string GetProjectName() => projectName;
+    public string? GetProjectDescription() => string.IsNullOrWhiteSpace(projectDescription) ? null : projectDescription;
+
+    private async Task HandleSave()
+    {
+        if (string.IsNullOrWhiteSpace(projectName))
+        {
+            ToastService.Show("Project name is required.", ToastType.Warning);
+            return;
+        }
+
+        await OnSaveRequested.InvokeAsync();
+        await LoadProjects();
+    }
+
+    private async Task HandleDuplicate()
+    {
+        if (ActiveProject == null) return;
+
+        try
+        {
+            var copy = await ProjectService.DuplicateProjectAsync(ActiveProject.Id);
+            await LoadProjects();
+            await ActiveProjectChanged.InvokeAsync(copy);
+            projectName = copy.Name;
+            projectDescription = copy.Description ?? "";
+            ToastService.Show("Project duplicated.", ToastType.Success);
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Failed to duplicate: {ex.Message}", ToastType.Error);
+        }
+    }
+
+    private async Task HandleDelete()
+    {
+        if (ActiveProject == null) return;
+
+        var confirm = await AlertService.ShowConfirmAsync(
+            "Delete Project",
+            $"Delete \"{ActiveProject.Name}\"? This cannot be undone.",
+            "Delete", "Cancel");
+        if (!confirm) return;
+
+        await ProjectService.DeleteProjectAsync(ActiveProject.Id);
+        await LoadProjects();
+
+        if (projects.Count > 0)
+        {
+            await ActiveProjectChanged.InvokeAsync(projects[0]);
+            projectName = projects[0].Name;
+            projectDescription = projects[0].Description ?? "";
+        }
+        else
+        {
+            await ActiveProjectChanged.InvokeAsync(null);
+            projectName = "Untitled";
+            projectDescription = "";
+        }
+
+        ToastService.Show("Project deleted.", ToastType.Success);
+    }
+
+    private void OnProjectsChanged()
+    {
+        InvokeAsync(async () =>
+        {
+            await LoadProjects();
+            StateHasChanged();
+        });
+    }
+
+    public void Dispose()
+    {
+        ProjectService.OnProjectsChanged -= OnProjectsChanged;
+    }
+}

--- a/src/MauiSherpa/MauiProgram.cs
+++ b/src/MauiSherpa/MauiProgram.cs
@@ -96,6 +96,7 @@ public static class MauiProgram
         builder.Services.AddSingleton<IAppleConnectService, AppleConnectService>();
         builder.Services.AddSingleton<IAppleRootCertService, AppleRootCertService>();
         builder.Services.AddSingleton<IApnsPushService, ApnsPushService>();
+        builder.Services.AddSingleton<IPushProjectService, PushProjectService>();
         builder.Services.AddSingleton<ILocalCertificateService>(sp =>
         {
             var logger = sp.GetRequiredService<ILoggingService>();

--- a/src/MauiSherpa/Pages/FirebasePush.razor
+++ b/src/MauiSherpa/Pages/FirebasePush.razor
@@ -5,6 +5,7 @@
 @inject IFirebasePushService PushService
 @inject IGoogleIdentityService GoogleIdentityService
 @inject IGoogleIdentityStateService GoogleIdentityState
+@inject IPushProjectService ProjectService
 @inject IAlertService AlertService
 @inject IDialogService DialogService
 @inject IFileSystemService FileSystem
@@ -15,6 +16,13 @@
 <h1><i class="fas fa-paper-plane"></i> Firebase Push Testing</h1>
 <p class="page-description">Send test push notifications via Firebase Cloud Messaging to Android devices.</p>
 
+<PushProjectBar @ref="projectBar"
+    Platform="PushProjectPlatform.Fcm"
+    ActiveProject="activeProject"
+    ActiveProjectChanged="OnActiveProjectChanged"
+    OnSaveRequested="SaveProject"
+    IsDirty="isDirty" />
+
 <GoogleIdentityPicker />
 
 <!-- Compose Section -->
@@ -22,10 +30,10 @@
     <div class="section-header">
         <h2><i class="fas fa-edit"></i> Compose Message</h2>
         <div class="target-toggle">
-            <button class="toggle-btn small @(!rawJsonMode ? "active" : "")" @onclick="() => rawJsonMode = false">
+            <button class="toggle-btn small @(!rawJsonMode ? "active" : "")" @onclick="() => { rawJsonMode = false; MarkDirty(); }">
                 <i class="fas fa-list-alt"></i> Form
             </button>
-            <button class="toggle-btn small @(rawJsonMode ? "active" : "")" @onclick="() => rawJsonMode = true">
+            <button class="toggle-btn small @(rawJsonMode ? "active" : "")" @onclick="() => { rawJsonMode = true; MarkDirty(); }">
                 <i class="fas fa-code"></i> JSON
             </button>
         </div>
@@ -37,7 +45,7 @@
             <div class="form-group">
                 <label>Message JSON</label>
                 <textarea class="form-input mono json-editor" rows="16" placeholder="@jsonPlaceholder"
-                          @bind="rawJson" @bind:event="oninput"></textarea>
+                          @bind="rawJson" @bind:event="oninput" @bind:after="MarkDirty"></textarea>
                 <p class="help-text">Enter the FCM v1 <code>message</code> object. The <code>{"{"}"message": ...{"}"}</code> wrapper is added automatically if omitted.</p>
             </div>
 
@@ -62,10 +70,10 @@
         <div class="form-group">
             <label>Target</label>
             <div class="target-toggle">
-                <button class="toggle-btn small @(useToken ? "active" : "")" @onclick="() => useToken = true">
+                <button class="toggle-btn small @(useToken ? "active" : "")" @onclick="() => { useToken = true; MarkDirty(); }">
                     <i class="fas fa-mobile-alt"></i> Device Token
                 </button>
-                <button class="toggle-btn small @(!useToken ? "active" : "")" @onclick="() => useToken = false">
+                <button class="toggle-btn small @(!useToken ? "active" : "")" @onclick="() => { useToken = false; MarkDirty(); }">
                     <i class="fas fa-hashtag"></i> Topic
                 </button>
             </div>
@@ -76,7 +84,7 @@
             <div class="form-group">
                 <label>Device Token</label>
                 <input type="text" class="form-input mono" placeholder="FCM registration token"
-                       @bind="deviceToken" @bind:event="oninput" />
+                       @bind="deviceToken" @bind:event="oninput" @bind:after="MarkDirty" />
             </div>
         }
         else
@@ -84,7 +92,7 @@
             <div class="form-group">
                 <label>Topic</label>
                 <input type="text" class="form-input" placeholder="e.g. news, updates"
-                       @bind="topic" @bind:event="oninput" />
+                       @bind="topic" @bind:event="oninput" @bind:after="MarkDirty" />
             </div>
         }
 
@@ -92,20 +100,20 @@
             <div class="form-group flex-1">
                 <label>Title</label>
                 <input type="text" class="form-input" placeholder="Notification title"
-                       @bind="title" @bind:event="oninput" />
+                       @bind="title" @bind:event="oninput" @bind:after="MarkDirty" />
             </div>
         </div>
 
         <div class="form-group">
             <label>Body</label>
             <textarea class="form-input" rows="3" placeholder="Notification body text"
-                      @bind="body" @bind:event="oninput"></textarea>
+                      @bind="body" @bind:event="oninput" @bind:after="MarkDirty"></textarea>
         </div>
 
         <div class="form-group">
             <label>Image URL <span class="optional">(optional)</span></label>
             <input type="text" class="form-input" placeholder="https://example.com/image.png"
-                   @bind="imageUrl" @bind:event="oninput" />
+                   @bind="imageUrl" @bind:event="oninput" @bind:after="MarkDirty" />
         </div>
 
         <!-- Data Payload -->
@@ -125,11 +133,11 @@
                         <div class="data-entry">
                             <input type="text" class="form-input" placeholder="Key"
                                    value="@dataEntries[index].Key"
-                                   @oninput="e => UpdateDataKey(index, e.Value?.ToString())" />
+                                   @oninput="e => { UpdateDataKey(index, e.Value?.ToString()); MarkDirty(); }" />
                             <input type="text" class="form-input" placeholder="Value"
                                    value="@dataEntries[index].Value"
-                                   @oninput="e => UpdateDataValue(index, e.Value?.ToString())" />
-                            <button class="btn btn-sm btn-icon btn-danger" @onclick="() => RemoveDataEntry(index)">
+                                   @oninput="e => { UpdateDataValue(index, e.Value?.ToString()); MarkDirty(); }" />
+                            <button class="btn btn-sm btn-icon btn-danger" @onclick="() => { RemoveDataEntry(index); MarkDirty(); }">
                                 <i class="fas fa-times"></i>
                             </button>
                         </div>
@@ -156,50 +164,42 @@
         }
     </div>
 </div>
-@if (history.Count > 0)
+@if (activeProject?.History.Count > 0)
 {
     <div class="section">
         <div class="section-header">
             <h2><i class="fas fa-history"></i> Recent Sends</h2>
-            <button class="btn btn-sm btn-ghost" @onclick="() => history.Clear()">
+            <button class="btn btn-sm btn-ghost" @onclick="ClearHistory">
                 <i class="fas fa-eraser"></i> Clear
             </button>
         </div>
 
         <div class="history-list">
-            @foreach (var entry in history)
+            @foreach (var entry in activeProject.History)
             {
-                <div class="history-card @(entry.Response.Success ? "success" : "error")">
+                <div class="history-card @(entry.Success ? "success" : "error")">
                     <div class="history-status">
-                        <i class="fas @(entry.Response.Success ? "fa-check-circle text-success" : "fa-times-circle text-danger")"></i>
-                        <span class="history-time">@entry.Response.Timestamp.ToLocalTime().ToString("HH:mm:ss")</span>
-                        @if (entry.Response.StatusCode.HasValue)
+                        <i class="fas @(entry.Success ? "fa-check-circle text-success" : "fa-times-circle text-danger")"></i>
+                        <span class="history-time">@entry.Timestamp.ToLocalTime().ToString("HH:mm:ss")</span>
+                        @if (entry.StatusCode.HasValue)
                         {
-                            <span class="badge @(entry.Response.Success ? "badge-success" : "badge-danger")">@entry.Response.StatusCode</span>
+                            <span class="badge @(entry.Success ? "badge-success" : "badge-danger")">@entry.StatusCode</span>
                         }
                     </div>
                     <div class="history-details">
-                        <div class="history-target mono">
-                            @if (!string.IsNullOrEmpty(entry.Request.Topic))
-                            {
-                                <span><i class="fas fa-hashtag"></i> @entry.Request.Topic</span>
-                            }
-                            else
-                            {
-                                <span><i class="fas fa-mobile-alt"></i> @TruncateToken(entry.Request.DeviceToken)</span>
-                            }
-                        </div>
-                        @if (!string.IsNullOrEmpty(entry.Request.Title))
+                        @if (!string.IsNullOrEmpty(entry.Target))
                         {
-                            <div class="history-title">@entry.Request.Title</div>
+                            <div class="history-target mono">
+                                <i class="fas fa-mobile-alt"></i> @entry.Target
+                            </div>
                         }
-                        @if (entry.Response.Success && !string.IsNullOrEmpty(entry.Response.MessageId))
+                        @if (entry.Success && !string.IsNullOrEmpty(entry.MessageId))
                         {
-                            <div class="history-message-id mono">@entry.Response.MessageId</div>
+                            <div class="history-message-id mono">@entry.MessageId</div>
                         }
-                        @if (!entry.Response.Success && !string.IsNullOrEmpty(entry.Response.Error))
+                        @if (!entry.Success && !string.IsNullOrEmpty(entry.ErrorReason))
                         {
-                            <div class="history-error">@entry.Response.Error</div>
+                            <div class="history-error">@entry.ErrorReason</div>
                         }
                     </div>
                 </div>
@@ -563,6 +563,8 @@
 </style>
 
 @code {
+    PushProjectBar? projectBar;
+    PushProject? activeProject;
     bool hasCredentials;
     string? projectId;
 
@@ -575,14 +577,12 @@
     string imageUrl = "";
     List<DataEntry> dataEntries = new();
     bool isSending;
+    bool isDirty;
 
     // Compose - JSON mode
     bool rawJsonMode;
     string rawJson = "";
     const string jsonPlaceholder = "{\n  \"token\": \"DEVICE_TOKEN\",\n  \"notification\": {\n    \"title\": \"Test\",\n    \"body\": \"Hello from Sherpa!\"\n  },\n  \"android\": {\n    \"priority\": \"high\",\n    \"notification\": {\n      \"channel_id\": \"default\"\n    }\n  },\n  \"data\": {\n    \"key\": \"value\"\n  }\n}";
-
-    // History
-    List<HistoryEntry> history = new();
 
     bool CanSend => hasCredentials
         && ((useToken && !string.IsNullOrWhiteSpace(deviceToken))
@@ -593,6 +593,12 @@
     {
         ToolbarService.ClearItems();
         GoogleIdentityState.OnSelectionChanged += OnIdentityChanged;
+
+        // Load projects and select most recent (or create blank)
+        var projects = await ProjectService.GetProjectsAsync(PushProjectPlatform.Fcm);
+        if (projects.Count > 0)
+            await LoadFromProject(projects[0]);
+
         await SyncCredentialsFromIdentity();
     }
 
@@ -624,9 +630,114 @@
         }
     }
 
-    async Task RefreshCredentialStatus()
+    async Task LoadFromProject(PushProject project)
     {
-        await SyncCredentialsFromIdentity();
+        activeProject = project;
+        var config = project.FcmConfig ?? new FcmPushProjectConfig();
+
+        useToken = config.UseToken;
+        deviceToken = config.DeviceToken ?? "";
+        topic = config.Topic ?? "";
+        title = config.Title ?? "";
+        body = config.Body ?? "";
+        imageUrl = config.ImageUrl ?? "";
+        dataEntries = config.DataEntries.Select(e => new DataEntry { Key = e.Key, Value = e.Value }).ToList();
+        rawJsonMode = config.RawJsonMode;
+        rawJson = config.RawJson ?? "";
+
+        // Restore Google identity selection
+        if (!string.IsNullOrEmpty(config.SelectedGoogleIdentityId))
+        {
+            var identity = await GoogleIdentityService.GetIdentityAsync(config.SelectedGoogleIdentityId);
+            if (identity != null)
+                GoogleIdentityState.SetSelectedIdentity(identity);
+        }
+
+        isDirty = false;
+    }
+
+    void ResetToBlank()
+    {
+        activeProject = null;
+        useToken = true;
+        deviceToken = "";
+        topic = "";
+        title = "";
+        body = "";
+        imageUrl = "";
+        dataEntries = new();
+        rawJsonMode = false;
+        rawJson = "";
+        isDirty = false;
+    }
+
+    async Task OnActiveProjectChanged(PushProject? project)
+    {
+        if (project != null)
+            await LoadFromProject(project);
+        else
+            ResetToBlank();
+
+        StateHasChanged();
+    }
+
+    void MarkDirty() => isDirty = true;
+
+    FcmPushProjectConfig BuildConfig() => new()
+    {
+        SelectedGoogleIdentityId = GoogleIdentityState.SelectedIdentity?.Id,
+        UseToken = useToken,
+        DeviceToken = string.IsNullOrEmpty(deviceToken) ? null : deviceToken,
+        Topic = string.IsNullOrEmpty(topic) ? null : topic,
+        Title = string.IsNullOrEmpty(title) ? null : title,
+        Body = string.IsNullOrEmpty(body) ? null : body,
+        ImageUrl = string.IsNullOrEmpty(imageUrl) ? null : imageUrl,
+        DataEntries = dataEntries
+            .Where(d => !string.IsNullOrWhiteSpace(d.Key))
+            .Select(d => new FcmDataEntry(d.Key, d.Value ?? ""))
+            .ToList(),
+        RawJsonMode = rawJsonMode,
+        RawJson = string.IsNullOrEmpty(rawJson) ? null : rawJson
+    };
+
+    async Task SaveProject()
+    {
+        try
+        {
+            var name = projectBar?.GetProjectName() ?? "Untitled";
+            var description = projectBar?.GetProjectDescription();
+
+            if (activeProject != null)
+            {
+                var updated = activeProject with
+                {
+                    Name = name,
+                    Description = description,
+                    FcmConfig = BuildConfig()
+                };
+                await ProjectService.SaveProjectAsync(updated);
+                activeProject = await ProjectService.GetProjectAsync(updated.Id);
+            }
+            else
+            {
+                var project = new PushProject
+                {
+                    Name = name,
+                    Description = description,
+                    Platform = PushProjectPlatform.Fcm,
+                    FcmConfig = BuildConfig()
+                };
+                await ProjectService.SaveProjectAsync(project);
+                activeProject = await ProjectService.GetProjectAsync(project.Id);
+            }
+
+            isDirty = false;
+            ToastService.Show("Project saved.", ToastType.Success);
+        }
+        catch (Exception ex)
+        {
+            ToastService.Show($"Save failed: {ex.Message}", ToastType.Error);
+        }
     }
 
     async Task SendPush()
@@ -650,7 +761,25 @@
             );
 
             var response = await PushService.SendPushAsync(request);
-            history.Insert(0, new HistoryEntry(request, response));
+
+            // Record history
+            if (activeProject != null)
+            {
+                var target = !string.IsNullOrEmpty(request.Topic)
+                    ? $"#{request.Topic}"
+                    : TruncateToken(request.DeviceToken);
+                var historyEntry = new PushSendHistoryEntry
+                {
+                    Timestamp = DateTime.UtcNow,
+                    Success = response.Success,
+                    StatusCode = response.StatusCode,
+                    MessageId = response.MessageId,
+                    ErrorReason = response.Error,
+                    Target = target
+                };
+                await ProjectService.AddHistoryEntryAsync(activeProject.Id, historyEntry);
+                activeProject = await ProjectService.GetProjectAsync(activeProject.Id);
+            }
 
             if (response.Success)
                 ToastService.Show("Push sent successfully!", ToastType.Success);
@@ -675,7 +804,22 @@
         try
         {
             var response = await PushService.SendRawJsonAsync(rawJson);
-            history.Insert(0, new HistoryEntry(new FcmPushRequest("raw-json", "Raw JSON", null), response));
+
+            // Record history
+            if (activeProject != null)
+            {
+                var historyEntry = new PushSendHistoryEntry
+                {
+                    Timestamp = DateTime.UtcNow,
+                    Success = response.Success,
+                    StatusCode = response.StatusCode,
+                    MessageId = response.MessageId,
+                    ErrorReason = response.Error,
+                    Target = "raw-json"
+                };
+                await ProjectService.AddHistoryEntryAsync(activeProject.Id, historyEntry);
+                activeProject = await ProjectService.GetProjectAsync(activeProject.Id);
+            }
 
             if (response.Success)
                 ToastService.Show("Push sent successfully!", ToastType.Success);
@@ -692,7 +836,15 @@
         }
     }
 
-    void AddDataEntry() => dataEntries.Add(new DataEntry());
+    async Task ClearHistory()
+    {
+        if (activeProject == null) return;
+        await ProjectService.ClearHistoryAsync(activeProject.Id);
+        activeProject = await ProjectService.GetProjectAsync(activeProject.Id);
+        StateHasChanged();
+    }
+
+    void AddDataEntry() { dataEntries.Add(new DataEntry()); MarkDirty(); }
     void RemoveDataEntry(int index) => dataEntries.RemoveAt(index);
     void UpdateDataKey(int index, string? value) => dataEntries[index].Key = value ?? "";
     void UpdateDataValue(int index, string? value) => dataEntries[index].Value = value ?? "";
@@ -705,8 +857,6 @@
         public string Key { get; set; } = "";
         public string Value { get; set; } = "";
     }
-
-    record HistoryEntry(FcmPushRequest Request, FcmPushResponse Response);
 
     public void Dispose()
     {

--- a/src/MauiSherpa/Pages/PushTesting.razor
+++ b/src/MauiSherpa/Pages/PushTesting.razor
@@ -4,7 +4,7 @@
 @inject IAppleIdentityService IdentityService
 @inject IApnsPushService PushService
 @inject IDialogService DialogService
-@inject IEncryptedSettingsService SettingsService
+@inject IPushProjectService ProjectService
 @inject BlazorToastService ToastService
 @inject ILoggingService Logger
 @inject IToolbarService ToolbarService
@@ -12,13 +12,20 @@
 
 <h1><i class="fas fa-paper-plane"></i> Push Testing</h1>
 
+<PushProjectBar @ref="projectBar"
+    Platform="PushProjectPlatform.Apns"
+    ActiveProject="activeProject"
+    ActiveProjectChanged="OnActiveProjectChanged"
+    OnSaveRequested="SaveProject"
+    IsDirty="isDirty" />
+
 <div class="push-layout">
     <div class="push-section">
         <div class="section-header"><i class="fas fa-key"></i> Authentication</div>
         <div class="section-body">
             <div class="form-group">
                 <label>Auth Method</label>
-                <select @bind="authMode" @bind:after="OnAuthModeChanged">
+                <select @bind="authMode" @bind:after="MarkDirty">
                     <option value="identity">Stored Apple Identity</option>
                     <option value="p8file">.p8 File from Filesystem</option>
                 </select>
@@ -34,7 +41,7 @@
                     }
                     else
                     {
-                        <select @bind="selectedIdentityId" @bind:after="OnIdentityChanged">
+                        <select @bind="selectedIdentityId" @bind:after="MarkDirty">
                             <option value="">-- Select Identity --</option>
                             @foreach (var identity in identities)
                             {
@@ -45,7 +52,7 @@
                 </div>
                 <div class="form-group">
                     <label>Team ID</label>
-                    <input type="text" @bind="teamId" @bind:after="SaveSettings" placeholder="e.g. ABC1234DEF" />
+                    <input type="text" @bind="teamId" @bind:after="MarkDirty" placeholder="e.g. ABC1234DEF" />
                 </div>
             }
             else
@@ -61,11 +68,11 @@
                 </div>
                 <div class="form-group">
                     <label>Team ID</label>
-                    <input type="text" @bind="teamId" @bind:after="SaveSettings" placeholder="e.g. ABC1234DEF" />
+                    <input type="text" @bind="teamId" @bind:after="MarkDirty" placeholder="e.g. ABC1234DEF" />
                 </div>
                 <div class="form-group">
                     <label>Key ID</label>
-                    <input type="text" @bind="p8KeyId" @bind:after="SaveSettings" placeholder="e.g. ABCDE12345" />
+                    <input type="text" @bind="p8KeyId" @bind:after="MarkDirty" placeholder="e.g. ABCDE12345" />
                 </div>
             }
         </div>
@@ -77,7 +84,7 @@
             <div class="form-row">
                 <div class="form-group flex-1">
                     <label>Push Type</label>
-                    <select @bind="pushType" @bind:after="SaveSettings">
+                    <select @bind="pushType" @bind:after="MarkDirty">
                         <option value="alert">Alert</option>
                         <option value="background">Background</option>
                         <option value="voip">VoIP</option>
@@ -91,7 +98,7 @@
                 </div>
                 <div class="form-group flex-1">
                     <label>Priority</label>
-                    <select @bind="priority" @bind:after="SaveSettings">
+                    <select @bind="priority" @bind:after="MarkDirty">
                         <option value="5">Normal (5)</option>
                         <option value="10">Immediate (10)</option>
                     </select>
@@ -101,22 +108,22 @@
             <div class="form-row">
                 <div class="form-group flex-1">
                     <label>Collapse ID <span class="optional">(optional)</span></label>
-                    <input type="text" @bind="collapseId" @bind:after="SaveSettings" placeholder="Collapse identifier" />
+                    <input type="text" @bind="collapseId" @bind:after="MarkDirty" placeholder="Collapse identifier" />
                 </div>
                 <div class="form-group flex-1">
                     <label>Notification ID <span class="optional">(optional)</span></label>
-                    <input type="text" @bind="notificationId" @bind:after="SaveSettings" placeholder="UUID format" />
+                    <input type="text" @bind="notificationId" @bind:after="MarkDirty" placeholder="UUID format" />
                 </div>
             </div>
 
             <div class="form-row">
                 <div class="form-group flex-1">
                     <label>Expiration <span class="optional">(seconds, optional)</span></label>
-                    <input type="number" @bind="expirationSeconds" @bind:after="SaveSettings" placeholder="0 = immediate expiry" />
+                    <input type="number" @bind="expirationSeconds" @bind:after="MarkDirty" placeholder="0 = immediate expiry" />
                 </div>
                 <div class="form-group flex-1">
                     <label>Environment</label>
-                    <select @bind="useSandbox" @bind:after="SaveSettings">
+                    <select @bind="useSandbox" @bind:after="MarkDirty">
                         <option value="true">Sandbox</option>
                         <option value="false">Production</option>
                     </select>
@@ -131,16 +138,16 @@
             <div class="form-row">
                 <div class="form-group flex-1">
                     <label>Bundle ID</label>
-                    <input type="text" @bind="bundleId" @bind:after="SaveSettings" placeholder="e.g. com.example.myapp" />
+                    <input type="text" @bind="bundleId" @bind:after="MarkDirty" placeholder="e.g. com.example.myapp" />
                 </div>
                 <div class="form-group flex-1">
                     <label>Device Token</label>
-                    <input type="text" @bind="deviceToken" @bind:after="SaveSettings" placeholder="Hex device token" />
+                    <input type="text" @bind="deviceToken" @bind:after="MarkDirty" placeholder="Hex device token" />
                 </div>
             </div>
             <div class="form-group">
                 <label>JSON Body</label>
-                <textarea class="json-editor" @bind="jsonPayload" @bind:after="SaveSettings" rows="12" spellcheck="false"></textarea>
+                <textarea class="json-editor" @bind="jsonPayload" @bind:after="MarkDirty" rows="12" spellcheck="false"></textarea>
             </div>
         </div>
     </div>
@@ -152,33 +159,46 @@
         </button>
     </div>
 
-    @if (lastResult != null)
+    @if (activeProject?.History.Count > 0)
     {
-        <div class="push-section result-section @(lastResult.Success ? "result-success" : "result-error")">
+        <div class="push-section">
             <div class="section-header">
-                <i class="fas @(lastResult.Success ? "fa-check-circle" : "fa-times-circle")"></i>
-                Result — HTTP @lastResult.StatusCode
+                <span><i class="fas fa-history"></i> Send History</span>
+                <button class="btn-clear" @onclick="ClearHistory">
+                    <i class="fas fa-eraser"></i> Clear
+                </button>
             </div>
-            <div class="section-body">
-                @if (lastResult.Success)
+            <div class="section-body history-list">
+                @foreach (var entry in activeProject.History)
                 {
-                    <div class="result-row"><strong>Status:</strong> Success</div>
-                    @if (!string.IsNullOrEmpty(lastResult.ApnsId))
-                    {
-                        <div class="result-row"><strong>apns-id:</strong> <code>@lastResult.ApnsId</code></div>
-                    }
-                }
-                else
-                {
-                    <div class="result-row"><strong>Status:</strong> Failed</div>
-                    @if (!string.IsNullOrEmpty(lastResult.ErrorReason))
-                    {
-                        <div class="result-row"><strong>Reason:</strong> <code>@lastResult.ErrorReason</code></div>
-                    }
-                    @if (!string.IsNullOrEmpty(lastResult.ErrorDescription))
-                    {
-                        <div class="result-row"><strong>Response:</strong> <pre class="error-detail">@lastResult.ErrorDescription</pre></div>
-                    }
+                    <div class="history-card @(entry.Success ? "success" : "error")">
+                        <div class="history-status">
+                            <i class="fas @(entry.Success ? "fa-check-circle text-success" : "fa-times-circle text-danger")"></i>
+                            <span class="history-time">@entry.Timestamp.ToLocalTime().ToString("HH:mm:ss")</span>
+                            @if (entry.StatusCode.HasValue)
+                            {
+                                <span class="badge @(entry.Success ? "badge-success" : "badge-danger")">@entry.StatusCode</span>
+                            }
+                        </div>
+                        <div class="history-details">
+                            @if (!string.IsNullOrEmpty(entry.Target))
+                            {
+                                <div class="history-target mono"><i class="fas fa-mobile-alt"></i> @entry.Target</div>
+                            }
+                            @if (entry.Success && !string.IsNullOrEmpty(entry.MessageId))
+                            {
+                                <div class="history-message-id mono">@entry.MessageId</div>
+                            }
+                            @if (!entry.Success && !string.IsNullOrEmpty(entry.ErrorReason))
+                            {
+                                <div class="history-error">@entry.ErrorReason</div>
+                            }
+                            @if (!entry.Success && !string.IsNullOrEmpty(entry.ErrorDescription))
+                            {
+                                <div class="history-error-detail">@entry.ErrorDescription</div>
+                            }
+                        </div>
+                    </div>
                 }
             </div>
         </div>
@@ -214,6 +234,7 @@
         border-bottom: 1px solid var(--border-color);
         display: flex;
         align-items: center;
+        justify-content: space-between;
         gap: 8px;
     }
 
@@ -338,54 +359,119 @@
         padding: 8px 0;
     }
 
-    .result-section {
-        border-width: 2px;
+    .btn-clear {
+        background: none;
+        border: none;
+        color: var(--text-muted);
+        font-size: 0.75rem;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        gap: 0.25rem;
+        padding: 0.25rem 0.5rem;
+        border-radius: 4px;
     }
 
-    .result-success {
-        border-color: var(--success-color, #48bb78);
+    .btn-clear:hover {
+        background: var(--bg-hover);
+        color: var(--text-secondary);
     }
 
-    .result-success .section-header {
-        color: var(--success-color, #48bb78);
+    /* History */
+    .history-list {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
     }
 
-    .result-error {
-        border-color: var(--danger-color, #f56565);
+    .history-card {
+        background: var(--card-bg);
+        border: 1px solid var(--border-color);
+        border-radius: 8px;
+        padding: 0.75rem 1rem;
+        display: flex;
+        gap: 0.75rem;
+        align-items: flex-start;
     }
 
-    .result-error .section-header {
+    .history-card.success {
+        border-left: 3px solid var(--success-color, #48bb78);
+    }
+
+    .history-card.error {
+        border-left: 3px solid var(--danger-color, #f56565);
+    }
+
+    .history-status {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        flex-shrink: 0;
+    }
+
+    .history-time {
+        font-size: 0.75rem;
+        color: var(--text-muted);
+        font-family: 'SF Mono', monospace;
+    }
+
+    .history-details {
+        flex: 1;
+        min-width: 0;
+    }
+
+    .history-target {
+        font-size: 0.75rem;
+        color: var(--text-secondary);
+        margin-bottom: 0.25rem;
+    }
+
+    .history-message-id {
+        font-size: 0.6875rem;
+        color: var(--text-muted);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .history-error {
+        font-size: 0.75rem;
         color: var(--danger-color, #f56565);
     }
 
-    .result-row {
-        padding: 4px 0;
-        font-size: 14px;
-        color: var(--text-primary);
+    .history-error-detail {
+        font-size: 0.6875rem;
+        color: var(--text-muted);
+        margin-top: 0.125rem;
+        word-break: break-word;
     }
 
-    .result-row code {
-        background: var(--bg-tertiary);
-        padding: 2px 6px;
+    .badge {
+        padding: 0.125rem 0.375rem;
         border-radius: 4px;
-        font-size: 13px;
-        user-select: text;
+        font-size: 0.6875rem;
+        font-weight: 600;
     }
 
-    .error-detail {
-        background: var(--bg-tertiary);
-        padding: 8px 12px;
-        border-radius: 6px;
-        font-size: 12px;
-        margin-top: 4px;
-        overflow-x: auto;
-        white-space: pre-wrap;
-        user-select: text;
+    .badge-success {
+        background: rgba(72, 187, 120, 0.15);
+        color: var(--success-color, #48bb78);
     }
+
+    .badge-danger {
+        background: rgba(245, 101, 101, 0.15);
+        color: var(--danger-color, #f56565);
+    }
+
+    .text-success { color: var(--success-color, #48bb78); }
+    .text-danger { color: var(--danger-color, #f56565); }
+    .mono { font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace; }
 </style>
 
 @code {
+    PushProjectBar? projectBar;
     List<AppleIdentity> identities = new();
+    PushProject? activeProject;
 
     // Auth
     string authMode = "identity";
@@ -409,8 +495,7 @@
 
     // State
     bool isSending;
-    ApnsPushResult? lastResult;
-    bool settingsLoaded;
+    bool isDirty;
 
     bool IsValid
     {
@@ -438,81 +523,132 @@
     {
         ToolbarService.ClearItems();
         identities = (await IdentityService.GetIdentitiesAsync()).ToList();
-        await LoadSettings();
-        SettingsService.OnSettingsChanged += OnSettingsChanged;
-    }
 
-    async Task LoadSettings()
-    {
-        try
-        {
-            var settings = await SettingsService.GetSettingsAsync();
-            var ps = settings.PushTesting;
+        // Migrate legacy settings if needed
+        var migrated = await ProjectService.MigrateFromLegacyAsync();
 
-            authMode = ps.AuthMode ?? "identity";
-            selectedIdentityId = ps.SelectedIdentityId ?? "";
-            p8FilePath = ps.P8FilePath ?? "";
-            p8KeyId = ps.P8KeyId ?? "";
-            teamId = ps.TeamId ?? "";
-            pushType = ps.PushType;
-            priority = ps.Priority;
-            collapseId = ps.CollapseId ?? "";
-            notificationId = ps.NotificationId ?? "";
-            expirationSeconds = ps.ExpirationSeconds;
-            bundleId = ps.BundleId ?? "";
-            deviceToken = ps.DeviceToken ?? "";
-            jsonPayload = ps.JsonPayload;
-            useSandbox = ps.UseSandbox;
-            settingsLoaded = true;
-        }
-        catch (Exception ex)
+        // Load projects and select most recent (or create blank)
+        var projects = await ProjectService.GetProjectsAsync(PushProjectPlatform.Apns);
+        if (projects.Count > 0)
         {
-            Logger.LogError($"Failed to load push testing settings: {ex.Message}", ex);
-            settingsLoaded = true;
+            var selected = migrated ?? projects[0];
+            LoadFromProject(selected);
         }
     }
 
-    async Task SaveSettings()
+    void LoadFromProject(PushProject project)
     {
-        if (!settingsLoaded) return;
+        activeProject = project;
+        var config = project.ApnsConfig ?? new ApnsPushProjectConfig();
 
+        authMode = config.AuthMode ?? "identity";
+        selectedIdentityId = config.SelectedIdentityId ?? "";
+        p8FilePath = config.P8FilePath ?? "";
+        p8KeyId = config.P8KeyId ?? "";
+        teamId = config.TeamId ?? "";
+        pushType = config.PushType;
+        priority = config.Priority;
+        collapseId = config.CollapseId ?? "";
+        notificationId = config.NotificationId ?? "";
+        expirationSeconds = config.ExpirationSeconds;
+        bundleId = config.BundleId ?? "";
+        deviceToken = config.DeviceToken ?? "";
+        jsonPayload = config.JsonPayload;
+        useSandbox = config.UseSandbox;
+        isDirty = false;
+    }
+
+    void ResetToBlank()
+    {
+        activeProject = null;
+        var defaults = new ApnsPushProjectConfig();
+        authMode = defaults.AuthMode ?? "identity";
+        selectedIdentityId = "";
+        p8FilePath = "";
+        p8KeyId = "";
+        teamId = "";
+        pushType = defaults.PushType;
+        priority = defaults.Priority;
+        collapseId = "";
+        notificationId = "";
+        expirationSeconds = null;
+        bundleId = "";
+        deviceToken = "";
+        jsonPayload = defaults.JsonPayload;
+        useSandbox = defaults.UseSandbox;
+        isDirty = false;
+    }
+
+    async Task OnActiveProjectChanged(PushProject? project)
+    {
+        if (project != null)
+            LoadFromProject(project);
+        else
+            ResetToBlank();
+
+        await Task.CompletedTask;
+        StateHasChanged();
+    }
+
+    void MarkDirty() => isDirty = true;
+
+    ApnsPushProjectConfig BuildConfig() => new()
+    {
+        AuthMode = authMode,
+        SelectedIdentityId = string.IsNullOrEmpty(selectedIdentityId) ? null : selectedIdentityId,
+        P8FilePath = string.IsNullOrEmpty(p8FilePath) ? null : p8FilePath,
+        P8KeyId = string.IsNullOrEmpty(p8KeyId) ? null : p8KeyId,
+        TeamId = string.IsNullOrEmpty(teamId) ? null : teamId,
+        PushType = pushType,
+        Priority = priority,
+        CollapseId = string.IsNullOrEmpty(collapseId) ? null : collapseId,
+        NotificationId = string.IsNullOrEmpty(notificationId) ? null : notificationId,
+        ExpirationSeconds = expirationSeconds,
+        BundleId = string.IsNullOrEmpty(bundleId) ? null : bundleId,
+        DeviceToken = string.IsNullOrEmpty(deviceToken) ? null : deviceToken,
+        JsonPayload = jsonPayload,
+        UseSandbox = useSandbox
+    };
+
+    async Task SaveProject()
+    {
         try
         {
-            await SettingsService.UpdateSettingsAsync(s => s with
+            var name = projectBar?.GetProjectName() ?? "Untitled";
+            var description = projectBar?.GetProjectDescription();
+
+            if (activeProject != null)
             {
-                PushTesting = new PushTestingSettings
+                var updated = activeProject with
                 {
-                    AuthMode = authMode,
-                    SelectedIdentityId = string.IsNullOrEmpty(selectedIdentityId) ? null : selectedIdentityId,
-                    P8FilePath = string.IsNullOrEmpty(p8FilePath) ? null : p8FilePath,
-                    P8KeyId = string.IsNullOrEmpty(p8KeyId) ? null : p8KeyId,
-                    TeamId = string.IsNullOrEmpty(teamId) ? null : teamId,
-                    PushType = pushType,
-                    Priority = priority,
-                    CollapseId = string.IsNullOrEmpty(collapseId) ? null : collapseId,
-                    NotificationId = string.IsNullOrEmpty(notificationId) ? null : notificationId,
-                    ExpirationSeconds = expirationSeconds,
-                    BundleId = string.IsNullOrEmpty(bundleId) ? null : bundleId,
-                    DeviceToken = string.IsNullOrEmpty(deviceToken) ? null : deviceToken,
-                    JsonPayload = jsonPayload,
-                    UseSandbox = useSandbox
-                }
-            });
+                    Name = name,
+                    Description = description,
+                    ApnsConfig = BuildConfig()
+                };
+                await ProjectService.SaveProjectAsync(updated);
+                activeProject = await ProjectService.GetProjectAsync(updated.Id);
+            }
+            else
+            {
+                var project = new PushProject
+                {
+                    Name = name,
+                    Description = description,
+                    Platform = PushProjectPlatform.Apns,
+                    ApnsConfig = BuildConfig()
+                };
+                await ProjectService.SaveProjectAsync(project);
+                activeProject = await ProjectService.GetProjectAsync(project.Id);
+            }
+
+            isDirty = false;
+            ToastService.Show("Project saved.", ToastType.Success);
         }
         catch (Exception ex)
         {
-            Logger.LogError($"Failed to save push testing settings: {ex.Message}", ex);
+            Logger.LogError($"Failed to save push project: {ex.Message}", ex);
+            ToastService.Show($"Save failed: {ex.Message}", ToastType.Error);
         }
-    }
-
-    async Task OnAuthModeChanged()
-    {
-        await SaveSettings();
-    }
-
-    async Task OnIdentityChanged()
-    {
-        await SaveSettings();
     }
 
     async Task PickP8File()
@@ -521,7 +657,7 @@
         if (!string.IsNullOrEmpty(path))
         {
             p8FilePath = path;
-            await SaveSettings();
+            MarkDirty();
         }
     }
 
@@ -530,7 +666,6 @@
         if (!IsValid) return;
 
         isSending = true;
-        lastResult = null;
         StateHasChanged();
 
         try
@@ -543,13 +678,13 @@
                 var identity = identities.FirstOrDefault(i => i.Id == selectedIdentityId);
                 if (identity == null)
                 {
-                    ToastService.ShowError("Selected identity not found.");
+                    ToastService.Show("Selected identity not found.", ToastType.Error);
                     return;
                 }
 
                 if (string.IsNullOrEmpty(identity.P8KeyContent))
                 {
-                    ToastService.ShowError("Selected identity has no P8 key content.");
+                    ToastService.Show("Selected identity has no P8 key content.", ToastType.Error);
                     return;
                 }
 
@@ -560,7 +695,7 @@
             {
                 if (!File.Exists(p8FilePath))
                 {
-                    ToastService.ShowError("P8 file not found.");
+                    ToastService.Show("P8 file not found.", ToastType.Error);
                     return;
                 }
 
@@ -583,17 +718,34 @@
                 UseSandbox: useSandbox
             );
 
-            lastResult = await PushService.SendPushAsync(request);
+            var result = await PushService.SendPushAsync(request);
 
-            if (lastResult.Success)
-                ToastService.ShowSuccess("Push notification sent successfully!");
+            // Record history
+            if (activeProject != null)
+            {
+                var historyEntry = new PushSendHistoryEntry
+                {
+                    Timestamp = DateTime.UtcNow,
+                    Success = result.Success,
+                    StatusCode = result.StatusCode,
+                    MessageId = result.ApnsId,
+                    ErrorReason = result.ErrorReason,
+                    ErrorDescription = result.ErrorDescription,
+                    Target = TruncateToken(deviceToken)
+                };
+                await ProjectService.AddHistoryEntryAsync(activeProject.Id, historyEntry);
+                activeProject = await ProjectService.GetProjectAsync(activeProject.Id);
+            }
+
+            if (result.Success)
+                ToastService.Show("Push notification sent successfully!", ToastType.Success);
             else
-                ToastService.ShowError($"Push failed: {lastResult.ErrorReason ?? "Unknown error"}");
+                ToastService.Show($"Push failed: {result.ErrorReason ?? "Unknown error"}", ToastType.Error);
         }
         catch (Exception ex)
         {
             Logger.LogError($"Push send error: {ex.Message}", ex);
-            ToastService.ShowError($"Error: {ex.Message}");
+            ToastService.Show($"Error: {ex.Message}", ToastType.Error);
         }
         finally
         {
@@ -602,17 +754,18 @@
         }
     }
 
-    void OnSettingsChanged()
+    async Task ClearHistory()
     {
-        InvokeAsync(async () =>
-        {
-            await LoadSettings();
-            StateHasChanged();
-        });
+        if (activeProject == null) return;
+        await ProjectService.ClearHistoryAsync(activeProject.Id);
+        activeProject = await ProjectService.GetProjectAsync(activeProject.Id);
+        StateHasChanged();
     }
+
+    static string TruncateToken(string token) =>
+        token.Length > 24 ? $"{token[..12]}...{token[^8..]}" : token;
 
     public void Dispose()
     {
-        SettingsService.OnSettingsChanged -= OnSettingsChanged;
     }
 }

--- a/src/MauiSherpa/Pages/Settings.razor
+++ b/src/MauiSherpa/Pages/Settings.razor
@@ -21,6 +21,7 @@
 @inject ISecretsPublisherService SecretsPublisherService
 @inject ISecretsPublisherFactory SecretsPublisherFactory
 @inject IBackupService BackupService
+@inject IPushProjectService PushProjectService
 @inject IEncryptedSettingsService EncryptedSettings
 @inject IUpdateService UpdateService
 @implements IDisposable
@@ -714,6 +715,27 @@
                                                    checked="@selectedExportGoogleIdentityIds.Contains(identity.Id)"
                                                    @onchange="e => SetExportGoogleIdentitySelection(identity.Id, e.Value is bool isChecked && isChecked)" />
                                             <span>@identity.Name</span>
+                                        </label>
+                                    }
+                                </div>
+                            }
+                        </div>
+
+                        <div class="backup-selection-group">
+                            <label class="backup-selection-item">
+                                <input type="checkbox" @bind="exportIncludePushProjects" />
+                                <span>Push Projects (@selectedExportPushProjectIds.Count/@pushProjects.Count)</span>
+                            </label>
+                            @if (exportIncludePushProjects && pushProjects.Count > 0)
+                            {
+                                <div class="backup-selection-children">
+                                    @foreach (var project in pushProjects)
+                                    {
+                                        <label class="backup-selection-item child">
+                                            <input type="checkbox"
+                                                   checked="@selectedExportPushProjectIds.Contains(project.Id)"
+                                                   @onchange="e => SetExportPushProjectSelection(project.Id, e.Value is bool isChecked && isChecked)" />
+                                            <span>@project.Name (@(project.Platform == PushProjectPlatform.Apns ? "APNs" : "FCM"))</span>
                                         </label>
                                     }
                                 </div>
@@ -1869,6 +1891,9 @@
     private HashSet<string> selectedExportPublisherIds = new(StringComparer.Ordinal);
     private bool exportIncludeGoogleIdentities = true;
     private HashSet<string> selectedExportGoogleIdentityIds = new(StringComparer.Ordinal);
+    private bool exportIncludePushProjects = true;
+    private HashSet<string> selectedExportPushProjectIds = new(StringComparer.Ordinal);
+    private List<PushProject> pushProjects = new();
     private string importFilePath = "";
     private string importPassword = "";
     private string importError = "";
@@ -1880,7 +1905,8 @@
         (exportIncludeAppleIdentities && selectedExportAppleIdentityIds.Count > 0) ||
         (exportIncludeCloudProviders && selectedExportCloudProviderIds.Count > 0) ||
         (exportIncludeSecretsPublishers && selectedExportPublisherIds.Count > 0) ||
-        (exportIncludeGoogleIdentities && selectedExportGoogleIdentityIds.Count > 0);
+        (exportIncludeGoogleIdentities && selectedExportGoogleIdentityIds.Count > 0) ||
+        (exportIncludePushProjects && selectedExportPushProjectIds.Count > 0);
 
     private bool CanSaveIdentity => 
         !string.IsNullOrWhiteSpace(identityName) &&
@@ -2824,7 +2850,7 @@
     }
 
     // Backup & Restore methods
-    private void InitializeExportSelection()
+    private async Task InitializeExportSelection()
     {
         exportIncludePreferences = true;
         exportIncludeAppleIdentities = appleIdentities.Count > 0;
@@ -2835,6 +2861,9 @@
         selectedExportCloudProviderIds = cloudProviders.Select(provider => provider.Id).ToHashSet(StringComparer.Ordinal);
         selectedExportPublisherIds = secretsPublishers.Select(publisher => publisher.Id).ToHashSet(StringComparer.Ordinal);
         selectedExportGoogleIdentityIds = googleIdentities.Select(identity => identity.Id).ToHashSet(StringComparer.Ordinal);
+        pushProjects = (await PushProjectService.GetProjectsAsync()).ToList();
+        exportIncludePushProjects = pushProjects.Count > 0;
+        selectedExportPushProjectIds = pushProjects.Select(p => p.Id).ToHashSet(StringComparer.Ordinal);
     }
 
     private void SetExportAppleIdentitySelection(string id, bool isSelected)
@@ -2869,12 +2898,20 @@
             selectedExportGoogleIdentityIds.Remove(id);
     }
 
-    private void ShowExportDialog()
+    private void SetExportPushProjectSelection(string id, bool isSelected)
+    {
+        if (isSelected)
+            selectedExportPushProjectIds.Add(id);
+        else
+            selectedExportPushProjectIds.Remove(id);
+    }
+
+    private async Task ShowExportDialog()
     {
         exportPassword = "";
         exportPasswordConfirm = "";
         exportError = "";
-        InitializeExportSelection();
+        await InitializeExportSelection();
         showExportDialog = true;
         _ = InitModalAsync("export-settings-modal");
     }
@@ -2956,6 +2993,9 @@
                     : new List<string>(),
                 GoogleIdentityIds = exportIncludeGoogleIdentities
                     ? selectedExportGoogleIdentityIds.ToList()
+                    : new List<string>(),
+                PushProjectIds = exportIncludePushProjects
+                    ? selectedExportPushProjectIds.ToList()
                     : new List<string>()
             };
             var encrypted = await BackupService.ExportSettingsAsync(exportPassword, exportSelection);
@@ -3065,6 +3105,11 @@
                 ClientEmail: googleIdentity.ClientEmail,
                 ServiceAccountJsonPath: null,
                 ServiceAccountJson: googleIdentity.ServiceAccountJson));
+        }
+
+        foreach (var pushProject in settings.PushProjects)
+        {
+            await PushProjectService.SaveProjectAsync(pushProject);
         }
 
         await LoadGoogleIdentities();


### PR DESCRIPTION
  Summary                                                                                                                                                                      

  - Add "Push Projects" feature: save, load, duplicate, and delete named push configurations for both APNs and FCM pages
  - Replace auto-save behavior on APNs page with explicit Save (no more silent writes on every field change)
  - Add persistent per-project send history (capped at 50 entries) to both push pages
  - Migrate legacy PushTestingSettings to a push project automatically on first load
  - Add push projects to backup/restore (settings only, no history)
  - Bump Platform.Maui.MacOS packages to 0.2.0-beta.12 (fixes macOS build)

  New files

  - PushProjectService.cs — file-based JSON storage (push-projects.json), follows the same pattern as AppleIdentityService
  - PushProjectBar.razor — reusable project selector bar with dropdown, name/description inputs, Save/Duplicate/Delete actions, dirty-state tracking, and unsaved-changes guard

  Changed files

  - Interfaces.cs — PushProject, ApnsPushProjectConfig, FcmPushProjectConfig, FcmDataEntry, PushSendHistoryEntry records; IPushProjectService interface; updated
  MauiSherpaSettings and BackupExportSelection
  - PushTesting.razor — removed auto-save, added project bar, project load/save, legacy migration, persisted history
  - FirebasePush.razor — added project bar, project load/save with Google identity restoration, persisted history (replaces in-memory list)
  - BackupService.cs — hydrates push projects (without history) into backup snapshots, resolves/applies selection for push project IDs
  - Settings.razor — push projects checkbox group in export dialog, import restores projects
  - MauiProgram.cs / MacOSMauiProgram.cs — DI registration
  - MauiSherpa.MacOS.csproj — Platform.Maui.MacOS 0.2.0-beta.11 → 0.2.0-beta.12

  Test plan

  - APNs page: create project, edit fields (verify no auto-save), save, reload page (verify persistence), duplicate, delete
  - FCM page: same flow, verify Google identity restores on project load
  - History: send push, verify entry appears, navigate away and back, verify history persists
  - Migration: with existing PushTestingSettings data, verify it creates an APNs project on first load
  - Backup: export with push projects selected, import on fresh state, verify projects restored (no history in export)
  - macOS head builds and launches cleanly

This closes #60 
