### PR TITLE
Fix Copilot auth detection in macOS release builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -305,22 +305,30 @@ jobs:
           APP_PATH=$(find ./artifacts/macos -name "*.app" -type d | head -1)
           if [ -n "$APP_PATH" ]; then
             echo "Re-signing with hardened runtime: $APP_PATH"
-            # Sign helper executables under MonoBundle/runtimes explicitly; --deep
-            # does not reliably recurse into that layout.
+            # Sign nested code first, then sign the app bundle last.
+            # Avoid --deep on the final app sign: it overwrites the Copilot CLI's
+            # Node/V8 entitlements and causes "Failed to reserve virtual memory
+            # for CodeRange" crashes in release builds.
             if [ -d "$APP_PATH/Contents/MonoBundle/runtimes" ]; then
               find "$APP_PATH/Contents/MonoBundle/runtimes" \( -name "copilot" -o -name "unxip" \) -type f | while read -r item; do
                 chmod +x "$item"
-                codesign --force --options runtime --timestamp \
-                  --sign "$APPLE_CODESIGN_IDENTITY" "$item"
+                if [ "$(basename "$item")" = "copilot" ]; then
+                  codesign --force --options runtime --timestamp \
+                    --preserve-metadata=entitlements \
+                    --sign "$APPLE_CODESIGN_IDENTITY" "$item"
+                else
+                  codesign --force --options runtime --timestamp \
+                    --sign "$APPLE_CODESIGN_IDENTITY" "$item"
+                fi
               done
             fi
             # Sign all nested frameworks and dylibs first
-            find "$APP_PATH" \( -name "*.dylib" -o -name "*.framework" \) | while read -r item; do
+            find "$APP_PATH/Contents" \( -name "*.dylib" -o -name "*.framework" \) | while read -r item; do
               codesign --force --options runtime --timestamp \
                 --sign "$APPLE_CODESIGN_IDENTITY" "$item"
             done
             # Sign the app bundle
-            codesign --force --deep --options runtime --timestamp \
+            codesign --force --options runtime --timestamp \
               --entitlements src/MauiSherpa.MacOS/Entitlements.plist \
               --sign "$APPLE_CODESIGN_IDENTITY" \
               "$APP_PATH"
@@ -341,6 +349,19 @@ jobs:
             else
               echo "::error::Hardened Runtime is NOT enabled — notarization will fail"
               exit 1
+            fi
+
+            COPILOT_PATH="$APP_PATH/Contents/MonoBundle/runtimes/osx-arm64/native/copilot"
+            if [ -f "$COPILOT_PATH" ]; then
+              codesign -d --entitlements :- "$COPILOT_PATH" 2>&1 | tee /tmp/copilot-entitlements.txt
+              if grep -q "com.apple.security.cs.allow-jit" /tmp/copilot-entitlements.txt \
+                && grep -q "com.apple.security.cs.allow-unsigned-executable-memory" /tmp/copilot-entitlements.txt \
+                && grep -q "com.apple.security.cs.disable-library-validation" /tmp/copilot-entitlements.txt; then
+                echo "✅ Copilot helper entitlements are preserved"
+              else
+                echo "::error::Copilot helper entitlements are missing — the CLI will crash in release builds"
+                exit 1
+              fi
             fi
           fi
 

--- a/src/MauiSherpa.Core/Services/CopilotService.cs
+++ b/src/MauiSherpa.Core/Services/CopilotService.cs
@@ -20,6 +20,8 @@ public class CopilotService : ICopilotService, IAsyncDisposable
     private readonly ILoggingService _logger;
     private readonly ICopilotToolsService _toolsService;
     private readonly string _skillsPath;
+    private readonly string _copilotWorkingDirectory;
+    private readonly SemaphoreSlim _clientGate = new(1, 1);
     private readonly List<CopilotChatMessage> _messages = new();
     private readonly Dictionary<string, string> _toolCallIdToName = new(); // Track callId -> toolName mapping
     
