### PR TITLE
Fix Doctor Android SDK acquisition and path persistence

### DIFF
--- a/src/MauiSherpa.Core/MauiSherpa.Core.csproj
+++ b/src/MauiSherpa.Core/MauiSherpa.Core.csproj
@@ -26,8 +26,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AndroidSdk" Version="0.33.0" />
-    <PackageReference Include="AndroidSdk.Adbd" Version="0.33.0" />
+    <PackageReference Include="AndroidSdk" Version="0.35.1" />
+    <PackageReference Include="AndroidSdk.Adbd" Version="0.35.1" />
     <PackageReference Include="AppStoreConnectClient" Version="0.2.24" />
     <PackageReference Include="AWSSDK.SecretsManager" Version="4.0.4.6" />
     <PackageReference Include="Azure.Identity" Version="1.13.2" />

--- a/src/MauiSherpa.Core/Services/AndroidSdkService.cs
+++ b/src/MauiSherpa.Core/Services/AndroidSdkService.cs
@@ -297,6 +297,7 @@ public class AndroidSdkService : IAndroidSdkService
                 
                 progress?.Report($"Android SDK installed at: {targetPath}");
                 _logger.LogInformation($"Acquired Android SDK at: {targetPath}");
+                SdkPathChanged?.Invoke();
                 return true;
             }
             catch (Exception ex)

--- a/src/MauiSherpa.Core/Services/DoctorService.cs
+++ b/src/MauiSherpa.Core/Services/DoctorService.cs
@@ -18,6 +18,7 @@ public class DoctorService : IDoctorService
     private readonly IAndroidSdkService _androidSdkService;
     private readonly ILoggingService _loggingService;
     private readonly IOpenJdkSettingsService _jdkSettingsService;
+    private readonly IAndroidSdkSettingsService? _androidSdkSettingsService;
     private readonly IDebugFlagService? _debugFlags;
     private readonly ILogger<DoctorService> _logger;
     private readonly ILoggerFactory _loggerFactory;
@@ -29,12 +30,13 @@ public class DoctorService : IDoctorService
     private WorkloadSetService? _workloadSetService;
     private SdkVersionService? _sdkVersionService;
     
-    public DoctorService(IAndroidSdkService androidSdkService, ILoggingService loggingService, IOpenJdkSettingsService jdkSettingsService, ILoggerFactory? loggerFactory = null, IDebugFlagService? debugFlags = null)
+    public DoctorService(IAndroidSdkService androidSdkService, ILoggingService loggingService, IOpenJdkSettingsService jdkSettingsService, ILoggerFactory? loggerFactory = null, IDebugFlagService? debugFlags = null, IAndroidSdkSettingsService? androidSdkSettingsService = null)
     {
         _androidSdkService = androidSdkService;
         _loggingService = loggingService;
         _jdkSettingsService = jdkSettingsService;
         _debugFlags = debugFlags;
+        _androidSdkSettingsService = androidSdkSettingsService;
         _loggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
         _logger = _loggerFactory.CreateLogger<DoctorService>();
     }
@@ -1037,7 +1039,15 @@ public class DoctorService : IDoctorService
             if (dependency.FixAction == "install-android-sdk")
             {
                 progress?.Report("Acquiring Android SDK...");
-                return await _androidSdkService.AcquireSdkAsync(progress: progress);
+                var acquired = await _androidSdkService.AcquireSdkAsync(progress: progress);
+                
+                if (acquired && _androidSdkSettingsService != null && !string.IsNullOrEmpty(_androidSdkService.SdkPath))
+                {
+                    await _androidSdkSettingsService.SetCustomSdkPathAsync(_androidSdkService.SdkPath);
+                    progress?.Report($"SDK path saved: {_androidSdkService.SdkPath}");
+                }
+                
+                return acquired;
             }
             
             if (dependency.FixAction == "install-workloads")


### PR DESCRIPTION
## Problem

The Doctor's 'Fix: Android SDK' action failed with:
  'Android SDK Directory was not specified.'

Even after fixing the upstream AndroidSdk.Tools library ([PR #91](https://github.com/Redth/AndroidSdk.Tools/pull/91)), a second issue remained: after successfully acquiring the SDK to ~/android-sdk, restarting the app caused the Doctor to pick up ~/.android instead — a user config directory, not an SDK installation.

## Root Cause

Two bugs contributed to the broken experience:

### 1. Upstream: SdkLocator discarded non-existent paths (fixed in AndroidSdk 0.35.1)

AndroidSdkManager and SdkTool constructors passed the user-specified target directory through SdkLocator.Locate(), which only returns paths where Directory.Exists() is true. When acquiring a fresh SDK, the target directory doesn't exist yet, so:
  - Locate() discarded the user's path
  - It returned either null or a different directory (e.g. ~/.android)
  - DownloadSdk() then threw because it had no valid target

This was fixed upstream in Redth/AndroidSdk.Tools#91 and released in AndroidSdk 0.35.1.

### 2. Local: Acquired SDK path was never persisted

After AcquireSdkAsync successfully installed the SDK to ~/android-sdk:
  - The in-memory _sdkManager was updated correctly
  - SdkPathChanged event was NOT fired (missing invoke)
  - The path was NOT saved to secure storage

On app restart, AndroidSdkSettingsService.InitializeAsync() found no saved custom path and fell back to DetectSdkAsync(), which auto- discovered ~/.android (a config directory created during the fix process) instead of ~/android-sdk (the actual SDK installation).

## Changes

### AndroidSdkService.cs
- Fire SdkPathChanged event after successful SDK acquisition so that listeners (device watchers, UI pages) are notified immediately

### DoctorService.cs
- Accept optional IAndroidSdkSettingsService via constructor injection
- After a successful 'install-android-sdk' fix action, persist the acquired SDK path via SetCustomSdkPathAsync() so it survives app restarts and is not overridden by auto-detection

### MauiSherpa.Core.csproj
- Update AndroidSdk from 0.33.0 to 0.35.1 (includes upstream fix)
- Update AndroidSdk.Adbd from 0.33.0 to 0.35.1