### PR TITLE
Fix black screen when installed in Program Files on Windows

### DIFF
--- a/src/MauiSherpa/MainPage.cs
+++ b/src/MauiSherpa/MainPage.cs
@@ -24,6 +24,19 @@ public class MainPage : ContentPage
             ComponentType = typeof(Components.App)
         });
 
+#if WINDOWS
+        // Set WebView2 user data folder to a writable location so the app works
+        // when installed in read-only directories like C:\Program Files\
+        _blazorWebView.BlazorWebViewInitializing += (_, e) =>
+        {
+            var webView2DataPath = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "MauiSherpa", "WebView2");
+            Directory.CreateDirectory(webView2DataPath);
+            e.UserDataFolder = webView2DataPath;
+        };
+#endif
+
         // Create splash overlay
         _splashOverlay = CreateSplashOverlay();
         


### PR DESCRIPTION
## Problem

When installed in `C:\Program Files\MAUI Sherpa`, the app shows the splash screen spinning then fades to black (#89).

## Root Cause

WebView2 defaults to creating its user data folder next to the executable. `C:\Program Files\` is read-only for non-admin processes, so WebView2 initialization fails silently — the BlazorWebView never loads and the splash screen times out to a black screen.

Moving the app to a writable directory (e.g. `C:\Tools\`) works because WebView2 can create its data folder there.

## Fix

Handle `BlazorWebViewInitializing` to set the WebView2 user data folder to `%LocalAppData%\MauiSherpa\WebView2` — a writable, per-user location that works regardless of where the app is installed.

Fixes #89