@@ -54,7 +56,9 @@ public class CopilotService : ICopilotService, IAsyncDisposable
         _logger = logger;
         _toolsService = toolsService;
         _skillsPath = GetSkillsPath();
+        _copilotWorkingDirectory = GetCopilotWorkingDirectory();
         _logger.LogInformation($"Copilot skills path: {_skillsPath}");
+        _logger.LogInformation($"Copilot working directory: {_copilotWorkingDirectory}");
     }
 
     private static string GetSkillsPath()
@@ -98,33 +102,207 @@ public class CopilotService : ICopilotService, IAsyncDisposable
         return baseDir;
     }
 
+    private static string GetCopilotWorkingDirectory()
+    {
+        var path = Path.Combine(AppDataPath.GetAppDataDirectory(), "copilot");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static string GetUserHomeDirectory()
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        return string.IsNullOrWhiteSpace(home) ? Environment.CurrentDirectory : home;
+    }
+
+    internal static string BuildLaunchPath(string? currentPath = null, IEnumerable<string>? extraDirectories = null)
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var orderedPaths = new List<string>();
+
+        static string NormalizeDirectory(string path)
+        {
+            try
+            {
+                return Path.GetFullPath(path.Trim());
+            }
+            catch
+            {
+                return path.Trim();
+            }
+        }
+
+        void AddDirectory(string? candidate)
+        {
+            if (string.IsNullOrWhiteSpace(candidate))
+                return;
+
+            var normalized = NormalizeDirectory(candidate);
+            if (!Directory.Exists(normalized) || !seen.Add(normalized))
+                return;
+
+            orderedPaths.Add(normalized);
+        }
+
+        foreach (var dir in (currentPath ?? Environment.GetEnvironmentVariable("PATH") ?? string.Empty)
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            AddDirectory(dir);
+        }
+
+        if (OperatingSystem.IsMacOS() || OperatingSystem.IsMacCatalyst() || OperatingSystem.IsLinux())
+        {
+            var home = GetUserHomeDirectory();
+
+            AddDirectory("/opt/homebrew/bin");
+            AddDirectory("/usr/local/bin");
+            AddDirectory("/opt/local/bin");
+            AddDirectory("/usr/bin");
+            AddDirectory("/bin");
+            AddDirectory("/usr/sbin");
+            AddDirectory("/sbin");
+
+            AddDirectory(Path.Combine(home, ".local", "bin"));
+            AddDirectory(Path.Combine(home, ".npm-global", "bin"));
+            AddDirectory(Path.Combine(home, ".yarn", "bin"));
+            AddDirectory(Path.Combine(home, ".volta", "bin"));
+            AddDirectory(Path.Combine(home, ".asdf", "shims"));
+            AddDirectory(Path.Combine(home, ".local", "share", "fnm", "aliases", "default", "bin"));
+            AddDirectory(Path.Combine(home, ".fnm", "aliases", "default", "bin"));
+            AddDirectory(Path.Combine(home, "bin"));
+        }
+
+        if (extraDirectories != null)
+        {
+            foreach (var dir in extraDirectories)
+                AddDirectory(dir);
+        }
+
+        return string.Join(Path.PathSeparator, orderedPaths);
+    }
+
+    private static Dictionary<string, string> BuildCliEnvironment(string? cliPath = null)
+    {
+        var environment = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var home = GetUserHomeDirectory();
+
+        if (!string.IsNullOrWhiteSpace(home))
+        {
+            environment["HOME"] = home;
+            environment["USERPROFILE"] = home;
+
+            if (OperatingSystem.IsMacOS() || OperatingSystem.IsMacCatalyst() || OperatingSystem.IsLinux())
+            {
+                var xdgConfigHome = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
+                if (string.IsNullOrWhiteSpace(xdgConfigHome))
+                    xdgConfigHome = Path.Combine(home, ".config");
+
+                environment["XDG_CONFIG_HOME"] = xdgConfigHome;
+
+                var ghConfigDir = Environment.GetEnvironmentVariable("GH_CONFIG_DIR");
+                if (string.IsNullOrWhiteSpace(ghConfigDir))
+                    ghConfigDir = Path.Combine(xdgConfigHome, "gh");
+
+                environment["GH_CONFIG_DIR"] = ghConfigDir;
+            }
+        }
+
+        var extraDirs = !string.IsNullOrWhiteSpace(cliPath)
+            ? new[] { Path.GetDirectoryName(cliPath)! }
+            : Array.Empty<string>();
+
+        var launchPath = BuildLaunchPath(extraDirectories: extraDirs);
+        if (!string.IsNullOrWhiteSpace(launchPath))
+            environment["PATH"] = launchPath;
+
+        foreach (var variable in new[] { "TMPDIR", "TMP", "TEMP", "LANG", "LC_ALL", "SHELL", "USER", "LOGNAME" })
+        {
+            var value = Environment.GetEnvironmentVariable(variable);
+            if (!string.IsNullOrWhiteSpace(value))
+                environment[variable] = value;
+        }
+
+        return environment;
+    }
+
     /// <summary>
     /// Resolves the Copilot CLI binary path. Checks the bundled runtimes path first,
