### PR TITLE
Deep Link Testing & AASA Validator

### DIFF
--- a/src/MauiSherpa.Core/Interfaces.cs
+++ b/src/MauiSherpa.Core/Interfaces.cs
@@ -3549,3 +3549,17 @@ public interface IFormPage<TResult>
     /// </summary>
     Task<TResult?> GetResultAsync();
 }
+
+public interface IDeepLinkValidationService
+{
+    Task<AasaValidationResult> ValidateAppleAppSiteAssociationAsync(string domain);
+    Task<AssetLinksValidationResult> ValidateAssetLinksAsync(string domain);
+}
+
+public record AasaValidationResult(bool Found, bool Valid, string? RawJson,
+    IReadOnlyList<AasaAppEntry> Apps, string? ErrorMessage);
+public record AasaAppEntry(string AppId, IReadOnlyList<string> Paths);
+
+public record AssetLinksValidationResult(bool Found, bool Valid, string? RawJson,
+    IReadOnlyList<AssetLinksEntry> Entries, string? ErrorMessage);
+public record AssetLinksEntry(string Package, string? Sha256Fingerprint);

--- a/src/MauiSherpa.Core/Interfaces.cs
+++ b/src/MauiSherpa.Core/Interfaces.cs
@@ -3557,7 +3557,7 @@ public interface IDeepLinkValidationService
 }
 
 public record AasaValidationResult(bool Found, bool Valid, string? RawJson,
-    IReadOnlyList<AasaAppEntry> Apps, string? ErrorMessage);
+    IReadOnlyList<AasaAppEntry> Apps, string? ErrorMessage, bool Signed = false);
 public record AasaAppEntry(string AppId, IReadOnlyList<string> Paths);
 
 public record AssetLinksValidationResult(bool Found, bool Valid, string? RawJson,

--- a/src/MauiSherpa.Core/Services/DeepLinkValidationService.cs
+++ b/src/MauiSherpa.Core/Services/DeepLinkValidationService.cs
@@ -1,0 +1,142 @@
+using System.Text.Json;
+using MauiSherpa.Core.Interfaces;
+
+namespace MauiSherpa.Core.Services;
+
+public class DeepLinkValidationService : IDeepLinkValidationService
+{
+    static readonly HttpClient Http = new()
+    {
+        Timeout = TimeSpan.FromSeconds(10)
+    };
+
+    public async Task<AasaValidationResult> ValidateAppleAppSiteAssociationAsync(string domain)
+    {
+        try
+        {
+            var url = $"https://{domain}/.well-known/apple-app-site-association";
+            var response = await Http.GetAsync(url).ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                return new AasaValidationResult(false, false, null, Array.Empty<AasaAppEntry>(),
+                    $"HTTP {(int)response.StatusCode} {response.ReasonPhrase}");
+            }
+
+            var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var doc = JsonDocument.Parse(json);
+            var apps = new List<AasaAppEntry>();
+
+            if (doc.RootElement.TryGetProperty("applinks", out var applinks) &&
+                applinks.TryGetProperty("details", out var details))
+            {
+                foreach (var detail in details.EnumerateArray())
+                {
+                    var appIds = new List<string>();
+                    var paths = new List<string>();
+
+                    // Modern format: appIDs array
+                    if (detail.TryGetProperty("appIDs", out var appIdsEl))
+                    {
+                        foreach (var id in appIdsEl.EnumerateArray())
+                            appIds.Add(id.GetString() ?? "");
+                    }
+                    // Legacy format: appID string
+                    else if (detail.TryGetProperty("appID", out var appIdEl))
+                    {
+                        appIds.Add(appIdEl.GetString() ?? "");
+                    }
+
+                    // Modern format: components array with path
+                    if (detail.TryGetProperty("components", out var components))
+                    {
+                        foreach (var comp in components.EnumerateArray())
+                        {
+                            if (comp.TryGetProperty("/", out var pathEl))
+                                paths.Add(pathEl.GetString() ?? "");
+                        }
+                    }
+                    // Legacy format: paths array
+                    else if (detail.TryGetProperty("paths", out var pathsEl))
+                    {
+                        foreach (var p in pathsEl.EnumerateArray())
+                            paths.Add(p.GetString() ?? "");
+                    }
+
+                    foreach (var appId in appIds)
+                        apps.Add(new AasaAppEntry(appId, paths));
+
+                    if (appIds.Count == 0 && paths.Count > 0)
+                        apps.Add(new AasaAppEntry("(unknown)", paths));
+                }
+            }
+
+            return new AasaValidationResult(true, apps.Count > 0, json, apps, null);
+        }
+        catch (TaskCanceledException)
+        {
+            return new AasaValidationResult(false, false, null, Array.Empty<AasaAppEntry>(), "Request timed out");
+        }
+        catch (Exception ex)
+        {
+            return new AasaValidationResult(false, false, null, Array.Empty<AasaAppEntry>(), ex.Message);
+        }
+    }
+
+    public async Task<AssetLinksValidationResult> ValidateAssetLinksAsync(string domain)
+    {
+        try
+        {
+            var url = $"https://{domain}/.well-known/assetlinks.json";
+            var response = await Http.GetAsync(url).ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                return new AssetLinksValidationResult(false, false, null, Array.Empty<AssetLinksEntry>(),
+                    $"HTTP {(int)response.StatusCode} {response.ReasonPhrase}");
+            }
+
+            var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var doc = JsonDocument.Parse(json);
+            var entries = new List<AssetLinksEntry>();
+
+            foreach (var element in doc.RootElement.EnumerateArray())
+            {
+                if (!element.TryGetProperty("relation", out var relation))
+                    continue;
+
+                var hasHandleAll = false;
+                foreach (var rel in relation.EnumerateArray())
+                {
+                    if (rel.GetString()?.Contains("delegate_permission/common.handle_all_urls") == true)
+                    {
+                        hasHandleAll = true;
+                        break;
+                    }
+                }
+
+                if (!hasHandleAll || !element.TryGetProperty("target", out var target))
+                    continue;
+
+                var package = target.TryGetProperty("package_name", out var pkg) ? pkg.GetString() : null;
+                if (package == null) continue;
+
+                string? fingerprint = null;
+                if (target.TryGetProperty("sha256_cert_fingerprints", out var fps) && fps.GetArrayLength() > 0)
+                    fingerprint = fps[0].GetString();
+
+                entries.Add(new AssetLinksEntry(package, fingerprint));
+            }
+
+            return new AssetLinksValidationResult(true, entries.Count > 0, json, entries, null);
+        }
+        catch (TaskCanceledException)
+        {
+            return new AssetLinksValidationResult(false, false, null, Array.Empty<AssetLinksEntry>(), "Request timed out");
+        }
+        catch (Exception ex)
+        {
+            return new AssetLinksValidationResult(false, false, null, Array.Empty<AssetLinksEntry>(), ex.Message);
+        }
+    }
+}

