### PR TITLE
Improve Android SDK first-run setup UX

### DIFF
--- a/src/MauiSherpa.Core/Services/AndroidSdkService.cs
+++ b/src/MauiSherpa.Core/Services/AndroidSdkService.cs
@@ -84,11 +84,11 @@ public class AndroidSdkService : IAndroidSdkService
             {
                 // Create a temporary manager to detect the default path
                 var tempManager = new AndroidSdkManager();
-                return tempManager.Home?.FullName;
+                return tempManager.Home?.FullName ?? GetRecommendedSdkPath();
             }
             catch
             {
-                return null;
+                return GetRecommendedSdkPath();
             }
         });
     }
@@ -287,10 +287,11 @@ public class AndroidSdkService : IAndroidSdkService
                 
                 if (string.IsNullOrEmpty(targetPath))
                 {
-                    targetPath = Path.Combine(
-                        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-                        "android-sdk");
+                    targetPath = GetRecommendedSdkPath();
                 }
+
+                Directory.CreateDirectory(targetPath);
+                progress?.Report($"Installing Android SDK to {targetPath}...");
 
                 _sdkManager = new AndroidSdkManager(new DirectoryInfo(targetPath));
                 await _sdkManager.Acquire();
@@ -307,6 +308,31 @@ public class AndroidSdkService : IAndroidSdkService
                 return false;
             }
         });
+    }
+
+    private static string GetRecommendedSdkPath()
+    {
+        if (OperatingSystem.IsMacOS() || OperatingSystem.IsMacCatalyst())
+        {
+            return Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                "Library",
+                "Android",
+                "sdk");
+        }
+
+        if (OperatingSystem.IsWindows())
+        {
+            return Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "Android",
+                "Sdk");
+        }
+
+        return Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            "Android",
+            "Sdk");
     }
 
     public Task<IReadOnlyList<Interfaces.AvdInfo>> GetAvdsAsync()

--- a/src/MauiSherpa.Core/ViewModels/AndroidSdkViewModel.cs
+++ b/src/MauiSherpa.Core/ViewModels/AndroidSdkViewModel.cs
@@ -122,7 +122,7 @@ public class AndroidSdkViewModel : ViewModelBase
             }
             else
             {
-                StatusMessage = "Android SDK not found. Click 'Install SDK' to download.";
+                StatusMessage = "Android SDK not found. Choose an install location below to get started.";
             }
         }
         catch (Exception ex)
@@ -244,25 +244,42 @@ public class AndroidSdkViewModel : ViewModelBase
         }
     }
 
-    public async Task AcquireSdkAsync()
+    public async Task<bool> AcquireSdkAsync(string? targetPath = null, IProgress<string>? progress = null)
     {
         IsLoading = true;
-        var progress = new Progress<string>(msg => StatusMessage = msg);
+
+        void ReportProgress(string message)
+        {
+            StatusMessage = message;
+            progress?.Report(message);
+        }
+
+        var combinedProgress = new Progress<string>(ReportProgress);
 
         try
         {
-            var success = await _sdkService.AcquireSdkAsync(progress: progress);
+            var installPath = string.IsNullOrWhiteSpace(targetPath)
+                ? await _sdkService.GetDefaultSdkPathAsync()
+                : targetPath;
+
+            var success = await _sdkService.AcquireSdkAsync(targetPath: installPath, progress: combinedProgress);
             if (success)
             {
+                var effectivePath = _sdkService.SdkPath ?? installPath;
+                if (!string.IsNullOrWhiteSpace(effectivePath))
+                {
+                    await _sdkSettings.SetCustomSdkPathAsync(effectivePath);
+                    await _mediator.FlushStores("android:sdkpath");
+                }
+
                 IsSdkInstalled = true;
-                SdkPath = _sdkService.SdkPath;
+                SdkPath = effectivePath;
                 await AlertService.ShowToastAsync("Android SDK installed successfully!");
-                await RefreshPackagesAsync(forceRefresh: true);
+                await DetectSdkAsync(forceRefresh: true);
+                return true;
             }
-            else
-            {
-                await AlertService.ShowAlertAsync("Installation Failed", "Could not download Android SDK");
-            }
+
+            await AlertService.ShowAlertAsync("Installation Failed", "Could not download Android SDK");
         }
         catch (Exception ex)
         {
@@ -273,5 +290,7 @@ public class AndroidSdkViewModel : ViewModelBase
         {
             IsLoading = false;
         }
+
+        return false;
     }
 }

