### PR TITLE
Update MauiDevFlow to 0.18.0, fix duplicate log source

### DIFF
--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "redth.mauidevflow.cli": {
-      "version": "0.17.5",
+      "version": "0.18.0",
       "commands": [
         "maui-devflow"
       ],

--- a/src/MauiSherpa.LinuxGtk/MauiSherpa.LinuxGtk.csproj
+++ b/src/MauiSherpa.LinuxGtk/MauiSherpa.LinuxGtk.csproj
@@ -39,8 +39,8 @@
     <PackageReference Condition="!Exists('$(HOME)/code/Maui.Gtk/src/Platform.Maui.Linux.Gtk4/Platform.Maui.Linux.Gtk4.csproj')" Include="Platform.Maui.Linux.Gtk4" Version="0.6.0" />
     <PackageReference Condition="!Exists('$(HOME)/code/Maui.Gtk/src/Platform.Maui.Linux.Gtk4.BlazorWebView/Platform.Maui.Linux.Gtk4.BlazorWebView.csproj')" Include="Platform.Maui.Linux.Gtk4.BlazorWebView" Version="0.6.0" />
     <PackageReference Condition="!Exists('$(HOME)/code/Maui.Gtk/src/Platform.Maui.Linux.Gtk4.Essentials/Platform.Maui.Linux.Gtk4.Essentials.csproj')" Include="Platform.Maui.Linux.Gtk4.Essentials" Version="0.6.0" />
-    <PackageReference Include="Redth.MauiDevFlow.Agent.Gtk" Version="0.17.5" Condition="'$(Configuration)' == 'Debug'" />
-    <PackageReference Include="Redth.MauiDevFlow.Blazor.Gtk" Version="0.17.5" Condition="'$(Configuration)' == 'Debug'" />
+    <PackageReference Include="Redth.MauiDevFlow.Agent.Gtk" Version="0.18.0" Condition="'$(Configuration)' == 'Debug'" />
+    <PackageReference Include="Redth.MauiDevFlow.Blazor.Gtk" Version="0.18.0" Condition="'$(Configuration)' == 'Debug'" />
     <PackageReference Include="Shiny.Mediator.Caching.MicrosoftMemoryCache" Version="6.1.1" />
     <PackageReference Include="Shiny.Mediator.Maui" Version="6.1.1" />
   </ItemGroup>

--- a/src/MauiSherpa.MacOS/MauiSherpa.MacOS.csproj
+++ b/src/MauiSherpa.MacOS/MauiSherpa.MacOS.csproj
@@ -38,8 +38,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
     <PackageReference Include="Shiny.Mediator.Caching.MicrosoftMemoryCache" Version="6.1.1" />
     <PackageReference Include="Shiny.Mediator.Maui" Version="6.1.1" />
-    <PackageReference Include="Redth.MauiDevFlow.Agent" Version="0.17.5" Condition="'$(Configuration)' == 'Debug'" />
-    <PackageReference Include="Redth.MauiDevFlow.Blazor" Version="0.17.5" Condition="'$(Configuration)' == 'Debug'" />
+    <PackageReference Include="Redth.MauiDevFlow.Agent" Version="0.18.0" Condition="'$(Configuration)' == 'Debug'" />
+    <PackageReference Include="Redth.MauiDevFlow.Blazor" Version="0.18.0" Condition="'$(Configuration)' == 'Debug'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MauiSherpa/MauiSherpa.csproj
+++ b/src/MauiSherpa/MauiSherpa.csproj
@@ -53,8 +53,8 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
     <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.31" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
-    <PackageReference Include="Redth.MauiDevFlow.Agent" Version="0.17.5" Condition="'$(Configuration)' == 'Debug'" />
-    <PackageReference Include="Redth.MauiDevFlow.Blazor" Version="0.17.5" Condition="'$(Configuration)' == 'Debug'" />
+    <PackageReference Include="Redth.MauiDevFlow.Agent" Version="0.18.0" Condition="'$(Configuration)' == 'Debug'" />
+    <PackageReference Include="Redth.MauiDevFlow.Blazor" Version="0.18.0" Condition="'$(Configuration)' == 'Debug'" />
     <PackageReference Include="Shiny.Mediator.Caching.MicrosoftMemoryCache" Version="6.1.1" />
     <PackageReference Include="Shiny.Mediator.Maui" Version="6.1.1" />
   </ItemGroup>

--- a/src/MauiSherpa/Pages/DevFlow.razor
+++ b/src/MauiSherpa/Pages/DevFlow.razor
@@ -143,7 +143,7 @@
     private List<BrokerAgent> agents = new();
     private Timer? _refreshTimer;
 
-    private static readonly Version MinSupportedAgentVersion = new("0.16.0");
+    private static readonly Version MinSupportedAgentVersion = new("0.18.0");
 
     protected override async Task OnInitializedAsync()
     {

--- a/src/MauiSherpa/Pages/Inspector/DevFlowLogsTab.razor
+++ b/src/MauiSherpa/Pages/Inspector/DevFlowLogsTab.razor
@@ -119,14 +119,8 @@
                 ValueAccessor = l => l.Message ?? "",
                 CellTemplate = item => builder =>
                 {
-                    if (!string.IsNullOrEmpty(item.Category))
-                    {
-                        builder.OpenElement(0, "span");
-                        builder.AddAttribute(1, "class", "log-category");
-                        builder.AddContent(2, $"[{item.Category}]");
-                        builder.CloseElement();
-                    }
-                    builder.AddContent(10, item.Message);
+                    var msg = item.Message ?? "";
+                    builder.AddContent(10, msg);
                     if (!string.IsNullOrEmpty(item.Exception))
                     {
                         builder.OpenElement(20, "pre");


### PR DESCRIPTION
- Update all MauiDevFlow packages and CLI tool from 0.17.5 to 0.18.0
- Bump minimum supported agent version to 0.18.0
- Remove duplicate `[category]` prefix from inspector log message column (already shown in Source column)