--- a/src/MauiSherpa.Core/Services/DeepLinkValidationService.cs
+++ b/src/MauiSherpa.Core/Services/DeepLinkValidationService.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography.Pkcs;
+using System.Text;
 using System.Text.Json;
 using MauiSherpa.Core.Interfaces;
 
@@ -20,11 +22,13 @@ public class DeepLinkValidationService : IDeepLinkValidationService
             if (!response.IsSuccessStatusCode)
             {
                 return new AasaValidationResult(false, false, null, Array.Empty<AasaAppEntry>(),
-                    $"HTTP {(int)response.StatusCode} {response.ReasonPhrase}");
+                    $"HTTP {(int)response.StatusCode} {response.ReasonPhrase}", false);
             }
 
-            var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-            var doc = JsonDocument.Parse(json);
+            var bytes = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+            var contentType = response.Content.Headers.ContentType?.MediaType;
+            var (json, wasSigned) = ExtractAasaJson(bytes, contentType);
+            using var doc = JsonDocument.Parse(json);
             var apps = new List<AasaAppEntry>();
 
             if (doc.RootElement.TryGetProperty("applinks", out var applinks) &&
@@ -71,16 +75,43 @@ public class DeepLinkValidationService : IDeepLinkValidationService
                 }
             }
 