--- a/src/MauiSherpa/Pages/AndroidSdk.razor
+++ b/src/MauiSherpa/Pages/AndroidSdk.razor
@@ -4,6 +4,8 @@
 @using MauiSherpa.Services
 @inject AndroidSdkViewModel ViewModel
 @inject IAndroidSdkService SdkService
+@inject IAndroidSdkSettingsService SdkSettings
+@inject IOpenJdkSettingsService JdkSettings
 @inject IDialogService DialogService
 @inject IAlertService AlertService
 @inject IFileSystemService FileSystem
@@ -50,6 +52,117 @@
         </div>
         <div class="loading-title">Loading SDK Packages</div>
         <div class="loading-description">Discovering installed and available packages...</div>
+    </div>
+}
+else if (!ViewModel.IsSdkInstalled)
+{
+    <div class="setup-card content-card">
+        <div class="setup-card-header">
+            <div class="setup-card-icon">
+                <i class="fab fa-android"></i>
+            </div>
+            <div class="setup-card-copy">
+                <h3>Android SDK not installed yet</h3>
+                <p>Set up the Android command-line tools here so you can browse packages, install platforms, and manage emulators from MAUI Sherpa.</p>
+            </div>
+        </div>
+
+        <div class="setup-card-grid">
+            <div class="setup-status-card missing">
+                <div class="setup-status-icon"><i class="fas fa-box-open"></i></div>
+                <div>
+                    <div class="setup-status-title">Android SDK</div>
+                    <div class="setup-status-text">Not currently installed</div>
+                </div>
+            </div>
+
+            <div class="setup-status-card @(HasJdkConfigured ? "ready" : "warning")">
+                <div class="setup-status-icon">
+                    <i class="fas @(HasJdkConfigured ? "fa-check-circle" : "fa-exclamation-triangle")"></i>
+                </div>
+                <div>
+                    <div class="setup-status-title">OpenJDK</div>
+                    <div class="setup-status-text">
+                        @if (HasJdkConfigured)
+                        {
+                            <span>Ready at <span class="mono text-selectable">@detectedJdkPath</span></span>
+                        }
+                        else
+                        {
+                            <span>Not configured yet. Some Android SDK tools need Java to work properly.</span>
+                        }
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="setup-path-section">
+            <label class="setup-label">Install location</label>
+            <div class="setup-path-row">
+                <input type="text"
+                       class="setup-path-input mono"
+                       @bind="installSdkPath"
+                       @bind:event="oninput"
+                       placeholder="Choose a folder for the Android SDK"
+                       disabled="@ViewModel.IsLoading" />
+                <button class="btn btn-secondary" @onclick="BrowseInstallFolder" disabled="@ViewModel.IsLoading">
+                    <i class="fas fa-folder-open"></i> Browse
+                </button>
+            </div>
+            <div class="setup-help-text">
+                Recommended default: <span class="mono text-selectable">@recommendedSdkPath</span>
+            </div>
+        </div>
+
+        @if (!HasJdkConfigured)
+        {
+            <div class="setup-warning-banner">
+                <div class="setup-warning-copy">
+                    <strong>OpenJDK is also recommended for a complete Android setup.</strong>
+                    <span>Configure a JDK before or after installation so tools like <code>sdkmanager</code> and <code>keytool</code> work reliably.</span>
+                </div>
+                <div class="setup-warning-actions">
+                    <a class="btn btn-secondary btn-sm" href="/settings">
+                        <i class="fas fa-sliders-h"></i> JDK Settings
+                    </a>
+                    <a class="btn btn-outline btn-sm" href="/doctor">
+                        <i class="fas fa-stethoscope"></i> Environment Doctor
+                    </a>
+                </div>
+            </div>
+        }
+
+        <div class="setup-actions">
+            <button class="btn btn-success" @onclick="AcquireSdk" disabled="@ViewModel.IsLoading || string.IsNullOrWhiteSpace(installSdkPath)">
+                <i class="fas fa-download"></i> @(ViewModel.IsLoading ? "Installing..." : "Install Android SDK")
+            </button>
+            <a class="btn btn-outline" href="/settings">
+                <i class="fas fa-cog"></i> Advanced Settings
+            </a>
+            <a class="btn btn-outline" href="/doctor">
+                <i class="fas fa-tools"></i> Run Doctor
+            </a>
+        </div>
+
+        <div class="setup-status-note">@ViewModel.StatusMessage</div>
+    </div>
+}
+
+@if (hasInitialized && ViewModel.IsSdkInstalled && !HasJdkConfigured)
+{
+    <div class="setup-warning-banner" style="margin-bottom: 1rem;">
+        <div class="setup-warning-copy">
+            <strong>OpenJDK is not configured.</strong>
+            <span>Android package management can require a working JDK. Configure it in Settings if installs or updates are failing.</span>
+        </div>
+        <div class="setup-warning-actions">
+            <a class="btn btn-secondary btn-sm" href="/settings">
+                <i class="fas fa-sliders-h"></i> JDK Settings
+            </a>
+            <a class="btn btn-outline btn-sm" href="/doctor">
+                <i class="fas fa-stethoscope"></i> Environment Doctor
+            </a>
+        </div>
     </div>
 }
 
