### PR TITLE
Show cert sync status and bundle IDs on provisioning profiles

### DIFF
--- a/src/MauiSherpa/Components/EditProfileDialog.razor
+++ b/src/MauiSherpa/Components/EditProfileDialog.razor
@@ -649,6 +649,7 @@
             }
 
             // Load sync statuses for certificates
+            await CloudSecretsService.InitializeAsync();
             await LoadSyncStatusesAsync();
         }
         catch (Exception ex)

--- a/src/MauiSherpa/Pages/ProvisioningProfiles.razor
+++ b/src/MauiSherpa/Pages/ProvisioningProfiles.razor
@@ -136,6 +136,12 @@
                                 <i class="fas fa-copy"></i>
                             </button>
                         </div>
+                        @if (!string.IsNullOrEmpty(profile.BundleId))
+                        {
+                            <div class="profile-bundle-id">
+                                <i class="fas fa-cube"></i> @profile.BundleId
+                            </div>
+                        }
                         <div class="profile-badges">
                             <span class="badge badge-type">@FormatProfileType(profile.ProfileType)</span>
                             @if (!string.IsNullOrEmpty(profile.Platform))
@@ -414,6 +420,16 @@
         gap: 0.5rem;
     }
     .profile-expiry { font-size: 0.8125rem; color: var(--text-muted); margin-top: 0.5rem; }
+    .profile-bundle-id {
+        font-size: 0.75rem;
+        color: var(--text-muted);
+        margin-top: 0.25rem;
+        font-family: monospace;
+        display: flex;
+        align-items: center;
+        gap: 0.375rem;
+    }
+    .profile-bundle-id i { font-size: 0.625rem; }
     .profile-badges { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-top: 0.5rem; }
 
     .profile-actions { display: flex; gap: 0.25rem; align-items: center; }


### PR DESCRIPTION
## Changes

- **Cert sync status badges** on the Edit Profile dialog's certificate list — shows Synced/Local/Cloud/No Key status for each certificate (matching the Certificates page pattern)
- **Bundle ID resolution** from App Store Connect API — resolves bundle identifiers from the `include=bundleId` relationship data instead of leaving them empty
- **Multiple bundle ID support** — joins all related bundle IDs as a comma-separated string
- **Bundle ID display on profile cards** — shows the bundle ID on each card in the main Provisioning Profiles list

### Files changed
- `src/MauiSherpa.Core/Services/AppleConnectService.cs` — resolve bundle IDs from API response relationships
- `src/MauiSherpa/Components/EditProfileDialog.razor` — add sync badges + initialize CloudSecretsService
- `src/MauiSherpa/Pages/ProvisioningProfiles.razor` — add bundle ID display to profile cards