-            return new AasaValidationResult(true, apps.Count > 0, json, apps, null);
+            return new AasaValidationResult(true, apps.Count > 0, json, apps, null, wasSigned);
         }
         catch (TaskCanceledException)
         {
-            return new AasaValidationResult(false, false, null, Array.Empty<AasaAppEntry>(), "Request timed out");
+            return new AasaValidationResult(false, false, null, Array.Empty<AasaAppEntry>(), "Request timed out", false);
         }
         catch (Exception ex)
         {
-            return new AasaValidationResult(false, false, null, Array.Empty<AasaAppEntry>(), ex.Message);
+            return new AasaValidationResult(false, false, null, Array.Empty<AasaAppEntry>(), ex.Message, false);
         }
+    }
+
+    static (string Json, bool WasSigned) ExtractAasaJson(byte[] bytes, string? contentType)
+    {
+        // AASA may be served as a CMS/PKCS7-signed blob (application/pkcs7-mime) or raw JSON.
+        // DER-encoded CMS starts with 0x30 (SEQUENCE); raw JSON starts with '{' or whitespace.
+        var looksSigned =
+            string.Equals(contentType, "application/pkcs7-mime", StringComparison.OrdinalIgnoreCase) ||
+            (bytes.Length > 0 && bytes[0] == 0x30);
+
+        if (looksSigned)
+        {
+            try
+            {
+                var cms = new SignedCms();
+                cms.Decode(bytes);
+                var inner = cms.ContentInfo.Content;
+                if (inner is { Length: > 0 })
+                    return (Encoding.UTF8.GetString(inner), true);
+            }
+            catch
+            {
+                // Fall through and try to parse as raw JSON anyway.
+            }
+        }
+
+        return (Encoding.UTF8.GetString(bytes), false);
     }
 
     public async Task<AssetLinksValidationResult> ValidateAssetLinksAsync(string domain)
@@ -97,7 +128,7 @@ public class DeepLinkValidationService : IDeepLinkValidationService
             }
 
             var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-            var doc = JsonDocument.Parse(json);
+            using var doc = JsonDocument.Parse(json);
             var entries = new List<AssetLinksEntry>();
 
             foreach (var element in doc.RootElement.EnumerateArray())

--- a/src/MauiSherpa.MacOS/MacOSMauiProgram.cs
+++ b/src/MauiSherpa.MacOS/MacOSMauiProgram.cs
@@ -139,6 +139,7 @@ public static class MacOSMauiProgram
         builder.Services.AddSingleton<IPhysicalDeviceService, MauiSherpa.Core.Services.PhysicalDeviceService>();
         builder.Services.AddSingleton<IPhysicalDeviceLogService, PhysicalDeviceLogService>();
         builder.Services.AddSingleton<SimInspectorService>();
+        builder.Services.AddSingleton<IDeepLinkValidationService, DeepLinkValidationService>();
 
         // Cloud Secrets Storage services
         builder.Services.AddSingleton<ICloudSecretsProviderFactory, CloudSecretsProviderFactory>();

--- a/src/MauiSherpa/Components/DeviceToolsTab.razor
+++ b/src/MauiSherpa/Components/DeviceToolsTab.razor
@@ -210,6 +210,13 @@
                     <i class="fas @(isValidatingLink ? "fa-spinner fa-spin" : "fa-shield-alt")"></i> Validate assetlinks.json
                 </button>
             </div>
+            @if (IsNonWebScheme(deepLinkUrl))
+            {
+                <div class="deep-link-warning">
+                    <i class="fas fa-triangle-exclamation"></i>
+                    <span>Custom URL scheme detected. assetlinks.json validation requires an <code>https://</code> URL. Launch will still attempt to open the scheme on the device.</span>
+                </div>
+            }
             @if (assetLinksResult != null)
             {
                 <div class="validation-result @(assetLinksResult.Valid ? "success" : assetLinksResult.Found ? "warning" : "error")">
@@ -337,6 +344,9 @@
     .validation-raw { margin-top: 0.375rem; }
     .validation-raw summary { cursor: pointer; color: var(--text-secondary); font-size: 0.625rem; }
     .validation-raw pre { margin: 0.25rem 0 0; padding: 0.375rem; background: var(--bg-tertiary); border-radius: 0.25rem; font-size: 0.625rem; overflow-x: auto; max-height: 200px; overflow-y: auto; white-space: pre-wrap; word-break: break-all; }
+    .deep-link-warning { margin-top: 0.375rem; padding: 0.375rem 0.5rem; border-radius: 0.375rem; font-size: 0.6875rem; background: rgba(234,179,8,0.08); border: 1px solid rgba(234,179,8,0.3); color: var(--text-primary); display: flex; gap: 0.375rem; align-items: flex-start; }
+    .deep-link-warning .fa-triangle-exclamation { color: #eab308; margin-top: 2px; }
+    .deep-link-warning code { background: var(--bg-tertiary); padding: 0 0.25rem; border-radius: 0.1875rem; font-size: 0.625rem; }
 </style>
 
 @code {
@@ -588,6 +598,13 @@
             (uri.Scheme == "https" || uri.Scheme == "http"))
             return uri.Host;
         return null;
+    }
+
+    private static bool IsNonWebScheme(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url)) return false;
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri)) return false;
+        return uri.Scheme != "https" && uri.Scheme != "http";
     }
 
     private static string FormatJson(string json)