-    /// then falls back to finding 'copilot' on the system PATH.
+    /// then common install locations for GUI-launched apps, and finally the system PATH.
     /// </summary>
-    private static string? ResolveCopilotCliPath()
+    internal static string? ResolveCopilotCliPath(string? pathEnv = null, string? baseDirectory = null, IEnumerable<string>? additionalSearchPaths = null)
     {
         var rid = System.Runtime.InteropServices.RuntimeInformation.RuntimeIdentifier;
         var binaryName = System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
             System.Runtime.InteropServices.OSPlatform.Windows) ? "copilot.exe" : "copilot";
 
-        // Check bundled path (runtimes/{rid}/native/copilot)
-        var bundledPath = Path.Combine(AppContext.BaseDirectory, "runtimes", rid, "native", binaryName);
-        if (File.Exists(bundledPath))
-            return bundledPath;
-
-        // On Mac Catalyst, also check osx-arm64/osx-x64 in case the RID mapping wasn't applied
-        if (rid.StartsWith("maccatalyst-", StringComparison.OrdinalIgnoreCase))
+        var candidateBaseDirs = new[]
         {
-            var osxRid = rid.Replace("maccatalyst-", "osx-");
-            var osxPath = Path.Combine(AppContext.BaseDirectory, "runtimes", osxRid, "native", binaryName);
-            if (File.Exists(osxPath))
-                return osxPath;
+            baseDirectory ?? AppContext.BaseDirectory,
+            Path.GetFullPath(Path.Combine(baseDirectory ?? AppContext.BaseDirectory, "..")),
+            Path.GetFullPath(Path.Combine(baseDirectory ?? AppContext.BaseDirectory, "..", "MonoBundle"))
+        }
+        .Distinct(StringComparer.Ordinal)
+        .ToArray();
+
+        foreach (var root in candidateBaseDirs)
+        {
+            var bundledPath = Path.Combine(root, "runtimes", rid, "native", binaryName);
+            if (File.Exists(bundledPath))
+                return bundledPath;
+
+            if (rid.StartsWith("maccatalyst-", StringComparison.OrdinalIgnoreCase))
+            {
+                var osxRid = rid.Replace("maccatalyst-", "osx-");
+                var osxPath = Path.Combine(root, "runtimes", osxRid, "native", binaryName);
+                if (File.Exists(osxPath))
+                    return osxPath;
+            }
         }
 