@@ -273,6 +386,159 @@
     .toolbar {
         margin-bottom: 1rem;
         display: flex;
+        align-items: center;
+    }
+
+    .setup-card {
+        padding: 1.5rem;
+        margin-bottom: 1rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+    }
+
+    .setup-card-header {
+        display: flex;
+        gap: 1rem;
+        align-items: flex-start;
+    }
+
+    .setup-card-icon {
+        width: 3rem;
+        height: 3rem;
+        border-radius: 0.875rem;
+        background: var(--bg-tertiary);
+        color: var(--accent-primary);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 1.4rem;
+        flex-shrink: 0;
+    }
+
+    .setup-card-copy h3 {
+        margin: 0 0 0.375rem 0;
+        font-size: 1.2rem;
+    }
+
+    .setup-card-copy p {
+        margin: 0;
+        line-height: 1.5;
+    }
+
+    .setup-card-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+        gap: 0.75rem;
+    }
+
+    .setup-status-card {
+        display: flex;
+        align-items: flex-start;
+        gap: 0.75rem;
+        padding: 0.875rem 1rem;
+        border-radius: 0.75rem;
+        border: 1px solid var(--border-color);
+        background: var(--bg-secondary);
+    }
+
+    .setup-status-card.ready {
+        background: var(--status-success-bg);
+        border-color: var(--status-success-text);
+    }
+
+    .setup-status-card.warning,
+    .setup-status-card.missing {
+        background: var(--status-warning-bg);
+        border-color: var(--border-color);
+    }
+
+    .setup-status-icon {
+        font-size: 1rem;
+        margin-top: 0.1rem;
+        color: var(--text-primary);
+    }
+
+    .setup-status-title {
+        font-weight: 600;
+        color: var(--text-primary);
+        margin-bottom: 0.2rem;
+    }
+
+    .setup-status-text {
+        color: var(--text-secondary);
+        font-size: 0.875rem;
+        line-height: 1.4;
+    }
+
+    .setup-path-section {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+    }
+
+    .setup-label {
+        font-size: 0.8125rem;
+        font-weight: 700;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        color: var(--text-muted);
+    }
+
+    .setup-path-row {
+        display: flex;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+    }
+
+    .setup-path-input {
+        flex: 1;
+        min-width: 260px;
+        padding: 0.75rem 0.9rem;
+        border-radius: 0.5rem;
+        border: 1px solid var(--border-color);
+        box-sizing: border-box;
+    }
+
+    .setup-path-input:focus {
+        outline: none;
+        border-color: var(--accent-primary);
+        box-shadow: 0 0 0 3px rgba(66, 153, 225, 0.12);
+    }
+
+    .setup-help-text,
+    .setup-status-note {
+        font-size: 0.875rem;
+        color: var(--text-secondary);
+    }
+
+    .setup-warning-banner {
+        display: flex;
+        justify-content: space-between;
+        gap: 1rem;
+        padding: 0.9rem 1rem;
+        border-radius: 0.75rem;
+        background: var(--status-warning-bg);
+        border: 1px solid var(--border-color);
+        flex-wrap: wrap;
+    }
+
+    .setup-warning-copy {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+        max-width: 46rem;
+    }
+
+    .setup-warning-copy strong {
+        color: var(--text-primary);
+    }
+
+    .setup-warning-actions,
+    .setup-actions {
+        display: flex;
+        gap: 0.75rem;
+        flex-wrap: wrap;
         align-items: center;
     }
 