--- a/src/MauiSherpa/Components/DeviceToolsTab.razor
+++ b/src/MauiSherpa/Components/DeviceToolsTab.razor
@@ -5,6 +5,7 @@
 @inject DeviceInspectorService Inspector
 @inject IAlertService AlertService
 @inject IDialogService DialogService
+@inject IDeepLinkValidationService DeepLinkValidator
 @implements IDisposable
 
 <div class="device-tools-tab">
@@ -204,7 +205,53 @@
                         disabled="@(isOpeningLink || string.IsNullOrWhiteSpace(deepLinkUrl))">
                     <i class="fas @(isOpeningLink ? "fa-spinner fa-spin" : "fa-rocket")"></i> Launch
                 </button>
+                <button class="btn btn-sm btn-secondary" @onclick="ValidateAssetLinks"
+                        disabled="@(isValidatingLink || string.IsNullOrWhiteSpace(deepLinkUrl))">
+                    <i class="fas @(isValidatingLink ? "fa-spinner fa-spin" : "fa-shield-alt")"></i> Validate assetlinks.json
+                </button>
             </div>
+            @if (assetLinksResult != null)
+            {
+                <div class="validation-result @(assetLinksResult.Valid ? "success" : assetLinksResult.Found ? "warning" : "error")">
+                    <div class="validation-status">
+                        <i class="fas @(assetLinksResult.Valid ? "fa-check-circle" : assetLinksResult.Found ? "fa-exclamation-triangle" : "fa-times-circle")"></i>
+                        @if (assetLinksResult.Valid)
+                        {
+                            <span>assetlinks.json found &mdash; @assetLinksResult.Entries.Count app(s) configured</span>
+                        }
+                        else if (assetLinksResult.Found)
+                        {
+                            <span>assetlinks.json found but no handle_all_urls entries detected</span>
+                        }
+                        else
+                        {
+                            <span>@(assetLinksResult.ErrorMessage ?? "assetlinks.json not found")</span>
+                        }
+                    </div>
+                    @if (assetLinksResult.Entries.Count > 0)
+                    {
+                        <div class="validation-entries">
+                            @foreach (var entry in assetLinksResult.Entries)
+                            {
+                                <div class="validation-entry">
+                                    <strong>@entry.Package</strong>
+                                    @if (entry.Sha256Fingerprint != null)
+                                    {
+                                        <span class="validation-fingerprint" title="@entry.Sha256Fingerprint">@entry.Sha256Fingerprint[..Math.Min(23, entry.Sha256Fingerprint.Length)]&hellip;</span>
+                                    }
+                                </div>
+                            }
+                        </div>
+                    }
+                    @if (assetLinksResult.RawJson != null)
+                    {
+                        <details class="validation-raw">
+                            <summary>Raw JSON</summary>
+                            <pre>@FormatJson(assetLinksResult.RawJson)</pre>
+                        </details>
+                    }
+                </div>
+            }
         </div>
     </div>
 </div>
@@ -274,6 +321,22 @@
     .tool-checkbox-row { display: flex; gap: 0.625rem; align-items: center; height: 28px; }
     .tool-checkbox { font-size: 0.6875rem; color: var(--text-secondary); display: flex; align-items: center; gap: 0.25rem; cursor: pointer; }
     .tool-checkbox input { margin: 0; }