-        // Fallback: find on system PATH
-        var pathEnv = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
-        var pathDirs = pathEnv.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
+        foreach (var candidate in additionalSearchPaths ?? Enumerable.Empty<string>())
+        {
+            if (!string.IsNullOrWhiteSpace(candidate) && File.Exists(candidate))
+                return candidate;
+        }
+
+        if (OperatingSystem.IsWindows())
+        {
+            var programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+            var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+
+            foreach (var candidate in new[]
+            {
+                Path.Combine(programFiles, "GitHub Copilot", binaryName),
+                Path.Combine(localAppData, "Microsoft", "WinGet", "Links", binaryName)
+            })
+            {
+                if (File.Exists(candidate))
+                    return candidate;
+            }
+        }
+        else
+        {
+            var home = GetUserHomeDirectory();
+            foreach (var candidate in new[]
+            {
+                "/opt/homebrew/bin/copilot",
+                "/usr/local/bin/copilot",
+                "/opt/local/bin/copilot",
+                Path.Combine(home, ".local", "bin", "copilot"),
+                Path.Combine(home, ".npm-global", "bin", "copilot"),
+                Path.Combine(home, ".yarn", "bin", "copilot"),
+                Path.Combine(home, ".volta", "bin", "copilot"),
+                Path.Combine(home, ".asdf", "shims", "copilot"),
+                Path.Combine(home, "bin", "copilot")
+            })
+            {
+                if (File.Exists(candidate))
+                    return candidate;
+            }
+        }
+
+        var pathDirs = BuildLaunchPath(pathEnv)
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
         foreach (var dir in pathDirs)
         {
             var candidate = Path.Combine(dir, binaryName);
@@ -144,132 +322,173 @@ public class CopilotService : ICopilotService, IAsyncDisposable
             return _cachedAvailability;
         }
 