@@ -659,11 +925,15 @@
     private string activeTab = "installed";
     private HashSet<string> expandedGroups = new();
     private bool hasInitialized = false;
+    private string recommendedSdkPath = "";
+    private string installSdkPath = "";
+    private string? detectedJdkPath;
 
     // Filter state
     private string searchQuery = "";
     private string filterCategory = "";
     private string filterUpdates = "";
+    private bool HasJdkConfigured => !string.IsNullOrWhiteSpace(detectedJdkPath);
 
     private bool HasActiveFilters => !string.IsNullOrEmpty(searchQuery) || 
                                       !string.IsNullOrEmpty(filterCategory) || 
@@ -764,7 +1034,17 @@
         ToolbarService.FilterChanged += OnFilterChanged;
 
         await ViewModel.InitializeAsync();
+        await RefreshSetupStateAsync();
         hasInitialized = true;
+    }
+
+    private async Task RefreshSetupStateAsync()
+    {
+        recommendedSdkPath = await SdkService.GetDefaultSdkPathAsync() ?? "";
+        installSdkPath = ViewModel.SdkPath ?? SdkSettings.CustomSdkPath ?? recommendedSdkPath;
+
+        await JdkSettings.InitializeAsync();
+        detectedJdkPath = await JdkSettings.GetEffectiveJdkPathAsync();
     }
 
     private void OnSearchTextChanged(string text)