+
+    .validation-result { margin-top: 0.375rem; padding: 0.5rem; border-radius: 0.375rem; font-size: 0.6875rem; border: 1px solid var(--border-color); }
+    .validation-result.success { background: rgba(34,197,94,0.08); border-color: rgba(34,197,94,0.3); }
+    .validation-result.warning { background: rgba(234,179,8,0.08); border-color: rgba(234,179,8,0.3); }
+    .validation-result.error { background: rgba(239,68,68,0.08); border-color: rgba(239,68,68,0.3); }
+    .validation-status { display: flex; align-items: center; gap: 0.375rem; font-weight: 600; }
+    .validation-status .fa-check-circle { color: #22c55e; }
+    .validation-status .fa-exclamation-triangle { color: #eab308; }
+    .validation-status .fa-times-circle { color: #ef4444; }
+    .validation-entries { margin-top: 0.375rem; display: flex; flex-direction: column; gap: 0.25rem; }
+    .validation-entry { padding: 0.25rem 0.375rem; background: var(--bg-tertiary); border-radius: 0.25rem; }
+    .validation-entry strong { color: var(--text-primary); }
+    .validation-fingerprint { color: var(--text-secondary); margin-left: 0.375rem; font-family: 'Consolas', 'Monaco', monospace; font-size: 0.625rem; }
+    .validation-raw { margin-top: 0.375rem; }
+    .validation-raw summary { cursor: pointer; color: var(--text-secondary); font-size: 0.625rem; }
+    .validation-raw pre { margin: 0.25rem 0 0; padding: 0.375rem; background: var(--bg-tertiary); border-radius: 0.25rem; font-size: 0.625rem; overflow-x: auto; max-height: 200px; overflow-y: auto; white-space: pre-wrap; word-break: break-all; }
 </style>
 
 @code {
@@ -307,6 +370,8 @@
     // Deep links
     private string deepLinkUrl = "";
     private bool isOpeningLink;
+    private bool isValidatingLink;
+    private AssetLinksValidationResult? assetLinksResult;
 
     protected override void OnInitialized()
     {
@@ -492,6 +557,47 @@
             isOpeningLink = false;
             StateHasChanged();
         }
+    }
+
+    private async Task ValidateAssetLinks()
+    {
+        if (string.IsNullOrWhiteSpace(deepLinkUrl)) return;
+        isValidatingLink = true;
+        assetLinksResult = null;
+        StateHasChanged();
+        try
+        {
+            var domain = ExtractDomain(deepLinkUrl);
+            if (domain == null)
+            {
+                await AlertService.ShowToastAsync("Enter an https:// URL to validate assetlinks.json");
+                return;
+            }
+            assetLinksResult = await DeepLinkValidator.ValidateAssetLinksAsync(domain);
+        }
+        finally
+        {
+            isValidatingLink = false;
+            StateHasChanged();
+        }
+    }
+
+    private static string? ExtractDomain(string url)
+    {
+        if (Uri.TryCreate(url, UriKind.Absolute, out var uri) &&
+            (uri.Scheme == "https" || uri.Scheme == "http"))
+            return uri.Host;
+        return null;
+    }
+
+    private static string FormatJson(string json)
+    {
+        try
+        {
+            using var doc = System.Text.Json.JsonDocument.Parse(json);
+            return System.Text.Json.JsonSerializer.Serialize(doc, new System.Text.Json.JsonSerializerOptions { WriteIndented = true });
+        }
+        catch { return json; }
     }
 
     public void Dispose()

--- a/src/MauiSherpa/Components/SimToolsTab.razor
+++ b/src/MauiSherpa/Components/SimToolsTab.razor
@@ -202,6 +202,13 @@
                     <i class="fas @(isValidatingLink ? "fa-spinner fa-spin" : "fa-shield-alt")"></i> Validate AASA
                 </button>
             </div>
+            @if (IsNonWebScheme(deepLinkUrl))
+            {
+                <div class="deep-link-warning">
+                    <i class="fas fa-triangle-exclamation"></i>
+                    <span>Custom URL scheme detected. AASA validation requires an <code>https://</code> URL. Launch will still attempt to open the scheme on the simulator.</span>
+                </div>
+            }
             @if (aasaResult != null)
             {
                 <div class="validation-result @(aasaResult.Valid ? "success" : aasaResult.Found ? "warning" : "error")">
@@ -209,7 +216,7 @@
                         <i class="fas @(aasaResult.Valid ? "fa-check-circle" : aasaResult.Found ? "fa-exclamation-triangle" : "fa-times-circle")"></i>
                         @if (aasaResult.Valid)
                         {
-                            <span>AASA found &mdash; @aasaResult.Apps.Count app(s) configured</span>
+                            <span>AASA found &mdash; @aasaResult.Apps.Count app(s) configured@(aasaResult.Signed ? " (signed)" : "")</span>
                         }
                         else if (aasaResult.Found)
                         {
@@ -332,6 +339,9 @@
     .validation-raw { margin-top: 0.375rem; }
     .validation-raw summary { cursor: pointer; color: var(--text-secondary); font-size: 0.625rem; }
     .validation-raw pre { margin: 0.25rem 0 0; padding: 0.375rem; background: var(--bg-tertiary); border-radius: 0.25rem; font-size: 0.625rem; overflow-x: auto; max-height: 200px; overflow-y: auto; white-space: pre-wrap; word-break: break-all; }
+    .deep-link-warning { margin-top: 0.375rem; padding: 0.375rem 0.5rem; border-radius: 0.375rem; font-size: 0.6875rem; background: rgba(234,179,8,0.08); border: 1px solid rgba(234,179,8,0.3); color: var(--text-primary); display: flex; gap: 0.375rem; align-items: flex-start; }
+    .deep-link-warning .fa-triangle-exclamation { color: #eab308; margin-top: 2px; }
+    .deep-link-warning code { background: var(--bg-tertiary); padding: 0 0.25rem; border-radius: 0.1875rem; font-size: 0.625rem; }
 </style>
 
 @code {
@@ -560,6 +570,13 @@
             (uri.Scheme == "https" || uri.Scheme == "http"))
             return uri.Host;
         return null;
+    }
+
+    private static bool IsNonWebScheme(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url)) return false;
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri)) return false;
+        return uri.Scheme != "https" && uri.Scheme != "http";
     }
 
     private static string FormatJson(string json)

--- a/src/MauiSherpa/Components/SimToolsTab.razor
+++ b/src/MauiSherpa/Components/SimToolsTab.razor
@@ -5,6 +5,7 @@
 @inject SimInspectorService Inspector
 @inject IAlertService AlertService
 @inject IDialogService DialogService
+@inject IDeepLinkValidationService DeepLinkValidator
 @implements IDisposable
 
 <div class="sim-tools-tab">
@@ -179,6 +180,72 @@
             </div>
         </div>
     </div>
+
+    <!-- Deep Links -->
+    <div class="tool-section">
+        <div class="tool-header">
+            <i class="fas fa-external-link-alt"></i>
+            <span>Deep Links</span>
+        </div>
+        <div class="tool-body">
+            <div class="tool-row">
+                <label>URL / Scheme</label>
+                <input type="text" class="tool-input" @bind="deepLinkUrl" placeholder="https://example.com/path or myapp://action" />
+            </div>
+            <div class="tool-actions">
+                <button class="btn btn-sm btn-primary" @onclick="OpenDeepLink"
+                        disabled="@(isOpeningLink || string.IsNullOrWhiteSpace(deepLinkUrl))">
+                    <i class="fas @(isOpeningLink ? "fa-spinner fa-spin" : "fa-rocket")"></i> Launch
+                </button>
+                <button class="btn btn-sm btn-secondary" @onclick="ValidateAasa"
+                        disabled="@(isValidatingLink || string.IsNullOrWhiteSpace(deepLinkUrl))">
+                    <i class="fas @(isValidatingLink ? "fa-spinner fa-spin" : "fa-shield-alt")"></i> Validate AASA
+                </button>
+            </div>
+            @if (aasaResult != null)
+            {
+                <div class="validation-result @(aasaResult.Valid ? "success" : aasaResult.Found ? "warning" : "error")">
+                    <div class="validation-status">
+                        <i class="fas @(aasaResult.Valid ? "fa-check-circle" : aasaResult.Found ? "fa-exclamation-triangle" : "fa-times-circle")"></i>
+                        @if (aasaResult.Valid)
+                        {
+                            <span>AASA found &mdash; @aasaResult.Apps.Count app(s) configured</span>
+                        }
+                        else if (aasaResult.Found)
+                        {
+                            <span>AASA found but no applinks entries detected</span>
+                        }
+                        else
+                        {
+                            <span>@(aasaResult.ErrorMessage ?? "AASA not found")</span>
+                        }
+                    </div>
+                    @if (aasaResult.Apps.Count > 0)
+                    {
+                        <div class="validation-entries">
+                            @foreach (var app in aasaResult.Apps)
+                            {
+                                <div class="validation-entry">
+                                    <strong>@app.AppId</strong>
+                                    @if (app.Paths.Count > 0)
+                                    {
+                                        <span class="validation-paths">@string.Join(", ", app.Paths)</span>
+                                    }
+                                </div>
+                            }
+                        </div>
+                    }
+                    @if (aasaResult.RawJson != null)
+                    {
+                        <details class="validation-raw">
+                            <summary>Raw JSON</summary>
+                            <pre>@FormatJson(aasaResult.RawJson)</pre>
+                        </details>
+                    }
+                </div>
+            }
+        </div>
+    </div>
 </div>
 
 <style>
@@ -249,6 +316,22 @@
     .tool-route-row { display: flex; align-items: center; gap: 0.5rem; }
     .route-file-name { font-size: 0.6875rem; color: var(--text-secondary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 180px; }
     .route-actions { display: flex; align-items: flex-end; }
+
+    .validation-result { margin-top: 0.375rem; padding: 0.5rem; border-radius: 0.375rem; font-size: 0.6875rem; border: 1px solid var(--border-color); }
+    .validation-result.success { background: rgba(34,197,94,0.08); border-color: rgba(34,197,94,0.3); }
+    .validation-result.warning { background: rgba(234,179,8,0.08); border-color: rgba(234,179,8,0.3); }
+    .validation-result.error { background: rgba(239,68,68,0.08); border-color: rgba(239,68,68,0.3); }
+    .validation-status { display: flex; align-items: center; gap: 0.375rem; font-weight: 600; }
+    .validation-status .fa-check-circle { color: #22c55e; }
+    .validation-status .fa-exclamation-triangle { color: #eab308; }
+    .validation-status .fa-times-circle { color: #ef4444; }
+    .validation-entries { margin-top: 0.375rem; display: flex; flex-direction: column; gap: 0.25rem; }
+    .validation-entry { padding: 0.25rem 0.375rem; background: var(--bg-tertiary); border-radius: 0.25rem; }
+    .validation-entry strong { color: var(--text-primary); }
+    .validation-paths { color: var(--text-secondary); margin-left: 0.375rem; }
+    .validation-raw { margin-top: 0.375rem; }
+    .validation-raw summary { cursor: pointer; color: var(--text-secondary); font-size: 0.625rem; }
+    .validation-raw pre { margin: 0.25rem 0 0; padding: 0.375rem; background: var(--bg-tertiary); border-radius: 0.25rem; font-size: 0.625rem; overflow-x: auto; max-height: 200px; overflow-y: auto; white-space: pre-wrap; word-break: break-all; }
 </style>
 
 @code {
@@ -268,6 +351,12 @@
     private string? routeFileName;
     private IReadOnlyList<RouteWaypoint>? routeWaypoints;
     private double routeSpeed = 20;
+
+    // Deep links
+    private string deepLinkUrl = "";
+    private bool isOpeningLink;
+    private bool isValidatingLink;
+    private AasaValidationResult? aasaResult;
 
     // Status bar
     private string statusTime = "";
@@ -421,6 +510,66 @@
             isApplyingStatus = false;
             StateHasChanged();
         }
+    }
+
+    // ── Deep Links ──
+
+    private async Task OpenDeepLink()
+    {
+        if (string.IsNullOrWhiteSpace(Udid) || string.IsNullOrWhiteSpace(deepLinkUrl)) return;
+        isOpeningLink = true;
+        StateHasChanged();
+        try
+        {
+            var ok = await SimulatorService.OpenUrlAsync(Udid, deepLinkUrl);
+            await AlertService.ShowToastAsync(ok ? "Deep link opened" : "Failed to open deep link");
+        }
+        finally
+        {
+            isOpeningLink = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task ValidateAasa()
+    {
+        if (string.IsNullOrWhiteSpace(deepLinkUrl)) return;
+        isValidatingLink = true;
+        aasaResult = null;
+        StateHasChanged();
+        try
+        {
+            var domain = ExtractDomain(deepLinkUrl);
+            if (domain == null)
+            {
+                await AlertService.ShowToastAsync("Enter an https:// URL to validate AASA");
+                return;
+            }
+            aasaResult = await DeepLinkValidator.ValidateAppleAppSiteAssociationAsync(domain);
+        }
+        finally
+        {
+            isValidatingLink = false;
+            StateHasChanged();
+        }
+    }
+
+    private static string? ExtractDomain(string url)
+    {
+        if (Uri.TryCreate(url, UriKind.Absolute, out var uri) &&
+            (uri.Scheme == "https" || uri.Scheme == "http"))
+            return uri.Host;
+        return null;
+    }
+
+    private static string FormatJson(string json)
+    {
+        try
+        {
+            using var doc = System.Text.Json.JsonDocument.Parse(json);
+            return System.Text.Json.JsonSerializer.Serialize(doc, new System.Text.Json.JsonSerializerOptions { WriteIndented = true });
+        }
+        catch { return json; }
     }
 
     public void Dispose()


### PR DESCRIPTION
This pull request adds deep link validation tools for both iOS (AASA) and Android (assetlinks.json) to the device and simulator tools tabs. It introduces a new `IDeepLinkValidationService` for validating domain association files, updates the UI to allow users to validate these files directly from the app, and displays detailed validation results with user-friendly feedback.

Key changes include:

**Core Service Implementation:**

* Added a new interface `IDeepLinkValidationService` and corresponding result record types (`AasaValidationResult`, `AssetLinksValidationResult`, etc.) to define methods for validating Apple App Site Association (AASA) and Android assetlinks.json files. (`src/MauiSherpa.Core/Interfaces.cs`)
* Implemented `DeepLinkValidationService` with logic to fetch, parse, and validate AASA and assetlinks.json files, handling both modern and legacy formats, and providing structured results. (`src/MauiSherpa.Core/Services/DeepLinkValidationService.cs`)
* Registered `DeepLinkValidationService` as a singleton in the DI container for MacOS. (`src/MauiSherpa.MacOS/MacOSMauiProgram.cs`)

**UI Integration – Device Tools Tab:**

* Injected `IDeepLinkValidationService` and added a new button to validate assetlinks.json from the device tools tab, showing a styled result section with summary, entry details, and raw JSON. (`src/MauiSherpa/Components/DeviceToolsTab.razor`) [[1]](diffhunk://#diff-27967622446497b64da1484d05cc73028a32ebf971609f470feb376d41d1edb3R8) [[2]](diffhunk://#diff-27967622446497b64da1484d05cc73028a32ebf971609f470feb376d41d1edb3R208-R254) [[3]](diffhunk://#diff-27967622446497b64da1484d05cc73028a32ebf971609f470feb376d41d1edb3R324-R339) [[4]](diffhunk://#diff-27967622446497b64da1484d05cc73028a32ebf971609f470feb376d41d1edb3R373-R374) [[5]](diffhunk://#diff-27967622446497b64da1484d05cc73028a32ebf971609f470feb376d41d1edb3R562-R602)

**UI Integration – Simulator Tools Tab:**

* Injected `IDeepLinkValidationService` and added a new deep links section to the simulator tools tab, allowing users to launch deep links and validate AASA files with detailed feedback and raw JSON display. (`src/MauiSherpa/Components/SimToolsTab.razor`) [[1]](diffhunk://#diff-55fff0672b44c0efea120238462573c04178f195488d0314e64edb94bb9f98f2R8) [[2]](diffhunk://#diff-55fff0672b44c0efea120238462573c04178f195488d0314e64edb94bb9f98f2R183-R248) [[3]](diffhunk://#diff-55fff0672b44c0efea120238462573c04178f195488d0314e64edb94bb9f98f2R319-R334) [[4]](diffhunk://#diff-55fff0672b44c0efea120238462573c04178f195488d0314e64edb94bb9f98f2R355-R360) [[5]](diffhunk://#diff-55fff0672b44c0efea120238462573c04178f195488d0314e64edb94bb9f98f2R515-R574)Initial commit