### PR TITLE
Fix: Azure Key Vault secret list not retrieved

### DIFF
--- a/src/MauiSherpa.Core/Services/AzureKeyVaultProvider.cs
+++ b/src/MauiSherpa.Core/Services/AzureKeyVaultProvider.cs
@@ -211,16 +211,16 @@ public class AzureKeyVaultProvider : ICloudSecretsProvider
             var client = GetClient();
             var allSecrets = new List<string>();
 
+            // Sanitize the prefix so it matches the stored (sanitized) key names
+            var sanitizedPrefix = string.IsNullOrEmpty(prefix) ? null : SanitizeKey(prefix);
+
             await foreach (var secretProperties in client.GetPropertiesOfSecretsAsync(cancellationToken))
             {
                 var secretName = secretProperties.Name;
-                
-                // Convert back from sanitized format (hyphens back to underscores for prefix matching)
-                var originalKey = secretName.Replace("-", "_").ToUpperInvariant();
-                
-                if (string.IsNullOrEmpty(prefix) || originalKey.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+
+                if (sanitizedPrefix == null || secretName.StartsWith(sanitizedPrefix, StringComparison.OrdinalIgnoreCase))
                 {
-                    allSecrets.Add(originalKey);
+                    allSecrets.Add(secretName);
                 }
             }
 


### PR DESCRIPTION
## Fix: Azure Key Vault secret list not retrieved

### Summary

Secrets stored in Azure Key Vault were never displayed on the secrets page.  
The root cause was a broken prefix-matching logic inside `AzureKeyVaultProvider.ListSecretsAsync`.

---

### Root Cause

When secrets are stored, `SanitizeKey` converts every non-alphanumeric character to `-`:

```
SanitizeKey("sherpa-secrets-meta/foo") → "sherpa-secrets-meta-foo"
```

When listing, the code tried to reverse that sanitization by replacing `-` with `_` and uppercasing the result, then compared it against the original prefix (which contains `/`):

```
// Before — broken
var originalKey = secretName.Replace("-", "_").ToUpperInvariant();
// "sherpa-secrets-meta-foo" → "SHERPA_SECRETS_META_FOO"

originalKey.StartsWith("sherpa-secrets-meta/") // → always false ❌
```

Two compounding bugs:
1. `/` was sanitized to `-` on write, but reconstructed as `_` on read — the `/` was never restored, so the prefix never matched.
2. The keys returned in `UPPER_SNAKE_CASE` were then passed to `GetSecretAsync`, which re-sanitized them into a key that does not exist in the vault.

---

### Fix

Apply `SanitizeKey` to the prefix before comparison, and return raw key names as stored in Azure:

```
// After — correct
var sanitizedPrefix = string.IsNullOrEmpty(prefix) ? null : SanitizeKey(prefix);
// SanitizeKey("sherpa-secrets-meta/") → "sherpa-secrets-meta-"

secretName.StartsWith(sanitizedPrefix, StringComparison.OrdinalIgnoreCase) // → true ✅
allSecrets.Add(secretName); // raw name, idempotent with further SanitizeKey calls
```

Since `SanitizeKey` is idempotent on already-sanitized names, keys returned by `ListSecretsAsync` are directly usable by `GetSecretAsync` without any additional transformation.

---

### Changed Files

| File | Change |
|------|--------|
| `src/MauiSherpa.Core/Services/AzureKeyVaultProvider.cs` | Fixed prefix matching in `ListSecretsAsync` |

---


<img width="1914" height="1014" alt="image" src="https://github.com/user-attachments/assets/afa5d764-46a4-4c41-9293-c8480e677ab5" />
