### PR TITLE
Add MAUI SemanticProperties to inspector properties panel

### DIFF
--- a/src/MauiSherpa.AppInspector/Pages/Inspector/DevFlowTreeTab.razor
+++ b/src/MauiSherpa.AppInspector/Pages/Inspector/DevFlowTreeTab.razor
@@ -172,6 +172,35 @@
                     }
                 </div>
 
+                <!-- Semantic Properties (from element info) -->
+                @if (!string.IsNullOrEmpty(selectedElement.SemanticDescription) || !string.IsNullOrEmpty(selectedElement.SemanticHint) || !string.IsNullOrEmpty(selectedElement.SemanticHeadingLevel))
+                {
+                    <div class="prop-section">
+                        <div class="prop-group-title"><i class="fas fa-universal-access prop-group-icon"></i> Accessibility</div>
+                        @if (!string.IsNullOrEmpty(selectedElement.SemanticDescription))
+                        {
+                            <div class="prop-row">
+                                <span class="prop-key">Description</span>
+                                <span class="prop-value">@selectedElement.SemanticDescription</span>
+                            </div>
+                        }
+                        @if (!string.IsNullOrEmpty(selectedElement.SemanticHint))
+                        {
+                            <div class="prop-row">
+                                <span class="prop-key">Hint</span>
+                                <span class="prop-value">@selectedElement.SemanticHint</span>
+                            </div>
+                        }
+                        @if (!string.IsNullOrEmpty(selectedElement.SemanticHeadingLevel) && !selectedElement.SemanticHeadingLevel.Equals("None", StringComparison.OrdinalIgnoreCase))
+                        {
+                            <div class="prop-row">
+                                <span class="prop-key">Heading Level</span>
+                                <span class="prop-value">@selectedElement.SemanticHeadingLevel</span>
+                            </div>
+                        }
+                    </div>
+                }
+
                 <!-- Gestures -->
                 @if (selectedElement.Gestures?.Count > 0)
                 {
@@ -388,11 +417,17 @@
             EnumValues: new[] { "Default", "Chat", "Email", "Numeric", "Plain", "Telephone", "Text", "Url" }),
         ["AutomationId"] = new(EditorType.Text, "Behavior", SortOrder: 0),
         ["Text"] = new(EditorType.Text, "Appearance", SortOrder: 0),
+
+        // --- Accessibility (SemanticProperties) ---
+        ["SemanticProperties.Description"] = new(EditorType.Text, "Accessibility", SortOrder: 0),
+        ["SemanticProperties.Hint"] = new(EditorType.Text, "Accessibility", SortOrder: 1),
+        ["SemanticProperties.HeadingLevel"] = new(EditorType.Enum, "Accessibility", SortOrder: 2,
+            EnumValues: new[] { "None", "Level1", "Level2", "Level3", "Level4", "Level5", "Level6", "Level7", "Level8", "Level9" }),
     };
 
     private static readonly string[] CommonProperties = PropertyRegistry.Keys.ToArray();
 
-    private static readonly string[] GroupOrder = new[] { "Appearance", "Layout", "Behavior", "Transform", "Other" };
+    private static readonly string[] GroupOrder = new[] { "Appearance", "Layout", "Behavior", "Accessibility", "Transform", "Other" };
 
     private static PropertyMeta GetMeta(string propName)
         => PropertyRegistry.TryGetValue(propName, out var meta) ? meta : new PropertyMeta(EditorType.Text, "Other");
@@ -2911,6 +2946,11 @@
         border-left: 3px solid var(--accent-color, #8b5cf6);
         text-transform: uppercase;
         letter-spacing: 0.04em;
+    }
+
+    .prop-group-icon {
+        margin-right: 0.25rem;
+        font-size: 0.65rem;
     }
 
     /* Boolean toggle */

--- a/src/MauiSherpa.Core/Models/DevFlow/DevFlowModels.cs
+++ b/src/MauiSherpa.Core/Models/DevFlow/DevFlowModels.cs
@@ -389,6 +389,15 @@ public class DevFlowElementInfo
     [JsonPropertyName("nativeProperties")]
     public Dictionary<string, string?>? NativeProperties { get; set; }
 
+    [JsonPropertyName("semanticDescription")]
+    public string? SemanticDescription { get; set; }
+
+    [JsonPropertyName("semanticHint")]
+    public string? SemanticHint { get; set; }
+
+    [JsonPropertyName("semanticHeadingLevel")]
+    public string? SemanticHeadingLevel { get; set; }
+
     [JsonPropertyName("children")]
     public List<DevFlowElementInfo>? Children { get; set; }
 }

--- a/src/MauiSherpa/Pages/Inspector/DevFlowTreeTab.razor
+++ b/src/MauiSherpa/Pages/Inspector/DevFlowTreeTab.razor
@@ -165,6 +165,35 @@
                     }
                 </div>
 