-        CopilotClient? tempClient = null;
-        var tempClientStarted = false;
+        await _clientGate.WaitAsync();
         try
         {
-            _logger.LogInformation("Checking Copilot availability via SDK...");
-            
-            var cliPath = ResolveCopilotCliPath();
-            if (cliPath != null)
-                _logger.LogInformation($"Resolved Copilot CLI path: {cliPath}");
-
-            // Create a temporary client to check status
-            var options = new CopilotClientOptions
+            if (!forceRefresh && _cachedAvailability != null)
             {
-                AutoStart = true,
-                CliPath = cliPath
-            };
-            
-            tempClient = new CopilotClient(options);
-            await tempClient.StartAsync();
-            tempClientStarted = true;
-            
-            // Get version/status info
-            var statusResponse = await tempClient.GetStatusAsync();
-            var version = statusResponse?.Version;
-            _logger.LogInformation($"Copilot CLI version: {version}");
-            
-            // Check authentication status using SDK
-            var authResponse = await tempClient.GetAuthStatusAsync();
-            
-            if (authResponse == null || !authResponse.IsAuthenticated)
-            {
-                var statusMsg = authResponse?.StatusMessage ?? "Not logged in to GitHub Copilot";
-                _logger.LogWarning($"Copilot not authenticated: {statusMsg}");
-                _cachedAvailability = new CopilotAvailability(
-                    IsInstalled: true,
-                    IsAuthenticated: false,
-                    Version: version,
-                    Login: authResponse?.Login,
-                    ErrorMessage: statusMsg
-                );
+                _logger.LogInformation("Returning cached Copilot availability after synchronization");
                 return _cachedAvailability;
             }
 
-            _logger.LogInformation($"Copilot authenticated as {authResponse.Login}");
-
-            if (_client == null)
+            CopilotClient? tempClient = null;
+            var tempClientStarted = false;
+            try
             {
-                _client = tempClient;
-                tempClient = null;
-                tempClientStarted = false;
-                _logger.LogInformation("Reusing availability-check Copilot client for the next session");
-            }
+                _logger.LogInformation("Checking Copilot availability via SDK...");
 
-            _cachedAvailability = new CopilotAvailability(
-                IsInstalled: true,
-                IsAuthenticated: true,
-                Version: version,
-                Login: authResponse.Login,
-                ErrorMessage: null
-            );
-            return _cachedAvailability;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError($"Error checking Copilot availability: {ex.Message}", ex);
-            
-            // If we can't start the client, assume CLI is not installed
-            var isNotInstalled = ex.Message.Contains("not found") || 
-                                 ex.Message.Contains("No such file") ||
-                                 ex.Message.Contains("cannot find") ||
-                                 ex is System.ComponentModel.Win32Exception;
-            
-            _cachedAvailability = new CopilotAvailability(
-                IsInstalled: !isNotInstalled,
-                IsAuthenticated: false,
-                Version: null,
-                Login: null,
-                ErrorMessage: isNotInstalled 
-                    ? "GitHub Copilot CLI is not installed" 
-                    : ex.Message
-            );
-            return _cachedAvailability;
+                var cliPath = ResolveCopilotCliPath();
+                var cliEnvironment = BuildCliEnvironment(cliPath);
+
+                if (cliPath != null)
+                    _logger.LogInformation($"Resolved Copilot CLI path: {cliPath}");
+                else
+                    _logger.LogWarning("Could not resolve Copilot CLI path from bundle, well-known locations, or PATH");
+
+                var options = new CopilotClientOptions
+                {
+                    AutoStart = true,
+                    CliPath = cliPath,
+                    Cwd = _copilotWorkingDirectory,
+                    Environment = cliEnvironment
+                };
+
+                tempClient = new CopilotClient(options);
+                await tempClient.StartAsync();
+                tempClientStarted = true;
+
+                var statusResponse = await tempClient.GetStatusAsync();
+                var version = statusResponse?.Version;
+                _logger.LogInformation($"Copilot CLI version: {version}");
+
+                var authResponse = await tempClient.GetAuthStatusAsync();
+
+                if (authResponse == null || !authResponse.IsAuthenticated)
+                {
+                    var statusMsg = authResponse?.StatusMessage ?? "Not logged in to GitHub Copilot";
+                    _logger.LogWarning($"Copilot not authenticated: {statusMsg}");
+                    _cachedAvailability = new CopilotAvailability(
+                        IsInstalled: true,
+                        IsAuthenticated: false,
+                        Version: version,
+                        Login: authResponse?.Login,
+                        ErrorMessage: statusMsg
+                    );
+                    return _cachedAvailability;
+                }
+
+                _logger.LogInformation($"Copilot authenticated as {authResponse.Login}");
+
+                if (_client == null)
+                {
+                    _client = tempClient;
+                    tempClient = null;
+                    tempClientStarted = false;
+                    _logger.LogInformation("Reusing availability-check Copilot client for the next session");
+                }
+
+                _cachedAvailability = new CopilotAvailability(
+                    IsInstalled: true,
+                    IsAuthenticated: true,
+                    Version: version,
+                    Login: authResponse.Login,
+                    ErrorMessage: null
+                );
+                return _cachedAvailability;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Error checking Copilot availability: {ex.Message}", ex);
+
+                var isNotInstalled = ex.Message.Contains("not found", StringComparison.OrdinalIgnoreCase) ||
+                                     ex.Message.Contains("No such file", StringComparison.OrdinalIgnoreCase) ||
+                                     ex.Message.Contains("cannot find", StringComparison.OrdinalIgnoreCase) ||
+                                     ex is System.ComponentModel.Win32Exception;
+
+                _cachedAvailability = new CopilotAvailability(
+                    IsInstalled: !isNotInstalled,
+                    IsAuthenticated: false,
+                    Version: null,
+                    Login: null,
+                    ErrorMessage: isNotInstalled
+                        ? "GitHub Copilot CLI is not installed"
+                        : ex.Message
+                );
+                return _cachedAvailability;
+            }
+            finally
+            {
+                if (tempClient != null)
+                {
+                    if (tempClientStarted)
+                    {
+                        try
+                        {
+                            await tempClient.StopAsync();
+                        }
+                        catch (Exception stopEx)
+                        {
+                            _logger.LogWarning($"Failed to stop temporary Copilot client cleanly: {stopEx.Message}");
+
+                            try
+                            {
+                                await tempClient.ForceStopAsync();
+                            }
+                            catch (Exception forceStopEx)
+                            {
+                                _logger.LogWarning($"Failed to force-stop temporary Copilot client: {forceStopEx.Message}");
+                            }
+                        }
+                    }
+
+                    await tempClient.DisposeAsync();
+                }
+            }
         }
         finally
         {
-            if (tempClient != null)
-            {
-                if (tempClientStarted)
-                {
-                    try
-                    {
-                        await tempClient.StopAsync();
-                    }
-                    catch (Exception stopEx)
-                    {
-                        _logger.LogWarning($"Failed to stop temporary Copilot client cleanly: {stopEx.Message}");
-
-                        try
-                        {
-                            await tempClient.ForceStopAsync();
-                        }
-                        catch (Exception forceStopEx)
-                        {
-                            _logger.LogWarning($"Failed to force-stop temporary Copilot client: {forceStopEx.Message}");
-                        }
-                    }
-                }
-
-                await tempClient.DisposeAsync();
-            }
+            _clientGate.Release();
         }
     }
 
     public async Task ConnectAsync()
     {
-        if (_client != null)
-        {
-            _logger.LogWarning("Already connected to Copilot");
-            return;
-        }
-
+        await _clientGate.WaitAsync();
         try
         {
+            if (_client?.State == ConnectionState.Connected)
+            {
+                _logger.LogInformation("Already connected to Copilot");
+                return;
+            }
+
+            if (_client != null)
+            {
+                _logger.LogWarning("Discarding stale Copilot client before reconnecting");
+
+                try
+                {
+                    await _client.StopAsync();
+                }
+                catch
+                {
+                    try
+                    {
+                        await _client.ForceStopAsync();
+                    }
+                    catch
+                    {
+                    }
+                }
+
+                await _client.DisposeAsync();
+                _client = null;
+            }
+
             _logger.LogInformation("Connecting to Copilot CLI...");
-            
+
             var cliPath = ResolveCopilotCliPath();
+            var cliEnvironment = BuildCliEnvironment(cliPath);
             if (cliPath != null)
                 _logger.LogInformation($"Resolved Copilot CLI path: {cliPath}");
 
@@ -277,14 +496,19 @@ public class CopilotService : ICopilotService, IAsyncDisposable
             {
                 AutoStart = true,
                 UseStdio = true,
-                Cwd = _skillsPath, // Set working directory to skills folder
+                Cwd = _copilotWorkingDirectory,
                 LogLevel = "info",
-                CliPath = cliPath
+                CliPath = cliPath,
+                Environment = cliEnvironment
             };
 
             _client = new CopilotClient(options);
             await _client.StartAsync();
-            
+
+            _cachedAvailability = _cachedAvailability is null
+                ? new CopilotAvailability(true, true, null, null, null)
+                : _cachedAvailability with { IsInstalled = true, IsAuthenticated = true, ErrorMessage = null };
+
             _logger.LogInformation("Connected to Copilot CLI");
         }
         catch (Exception ex)
@@ -292,6 +516,10 @@ public class CopilotService : ICopilotService, IAsyncDisposable
             _logger.LogError($"Failed to connect to Copilot: {ex.Message}", ex);
             _client = null;
             throw;
+        }
+        finally
+        {
+            _clientGate.Release();
         }
     }
 

