### PR TITLE
Prompt for password when importing a keystore

### DIFF
--- a/src/MauiSherpa/Pages/Keystores.razor
+++ b/src/MauiSherpa/Pages/Keystores.razor
@@ -389,7 +389,27 @@ else
         var path = await DialogService.PickOpenFileAsync("Select Keystore", new[] { ".jks", ".keystore", ".p12", ".pfx" });
         if (path == null) return;
 
+        // Prompt for the keystore password
+        var password = await DialogService.ShowInputDialogAsync(
+            "Keystore Password",
+            "Enter the password for this keystore:",
+            "Password");
+        if (string.IsNullOrEmpty(password)) return;
+
         var alias = System.IO.Path.GetFileNameWithoutExtension(path);
+
+        // Validate password by attempting to read the keystore
+        try
+        {
+            await KeystoreService.GetSignatureHashesAsync(path, alias, password);
+        }
+        catch
+        {
+            await AlertService.ShowAlertAsync("Invalid Password",
+                "The password you entered is incorrect or the keystore file is corrupted.");
+            return;
+        }
+
         var keystore = new AndroidKeystore(
             Id: Guid.NewGuid().ToString(),
             Alias: alias,
@@ -398,6 +418,7 @@ else
             CreatedDate: File.GetCreationTimeUtc(path));
 
         await KeystoreService.AddKeystoreAsync(keystore);
+        await SecureStorage.SetAsync($"android_keystore_pwd_{keystore.Id}", password);
         await RefreshData(true);
         ToastService.ShowSuccess($"Keystore '{alias}' imported!");
     }


### PR DESCRIPTION
## Summary

Fixes #100 — Keystore import was missing a password prompt, so the password was never stored in secure storage. This caused sync/upload and signature viewing to fail with "no saved password".

## Changes

The `ImportKeystore()` method now:
1. Picks the keystore file (unchanged)
2. **Prompts for the keystore password** via `ShowInputDialogAsync`
3. **Validates the password** by attempting to read the keystore with `GetSignatureHashesAsync`
4. **Stores the password** in secure storage (same pattern as `CreateKeystoreAsync` and cloud download)

Single file changed: `src/MauiSherpa/Pages/Keystores.razor` (+21 lines)