+                <!-- Semantic Properties (from element info) -->
+                @if (!string.IsNullOrEmpty(selectedElement.SemanticDescription) || !string.IsNullOrEmpty(selectedElement.SemanticHint) || !string.IsNullOrEmpty(selectedElement.SemanticHeadingLevel))
+                {
+                    <div class="prop-section">
+                        <div class="prop-group-title"><i class="fas fa-universal-access prop-group-icon"></i> Accessibility</div>
+                        @if (!string.IsNullOrEmpty(selectedElement.SemanticDescription))
+                        {
+                            <div class="prop-row">
+                                <span class="prop-key">Description</span>
+                                <span class="prop-value">@selectedElement.SemanticDescription</span>
+                            </div>
+                        }
+                        @if (!string.IsNullOrEmpty(selectedElement.SemanticHint))
+                        {
+                            <div class="prop-row">
+                                <span class="prop-key">Hint</span>
+                                <span class="prop-value">@selectedElement.SemanticHint</span>
+                            </div>
+                        }
+                        @if (!string.IsNullOrEmpty(selectedElement.SemanticHeadingLevel) && !selectedElement.SemanticHeadingLevel.Equals("None", StringComparison.OrdinalIgnoreCase))
+                        {
+                            <div class="prop-row">
+                                <span class="prop-key">Heading Level</span>
+                                <span class="prop-value">@selectedElement.SemanticHeadingLevel</span>
+                            </div>
+                        }
+                    </div>
+                }
+
                 <!-- Gestures -->
                 @if (selectedElement.Gestures?.Count > 0)
                 {
@@ -380,11 +409,17 @@
             EnumValues: new[] { "Default", "Chat", "Email", "Numeric", "Plain", "Telephone", "Text", "Url" }),
         ["AutomationId"] = new(EditorType.Text, "Behavior", SortOrder: 0),
         ["Text"] = new(EditorType.Text, "Appearance", SortOrder: 0),
+
+        // --- Accessibility (SemanticProperties) ---
+        ["SemanticProperties.Description"] = new(EditorType.Text, "Accessibility", SortOrder: 0),
+        ["SemanticProperties.Hint"] = new(EditorType.Text, "Accessibility", SortOrder: 1),
+        ["SemanticProperties.HeadingLevel"] = new(EditorType.Enum, "Accessibility", SortOrder: 2,
+            EnumValues: new[] { "None", "Level1", "Level2", "Level3", "Level4", "Level5", "Level6", "Level7", "Level8", "Level9" }),
     };
 
     private static readonly string[] CommonProperties = PropertyRegistry.Keys.ToArray();
 
-    private static readonly string[] GroupOrder = new[] { "Appearance", "Layout", "Behavior", "Transform", "Other" };
+    private static readonly string[] GroupOrder = new[] { "Appearance", "Layout", "Behavior", "Accessibility", "Transform", "Other" };
 
     private static PropertyMeta GetMeta(string propName)
         => PropertyRegistry.TryGetValue(propName, out var meta) ? meta : new PropertyMeta(EditorType.Text, "Other");
@@ -2857,6 +2892,11 @@
         border-left: 3px solid var(--accent-color, #8b5cf6);
         text-transform: uppercase;
         letter-spacing: 0.04em;
+    }
+
+    .prop-group-icon {
+        margin-right: 0.25rem;
+        font-size: 0.65rem;
     }
 
     /* Boolean toggle */


### PR DESCRIPTION
The DevFlow inspector's Visual Tree properties panel shows Appearance, Layout, Behavior, and Transform groups but has no visibility into accessibility metadata. This makes it harder to verify that `SemanticProperties` are correctly set on MAUI elements during development.

## Approach

Adds a new **Accessibility** property group that queries MAUI's `SemanticProperties` attached properties via the DevFlow agent's property API:

- `SemanticProperties.Description` -- descriptive text for screen readers (text editor)
- `SemanticProperties.Hint` -- hint about what happens on interaction (text editor)
- `SemanticProperties.HeadingLevel` -- heading level enum (None, Level1--Level9)

These are registered in the `PropertyRegistry` alongside existing common properties, so they're fetched automatically when an element is selected. The "Accessibility" group appears between Behavior and Transform in the panel ordering.

Additionally, enriches the `DevFlowElementInfo` model with optional `semanticDescription`, `semanticHint`, and `semanticHeadingLevel` fields. When a MauiDevFlow agent includes these in tree data, they're displayed in a dedicated section in the Element identity area with a universal-access icon.

## Graceful degradation

Properties with null values are already filtered out by the existing `Where(p => p.Value != null)` pipeline, so if the connected agent doesn't support attached property queries, the Accessibility section simply won't appear -- no errors, no empty groups.