--- a/src/MauiSherpa.Core/Services/CopilotService.cs
+++ b/src/MauiSherpa.Core/Services/CopilotService.cs
@@ -226,38 +226,15 @@ public class CopilotService : ICopilotService, IAsyncDisposable
     }
 
     /// <summary>
-    /// Resolves the Copilot CLI binary path. Checks the bundled runtimes path first,
-    /// then common install locations for GUI-launched apps, and finally the system PATH.
+    /// Resolves the Copilot CLI binary path. Prefer the user's installed CLI when available
+    /// so release builds can reuse the normal auth state and avoid bundle-signing edge cases,
+    /// then fall back to the bundled runtimes copy.
     /// </summary>
     internal static string? ResolveCopilotCliPath(string? pathEnv = null, string? baseDirectory = null, IEnumerable<string>? additionalSearchPaths = null)
     {
         var rid = System.Runtime.InteropServices.RuntimeInformation.RuntimeIdentifier;
         var binaryName = System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
             System.Runtime.InteropServices.OSPlatform.Windows) ? "copilot.exe" : "copilot";
-
-        var candidateBaseDirs = new[]
-        {
-            baseDirectory ?? AppContext.BaseDirectory,
-            Path.GetFullPath(Path.Combine(baseDirectory ?? AppContext.BaseDirectory, "..")),
-            Path.GetFullPath(Path.Combine(baseDirectory ?? AppContext.BaseDirectory, "..", "MonoBundle"))
-        }
-        .Distinct(StringComparer.Ordinal)
-        .ToArray();
-
-        foreach (var root in candidateBaseDirs)
-        {
-            var bundledPath = Path.Combine(root, "runtimes", rid, "native", binaryName);
-            if (File.Exists(bundledPath))
-                return bundledPath;
-
-            if (rid.StartsWith("maccatalyst-", StringComparison.OrdinalIgnoreCase))
-            {
-                var osxRid = rid.Replace("maccatalyst-", "osx-");
-                var osxPath = Path.Combine(root, "runtimes", osxRid, "native", binaryName);
-                if (File.Exists(osxPath))
-                    return osxPath;
-            }
-        }
 
         foreach (var candidate in additionalSearchPaths ?? Enumerable.Empty<string>())
         {
@@ -308,6 +285,30 @@ public class CopilotService : ICopilotService, IAsyncDisposable
             var candidate = Path.Combine(dir, binaryName);
             if (File.Exists(candidate))
                 return candidate;
+        }
+
+        var candidateBaseDirs = new[]
+        {
+            baseDirectory ?? AppContext.BaseDirectory,
+            Path.GetFullPath(Path.Combine(baseDirectory ?? AppContext.BaseDirectory, "..")),
+            Path.GetFullPath(Path.Combine(baseDirectory ?? AppContext.BaseDirectory, "..", "MonoBundle"))
+        }
+        .Distinct(StringComparer.Ordinal)
+        .ToArray();
+
+        foreach (var root in candidateBaseDirs)
+        {
+            var bundledPath = Path.Combine(root, "runtimes", rid, "native", binaryName);
+            if (File.Exists(bundledPath))
+                return bundledPath;
+
+            if (rid.StartsWith("maccatalyst-", StringComparison.OrdinalIgnoreCase))
+            {
+                var osxRid = rid.Replace("maccatalyst-", "osx-");
+                var osxPath = Path.Combine(root, "runtimes", osxRid, "native", binaryName);
+                if (File.Exists(osxPath))
+                    return osxPath;
+            }
         }
 
         return null;

