### PR TITLE
Fix linux menu for settings & doctor

### DIFF
--- a/src/MauiSherpa.LinuxGtk/LinuxToolbarManager.cs
+++ b/src/MauiSherpa.LinuxGtk/LinuxToolbarManager.cs
@@ -121,12 +121,24 @@ public class LinuxToolbarManager
         _copilotButton.OnClicked += (s, _) => _copilotContext.ToggleOverlay();
         _headerBar.PackStart(_copilotButton);
 
-        // Settings gear button on the right side
+        // Settings gear button beside copilot
         var settingsButton = Gtk.Button.New();
         settingsButton.SetIconName("emblem-system-symbolic");
         settingsButton.SetTooltipText("Settings");
         settingsButton.OnClicked += (s, _) => OpenSettingsDialog();
-        _headerBar.PackEnd(settingsButton);
+        _headerBar.PackStart(settingsButton);
+
+        // Doctor button beside settings
+        var doctorButton = Gtk.Button.New();
+        var doctorIconName = _themeService.IsDarkMode ? "fa-stethoscope-white-24.png" : "fa-stethoscope-24.png";
+        var doctorIconPath = System.IO.Path.Combine(AppContext.BaseDirectory, "Resources", doctorIconName);
+        if (System.IO.File.Exists(doctorIconPath))
+            doctorButton.SetChild(Gtk.Image.NewFromFile(doctorIconPath));
+        else
+            doctorButton.SetIconName("dialog-information-symbolic");
+        doctorButton.SetTooltipText("Doctor");
+        doctorButton.OnClicked += (s, _) => _toolbarService.RequestNavigation("/doctor");
+        _headerBar.PackStart(doctorButton);
 
         _window.SetTitlebar(_headerBar);
     }

--- a/src/MauiSherpa/Components/MainLayout.razor
+++ b/src/MauiSherpa/Components/MainLayout.razor
@@ -275,11 +275,6 @@
         ToolbarService.NotifyRouteChanged(route);
     }
 
-    private void OnNavigationRequested(string route)
-    {
-        InvokeAsync(() => NavManager.NavigateTo(route));
-    }
-
     private void OpenCopilot() => CopilotContext.OpenOverlay();
 
     private void OnNavigationRequested(string route)

--- a/src/MauiSherpa/Components/MainLayout.razor
+++ b/src/MauiSherpa/Components/MainLayout.razor
@@ -284,6 +284,19 @@
 
     private void OnNavigationRequested(string route)
     {
+        // Defensively validate/normalize the route coming from native UI
+        if (string.IsNullOrWhiteSpace(route))
+        {
+            return;
+        }
+
+        route = route.Trim();
+
+        // Reject absolute URIs/schemes to avoid accidental external navigation
+        if (Uri.TryCreate(route, UriKind.Absolute, out _))
+        {
+            return;
+        }
         _ = InvokeAsync(() => NavManager.NavigateTo(route));
     }
 }

--- a/src/MauiSherpa/Components/MainLayout.razor
+++ b/src/MauiSherpa/Components/MainLayout.razor
@@ -158,8 +158,7 @@
     protected override void OnInitialized()
     {
         ThemeService.ThemeChanged += OnThemeChanged;
-        if (PlatformInfo.IsWindows)
-            ToolbarService.NavigationRequested += OnNavigationRequested;
+        ToolbarService.NavigationRequested += OnNavigationRequested;
     }
     
     protected override void OnAfterRender(bool firstRender)
@@ -265,8 +264,7 @@
     {
         ThemeService.ThemeChanged -= OnThemeChanged;
         NavManager.LocationChanged -= OnLocationChanged;
-        if (PlatformInfo.IsWindows)
-            ToolbarService.NavigationRequested -= OnNavigationRequested;
+        ToolbarService.NavigationRequested -= OnNavigationRequested;
     }
 
     private void OnLocationChanged(object? sender, Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs e)
@@ -283,6 +281,11 @@
     }
 
     private void OpenCopilot() => CopilotContext.OpenOverlay();
+
+    private void OnNavigationRequested(string route)
+    {
+        _ = InvokeAsync(() => NavManager.NavigateTo(route));
+    }
 }
 
 <style>


### PR DESCRIPTION
This pull request adds the ability for native UI elements to trigger navigation to Blazor routes, and introduces a new "Doctor" button to the Linux GTK toolbar that uses this feature to navigate to a diagnostic page. The changes include updates to the toolbar service interface and implementation, the GTK toolbar manager, and the main layout component to support and handle navigation requests from native UI.

**Native-to-Blazor Navigation Integration:**

* Added a new event `NavigationRequested` and method `RequestNavigation` to the `IToolbarService` interface and implemented them in `ToolbarService`, allowing native UI to request navigation to a specific Blazor route. [[1]](diffhunk://#diff-364b0ab7396b42e17c3f7ef7f6636b77ac4700102899bb95645ea96bc75fd2d4R3674-R3677) [[2]](diffhunk://#diff-3f5452a988e0f52bd8376983dce0572c6c6083186a209c5c6cbffe6332afb836R106-R112)
* Subscribed to and handled the `NavigationRequested` event in `MainLayout.razor` to perform navigation using `NavManager`, and ensured proper event unsubscription during component disposal. [[1]](diffhunk://#diff-d3bbdf023e3c83d5f234d04372823674da391a614b7c1c9948e9519384c44e94R161) [[2]](diffhunk://#diff-d3bbdf023e3c83d5f234d04372823674da391a614b7c1c9948e9519384c44e94R267) [[3]](diffhunk://#diff-d3bbdf023e3c83d5f234d04372823674da391a614b7c1c9948e9519384c44e94R279-R283)

**GTK Toolbar Enhancements:**

* Added a new "Doctor" button to the Linux GTK toolbar, which uses a context-sensitive icon and, when clicked, triggers navigation to the `/doctor` route via the new toolbar service method. Also repositioned the settings button to be beside the Copilot button for improved UI consistency.


Part of this effort will be in conflict with #136 - but merge is simple