@@ -923,6 +1203,7 @@
     private async Task RefreshData()
     {
         await ViewModel.RefreshPackagesAsync(forceRefresh: true);
+        await RefreshSetupStateAsync();
 
         // Update category filter with dynamic values from loaded packages
         ToolbarService.SetFilters(
@@ -933,13 +1214,29 @@
 
     private async Task AcquireSdk()
     {
+        var targetPath = string.IsNullOrWhiteSpace(installSdkPath)
+            ? recommendedSdkPath
+            : installSdkPath;
+
+        if (string.IsNullOrWhiteSpace(targetPath))
+        {
+            await AlertService.ShowAlertAsync("Install Location Required", "Choose an install folder for the Android SDK first.");
+            return;
+        }
+
         var result = await OperationModal.RunAsync(
             "Install Android SDK",
-            "Downloading and installing the Android SDK...",
+            $"Downloading and installing the Android SDK to {targetPath}...",
             async ctx =>
             {
+                ctx.LogInfo($"Target install path: {targetPath}");
+                if (!HasJdkConfigured)
+                {
+                    ctx.LogWarning("OpenJDK is not configured. Some Android tooling may require a JDK after installation.");
+                }
+
                 ctx.SetStatus("Initializing...");
-                var success = await SdkService.AcquireSdkAsync(progress: new Progress<string>(msg =>
+                var success = await ViewModel.AcquireSdkAsync(targetPath, new Progress<string>(msg =>
                 {
                     ctx.LogInfo(msg);
                     ctx.SetStatus(msg);
@@ -949,7 +1246,16 @@
 
         if (result.Success)
         {
-            await ViewModel.RefreshPackagesAsync(forceRefresh: true);
+            await RefreshSetupStateAsync();
+        }
+    }
+
+    private async Task BrowseInstallFolder()
+    {
+        var path = await DialogService.PickFolderAsync("Select Android SDK Install Location");
+        if (!string.IsNullOrWhiteSpace(path))
+        {
+            installSdkPath = path;
         }
     }
 

--- a/tests/MauiSherpa.Core.Tests/ViewModels/AndroidSdkViewModelTests.cs
+++ b/tests/MauiSherpa.Core.Tests/ViewModels/AndroidSdkViewModelTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using MauiSherpa.Core.Interfaces;
+using MauiSherpa.Core.Requests.Android;
 using MauiSherpa.Core.ViewModels;
 using Moq;
 using Shiny.Mediator;
@@ -156,5 +157,66 @@ public class AndroidSdkViewModelTests
 
         // Assert
         _viewModel.AvailablePackages.Should().BeEquivalentTo(packages);
+    }
+
+    [Fact]
+    public async Task DetectSdkAsync_SetsInstalledStateAndLoadsPackages_WhenSdkPathExists()
+    {
+        // Arrange
+        var expectedPath = "/Users/test/Library/Android/sdk";
+        var installedPackages = new List<SdkPackageInfo>
+        {
+            new("platform-tools", "Platform Tools", "35.0.0", expectedPath, true)
+        };
+        var availablePackages = new List<SdkPackageInfo>
+        {
+            new("platforms;android-35", "Android 35", "35", null, false)
+        };
+        var devices = new List<DeviceInfo>
+        {
+            new("emulator-5554", "device", "Pixel", true)
+        };
+
+        _mockMediator
+            .Setup(m => m.Request(It.IsAny<GetSdkPathRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Mock.Of<IMediatorContext>(), expectedPath));
+        _mockMediator
+            .Setup(m => m.Request(It.IsAny<GetInstalledPackagesRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Mock.Of<IMediatorContext>(), (IReadOnlyList<SdkPackageInfo>)installedPackages));
+        _mockMediator
+            .Setup(m => m.Request(It.IsAny<GetAvailablePackagesRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Mock.Of<IMediatorContext>(), (IReadOnlyList<SdkPackageInfo>)availablePackages));
+        _mockMediator
+            .Setup(m => m.Request(It.IsAny<GetAndroidDevicesRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Mock.Of<IMediatorContext>(), (IReadOnlyList<DeviceInfo>)devices));
+
+        // Act
+        await _viewModel.DetectSdkAsync();
+
+        // Assert
+        _viewModel.IsSdkInstalled.Should().BeTrue();
+        _viewModel.SdkPath.Should().Be(expectedPath);
+        _viewModel.InstalledPackages.Should().BeEquivalentTo(installedPackages);
+        _viewModel.AvailablePackages.Should().BeEquivalentTo(availablePackages);
+        _viewModel.Devices.Should().BeEquivalentTo(devices);
+    }
+
+    [Fact]
+    public async Task AcquireSdkAsync_ReturnsFalse_WhenDownloadFails()
+    {
+        // Arrange
+        _mockSdkService
+            .Setup(s => s.AcquireSdkAsync(It.IsAny<string?>(), It.IsAny<IProgress<string>?>()))
+            .ReturnsAsync(false);
+        _mockAlertService
+            .Setup(a => a.ShowAlertAsync("Installation Failed", It.IsAny<string>()))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        var result = await _viewModel.AcquireSdkAsync("/tmp/android-sdk");
+
+        // Assert
+        result.Should().BeFalse();
+        _mockAlertService.Verify(a => a.ShowAlertAsync("Installation Failed", It.IsAny<string>()), Times.Once);
     }
 }


### PR DESCRIPTION
## Why
When no Android SDK was installed, the packages page could leave users at a blank dead end with no clear way to get started. A missing JDK also makes Android tooling setup confusing and easy to misdiagnose.

## What changed
- add a proper first-run setup card on the Android SDK page instead of the blank state
- show a recommended default SDK install location, while still allowing a custom folder via browse/edit
- surface OpenJDK readiness and link to Settings or Doctor when Java is missing
- persist the chosen SDK path and reload package data immediately after install

## Notes
- the default SDK location now follows standard Android Studio conventions on each platform
- added targeted view model coverage for the new detect/install behavior