--- a/src/MauiSherpa/Pages/Copilot.razor
+++ b/src/MauiSherpa/Pages/Copilot.razor
@@ -89,7 +89,7 @@ else if (availability != null && !availability.IsInstalled)
             </div>
         </div>
 
-        <button class="btn btn-secondary" @onclick="CheckAvailability">
+        <button class="btn btn-secondary" @onclick="@(() => CheckAvailability(forceRefresh: true))">
             <i class="fas fa-sync-alt"></i> Check Again
         </button>
     </div>
@@ -136,7 +136,7 @@ else if (availability != null && !availability.IsAuthenticated)
             </div>
         </div>
 
-        <button class="btn btn-secondary" @onclick="CheckAvailability">
+        <button class="btn btn-secondary" @onclick="@(() => CheckAvailability(forceRefresh: true))">
             <i class="fas fa-sync-alt"></i> Check Again
         </button>
     </div>
@@ -2371,10 +2371,10 @@ else
         _copilotDotNetRef?.Dispose();
     }
 
-    private async Task CheckAvailability()
+    private async Task CheckAvailability(bool forceRefresh = false)
     {
         // Use cached availability if available for instant display
-        if (CopilotService.CachedAvailability != null)
+        if (!forceRefresh && CopilotService.CachedAvailability != null)
         {
             availability = CopilotService.CachedAvailability;
             isCheckingAvailability = false;
@@ -2400,7 +2400,7 @@ else
 
         try
         {
-            availability = await CopilotService.CheckAvailabilityAsync();
+            availability = await CopilotService.CheckAvailabilityAsync(forceRefresh);
             
             // Auto-connect if Copilot is available and authenticated
             if (availability.IsInstalled && availability.IsAuthenticated && CopilotService.CurrentSessionId == null)
@@ -2439,6 +2439,9 @@ else
 
     private async Task Connect()
     {
+        if (isConnecting || CopilotService.IsConnected)
+            return;
+
         isConnecting = true;
         StateHasChanged();
 
@@ -2446,10 +2449,14 @@ else
         {
             await CopilotService.ConnectAsync();
             await CopilotService.StartSessionAsync(systemPrompt: _systemPrompt);
+            availability = availability is null
+                ? new CopilotAvailability(true, true, null, null, null)
+                : availability with { IsInstalled = true, IsAuthenticated = true, ErrorMessage = null };
         }
         catch (Exception ex)
         {
             _logger.LogError($"Connection failed: {ex.Message}", ex);
+            availability = await CopilotService.CheckAvailabilityAsync(forceRefresh: true);
             try
             {
                 await AlertService.ShowAlertAsync("Connection Failed", ex.Message);

--- a/tests/MauiSherpa.Core.Tests/Services/CopilotServiceTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/CopilotServiceTests.cs
@@ -1,0 +1,45 @@
+using FluentAssertions;
+using MauiSherpa.Core.Services;
+
+namespace MauiSherpa.Core.Tests.Services;
+
+public class CopilotServiceTests
+{
+    [Fact]
+    public void BuildLaunchPath_RemovesDuplicates_WhileKeepingExistingEntries()
+    {
+        var basePath = string.Join(Path.PathSeparator, ["/usr/bin", "/bin", "/usr/bin"]);
+
+        var launchPath = CopilotService.BuildLaunchPath(basePath, ["/bin"]);
+        var entries = launchPath.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
+
+        entries.Should().OnlyHaveUniqueItems();
+        entries.Should().Contain("/usr/bin");
+        entries.Should().Contain("/bin");
+    }
+
+    [Fact]
+    public void ResolveCopilotCliPath_UsesAdditionalSearchPaths()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var binaryName = OperatingSystem.IsWindows() ? "copilot.exe" : "copilot";
+            var expectedPath = Path.Combine(tempDir, binaryName);
+            File.WriteAllText(expectedPath, string.Empty);
+
+            var resolvedPath = CopilotService.ResolveCopilotCliPath(
+                pathEnv: string.Empty,
+                baseDirectory: tempDir,
+                additionalSearchPaths: [expectedPath]);
+
+            resolvedPath.Should().Be(expectedPath);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
Signed and notarized macOS builds could incorrectly report that the Copilot CLI was missing or that the user was logged out, even when the CLI and auth were already valid. This happens because GUI-launched apps do not inherit the same shell environment as Terminal, so Copilot startup was sometimes running with the wrong PATH/HOME context and stale availability state.

This change hardens the Copilot integration by:

- resolving the CLI from bundled and common macOS install locations instead of relying on the inherited PATH alone
- passing a stable user-scoped environment and writable working directory into the SDK-launched Copilot process
- serializing connect/availability checks to avoid stale or overlapping state during retries
- making the UI "Check Again" path perform a real refresh instead of reusing the first cached failure
- adding focused tests around CLI path resolution and launch environment construction

This is a behavior fix only; no user-facing workflow changes are intended beyond making Connect behave reliably in release builds.