### PR TITLE
Add DevFlow v1 spec abstraction layer

### DIFF
--- a/src/MauiSherpa.Core/Interfaces/IAppInspectorClient.cs
+++ b/src/MauiSherpa.Core/Interfaces/IAppInspectorClient.cs
@@ -1,0 +1,185 @@
+using MauiSherpa.Core.Models.Inspector;
+
+namespace MauiSherpa.Core.Interfaces;
+
+/// <summary>
+/// Framework-agnostic interface for inspecting and interacting with running
+/// applications via the DevFlow protocol. UI code programs against this
+/// interface — never a concrete client.
+/// </summary>
+public interface IAppInspectorClient : IDisposable
+{
+    // ─────────────────────── Connection ───────────────────────
+
+    /// <summary>Which protocol version this client speaks.</summary>
+    InspectorProtocolVersion ProtocolVersion { get; }
+
+    /// <summary>Host the agent is running on.</summary>
+    string Host { get; }
+
+    /// <summary>Port the agent is listening on.</summary>
+    int Port { get; }
+
+    /// <summary>Get the agent's status including platform and device info.</summary>
+    Task<InspectorAgentStatus> GetAgentStatusAsync(CancellationToken ct = default);
+
+    /// <summary>Get the agent's capability manifest.</summary>
+    Task<InspectorCapabilities> GetCapabilitiesAsync(CancellationToken ct = default);
+
+    // ─────────────────────── Visual Tree ─────────────────────
+
+    /// <summary>Get the full visual tree.</summary>
+    Task<IReadOnlyList<InspectorElement>> GetTreeAsync(TreeOptions? options = null, CancellationToken ct = default);
+
+    /// <summary>Get a single element by its globally unique ID.</summary>
+    Task<InspectorElement?> GetElementAsync(string elementId, CancellationToken ct = default);
+
+    /// <summary>Query elements using a locator strategy.</summary>
+    Task<IReadOnlyList<InspectorElement>> QueryElementsAsync(ElementQuery query, CancellationToken ct = default);
+
+    /// <summary>Find elements at the given coordinates (deepest first).</summary>
+    Task<IReadOnlyList<InspectorElement>> HitTestAsync(double x, double y, string? window = null, CancellationToken ct = default);
+
+    // ─────────────────────── Screenshots ─────────────────────
+
+    /// <summary>Capture a screenshot (full window or specific element).</summary>
+    Task<byte[]?> GetScreenshotAsync(ScreenshotOptions? options = null, CancellationToken ct = default);
+
+    // ─────────────────────── Element Properties ──────────────
+
+    /// <summary>Get the current value of a named property on an element.</summary>
+    Task<object?> GetPropertyAsync(string elementId, string propertyName, CancellationToken ct = default);
+
+    /// <summary>Set the value of a named property on an element.</summary>
+    Task<object?> SetPropertyAsync(string elementId, string propertyName, object value, CancellationToken ct = default);
+
+    // ─────────────────────── UI Actions ──────────────────────
+
+    Task<ActionResult> TapAsync(TapRequest request, CancellationToken ct = default);
+    Task<ActionResult> FillAsync(FillRequest request, CancellationToken ct = default);
+    Task<ActionResult> ClearAsync(ClearRequest request, CancellationToken ct = default);
+    Task<ActionResult> FocusAsync(FocusRequest request, CancellationToken ct = default);
+    Task<ActionResult> ScrollAsync(ScrollRequest request, CancellationToken ct = default);
+    Task<ActionResult> NavigateAsync(NavigateRequest request, CancellationToken ct = default);
+    Task<ActionResult> ResizeAsync(ResizeRequest request, CancellationToken ct = default);
+    Task<ActionResult> BackAsync(BackRequest request, CancellationToken ct = default);
+    Task<ActionResult> KeyAsync(KeyRequest request, CancellationToken ct = default);
+    Task<ActionResult> GestureAsync(GestureRequest request, CancellationToken ct = default);
+    Task<ActionResult> BatchAsync(BatchRequest request, CancellationToken ct = default);
+
+    // ─────────────────────── WebView ─────────────────────────
+
+    /// <summary>List all active WebView contexts.</summary>
+    Task<IReadOnlyList<InspectorWebViewContext>> GetWebViewContextsAsync(CancellationToken ct = default);
+
+    /// <summary>Evaluate a JavaScript expression in a WebView.</summary>
+    Task<WebViewEvalResult> EvaluateJavaScriptAsync(string expression, string? contextId = null, CancellationToken ct = default);
+
+    /// <summary>Get a DOM snapshot from a WebView.</summary>
+    Task<object?> GetWebViewDomAsync(string? contextId = null, CancellationToken ct = default);
+
+    /// <summary>Query the DOM with a CSS selector.</summary>
+    Task<IReadOnlyList<object>> QueryWebViewDomAsync(string selector, string? contextId = null, CancellationToken ct = default);
+
+    /// <summary>Get the HTML source of a WebView page.</summary>
+    Task<string?> GetWebViewSourceAsync(string? contextId = null, CancellationToken ct = default);
+
+    /// <summary>Navigate a WebView to a URL.</summary>
+    Task<bool> NavigateWebViewAsync(string url, string? contextId = null, CancellationToken ct = default);
+
+    /// <summary>Click an element in a WebView by CSS selector.</summary>
+    Task<bool> ClickInWebViewAsync(string selector, string? contextId = null, CancellationToken ct = default);
+
+    /// <summary>Fill text into a WebView input element by CSS selector.</summary>
+    Task<bool> FillInWebViewAsync(string selector, string text, string? contextId = null, CancellationToken ct = default);
+
+    /// <summary>Capture a screenshot of a WebView.</summary>
+    Task<byte[]?> GetWebViewScreenshotAsync(string? contextId = null, CancellationToken ct = default);
+
+    // ─────────────────────── Network ─────────────────────────
+
+    /// <summary>Get captured network requests.</summary>
+    Task<IReadOnlyList<InspectorNetworkRequest>> GetNetworkRequestsAsync(CancellationToken ct = default);
+
+    /// <summary>Get full details of a network request.</summary>
+    Task<InspectorNetworkRequestDetail?> GetNetworkRequestDetailAsync(string id, CancellationToken ct = default);
+
+    /// <summary>Clear the captured request buffer.</summary>
+    Task ClearNetworkRequestsAsync(CancellationToken ct = default);
+
+    /// <summary>Stream network requests in real time.</summary>
+    Task StreamNetworkRequestsAsync(
+        Action<IReadOnlyList<InspectorNetworkRequest>>? onReplay,
+        Action<InspectorNetworkRequest> onRequest,
+        CancellationToken ct = default);
+
+    // ─────────────────────── Logs ────────────────────────────
+
+    /// <summary>Get recent log entries.</summary>
+    Task<IReadOnlyList<InspectorLogEntry>> GetLogsAsync(LogQuery? query = null, CancellationToken ct = default);
+
+    /// <summary>Stream log entries in real time.</summary>
+    Task StreamLogsAsync(
+        Action<IReadOnlyList<InspectorLogEntry>>? onReplay,
+        Action<InspectorLogEntry> onEntry,
+        LogStreamOptions? options = null,
+        CancellationToken ct = default);
+
+    // ─────────────────────── Profiler ────────────────────────
+
+    Task<InspectorProfilerCapabilities> GetProfilerCapabilitiesAsync(CancellationToken ct = default);
+    Task<IReadOnlyList<InspectorProfilerSession>> GetProfilerSessionsAsync(CancellationToken ct = default);
+    Task<InspectorProfilerSession> StartProfilingAsync(int? sampleIntervalMs = null, CancellationToken ct = default);
+    Task StopProfilingAsync(string sessionId, CancellationToken ct = default);
+    Task<InspectorProfilerBatch> GetProfilerSamplesAsync(string sessionId, int? sampleCursor = null, int? markerCursor = null, int? spanCursor = null, int? limit = null, CancellationToken ct = default);
+    Task<IReadOnlyList<InspectorProfilerHotspot>> GetProfilerHotspotsAsync(int? limit = null, double? minDurationMs = null, string? kind = null, CancellationToken ct = default);
+    Task<IReadOnlyList<InspectorProfilerMarker>> GetProfilerMarkersAsync(int? sampleCursor = null, int? limit = null, CancellationToken ct = default);
+    Task<IReadOnlyList<InspectorProfilerSpan>> GetProfilerSpansAsync(int? spanCursor = null, int? limit = null, CancellationToken ct = default);
+
+    // ─────────────────────── Device ──────────────────────────
+
+    Task<InspectorDeviceInfo> GetDeviceInfoAsync(CancellationToken ct = default);
+    Task<InspectorDisplayInfo> GetDisplayInfoAsync(CancellationToken ct = default);
+    Task<InspectorBatteryInfo> GetBatteryInfoAsync(CancellationToken ct = default);
+    Task<InspectorConnectivityInfo> GetConnectivityAsync(CancellationToken ct = default);
+    Task<InspectorAppInfo> GetAppInfoAsync(CancellationToken ct = default);
+
+    // ─────────────────────── Sensors ─────────────────────────
+
+    Task<IReadOnlyList<InspectorSensorInfo>> GetSensorsAsync(CancellationToken ct = default);
+    Task StartSensorAsync(string sensor, string? speed = null, CancellationToken ct = default);
+    Task StopSensorAsync(string sensor, CancellationToken ct = default);
+    Task StreamSensorAsync(string sensor, Action<InspectorSensorReading> onReading, string? speed = null, int? throttleMs = null, CancellationToken ct = default);
+
+    // ─────────────────────── Permissions & Geolocation ───────
+
+    Task<IReadOnlyList<InspectorPermissionStatus>> GetPermissionsAsync(CancellationToken ct = default);
+    Task<InspectorPermissionStatus> CheckPermissionAsync(string permission, CancellationToken ct = default);
+    Task<InspectorGeolocation> GetGeolocationAsync(string? accuracy = null, int? timeoutSeconds = null, CancellationToken ct = default);
+
+    // ─────────────────────── Storage ─────────────────────────
+
+    Task<IReadOnlyList<InspectorPreferenceEntry>> GetPreferencesAsync(string? sharedName = null, CancellationToken ct = default);
+    Task<InspectorPreferenceEntry?> GetPreferenceAsync(string key, string? type = null, string? sharedName = null, CancellationToken ct = default);
+    Task SetPreferenceAsync(string key, object value, string? type = null, string? sharedName = null, CancellationToken ct = default);
+    Task DeletePreferenceAsync(string key, string? sharedName = null, CancellationToken ct = default);
+    Task ClearPreferencesAsync(string? sharedName = null, CancellationToken ct = default);
+
+    Task<InspectorSecureStorageEntry?> GetSecureStorageAsync(string key, CancellationToken ct = default);
+    Task SetSecureStorageAsync(string key, string value, CancellationToken ct = default);
+    Task DeleteSecureStorageAsync(string key, CancellationToken ct = default);
+    Task ClearSecureStorageAsync(CancellationToken ct = default);
+}
+
+/// <summary>
+/// Factory that auto-detects whether the target agent speaks v1 or legacy
+/// and returns the correct <see cref="IAppInspectorClient"/> implementation.
+/// </summary>
+public interface IAppInspectorClientFactory
+{
+    /// <summary>
+    /// Create a client for the agent at the given host and port.
+    /// Probes v1 first; falls back to legacy on failure.
+    /// </summary>
+    Task<IAppInspectorClient> CreateAsync(string host, int port, CancellationToken ct = default);
+}

--- a/src/MauiSherpa.Core/Models/Inspector/InspectorModels.cs
+++ b/src/MauiSherpa.Core/Models/Inspector/InspectorModels.cs
@@ -1,0 +1,659 @@
+using System.Text.Json.Serialization;
+
+namespace MauiSherpa.Core.Models.Inspector;
+
+// ─────────────────────────── Agent & Capabilities ───────────────────────────
+
+/// <summary>
+/// Information about the connected DevFlow agent.
+/// </summary>
+public record InspectorAgentInfo
+{
+    /// <summary>Agent implementation name (e.g. "devflow-maui").</summary>
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>Semantic version of the agent.</summary>
+    public string Version { get; init; } = string.Empty;
+
+    /// <summary>UI framework the agent instruments (e.g. "maui", "flutter", "react-native").</summary>
+    public string Framework { get; init; } = string.Empty;
+
+    /// <summary>Version of the UI framework.</summary>
+    public string FrameworkVersion { get; init; } = string.Empty;
+}
+
+/// <summary>
+/// Agent status including platform, device, and application context.
+/// </summary>
+public record InspectorAgentStatus
+{
+    public InspectorAgentInfo Agent { get; init; } = new();
+    public string Platform { get; init; } = string.Empty;
+    public InspectorDeviceStatus Device { get; init; } = new();
+    public InspectorAppStatus App { get; init; } = new();
+    public bool Running { get; init; }
+    public string? Uptime { get; init; }
+}
+
+public record InspectorDeviceStatus
+{
+    public string Model { get; init; } = string.Empty;
+    public string Manufacturer { get; init; } = string.Empty;
+    public string OsVersion { get; init; } = string.Empty;
+    public string Idiom { get; init; } = string.Empty;
+}
+
+public record InspectorAppStatus
+{
+    public string Name { get; init; } = string.Empty;
+    public string Version { get; init; } = string.Empty;
+    public string PackageId { get; init; } = string.Empty;
+}
+
+/// <summary>
+/// Capability discovery: what features the connected agent supports.
+/// </summary>
+public record InspectorCapabilities
+{
+    public InspectorAgentInfo Agent { get; init; } = new();
+
+    /// <summary>
+    /// Map of capability namespaces to their details.
+    /// Keys are dot-separated (e.g. "ui.tree", "ui.actions", "profiler").
+    /// </summary>
+    public IReadOnlyDictionary<string, CapabilityDetail> Capabilities { get; init; }
+        = new Dictionary<string, CapabilityDetail>();
+
+    /// <summary>
+    /// Map of extension namespaces (reverse-domain) to their route registrations.
+    /// </summary>
+    public IReadOnlyDictionary<string, ExtensionDetail>? Extensions { get; init; }
+
+    /// <summary>Check whether a capability namespace is supported.</summary>
+    public bool HasCapability(string ns) => Capabilities.ContainsKey(ns);
+
+    /// <summary>Check whether a specific feature is supported within a namespace.</summary>
+    public bool HasFeature(string ns, string feature) =>
+        Capabilities.TryGetValue(ns, out var cap) && cap.Features.Contains(feature);
+}
+
+public record CapabilityDetail
+{
+    public int Version { get; init; } = 1;
+    public IReadOnlyList<string> Features { get; init; } = [];
+}
+
+public record ExtensionDetail
+{
+    public IReadOnlyList<ExtensionRoute> Routes { get; init; } = [];
+    public string? Description { get; init; }
+}
+
+public record ExtensionRoute
+{
+    public string Method { get; init; } = string.Empty;
+    public string Path { get; init; } = string.Empty;
+}
+
+// ─────────────────────────── Visual Tree Elements ───────────────────────────
+
+/// <summary>
+/// Framework-agnostic visual tree element — the common denominator for MAUI,
+/// Flutter, React Native, and any future UI stack.
+/// </summary>
+public record InspectorElement
+{
+    /// <summary>Globally unique element identifier.</summary>
+    public string Id { get; init; } = string.Empty;
+
+    /// <summary>Parent element ID, or null for root elements.</summary>
+    public string? ParentId { get; init; }
+
+    /// <summary>Short type name (e.g. "Button").</summary>
+    public string Type { get; init; } = string.Empty;
+
+    /// <summary>Fully qualified type name (e.g. "Microsoft.Maui.Controls.Button").</summary>
+    public string FullType { get; init; } = string.Empty;
+
+    /// <summary>UI framework that owns this element ("maui", "flutter", etc.). Null for legacy agents.</summary>
+    public string? Framework { get; init; }
+
+    /// <summary>Automation/test identifier set by the developer.</summary>
+    public string? AutomationId { get; init; }
+
+    /// <summary>Visible text content.</summary>
+    public string? Text { get; init; }
+
+    /// <summary>Current value for input elements (text field content, slider value).</summary>
+    public string? Value { get; init; }
+
+    /// <summary>Semantic role (button, textbox, checkbox, image, etc.).</summary>
+    public string? Role { get; init; }
+
+    /// <summary>Semantic traits (interactive, focusable, scrollable, etc.).</summary>
+    public IReadOnlyList<string>? Traits { get; init; }
+
+    /// <summary>Current interactive and visual state.</summary>
+    public ElementState State { get; init; } = new();
+
+    /// <summary>Bounding rectangle.</summary>
+    public BoundsInfo? Bounds { get; init; }
+
+    /// <summary>Gesture types recognized by this element.</summary>
+    public IReadOnlyList<string>? Gestures { get; init; }
+
+    /// <summary>Style information (CSS classes, etc.).</summary>
+    public StyleInfo? Style { get; init; }
+
+    /// <summary>Underlying native platform view info.</summary>
+    public NativeViewInfo? NativeView { get; init; }
+
+    /// <summary>
+    /// Framework-specific key-value pairs not captured by standard fields.
+    /// For MAUI: maui:bindingContext, maui:keyboard, etc.
+    /// </summary>
+    public IReadOnlyDictionary<string, object>? FrameworkProperties { get; init; }
+
+    /// <summary>Child elements forming the subtree.</summary>
+    public IReadOnlyList<InspectorElement>? Children { get; init; }
+}
+
+/// <summary>Current interactive/visual state of an element.</summary>
+public record ElementState
+{
+    public bool Displayed { get; init; } = true;
+    public bool Enabled { get; init; } = true;
+    public bool Selected { get; init; }
+    public bool Focused { get; init; }
+    public double Opacity { get; init; } = 1.0;
+}
+
+/// <summary>Bounding rectangle of an element.</summary>
+public record BoundsInfo
+{
+    public double X { get; init; }
+    public double Y { get; init; }
+    public double Width { get; init; }
+    public double Height { get; init; }
+    /// <summary>Coordinate system: "window" or "screen". Null for legacy agents.</summary>
+    public string? CoordinateSystem { get; init; }
+}
+
+/// <summary>Style information.</summary>
+public record StyleInfo
+{
+    public IReadOnlyList<string>? Classes { get; init; }
+}
+
+/// <summary>Information about the underlying native platform view.</summary>
+public record NativeViewInfo
+{
+    /// <summary>Native type name (e.g. "UIButton", "android.widget.Button").</summary>
+    public string? Type { get; init; }
+    /// <summary>Key-value pairs of native view properties.</summary>
+    public IReadOnlyDictionary<string, object>? Properties { get; init; }
+}
+
+// ─────────────────────────── Tree Options ────────────────────────────────
+
+/// <summary>Options for visual tree retrieval.</summary>
+public record TreeOptions
+{
+    /// <summary>Maximum depth of tree to return. Null = unlimited.</summary>
+    public int? Depth { get; init; }
+
+    /// <summary>Which tree layer: "framework", "native", or "render".</summary>
+    public string? Layer { get; init; }
+
+    /// <summary>Element ID to scope tree to a subtree.</summary>
+    public string? RootId { get; init; }
+
+    /// <summary>Additional data to include (e.g. "properties").</summary>
+    public IReadOnlyList<string>? Include { get; init; }
+
+    /// <summary>Window identifier for multi-window scenarios.</summary>
+    public string? Window { get; init; }
+}
+
+/// <summary>Parameters for querying elements.</summary>
+public record ElementQuery
+{
+    /// <summary>Locator strategy: accessibility-id, css-selector, type, text, xpath.</summary>
+    public string Strategy { get; init; } = "type";
+
+    /// <summary>Locator value.</summary>
+    public string Value { get; init; } = string.Empty;
+
+    /// <summary>Maximum number of results.</summary>
+    public int? Limit { get; init; }
+
+    /// <summary>Additional data to include (e.g. "properties", "bounds").</summary>
+    public IReadOnlyList<string>? Include { get; init; }
+}
+
+// ─────────────────────────── Actions ─────────────────────────────────────
+
+/// <summary>Result of a UI action.</summary>
+public record ActionResult
+{
+    public bool Success { get; init; }
+    public InspectorError? Error { get; init; }
+    /// <summary>Base64-encoded screenshot, if requested via Include.</summary>
+    public string? Screenshot { get; init; }
+    /// <summary>Visual tree snapshot, if requested via Include.</summary>
+    public IReadOnlyList<InspectorElement>? Tree { get; init; }
+}
+
+/// <summary>Structured error (RFC 7807 ProblemDetails).</summary>
+public record InspectorError
+{
+    public string Type { get; init; } = string.Empty;
+    public string Title { get; init; } = string.Empty;
+    public int Status { get; init; }
+    public string? Detail { get; init; }
+    public string? ErrorCode { get; init; }
+}
+
+/// <summary>What to include in action responses.</summary>
+public enum ActionInclude
+{
+    Screenshot,
+    Tree
+}
+
+public record TapRequest
+{
+    public string? ElementId { get; init; }
+    public double? X { get; init; }
+    public double? Y { get; init; }
+    public IReadOnlyList<ActionInclude>? Include { get; init; }
+}
+
+public record FillRequest
+{
+    public string ElementId { get; init; } = string.Empty;
+    public string Text { get; init; } = string.Empty;
+    public IReadOnlyList<ActionInclude>? Include { get; init; }
+}
+
+public record ClearRequest
+{
+    public string ElementId { get; init; } = string.Empty;
+    public IReadOnlyList<ActionInclude>? Include { get; init; }
+}
+
+public record FocusRequest
+{
+    public string ElementId { get; init; } = string.Empty;
+    public IReadOnlyList<ActionInclude>? Include { get; init; }
+}
+
+public record ScrollRequest
+{
+    public string? ElementId { get; init; }
+    public double? DeltaX { get; init; }
+    public double? DeltaY { get; init; }
+    public bool Animated { get; init; } = true;
+    public int? ItemIndex { get; init; }
+    public int? GroupIndex { get; init; }
+    public string? ScrollToPosition { get; init; }
+    public IReadOnlyList<ActionInclude>? Include { get; init; }
+}
+
+public record NavigateRequest
+{
+    public string Route { get; init; } = string.Empty;
+    public IReadOnlyList<ActionInclude>? Include { get; init; }
+}
+
+public record ResizeRequest
+{
+    public string? ElementId { get; init; }
+    public int Width { get; init; }
+    public int Height { get; init; }
+    public IReadOnlyList<ActionInclude>? Include { get; init; }
+}
+
+public record BackRequest
+{
+    public IReadOnlyList<ActionInclude>? Include { get; init; }
+}
+
+public record KeyRequest
+{
+    public string Key { get; init; } = string.Empty;
+    public IReadOnlyList<ActionInclude>? Include { get; init; }
+}
+
+public record GestureAction
+{
+    public string Type { get; init; } = string.Empty;
+    public double? X { get; init; }
+    public double? Y { get; init; }
+    public int? Duration { get; init; }
+    public int? Button { get; init; }
+}
+
+public record GestureRequest
+{
+    public IReadOnlyList<GestureAction> Actions { get; init; } = [];
+    public IReadOnlyList<ActionInclude>? Include { get; init; }
+}
+
+public record BatchActionItem
+{
+    public string Action { get; init; } = string.Empty;
+    public string? ElementId { get; init; }
+    public double? X { get; init; }
+    public double? Y { get; init; }
+    public string? Text { get; init; }
+    public double? DeltaX { get; init; }
+    public double? DeltaY { get; init; }
+    public bool? Animated { get; init; }
+    public int? ItemIndex { get; init; }
+    public string? Route { get; init; }
+    public int? Width { get; init; }
+    public int? Height { get; init; }
+    public string? Key { get; init; }
+    public IReadOnlyList<GestureAction>? Actions { get; init; }
+}
+
+public record BatchRequest
+{
+    public IReadOnlyList<BatchActionItem> Actions { get; init; } = [];
+    public IReadOnlyList<ActionInclude>? Include { get; init; }
+    public bool ContinueOnError { get; init; }
+}
+
+// ─────────────────────────── Screenshots ─────────────────────────────────
+
+public record ScreenshotOptions
+{
+    public string? ElementId { get; init; }
+    public int? MaxWidth { get; init; }
+    public string? Scale { get; init; }
+    public string? Format { get; init; }
+    public string? Window { get; init; }
+}
+
+// ─────────────────────────── WebView ─────────────────────────────────────
+
+public record InspectorWebViewContext
+{
+    public string Id { get; init; } = string.Empty;
+    public string? ElementId { get; init; }
+    public string Url { get; init; } = string.Empty;
+    public string? Title { get; init; }
+    public bool Ready { get; init; }
+}
+
+public record WebViewEvalResult
+{
+    public object? Result { get; init; }
+    public WebViewExceptionDetails? ExceptionDetails { get; init; }
+}
+
+public record WebViewExceptionDetails
+{
+    public string Text { get; init; } = string.Empty;
+    public int? LineNumber { get; init; }
+    public int? ColumnNumber { get; init; }
+}
+
+// ─────────────────────────── Network ─────────────────────────────────────
+
+public record InspectorNetworkRequest
+{
+    public string Id { get; init; } = string.Empty;
+    public DateTimeOffset Timestamp { get; init; }
+    public string Method { get; init; } = string.Empty;
+    public string Url { get; init; } = string.Empty;
+    public string? Host { get; init; }
+    public string? Path { get; init; }
+    public int? StatusCode { get; init; }
+    public string? StatusText { get; init; }
+    public double? DurationMs { get; init; }
+    public string? Error { get; init; }
+    public string? RequestContentType { get; init; }
+    public string? ResponseContentType { get; init; }
+    public long? RequestSize { get; init; }
+    public long? ResponseSize { get; init; }
+}
+
+public record InspectorNetworkRequestDetail : InspectorNetworkRequest
+{
+    public IReadOnlyDictionary<string, string>? RequestHeaders { get; init; }
+    public IReadOnlyDictionary<string, string>? ResponseHeaders { get; init; }
+    public string? RequestBody { get; init; }
+    public string? ResponseBody { get; init; }
+    public string? RequestBodyEncoding { get; init; }
+    public string? ResponseBodyEncoding { get; init; }
+    public bool? RequestBodyTruncated { get; init; }
+    public bool? ResponseBodyTruncated { get; init; }
+}
+
+// ─────────────────────────── Logs ────────────────────────────────────────
+
+public record InspectorLogEntry
+{
+    public DateTimeOffset Timestamp { get; init; }
+    public string Level { get; init; } = "info";
+    public string Category { get; init; } = string.Empty;
+    public string Message { get; init; } = string.Empty;
+    public string? Exception { get; init; }
+    public string Source { get; init; } = "framework";
+}
+
+public record LogQuery
+{
+    public int? Limit { get; init; }
+    public int? Skip { get; init; }
+    public string? Source { get; init; }
+    public string? Level { get; init; }
+}
+
+public record LogStreamOptions
+{
+    public string? Source { get; init; }
+    public string? Level { get; init; }
+    public int? Replay { get; init; }
+}
+
+// ─────────────────────────── Profiler ────────────────────────────────────
+
+public record InspectorProfilerCapabilities
+{
+    public string Platform { get; init; } = string.Empty;
+    public bool ManagedMemorySupported { get; init; }
+    public bool NativeMemorySupported { get; init; }
+    public bool GcSupported { get; init; }
+    public bool CpuPercentSupported { get; init; }
+    public bool FpsSupported { get; init; }
+    public bool FrameTimingsEstimated { get; init; }
+    public bool NativeFrameTimingsSupported { get; init; }
+    public bool JankEventsSupported { get; init; }
+    public bool UiThreadStallSupported { get; init; }
+    public bool ThreadCountSupported { get; init; }
+}
+
+public record InspectorProfilerSession
+{
+    public string SessionId { get; init; } = string.Empty;
+    public DateTimeOffset StartedAtUtc { get; init; }
+    public int SampleIntervalMs { get; init; }
+    public bool IsActive { get; init; }
+}
+
+public record InspectorProfilerSample
+{
+    public DateTimeOffset TsUtc { get; init; }
+    public double? Fps { get; init; }
+    public double? FrameTimeMsP50 { get; init; }
+    public double? FrameTimeMsP95 { get; init; }
+    public double? WorstFrameTimeMs { get; init; }
+    public long? ManagedBytes { get; init; }
+    public int? Gc0 { get; init; }
+    public int? Gc1 { get; init; }
+    public int? Gc2 { get; init; }
+    public long? NativeMemoryBytes { get; init; }
+    public string? NativeMemoryKind { get; init; }
+    public double? CpuPercent { get; init; }
+    public int? ThreadCount { get; init; }
+    public int? JankFrameCount { get; init; }
+    public int? UiThreadStallCount { get; init; }
+    public string? FrameSource { get; init; }
+    public string? FrameQuality { get; init; }
+}
+
+public record InspectorProfilerMarker
+{
+    public DateTimeOffset TsUtc { get; init; }
+    public string Type { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public string? PayloadJson { get; init; }
+}
+
+public record InspectorProfilerSpan
+{
+    public string SpanId { get; init; } = string.Empty;
+    public string? ParentSpanId { get; init; }
+    public string? TraceId { get; init; }
+    public DateTimeOffset StartTsUtc { get; init; }
+    public DateTimeOffset? EndTsUtc { get; init; }
+    public double DurationMs { get; init; }
+    public string Kind { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public string? Status { get; init; }
+    public string? ThreadId { get; init; }
+    public string? Screen { get; init; }
+    public string? ElementPath { get; init; }
+    public string? TagsJson { get; init; }
+    public string? Error { get; init; }
+}
+
+public record InspectorProfilerBatch
+{
+    public string SessionId { get; init; } = string.Empty;
+    public IReadOnlyList<InspectorProfilerSample> Samples { get; init; } = [];
+    public IReadOnlyList<InspectorProfilerMarker> Markers { get; init; } = [];
+    public IReadOnlyList<InspectorProfilerSpan> Spans { get; init; } = [];
+    public int SampleCursor { get; init; }
+    public int MarkerCursor { get; init; }
+    public int SpanCursor { get; init; }
+    public bool IsActive { get; init; }
+}
+
+public record InspectorProfilerHotspot
+{
+    public string Kind { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public string? Screen { get; init; }
+    public int Count { get; init; }
+    public int? ErrorCount { get; init; }
+    public double AvgDurationMs { get; init; }
+    public double? P95DurationMs { get; init; }
+    public double? MaxDurationMs { get; init; }
+}
+
+// ─────────────────────────── Device ──────────────────────────────────────
+
+public record InspectorDeviceInfo
+{
+    public string Model { get; init; } = string.Empty;
+    public string Manufacturer { get; init; } = string.Empty;
+    public string OsVersion { get; init; } = string.Empty;
+    public string Platform { get; init; } = string.Empty;
+    public string Idiom { get; init; } = string.Empty;
+    public string? Architecture { get; init; }
+}
+
+public record InspectorDisplayInfo
+{
+    public double Width { get; init; }
+    public double Height { get; init; }
+    public double Density { get; init; }
+    public string Orientation { get; init; } = "portrait";
+    public double? RefreshRate { get; init; }
+}
+
+public record InspectorBatteryInfo
+{
+    public double Level { get; init; }
+    public string State { get; init; } = "unknown";
+    public string PowerSource { get; init; } = "unknown";
+}
+
+public record InspectorConnectivityInfo
+{
+    public string NetworkAccess { get; init; } = "none";
+    public IReadOnlyList<string> ConnectionProfiles { get; init; } = [];
+}
+
+public record InspectorAppInfo
+{
+    public string Name { get; init; } = string.Empty;
+    public string Version { get; init; } = string.Empty;
+    public string BuildNumber { get; init; } = string.Empty;
+    public string PackageId { get; init; } = string.Empty;
+    public string? Theme { get; init; }
+}
+
+// ─────────────────────────── Permissions & Geolocation ───────────────────
+
+public record InspectorPermissionStatus
+{
+    public string Name { get; init; } = string.Empty;
+    public string Status { get; init; } = "unknown";
+}
+
+public record InspectorGeolocation
+{
+    public double Latitude { get; init; }
+    public double Longitude { get; init; }
+    public double? Altitude { get; init; }
+    public double Accuracy { get; init; }
+    public DateTimeOffset Timestamp { get; init; }
+}
+
+// ─────────────────────────── Sensors ─────────────────────────────────────
+
+public record InspectorSensorInfo
+{
+    public string Name { get; init; } = string.Empty;
+    public bool Available { get; init; }
+    public bool Active { get; init; }
+}
+
+public record InspectorSensorReading
+{
+    public string Sensor { get; init; } = string.Empty;
+    public DateTimeOffset Timestamp { get; init; }
+    public IReadOnlyDictionary<string, object> Values { get; init; } = new Dictionary<string, object>();
+}
+
+// ─────────────────────────── Storage ─────────────────────────────────────
+
+public record InspectorPreferenceEntry
+{
+    public string Key { get; init; } = string.Empty;
+    public object? Value { get; init; }
+    public string Type { get; init; } = "string";
+}
+
+public record InspectorSecureStorageEntry
+{
+    public string Key { get; init; } = string.Empty;
+    public string? Value { get; init; }
+    public bool Exists { get; init; }
+}
+
+// ─────────────────────────── Protocol Version ────────────────────────────
+
+/// <summary>Identifies which protocol version an agent speaks.</summary>
+public enum InspectorProtocolVersion
+{
+    /// <summary>Legacy pre-v1 API (/api/*).</summary>
+    Legacy,
+    /// <summary>v1 spec (/api/v1/*).</summary>
+    V1
+}

--- a/src/MauiSherpa.Core/Services/AppInspectorClientFactory.cs
+++ b/src/MauiSherpa.Core/Services/AppInspectorClientFactory.cs
@@ -1,0 +1,65 @@
+using MauiSherpa.Core.Interfaces;
+using MauiSherpa.Core.Models.Inspector;
+using Microsoft.Extensions.Logging;
+
+namespace MauiSherpa.Core.Services;
+
+/// <summary>
+/// Creates the appropriate <see cref="IAppInspectorClient"/> based on what
+/// the target agent supports. Probes the v1 endpoint first; falls back to
+/// legacy if the agent doesn't support v1.
+/// </summary>
+public class AppInspectorClientFactory : IAppInspectorClientFactory
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<AppInspectorClientFactory> _logger;
+
+    public AppInspectorClientFactory(
+        IHttpClientFactory httpClientFactory,
+        ILogger<AppInspectorClientFactory> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+    }
+
+    public async Task<IAppInspectorClient> CreateAsync(string host, int port, CancellationToken ct = default)
+    {
+        var httpClient = _httpClientFactory.CreateClient("DevFlowAgent");
+        httpClient.BaseAddress = new Uri($"http://{host}:{port}");
+        httpClient.Timeout = TimeSpan.FromSeconds(5);
+
+        // Try v1 first
+        try
+        {
+            var response = await httpClient.GetAsync("/api/v1/agent/status", ct);
+            if (response.IsSuccessStatusCode)
+            {
+                _logger.LogInformation("Agent at {Host}:{Port} supports DevFlow v1 protocol", host, port);
+                return new DevFlowV1Client(host, port, _httpClientFactory, _logger);
+            }
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            _logger.LogDebug(ex, "v1 probe failed for {Host}:{Port}, trying legacy", host, port);
+        }
+
+        // Fall back to legacy
+        try
+        {
+            var response = await httpClient.GetAsync("/api/status", ct);
+            if (response.IsSuccessStatusCode)
+            {
+                _logger.LogInformation("Agent at {Host}:{Port} uses legacy DevFlow protocol", host, port);
+                return new DevFlowLegacyClient(host, port, _httpClientFactory, _logger);
+            }
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            _logger.LogWarning(ex, "Legacy probe also failed for {Host}:{Port}", host, port);
+        }
+
+        // Default to v1 — will produce clear errors on actual calls
+        _logger.LogWarning("Could not determine protocol version for {Host}:{Port}, defaulting to v1", host, port);
+        return new DevFlowV1Client(host, port, _httpClientFactory, _logger);
+    }
+}

--- a/src/MauiSherpa.Core/Services/Inspector/DevFlowLegacyClient.cs
+++ b/src/MauiSherpa.Core/Services/Inspector/DevFlowLegacyClient.cs
@@ -1,0 +1,706 @@
+using MauiSherpa.Core.Interfaces;
+using MauiSherpa.Core.Models.DevFlow;
+using MauiSherpa.Core.Models.Inspector;
+using Microsoft.Extensions.Logging;
+
+namespace MauiSherpa.Core.Services;
+
+/// <summary>
+/// Adapter that wraps the legacy <see cref="DevFlowAgentClient"/> behind the
+/// <see cref="IAppInspectorClient"/> interface. Maps old models to common ones.
+/// When the legacy API is sunsetted, delete this class and DevFlowAgentClient.
+/// </summary>
+public class DevFlowLegacyClient : IAppInspectorClient
+{
+    private readonly DevFlowAgentClient _legacy;
+    private readonly ILogger _logger;
+
+    public InspectorProtocolVersion ProtocolVersion => InspectorProtocolVersion.Legacy;
+    public string Host { get; }
+    public int Port { get; }
+
+    public DevFlowLegacyClient(string host, int port, IHttpClientFactory httpClientFactory, ILogger logger)
+    {
+        Host = host;
+        Port = port;
+        _logger = logger;
+        _legacy = new DevFlowAgentClient(host, port);
+    }
+
+    // ─────────── Mapping Helpers ────────────
+
+    private static InspectorElement MapElement(DevFlowElementInfo e) => new()
+    {
+        Id = e.Id,
+        ParentId = e.ParentId,
+        Type = e.Type,
+        FullType = e.FullType,
+        Framework = null, // Legacy doesn't report framework
+        AutomationId = e.AutomationId,
+        Text = e.Text,
+        Value = null, // Not available in legacy
+        Role = null, // Not available in legacy
+        Traits = null, // Not available in legacy
+        State = new ElementState
+        {
+            Displayed = e.IsVisible,
+            Enabled = e.IsEnabled,
+            Selected = false,
+            Focused = e.IsFocused,
+            Opacity = e.Opacity
+        },
+        Bounds = e.Bounds != null ? new BoundsInfo
+        {
+            X = e.Bounds.X,
+            Y = e.Bounds.Y,
+            Width = e.Bounds.Width,
+            Height = e.Bounds.Height,
+            CoordinateSystem = null
+        } : null,
+        Gestures = e.Gestures?.AsReadOnly(),
+        Style = null,
+        NativeView = e.NativeType != null ? new NativeViewInfo
+        {
+            Type = e.NativeType,
+            Properties = e.NativeProperties?.ToDictionary(kv => kv.Key, kv => (object)(kv.Value ?? ""))
+        } : null,
+        FrameworkProperties = null,
+        Children = e.Children?.Select(MapElement).ToList()?.AsReadOnly()
+    };
+
+    private static InspectorElement MapHitTestElement(DevFlowHitTestElement e) => new()
+    {
+        Id = e.Id,
+        Type = e.Type ?? string.Empty,
+        FullType = string.Empty,
+        AutomationId = e.AutomationId,
+        Text = e.Text,
+        State = new ElementState(),
+        Bounds = e.Bounds != null ? new BoundsInfo
+        {
+            X = e.Bounds.X,
+            Y = e.Bounds.Y,
+            Width = e.Bounds.Width,
+            Height = e.Bounds.Height
+        } : null,
+    };
+
+    private static InspectorNetworkRequest MapNetworkRequest(DevFlowNetworkRequest r) => new()
+    {
+        Id = r.Id,
+        Timestamp = r.Timestamp,
+        Method = r.Method,
+        Url = r.Url,
+        Host = r.Host,
+        Path = r.Path,
+        StatusCode = r.StatusCode,
+        StatusText = r.StatusText,
+        DurationMs = r.DurationMs,
+        Error = r.Error,
+        RequestContentType = r.RequestContentType,
+        ResponseContentType = r.ResponseContentType,
+        RequestSize = r.RequestSize,
+        ResponseSize = r.ResponseSize
+    };
+
+    private static InspectorLogEntry MapLogEntry(DevFlowLogEntry e) => new()
+    {
+        Timestamp = e.Timestamp,
+        Level = e.Level ?? "info",
+        Category = e.Category ?? string.Empty,
+        Message = e.Message ?? string.Empty,
+        Exception = e.Exception,
+        Source = e.Source ?? "framework"
+    };
+
+    // ─────────── Agent ────────────
+
+    public async Task<InspectorAgentStatus> GetAgentStatusAsync(CancellationToken ct = default)
+    {
+        var status = await _legacy.GetStatusAsync(ct);
+        return new InspectorAgentStatus
+        {
+            Agent = new InspectorAgentInfo
+            {
+                Name = status?.Agent ?? "unknown",
+                Version = status?.Version ?? "0.0.0",
+                Framework = "maui", // Legacy was MAUI-only
+                FrameworkVersion = string.Empty
+            },
+            Platform = status?.Platform ?? string.Empty,
+            Device = new InspectorDeviceStatus
+            {
+                Model = string.Empty,
+                Manufacturer = string.Empty,
+                OsVersion = string.Empty,
+                Idiom = status?.Idiom ?? string.Empty
+            },
+            App = new InspectorAppStatus
+            {
+                Name = status?.AppName ?? string.Empty,
+                Version = string.Empty,
+                PackageId = string.Empty
+            },
+            Running = status?.Running ?? false,
+        };
+    }
+
+    public Task<InspectorCapabilities> GetCapabilitiesAsync(CancellationToken ct = default)
+    {
+        // Legacy doesn't have capability discovery. Return a reasonable default for MAUI.
+        var caps = new Dictionary<string, CapabilityDetail>
+        {
+            ["ui.tree"] = new() { Version = 1, Features = ["find", "query"] },
+            ["ui.actions"] = new() { Version = 1, Features = ["tap", "fill", "focus"] },
+            ["ui.screenshot"] = new() { Version = 1, Features = ["fullPage", "element"] },
+            ["profiler"] = new() { Version = 1, Features = ["samples", "spans", "markers", "hotspots"] },
+            ["network"] = new() { Version = 1, Features = ["capture", "detail"] },
+            ["logs"] = new() { Version = 1, Features = ["stream", "query"] },
+            ["device.info"] = new() { Version = 1, Features = ["display", "battery", "connectivity"] },
+            ["storage.preferences"] = new() { Version = 1, Features = ["get", "set", "delete"] },
+            ["storage.secure"] = new() { Version = 1, Features = ["get", "set", "delete"] },
+        };
+
+        return Task.FromResult(new InspectorCapabilities
+        {
+            Agent = new InspectorAgentInfo { Name = "devflow-legacy", Framework = "maui" },
+            Capabilities = caps
+        });
+    }
+
+    // ─────────── Visual Tree ────────────
+
+    public async Task<IReadOnlyList<InspectorElement>> GetTreeAsync(TreeOptions? options = null, CancellationToken ct = default)
+    {
+        int windowInt = options?.Window != null && int.TryParse(options.Window, out var w) ? w : 0;
+        var tree = await _legacy.GetTreeAsync(options?.Depth ?? 0, windowInt > 0 ? windowInt : null, ct);
+        return tree?.Select(MapElement).ToList()?.AsReadOnly() ?? (IReadOnlyList<InspectorElement>)[];
+    }
+
+    public async Task<InspectorElement?> GetElementAsync(string elementId, CancellationToken ct = default)
+    {
+        var element = await _legacy.GetElementAsync(elementId, ct);
+        return element != null ? MapElement(element) : null;
+    }
+
+    public async Task<IReadOnlyList<InspectorElement>> QueryElementsAsync(ElementQuery query, CancellationToken ct = default)
+    {
+        // Map v1 locator strategies to legacy query parameters
+        string? type = null, automationId = null, text = null, selector = null;
+        switch (query.Strategy)
+        {
+            case "type": type = query.Value; break;
+            case "accessibility-id": automationId = query.Value; break;
+            case "text": text = query.Value; break;
+            case "css-selector": selector = query.Value; break;
+        }
+
+        var results = await _legacy.QueryAsync(type, automationId, text, selector, ct);
+        return results?.Select(MapElement).ToList()?.AsReadOnly() ?? (IReadOnlyList<InspectorElement>)[];
+    }
+
+    public async Task<IReadOnlyList<InspectorElement>> HitTestAsync(double x, double y, string? window = null, CancellationToken ct = default)
+    {
+        int? windowInt = window != null && int.TryParse(window, out var w) ? w : null;
+        var result = await _legacy.HitTestAsync(x, y, windowInt, ct);
+        return result?.Elements?.Select(MapHitTestElement).ToList()?.AsReadOnly() ?? (IReadOnlyList<InspectorElement>)[];
+    }
+
+    // ─────────── Screenshots ────────────
+
+    public Task<byte[]?> GetScreenshotAsync(ScreenshotOptions? options = null, CancellationToken ct = default)
+    {
+        int? windowInt = options?.Window != null && int.TryParse(options.Window, out var w) ? w : null;
+        return _legacy.GetScreenshotAsync(windowInt, options?.ElementId, ct);
+    }
+
+    // ─────────── Properties ────────────
+
+    public async Task<object?> GetPropertyAsync(string elementId, string propertyName, CancellationToken ct = default)
+        => await _legacy.GetPropertyAsync(elementId, propertyName, ct);
+
+    public async Task<object?> SetPropertyAsync(string elementId, string propertyName, object value, CancellationToken ct = default)
+    {
+        var result = await _legacy.SetPropertyAsync(elementId, propertyName, value?.ToString() ?? string.Empty, ct);
+        return result ? value : null;
+    }
+
+    // ─────────── Actions ────────────
+
+    public async Task<ActionResult> TapAsync(TapRequest request, CancellationToken ct = default)
+    {
+        try
+        {
+            if (request.ElementId != null)
+                await _legacy.TapAsync(request.ElementId, ct);
+            return new ActionResult { Success = true };
+        }
+        catch (Exception ex)
+        {
+            return new ActionResult { Success = false, Error = new InspectorError { Title = ex.Message, Status = 500 } };
+        }
+    }
+
+    public async Task<ActionResult> FillAsync(FillRequest request, CancellationToken ct = default)
+    {
+        try
+        {
+            await _legacy.FillAsync(request.ElementId, request.Text, ct);
+            return new ActionResult { Success = true };
+        }
+        catch (Exception ex)
+        {
+            return new ActionResult { Success = false, Error = new InspectorError { Title = ex.Message, Status = 500 } };
+        }
+    }
+
+    public async Task<ActionResult> FocusAsync(FocusRequest request, CancellationToken ct = default)
+    {
+        try
+        {
+            await _legacy.FocusAsync(request.ElementId, ct);
+            return new ActionResult { Success = true };
+        }
+        catch (Exception ex)
+        {
+            return new ActionResult { Success = false, Error = new InspectorError { Title = ex.Message, Status = 500 } };
+        }
+    }
+
+    // These actions don't exist in legacy — return unsupported
+    public Task<ActionResult> ClearAsync(ClearRequest request, CancellationToken ct = default)
+        => Task.FromResult(new ActionResult { Success = false, Error = new InspectorError { Title = "Clear not supported in legacy protocol", Status = 501, ErrorCode = "unsupported-capability" } });
+
+    public Task<ActionResult> ScrollAsync(ScrollRequest request, CancellationToken ct = default)
+        => Task.FromResult(new ActionResult { Success = false, Error = new InspectorError { Title = "Scroll not supported in legacy protocol", Status = 501, ErrorCode = "unsupported-capability" } });
+
+    public Task<ActionResult> NavigateAsync(NavigateRequest request, CancellationToken ct = default)
+        => Task.FromResult(new ActionResult { Success = false, Error = new InspectorError { Title = "Navigate not supported in legacy protocol", Status = 501, ErrorCode = "unsupported-capability" } });
+
+    public Task<ActionResult> ResizeAsync(ResizeRequest request, CancellationToken ct = default)
+        => Task.FromResult(new ActionResult { Success = false, Error = new InspectorError { Title = "Resize not supported in legacy protocol", Status = 501, ErrorCode = "unsupported-capability" } });
+
+    public Task<ActionResult> BackAsync(BackRequest request, CancellationToken ct = default)
+        => Task.FromResult(new ActionResult { Success = false, Error = new InspectorError { Title = "Back not supported in legacy protocol", Status = 501, ErrorCode = "unsupported-capability" } });
+
+    public Task<ActionResult> KeyAsync(KeyRequest request, CancellationToken ct = default)
+        => Task.FromResult(new ActionResult { Success = false, Error = new InspectorError { Title = "Key not supported in legacy protocol", Status = 501, ErrorCode = "unsupported-capability" } });
+
+    public Task<ActionResult> GestureAsync(GestureRequest request, CancellationToken ct = default)
+        => Task.FromResult(new ActionResult { Success = false, Error = new InspectorError { Title = "Gesture not supported in legacy protocol", Status = 501, ErrorCode = "unsupported-capability" } });
+
+    public Task<ActionResult> BatchAsync(BatchRequest request, CancellationToken ct = default)
+        => Task.FromResult(new ActionResult { Success = false, Error = new InspectorError { Title = "Batch not supported in legacy protocol", Status = 501, ErrorCode = "unsupported-capability" } });
+
+    // ─────────── WebView ────────────
+
+    public async Task<IReadOnlyList<InspectorWebViewContext>> GetWebViewContextsAsync(CancellationToken ct = default)
+    {
+        var targets = await _legacy.GetCdpTargetsAsync(ct);
+        return targets?.Select(t => new InspectorWebViewContext
+        {
+            Id = t.Id,
+            Url = t.Url ?? string.Empty,
+            Title = t.Title,
+            Ready = t.Ready
+        }).ToList()?.AsReadOnly() ?? (IReadOnlyList<InspectorWebViewContext>)[];
+    }
+
+    public async Task<WebViewEvalResult> EvaluateJavaScriptAsync(string expression, string? contextId = null, CancellationToken ct = default)
+    {
+        var response = await _legacy.SendCdpCommandAsync("Runtime.evaluate",
+            new Dictionary<string, object> { ["expression"] = expression, ["returnByValue"] = true },
+            contextId, ct);
+        return new WebViewEvalResult { Result = response?.Result };
+    }
+
+    public Task<object?> GetWebViewDomAsync(string? contextId = null, CancellationToken ct = default)
+        => Task.FromResult<object?>(null); // Not available in legacy
+
+    public Task<IReadOnlyList<object>> QueryWebViewDomAsync(string selector, string? contextId = null, CancellationToken ct = default)
+        => Task.FromResult<IReadOnlyList<object>>([]);
+
+    public Task<string?> GetWebViewSourceAsync(string? contextId = null, CancellationToken ct = default)
+        => Task.FromResult<string?>(null);
+
+    public Task<bool> NavigateWebViewAsync(string url, string? contextId = null, CancellationToken ct = default)
+        => Task.FromResult(false);
+
+    public Task<bool> ClickInWebViewAsync(string selector, string? contextId = null, CancellationToken ct = default)
+        => Task.FromResult(false);
+
+    public Task<bool> FillInWebViewAsync(string selector, string text, string? contextId = null, CancellationToken ct = default)
+        => Task.FromResult(false);
+
+    public Task<byte[]?> GetWebViewScreenshotAsync(string? contextId = null, CancellationToken ct = default)
+        => Task.FromResult<byte[]?>(null);
+
+    // ─────────── Network ────────────
+
+    public async Task<IReadOnlyList<InspectorNetworkRequest>> GetNetworkRequestsAsync(CancellationToken ct = default)
+    {
+        var requests = await _legacy.GetNetworkRequestsAsync(ct);
+        return requests?.Select(MapNetworkRequest).ToList()?.AsReadOnly() ?? (IReadOnlyList<InspectorNetworkRequest>)[];
+    }
+
+    public async Task<InspectorNetworkRequestDetail?> GetNetworkRequestDetailAsync(string id, CancellationToken ct = default)
+    {
+        var detail = await _legacy.GetNetworkRequestDetailAsync(id, ct);
+        if (detail == null) return null;
+        return new InspectorNetworkRequestDetail
+        {
+            Id = detail.Id,
+            Timestamp = detail.Timestamp,
+            Method = detail.Method,
+            Url = detail.Url,
+            Host = detail.Host,
+            Path = detail.Path,
+            StatusCode = detail.StatusCode,
+            StatusText = detail.StatusText,
+            DurationMs = detail.DurationMs,
+            Error = detail.Error,
+            RequestContentType = detail.RequestContentType,
+            ResponseContentType = detail.ResponseContentType,
+            RequestSize = detail.RequestSize,
+            ResponseSize = detail.ResponseSize,
+            RequestHeaders = detail.RequestHeaders?.ToDictionary(kv => kv.Key, kv => string.Join(", ", kv.Value)),
+            ResponseHeaders = detail.ResponseHeaders?.ToDictionary(kv => kv.Key, kv => string.Join(", ", kv.Value)),
+            RequestBody = detail.RequestBody,
+            ResponseBody = detail.ResponseBody,
+            RequestBodyEncoding = detail.RequestBodyEncoding,
+            ResponseBodyEncoding = detail.ResponseBodyEncoding,
+            RequestBodyTruncated = detail.RequestBodyTruncated,
+            ResponseBodyTruncated = detail.ResponseBodyTruncated
+        };
+    }
+
+    public Task ClearNetworkRequestsAsync(CancellationToken ct = default)
+        => _legacy.ClearNetworkRequestsAsync(ct);
+
+    public Task StreamNetworkRequestsAsync(
+        Action<IReadOnlyList<InspectorNetworkRequest>>? onReplay,
+        Action<InspectorNetworkRequest> onRequest,
+        CancellationToken ct = default)
+        => _legacy.StreamNetworkRequestsAsync(r => onRequest(MapNetworkRequest(r)), ct);
+
+    // ─────────── Logs ────────────
+
+    public async Task<IReadOnlyList<InspectorLogEntry>> GetLogsAsync(LogQuery? query = null, CancellationToken ct = default)
+    {
+        var logs = await _legacy.GetLogsAsync(query?.Limit ?? 100, query?.Skip ?? 0, query?.Source, ct);
+        return logs?.Select(MapLogEntry).ToList()?.AsReadOnly() ?? (IReadOnlyList<InspectorLogEntry>)[];
+    }
+
+    public Task StreamLogsAsync(
+        Action<IReadOnlyList<InspectorLogEntry>>? onReplay,
+        Action<InspectorLogEntry> onEntry,
+        LogStreamOptions? options = null,
+        CancellationToken ct = default)
+        => _legacy.StreamLogsAsync(
+            replay => onReplay?.Invoke(replay.Select(MapLogEntry).ToList()),
+            entry => onEntry(MapLogEntry(entry)),
+            options?.Source, options?.Replay ?? 100, ct);
+
+    // ─────────── Profiler ────────────
+
+    public async Task<InspectorProfilerCapabilities> GetProfilerCapabilitiesAsync(CancellationToken ct = default)
+    {
+        var caps = await _legacy.GetProfilerCapabilitiesAsync(ct);
+        return new InspectorProfilerCapabilities
+        {
+            Platform = caps?.Platform ?? string.Empty,
+            ManagedMemorySupported = caps?.ManagedMemorySupported ?? false,
+            NativeMemorySupported = caps?.NativeMemorySupported ?? false,
+            GcSupported = caps?.GcSupported ?? false,
+            CpuPercentSupported = caps?.CpuPercentSupported ?? false,
+            FpsSupported = caps?.FpsSupported ?? false,
+            FrameTimingsEstimated = caps?.FrameTimingsEstimated ?? false,
+            NativeFrameTimingsSupported = caps?.NativeFrameTimingsSupported ?? false,
+            JankEventsSupported = caps?.JankEventsSupported ?? false,
+            UiThreadStallSupported = caps?.UiThreadStallSupported ?? false,
+            ThreadCountSupported = caps?.ThreadCountSupported ?? false
+        };
+    }
+
+    public Task<IReadOnlyList<InspectorProfilerSession>> GetProfilerSessionsAsync(CancellationToken ct = default)
+        => Task.FromResult<IReadOnlyList<InspectorProfilerSession>>([]); // Legacy doesn't list sessions
+
+    public async Task<InspectorProfilerSession> StartProfilingAsync(int? sampleIntervalMs = null, CancellationToken ct = default)
+    {
+        var result = await _legacy.StartProfilerAsync(sampleIntervalMs, ct);
+        return new InspectorProfilerSession
+        {
+            SessionId = result?.Session?.SessionId ?? "legacy",
+            StartedAtUtc = result?.Session?.StartedAtUtc ?? DateTimeOffset.UtcNow,
+            SampleIntervalMs = result?.Session?.SampleIntervalMs ?? sampleIntervalMs ?? 1000,
+            IsActive = true
+        };
+    }
+
+    public Task StopProfilingAsync(string sessionId, CancellationToken ct = default)
+        => _legacy.StopProfilerAsync(ct);
+
+    public async Task<InspectorProfilerBatch> GetProfilerSamplesAsync(string sessionId, int? sampleCursor = null, int? markerCursor = null, int? spanCursor = null, int? limit = null, CancellationToken ct = default)
+    {
+        var batch = await _legacy.GetProfilerSamplesAsync(
+            sampleCursor ?? 0, markerCursor ?? 0, spanCursor ?? 0, limit ?? 1000, ct);
+
+        return new InspectorProfilerBatch
+        {
+            SessionId = batch?.SessionId ?? sessionId,
+            Samples = batch?.Samples?.Select(s => new InspectorProfilerSample
+            {
+                TsUtc = s.TsUtc,
+                Fps = s.Fps,
+                FrameTimeMsP50 = s.FrameTimeMsP50,
+                FrameTimeMsP95 = s.FrameTimeMsP95,
+                WorstFrameTimeMs = s.WorstFrameTimeMs,
+                ManagedBytes = s.ManagedBytes,
+                Gc0 = s.Gc0,
+                Gc1 = s.Gc1,
+                Gc2 = s.Gc2,
+                NativeMemoryBytes = s.NativeMemoryBytes,
+                NativeMemoryKind = s.NativeMemoryKind,
+                CpuPercent = s.CpuPercent,
+                ThreadCount = s.ThreadCount,
+                JankFrameCount = s.JankFrameCount,
+                UiThreadStallCount = s.UiThreadStallCount,
+                FrameSource = s.FrameSource,
+                FrameQuality = s.FrameQuality
+            }).ToList()?.AsReadOnly() ?? (IReadOnlyList<InspectorProfilerSample>)[],
+            Markers = batch?.Markers?.Select(m => new InspectorProfilerMarker
+            {
+                TsUtc = m.TsUtc,
+                Type = m.Type,
+                Name = m.Name,
+                PayloadJson = m.PayloadJson
+            }).ToList()?.AsReadOnly() ?? (IReadOnlyList<InspectorProfilerMarker>)[],
+            Spans = batch?.Spans?.Select(s => new InspectorProfilerSpan
+            {
+                SpanId = s.SpanId,
+                ParentSpanId = s.ParentSpanId,
+                TraceId = s.TraceId,
+                StartTsUtc = s.StartTsUtc,
+                EndTsUtc = s.EndTsUtc,
+                DurationMs = s.DurationMs,
+                Kind = s.Kind,
+                Name = s.Name,
+                Status = s.Status,
+                ThreadId = s.ThreadId?.ToString(),
+                Screen = s.Screen,
+                ElementPath = s.ElementPath,
+                TagsJson = s.TagsJson,
+                Error = s.Error
+            }).ToList()?.AsReadOnly() ?? (IReadOnlyList<InspectorProfilerSpan>)[],
+            SampleCursor = (int)Math.Min(batch?.SampleCursor ?? 0, int.MaxValue),
+            MarkerCursor = (int)Math.Min(batch?.MarkerCursor ?? 0, int.MaxValue),
+            SpanCursor = (int)Math.Min(batch?.SpanCursor ?? 0, int.MaxValue),
+            IsActive = batch?.IsActive ?? false
+        };
+    }
+
+    public async Task<IReadOnlyList<InspectorProfilerHotspot>> GetProfilerHotspotsAsync(int? limit = null, double? minDurationMs = null, string? kind = null, CancellationToken ct = default)
+    {
+        var hotspots = await _legacy.GetProfilerHotspotsAsync(limit ?? 20, (int)(minDurationMs ?? 16), kind, ct);
+        return hotspots?.Select(h => new InspectorProfilerHotspot
+        {
+            Kind = h.Kind,
+            Name = h.Name,
+            Screen = h.Screen,
+            Count = h.Count,
+            ErrorCount = h.ErrorCount,
+            AvgDurationMs = h.AvgDurationMs,
+            P95DurationMs = h.P95DurationMs,
+            MaxDurationMs = h.MaxDurationMs
+        }).ToList()?.AsReadOnly() ?? (IReadOnlyList<InspectorProfilerHotspot>)[];
+    }
+
+    public Task<IReadOnlyList<InspectorProfilerMarker>> GetProfilerMarkersAsync(int? sampleCursor = null, int? limit = null, CancellationToken ct = default)
+        => Task.FromResult<IReadOnlyList<InspectorProfilerMarker>>([]); // Legacy doesn't have separate marker endpoint
+
+    public Task<IReadOnlyList<InspectorProfilerSpan>> GetProfilerSpansAsync(int? spanCursor = null, int? limit = null, CancellationToken ct = default)
+        => Task.FromResult<IReadOnlyList<InspectorProfilerSpan>>([]); // Legacy doesn't have separate span endpoint
+
+    // ─────────── Device ────────────
+
+    public async Task<InspectorDeviceInfo> GetDeviceInfoAsync(CancellationToken ct = default)
+    {
+        var info = await _legacy.GetDeviceInfoAsync(ct);
+        return new InspectorDeviceInfo
+        {
+            Model = info?.Model ?? string.Empty,
+            Manufacturer = info?.Manufacturer ?? string.Empty,
+            OsVersion = info?.OsVersion ?? string.Empty,
+            Platform = info?.Platform ?? string.Empty,
+            Idiom = info?.Idiom ?? string.Empty,
+            Architecture = null
+        };
+    }
+
+    public async Task<InspectorDisplayInfo> GetDisplayInfoAsync(CancellationToken ct = default)
+    {
+        var info = await _legacy.GetDisplayInfoAsync(ct);
+        return new InspectorDisplayInfo
+        {
+            Width = info?.Width ?? 0,
+            Height = info?.Height ?? 0,
+            Density = info?.Density ?? 1,
+            Orientation = info?.Orientation ?? "portrait",
+            RefreshRate = info?.RefreshRate
+        };
+    }
+
+    public async Task<InspectorBatteryInfo> GetBatteryInfoAsync(CancellationToken ct = default)
+    {
+        var info = await _legacy.GetBatteryInfoAsync(ct);
+        return new InspectorBatteryInfo
+        {
+            Level = info?.ChargeLevel ?? 0,
+            State = info?.State ?? "unknown",
+            PowerSource = info?.PowerSource ?? "unknown"
+        };
+    }
+
+    public async Task<InspectorConnectivityInfo> GetConnectivityAsync(CancellationToken ct = default)
+    {
+        var info = await _legacy.GetConnectivityAsync(ct);
+        return new InspectorConnectivityInfo
+        {
+            NetworkAccess = info?.NetworkAccess ?? "none",
+            ConnectionProfiles = info?.ConnectionProfiles?.AsReadOnly() ?? (IReadOnlyList<string>)[]
+        };
+    }
+
+    public async Task<InspectorAppInfo> GetAppInfoAsync(CancellationToken ct = default)
+    {
+        var info = await _legacy.GetAppInfoAsync(ct);
+        return new InspectorAppInfo
+        {
+            Name = info?.Name ?? string.Empty,
+            Version = info?.Version ?? string.Empty,
+            BuildNumber = info?.BuildNumber ?? string.Empty,
+            PackageId = info?.PackageName ?? string.Empty,
+            Theme = info?.RequestedTheme
+        };
+    }
+
+    // ─────────── Sensors ────────────
+
+    public async Task<IReadOnlyList<InspectorSensorInfo>> GetSensorsAsync(CancellationToken ct = default)
+    {
+        var sensors = await _legacy.GetSensorsAsync(ct);
+        return sensors?.Select(s => new InspectorSensorInfo
+        {
+            Name = s.Sensor,
+            Available = s.Supported,
+            Active = s.Active
+        }).ToList()?.AsReadOnly() ?? (IReadOnlyList<InspectorSensorInfo>)[];
+    }
+
+    public Task StartSensorAsync(string sensor, string? speed = null, CancellationToken ct = default)
+        => _legacy.StartSensorAsync(sensor, speed, ct);
+
+    public Task StopSensorAsync(string sensor, CancellationToken ct = default)
+        => _legacy.StopSensorAsync(sensor, ct);
+
+    public Task StreamSensorAsync(string sensor, Action<InspectorSensorReading> onReading, string? speed = null, int? throttleMs = null, CancellationToken ct = default)
+        => _legacy.StreamSensorAsync(sensor, r =>
+        {
+            // Legacy sensor readings have Data as a JsonElement — flatten to Dictionary<string, object>
+            var values = new Dictionary<string, object>();
+            if (r.Data.ValueKind == System.Text.Json.JsonValueKind.Object)
+            {
+                foreach (var prop in r.Data.EnumerateObject())
+                    values[prop.Name] = prop.Value.ToString() ?? string.Empty;
+            }
+            onReading(new InspectorSensorReading
+            {
+                Sensor = r.Sensor ?? sensor,
+                Timestamp = DateTimeOffset.TryParse(r.Timestamp, out var ts) ? ts : DateTimeOffset.UtcNow,
+                Values = values
+            });
+        }, speed ?? "UI", throttleMs ?? 100, ct);
+
+    // ─────────── Permissions & Geolocation ────────────
+
+    public async Task<IReadOnlyList<InspectorPermissionStatus>> GetPermissionsAsync(CancellationToken ct = default)
+    {
+        var result = await _legacy.GetPermissionsAsync(ct);
+        return result?.Select(p => new InspectorPermissionStatus
+        {
+            Name = p.Permission ?? string.Empty,
+            Status = p.Status ?? "unknown"
+        }).ToList()?.AsReadOnly() ?? (IReadOnlyList<InspectorPermissionStatus>)[];
+    }
+
+    public async Task<InspectorPermissionStatus> CheckPermissionAsync(string permission, CancellationToken ct = default)
+    {
+        var result = await _legacy.CheckPermissionAsync(permission, ct);
+        return new InspectorPermissionStatus
+        {
+            Name = permission,
+            Status = result?.Status ?? "unknown"
+        };
+    }
+
+    public async Task<InspectorGeolocation> GetGeolocationAsync(string? accuracy = null, int? timeoutSeconds = null, CancellationToken ct = default)
+    {
+        var result = await _legacy.GetGeolocationAsync(accuracy ?? "Medium", timeoutSeconds ?? 10, ct);
+        return new InspectorGeolocation
+        {
+            Latitude = result?.Latitude ?? 0,
+            Longitude = result?.Longitude ?? 0,
+            Altitude = result?.Altitude,
+            Accuracy = result?.Accuracy ?? 0,
+            Timestamp = result?.Timestamp ?? DateTimeOffset.UtcNow
+        };
+    }
+
+    // ─────────── Storage ────────────
+
+    public async Task<IReadOnlyList<InspectorPreferenceEntry>> GetPreferencesAsync(string? sharedName = null, CancellationToken ct = default)
+    {
+        var prefs = await _legacy.GetPreferencesAsync(sharedName, ct);
+        return prefs?.Select(p => new InspectorPreferenceEntry
+        {
+            Key = p.Key ?? string.Empty,
+            Value = p.Value,
+            Type = "string" // Legacy doesn't track types
+        }).ToList()?.AsReadOnly() ?? (IReadOnlyList<InspectorPreferenceEntry>)[];
+    }
+
+    public async Task<InspectorPreferenceEntry?> GetPreferenceAsync(string key, string? type = null, string? sharedName = null, CancellationToken ct = default)
+    {
+        var pref = await _legacy.GetPreferenceAsync(key, type ?? "string", sharedName, ct);
+        return pref != null ? new InspectorPreferenceEntry { Key = pref.Key ?? key, Value = pref.Value, Type = type ?? "string" } : null;
+    }
+
+    public Task SetPreferenceAsync(string key, object value, string? type = null, string? sharedName = null, CancellationToken ct = default)
+        => _legacy.SetPreferenceAsync(key, value, type, sharedName, ct);
+
+    public Task DeletePreferenceAsync(string key, string? sharedName = null, CancellationToken ct = default)
+        => _legacy.DeletePreferenceAsync(key, sharedName, ct);
+
+    public Task ClearPreferencesAsync(string? sharedName = null, CancellationToken ct = default)
+        => _legacy.ClearPreferencesAsync(sharedName, ct);
+
+    public async Task<InspectorSecureStorageEntry?> GetSecureStorageAsync(string key, CancellationToken ct = default)
+    {
+        var entry = await _legacy.GetSecureStorageAsync(key, ct);
+        return entry != null ? new InspectorSecureStorageEntry { Key = key, Value = entry.Value, Exists = entry.Exists } : null;
+    }
+
+    public Task SetSecureStorageAsync(string key, string value, CancellationToken ct = default)
+        => _legacy.SetSecureStorageAsync(key, value, ct);
+
+    public Task DeleteSecureStorageAsync(string key, CancellationToken ct = default)
+        => _legacy.DeleteSecureStorageAsync(key, ct);
+
+    public Task ClearSecureStorageAsync(CancellationToken ct = default)
+        => _legacy.ClearSecureStorageAsync(ct);
+
+    public void Dispose()
+    {
+        _legacy.Dispose();
+    }
+}

--- a/src/MauiSherpa.Core/Services/Inspector/DevFlowV1Client.cs
+++ b/src/MauiSherpa.Core/Services/Inspector/DevFlowV1Client.cs
@@ -1,0 +1,552 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using MauiSherpa.Core.Interfaces;
+using MauiSherpa.Core.Models.Inspector;
+using Microsoft.Extensions.Logging;
+
+namespace MauiSherpa.Core.Services;
+
+/// <summary>
+/// Client implementation for the DevFlow v1 protocol (/api/v1/*).
+/// </summary>
+public class DevFlowV1Client : IAppInspectorClient
+{
+    private readonly HttpClient _http;
+    private readonly ILogger _logger;
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        PropertyNameCaseInsensitive = true,
+    };
+
+    public InspectorProtocolVersion ProtocolVersion => InspectorProtocolVersion.V1;
+    public string Host { get; }
+    public int Port { get; }
+
+    public DevFlowV1Client(string host, int port, IHttpClientFactory httpClientFactory, ILogger logger)
+    {
+        Host = host;
+        Port = port;
+        _logger = logger;
+        _http = httpClientFactory.CreateClient("DevFlowAgent");
+        _http.BaseAddress = new Uri($"http://{host}:{port}");
+        _http.Timeout = TimeSpan.FromSeconds(15);
+    }
+
+    // ─────────────────────── Agent ───────────────────────────
+
+    public async Task<InspectorAgentStatus> GetAgentStatusAsync(CancellationToken ct = default)
+    {
+        var result = await _http.GetFromJsonAsync<InspectorAgentStatus>("/api/v1/agent/status", JsonOptions, ct);
+        return result ?? new InspectorAgentStatus();
+    }
+
+    public async Task<InspectorCapabilities> GetCapabilitiesAsync(CancellationToken ct = default)
+    {
+        var result = await _http.GetFromJsonAsync<InspectorCapabilities>("/api/v1/agent/capabilities", JsonOptions, ct);
+        return result ?? new InspectorCapabilities();
+    }
+
+    // ─────────────────────── Visual Tree ─────────────────────
+
+    public async Task<IReadOnlyList<InspectorElement>> GetTreeAsync(TreeOptions? options = null, CancellationToken ct = default)
+    {
+        var url = "/api/v1/ui/tree";
+        var query = new List<string>();
+        if (options?.Depth.HasValue == true) query.Add($"depth={options.Depth.Value}");
+        if (options?.Layer != null) query.Add($"layer={Uri.EscapeDataString(options.Layer)}");
+        if (options?.RootId != null) query.Add($"rootId={Uri.EscapeDataString(options.RootId)}");
+        if (options?.Include?.Count > 0) query.Add($"include={string.Join(",", options.Include)}");
+        if (query.Count > 0) url += "?" + string.Join("&", query);
+
+        var result = await _http.GetFromJsonAsync<List<InspectorElement>>(url, JsonOptions, ct);
+        return result?.AsReadOnly() ?? (IReadOnlyList<InspectorElement>)[];
+    }
+
+    public async Task<InspectorElement?> GetElementAsync(string elementId, CancellationToken ct = default)
+    {
+        try
+        {
+            return await _http.GetFromJsonAsync<InspectorElement>(
+                $"/api/v1/ui/elements/{Uri.EscapeDataString(elementId)}", JsonOptions, ct);
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
+    public async Task<IReadOnlyList<InspectorElement>> QueryElementsAsync(ElementQuery query, CancellationToken ct = default)
+    {
+        var url = $"/api/v1/ui/elements?strategy={Uri.EscapeDataString(query.Strategy)}&value={Uri.EscapeDataString(query.Value)}";
+        if (query.Limit.HasValue) url += $"&limit={query.Limit.Value}";
+        if (query.Include?.Count > 0) url += $"&include={string.Join(",", query.Include)}";
+
+        var result = await _http.GetFromJsonAsync<List<InspectorElement>>(url, JsonOptions, ct);
+        return result?.AsReadOnly() ?? (IReadOnlyList<InspectorElement>)[];
+    }
+
+    public async Task<IReadOnlyList<InspectorElement>> HitTestAsync(double x, double y, string? window = null, CancellationToken ct = default)
+    {
+        var url = $"/api/v1/ui/hit-test?x={x}&y={y}";
+        var result = await _http.GetFromJsonAsync<List<InspectorElement>>(url, JsonOptions, ct);
+        return result?.AsReadOnly() ?? (IReadOnlyList<InspectorElement>)[];
+    }
+
+    // ─────────────────────── Screenshots ─────────────────────
+
+    public async Task<byte[]?> GetScreenshotAsync(ScreenshotOptions? options = null, CancellationToken ct = default)
+    {
+        var url = "/api/v1/ui/screenshot";
+        var query = new List<string>();
+        if (options?.ElementId != null) query.Add($"elementId={Uri.EscapeDataString(options.ElementId)}");
+        if (options?.MaxWidth.HasValue == true) query.Add($"maxWidth={options.MaxWidth.Value}");
+        if (options?.Scale != null) query.Add($"scale={Uri.EscapeDataString(options.Scale)}");
+        if (options?.Format != null) query.Add($"format={Uri.EscapeDataString(options.Format)}");
+        if (query.Count > 0) url += "?" + string.Join("&", query);
+
+        try
+        {
+            return await _http.GetByteArrayAsync(url, ct);
+        }
+        catch (HttpRequestException)
+        {
+            return null;
+        }
+    }
+
+    // ─────────────────────── Element Properties ──────────────
+
+    public async Task<object?> GetPropertyAsync(string elementId, string propertyName, CancellationToken ct = default)
+    {
+        var url = $"/api/v1/ui/elements/{Uri.EscapeDataString(elementId)}/properties/{Uri.EscapeDataString(propertyName)}";
+        var result = await _http.GetFromJsonAsync<JsonElement>(url, JsonOptions, ct);
+        return result.TryGetProperty("value", out var val) ? val.Deserialize<object>(JsonOptions) : null;
+    }
+
+    public async Task<object?> SetPropertyAsync(string elementId, string propertyName, object value, CancellationToken ct = default)
+    {
+        var url = $"/api/v1/ui/elements/{Uri.EscapeDataString(elementId)}/properties/{Uri.EscapeDataString(propertyName)}";
+        var response = await _http.PutAsJsonAsync(url, new { value }, JsonOptions, ct);
+        response.EnsureSuccessStatusCode();
+        var result = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions, ct);
+        return result.TryGetProperty("value", out var val) ? val.Deserialize<object>(JsonOptions) : null;
+    }
+
+    // ─────────────────────── UI Actions ──────────────────────
+
+    private async Task<ActionResult> PostActionAsync<T>(string path, T request, CancellationToken ct)
+    {
+        var response = await _http.PostAsJsonAsync(path, request, JsonOptions, ct);
+        if (!response.IsSuccessStatusCode)
+        {
+            var error = await response.Content.ReadFromJsonAsync<InspectorError>(JsonOptions, ct);
+            return new ActionResult { Success = false, Error = error };
+        }
+        var result = await response.Content.ReadFromJsonAsync<ActionResult>(JsonOptions, ct);
+        return result ?? new ActionResult { Success = true };
+    }
+
+    public Task<ActionResult> TapAsync(TapRequest request, CancellationToken ct = default) =>
+        PostActionAsync("/api/v1/ui/actions/tap", request, ct);
+
+    public Task<ActionResult> FillAsync(FillRequest request, CancellationToken ct = default) =>
+        PostActionAsync("/api/v1/ui/actions/fill", request, ct);
+
+    public Task<ActionResult> ClearAsync(ClearRequest request, CancellationToken ct = default) =>
+        PostActionAsync("/api/v1/ui/actions/clear", request, ct);
+
+    public Task<ActionResult> FocusAsync(FocusRequest request, CancellationToken ct = default) =>
+        PostActionAsync("/api/v1/ui/actions/focus", request, ct);
+
+    public Task<ActionResult> ScrollAsync(ScrollRequest request, CancellationToken ct = default) =>
+        PostActionAsync("/api/v1/ui/actions/scroll", request, ct);
+
+    public Task<ActionResult> NavigateAsync(NavigateRequest request, CancellationToken ct = default) =>
+        PostActionAsync("/api/v1/ui/actions/navigate", request, ct);
+
+    public Task<ActionResult> ResizeAsync(ResizeRequest request, CancellationToken ct = default) =>
+        PostActionAsync("/api/v1/ui/actions/resize", request, ct);
+
+    public Task<ActionResult> BackAsync(BackRequest request, CancellationToken ct = default) =>
+        PostActionAsync("/api/v1/ui/actions/back", request, ct);
+
+    public Task<ActionResult> KeyAsync(KeyRequest request, CancellationToken ct = default) =>
+        PostActionAsync("/api/v1/ui/actions/key", request, ct);
+
+    public Task<ActionResult> GestureAsync(GestureRequest request, CancellationToken ct = default) =>
+        PostActionAsync("/api/v1/ui/actions/gesture", request, ct);
+
+    public Task<ActionResult> BatchAsync(BatchRequest request, CancellationToken ct = default) =>
+        PostActionAsync("/api/v1/ui/actions/batch", request, ct);
+
+    // ─────────────────────── WebView ─────────────────────────
+
+    public async Task<IReadOnlyList<InspectorWebViewContext>> GetWebViewContextsAsync(CancellationToken ct = default)
+    {
+        var result = await _http.GetFromJsonAsync<List<InspectorWebViewContext>>("/api/v1/webview/contexts", JsonOptions, ct);
+        return result?.AsReadOnly() ?? (IReadOnlyList<InspectorWebViewContext>)[];
+    }
+
+    public async Task<WebViewEvalResult> EvaluateJavaScriptAsync(string expression, string? contextId = null, CancellationToken ct = default)
+    {
+        var response = await _http.PostAsJsonAsync("/api/v1/webview/evaluate",
+            new { expression, contextId }, JsonOptions, ct);
+        response.EnsureSuccessStatusCode();
+        var result = await response.Content.ReadFromJsonAsync<WebViewEvalResult>(JsonOptions, ct);
+        return result ?? new WebViewEvalResult();
+    }
+
+    public async Task<object?> GetWebViewDomAsync(string? contextId = null, CancellationToken ct = default)
+    {
+        var url = contextId != null ? $"/api/v1/webview/dom?contextId={Uri.EscapeDataString(contextId)}" : "/api/v1/webview/dom";
+        return await _http.GetFromJsonAsync<object>(url, JsonOptions, ct);
+    }
+
+    public async Task<IReadOnlyList<object>> QueryWebViewDomAsync(string selector, string? contextId = null, CancellationToken ct = default)
+    {
+        var response = await _http.PostAsJsonAsync("/api/v1/webview/dom/query",
+            new { selector, contextId }, JsonOptions, ct);
+        response.EnsureSuccessStatusCode();
+        var result = await response.Content.ReadFromJsonAsync<List<object>>(JsonOptions, ct);
+        return result?.AsReadOnly() ?? (IReadOnlyList<object>)[];
+    }
+
+    public async Task<string?> GetWebViewSourceAsync(string? contextId = null, CancellationToken ct = default)
+    {
+        var url = contextId != null ? $"/api/v1/webview/source?contextId={Uri.EscapeDataString(contextId)}" : "/api/v1/webview/source";
+        return await _http.GetStringAsync(url, ct);
+    }
+
+    public async Task<bool> NavigateWebViewAsync(string url, string? contextId = null, CancellationToken ct = default)
+    {
+        var response = await _http.PostAsJsonAsync("/api/v1/webview/navigate",
+            new { url, contextId }, JsonOptions, ct);
+        return response.IsSuccessStatusCode;
+    }
+
+    public async Task<bool> ClickInWebViewAsync(string selector, string? contextId = null, CancellationToken ct = default)
+    {
+        var response = await _http.PostAsJsonAsync("/api/v1/webview/input/click",
+            new { selector, contextId }, JsonOptions, ct);
+        return response.IsSuccessStatusCode;
+    }
+
+    public async Task<bool> FillInWebViewAsync(string selector, string text, string? contextId = null, CancellationToken ct = default)
+    {
+        var response = await _http.PostAsJsonAsync("/api/v1/webview/input/fill",
+            new { selector, text, contextId }, JsonOptions, ct);
+        return response.IsSuccessStatusCode;
+    }
+
+    public async Task<byte[]?> GetWebViewScreenshotAsync(string? contextId = null, CancellationToken ct = default)
+    {
+        var url = contextId != null ? $"/api/v1/webview/screenshot?contextId={Uri.EscapeDataString(contextId)}" : "/api/v1/webview/screenshot";
+        try { return await _http.GetByteArrayAsync(url, ct); }
+        catch (HttpRequestException) { return null; }
+    }
+
+    // ─────────────────────── Network ─────────────────────────
+
+    public async Task<IReadOnlyList<InspectorNetworkRequest>> GetNetworkRequestsAsync(CancellationToken ct = default)
+    {
+        var result = await _http.GetFromJsonAsync<List<InspectorNetworkRequest>>("/api/v1/network/requests", JsonOptions, ct);
+        return result?.AsReadOnly() ?? (IReadOnlyList<InspectorNetworkRequest>)[];
+    }
+
+    public async Task<InspectorNetworkRequestDetail?> GetNetworkRequestDetailAsync(string id, CancellationToken ct = default)
+    {
+        try
+        {
+            return await _http.GetFromJsonAsync<InspectorNetworkRequestDetail>(
+                $"/api/v1/network/requests/{Uri.EscapeDataString(id)}", JsonOptions, ct);
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
+    public async Task ClearNetworkRequestsAsync(CancellationToken ct = default)
+    {
+        await _http.DeleteAsync("/api/v1/network/requests", ct);
+    }
+
+    public Task StreamNetworkRequestsAsync(
+        Action<IReadOnlyList<InspectorNetworkRequest>>? onReplay,
+        Action<InspectorNetworkRequest> onRequest,
+        CancellationToken ct = default)
+    {
+        // WebSocket streaming — will be implemented in create-v1-websocket todo
+        throw new NotImplementedException("WebSocket streaming not yet implemented");
+    }
+
+    // ─────────────────────── Logs ────────────────────────────
+
+    public async Task<IReadOnlyList<InspectorLogEntry>> GetLogsAsync(LogQuery? query = null, CancellationToken ct = default)
+    {
+        var url = "/api/v1/logs";
+        var q = new List<string>();
+        if (query?.Limit.HasValue == true) q.Add($"limit={query.Limit.Value}");
+        if (query?.Skip.HasValue == true) q.Add($"skip={query.Skip.Value}");
+        if (query?.Source != null) q.Add($"source={Uri.EscapeDataString(query.Source)}");
+        if (query?.Level != null) q.Add($"level={Uri.EscapeDataString(query.Level)}");
+        if (q.Count > 0) url += "?" + string.Join("&", q);
+
+        var result = await _http.GetFromJsonAsync<List<InspectorLogEntry>>(url, JsonOptions, ct);
+        return result?.AsReadOnly() ?? (IReadOnlyList<InspectorLogEntry>)[];
+    }
+
+    public Task StreamLogsAsync(
+        Action<IReadOnlyList<InspectorLogEntry>>? onReplay,
+        Action<InspectorLogEntry> onEntry,
+        LogStreamOptions? options = null,
+        CancellationToken ct = default)
+    {
+        // WebSocket streaming — will be implemented in create-v1-websocket todo
+        throw new NotImplementedException("WebSocket streaming not yet implemented");
+    }
+
+    // ─────────────────────── Profiler ────────────────────────
+
+    public async Task<InspectorProfilerCapabilities> GetProfilerCapabilitiesAsync(CancellationToken ct = default)
+    {
+        var result = await _http.GetFromJsonAsync<InspectorProfilerCapabilities>("/api/v1/profiler/capabilities", JsonOptions, ct);
+        return result ?? new InspectorProfilerCapabilities();
+    }
+
+    public async Task<IReadOnlyList<InspectorProfilerSession>> GetProfilerSessionsAsync(CancellationToken ct = default)
+    {
+        var result = await _http.GetFromJsonAsync<List<InspectorProfilerSession>>("/api/v1/profiler/sessions", JsonOptions, ct);
+        return result?.AsReadOnly() ?? (IReadOnlyList<InspectorProfilerSession>)[];
+    }
+
+    public async Task<InspectorProfilerSession> StartProfilingAsync(int? sampleIntervalMs = null, CancellationToken ct = default)
+    {
+        var payload = sampleIntervalMs.HasValue ? new { sampleIntervalMs = sampleIntervalMs.Value } : (object?)null;
+        var response = await _http.PostAsJsonAsync("/api/v1/profiler/sessions", payload, JsonOptions, ct);
+        response.EnsureSuccessStatusCode();
+        var result = await response.Content.ReadFromJsonAsync<InspectorProfilerSession>(JsonOptions, ct);
+        return result ?? new InspectorProfilerSession();
+    }
+
+    public async Task StopProfilingAsync(string sessionId, CancellationToken ct = default)
+    {
+        await _http.DeleteAsync($"/api/v1/profiler/sessions/{Uri.EscapeDataString(sessionId)}", ct);
+    }
+
+    public async Task<InspectorProfilerBatch> GetProfilerSamplesAsync(string sessionId, int? sampleCursor = null, int? markerCursor = null, int? spanCursor = null, int? limit = null, CancellationToken ct = default)
+    {
+        var url = $"/api/v1/profiler/sessions/{Uri.EscapeDataString(sessionId)}/samples";
+        var q = new List<string>();
+        if (sampleCursor.HasValue) q.Add($"sampleCursor={sampleCursor.Value}");
+        if (markerCursor.HasValue) q.Add($"markerCursor={markerCursor.Value}");
+        if (spanCursor.HasValue) q.Add($"spanCursor={spanCursor.Value}");
+        if (limit.HasValue) q.Add($"limit={limit.Value}");
+        if (q.Count > 0) url += "?" + string.Join("&", q);
+
+        var result = await _http.GetFromJsonAsync<InspectorProfilerBatch>(url, JsonOptions, ct);
+        return result ?? new InspectorProfilerBatch();
+    }
+
+    public async Task<IReadOnlyList<InspectorProfilerHotspot>> GetProfilerHotspotsAsync(int? limit = null, double? minDurationMs = null, string? kind = null, CancellationToken ct = default)
+    {
+        var url = "/api/v1/profiler/hotspots";
+        var q = new List<string>();
+        if (limit.HasValue) q.Add($"limit={limit.Value}");
+        if (minDurationMs.HasValue) q.Add($"minDurationMs={minDurationMs.Value}");
+        if (kind != null) q.Add($"kind={Uri.EscapeDataString(kind)}");
+        if (q.Count > 0) url += "?" + string.Join("&", q);
+
+        var result = await _http.GetFromJsonAsync<List<InspectorProfilerHotspot>>(url, JsonOptions, ct);
+        return result?.AsReadOnly() ?? (IReadOnlyList<InspectorProfilerHotspot>)[];
+    }
+
+    public async Task<IReadOnlyList<InspectorProfilerMarker>> GetProfilerMarkersAsync(int? sampleCursor = null, int? limit = null, CancellationToken ct = default)
+    {
+        var url = "/api/v1/profiler/markers";
+        var q = new List<string>();
+        if (sampleCursor.HasValue) q.Add($"cursor={sampleCursor.Value}");
+        if (limit.HasValue) q.Add($"limit={limit.Value}");
+        if (q.Count > 0) url += "?" + string.Join("&", q);
+
+        var result = await _http.GetFromJsonAsync<List<InspectorProfilerMarker>>(url, JsonOptions, ct);
+        return result?.AsReadOnly() ?? (IReadOnlyList<InspectorProfilerMarker>)[];
+    }
+
+    public async Task<IReadOnlyList<InspectorProfilerSpan>> GetProfilerSpansAsync(int? spanCursor = null, int? limit = null, CancellationToken ct = default)
+    {
+        var url = "/api/v1/profiler/spans";
+        var q = new List<string>();
+        if (spanCursor.HasValue) q.Add($"cursor={spanCursor.Value}");
+        if (limit.HasValue) q.Add($"limit={limit.Value}");
+        if (q.Count > 0) url += "?" + string.Join("&", q);
+
+        var result = await _http.GetFromJsonAsync<List<InspectorProfilerSpan>>(url, JsonOptions, ct);
+        return result?.AsReadOnly() ?? (IReadOnlyList<InspectorProfilerSpan>)[];
+    }
+
+    // ─────────────────────── Device ──────────────────────────
+
+    public async Task<InspectorDeviceInfo> GetDeviceInfoAsync(CancellationToken ct = default)
+    {
+        var result = await _http.GetFromJsonAsync<InspectorDeviceInfo>("/api/v1/device/info", JsonOptions, ct);
+        return result ?? new InspectorDeviceInfo();
+    }
+
+    public async Task<InspectorDisplayInfo> GetDisplayInfoAsync(CancellationToken ct = default)
+    {
+        var result = await _http.GetFromJsonAsync<InspectorDisplayInfo>("/api/v1/device/display", JsonOptions, ct);
+        return result ?? new InspectorDisplayInfo();
+    }
+
+    public async Task<InspectorBatteryInfo> GetBatteryInfoAsync(CancellationToken ct = default)
+    {
+        var result = await _http.GetFromJsonAsync<InspectorBatteryInfo>("/api/v1/device/battery", JsonOptions, ct);
+        return result ?? new InspectorBatteryInfo();
+    }
+
+    public async Task<InspectorConnectivityInfo> GetConnectivityAsync(CancellationToken ct = default)
+    {
+        var result = await _http.GetFromJsonAsync<InspectorConnectivityInfo>("/api/v1/device/connectivity", JsonOptions, ct);
+        return result ?? new InspectorConnectivityInfo();
+    }
+
+    public async Task<InspectorAppInfo> GetAppInfoAsync(CancellationToken ct = default)
+    {
+        var result = await _http.GetFromJsonAsync<InspectorAppInfo>("/api/v1/device/app", JsonOptions, ct);
+        return result ?? new InspectorAppInfo();
+    }
+
+    // ─────────────────────── Sensors ─────────────────────────
+
+    public async Task<IReadOnlyList<InspectorSensorInfo>> GetSensorsAsync(CancellationToken ct = default)
+    {
+        var result = await _http.GetFromJsonAsync<List<InspectorSensorInfo>>("/api/v1/device/sensors", JsonOptions, ct);
+        return result?.AsReadOnly() ?? (IReadOnlyList<InspectorSensorInfo>)[];
+    }
+
+    public async Task StartSensorAsync(string sensor, string? speed = null, CancellationToken ct = default)
+    {
+        var url = $"/api/v1/device/sensors/{Uri.EscapeDataString(sensor)}/start";
+        if (speed != null) url += $"?speed={Uri.EscapeDataString(speed)}";
+        var response = await _http.PostAsync(url, null, ct);
+        response.EnsureSuccessStatusCode();
+    }
+
+    public async Task StopSensorAsync(string sensor, CancellationToken ct = default)
+    {
+        var response = await _http.PostAsync($"/api/v1/device/sensors/{Uri.EscapeDataString(sensor)}/stop", null, ct);
+        response.EnsureSuccessStatusCode();
+    }
+
+    public Task StreamSensorAsync(string sensor, Action<InspectorSensorReading> onReading, string? speed = null, int? throttleMs = null, CancellationToken ct = default)
+    {
+        // WebSocket streaming — will be implemented in create-v1-websocket todo
+        throw new NotImplementedException("WebSocket streaming not yet implemented");
+    }
+
+    // ─────────────────────── Permissions & Geolocation ───────
+
+    public async Task<IReadOnlyList<InspectorPermissionStatus>> GetPermissionsAsync(CancellationToken ct = default)
+    {
+        var result = await _http.GetFromJsonAsync<List<InspectorPermissionStatus>>("/api/v1/device/permissions", JsonOptions, ct);
+        return result?.AsReadOnly() ?? (IReadOnlyList<InspectorPermissionStatus>)[];
+    }
+
+    public async Task<InspectorPermissionStatus> CheckPermissionAsync(string permission, CancellationToken ct = default)
+    {
+        var result = await _http.GetFromJsonAsync<InspectorPermissionStatus>(
+            $"/api/v1/device/permissions/{Uri.EscapeDataString(permission)}", JsonOptions, ct);
+        return result ?? new InspectorPermissionStatus { Name = permission };
+    }
+
+    public async Task<InspectorGeolocation> GetGeolocationAsync(string? accuracy = null, int? timeoutSeconds = null, CancellationToken ct = default)
+    {
+        var url = "/api/v1/device/geolocation";
+        var q = new List<string>();
+        if (accuracy != null) q.Add($"accuracy={Uri.EscapeDataString(accuracy)}");
+        if (timeoutSeconds.HasValue) q.Add($"timeout={timeoutSeconds.Value}");
+        if (q.Count > 0) url += "?" + string.Join("&", q);
+
+        var result = await _http.GetFromJsonAsync<InspectorGeolocation>(url, JsonOptions, ct);
+        return result ?? new InspectorGeolocation();
+    }
+
+    // ─────────────────────── Storage ─────────────────────────
+
+    public async Task<IReadOnlyList<InspectorPreferenceEntry>> GetPreferencesAsync(string? sharedName = null, CancellationToken ct = default)
+    {
+        var url = "/api/v1/storage/preferences";
+        if (sharedName != null) url += $"?sharedName={Uri.EscapeDataString(sharedName)}";
+        var result = await _http.GetFromJsonAsync<List<InspectorPreferenceEntry>>(url, JsonOptions, ct);
+        return result?.AsReadOnly() ?? (IReadOnlyList<InspectorPreferenceEntry>)[];
+    }
+
+    public async Task<InspectorPreferenceEntry?> GetPreferenceAsync(string key, string? type = null, string? sharedName = null, CancellationToken ct = default)
+    {
+        var url = $"/api/v1/storage/preferences/{Uri.EscapeDataString(key)}";
+        var q = new List<string>();
+        if (type != null) q.Add($"type={Uri.EscapeDataString(type)}");
+        if (sharedName != null) q.Add($"sharedName={Uri.EscapeDataString(sharedName)}");
+        if (q.Count > 0) url += "?" + string.Join("&", q);
+
+        try { return await _http.GetFromJsonAsync<InspectorPreferenceEntry>(url, JsonOptions, ct); }
+        catch (HttpRequestException) { return null; }
+    }
+
+    public async Task SetPreferenceAsync(string key, object value, string? type = null, string? sharedName = null, CancellationToken ct = default)
+    {
+        var url = $"/api/v1/storage/preferences/{Uri.EscapeDataString(key)}";
+        var response = await _http.PutAsJsonAsync(url, new { value, type, sharedName }, JsonOptions, ct);
+        response.EnsureSuccessStatusCode();
+    }
+
+    public async Task DeletePreferenceAsync(string key, string? sharedName = null, CancellationToken ct = default)
+    {
+        var url = $"/api/v1/storage/preferences/{Uri.EscapeDataString(key)}";
+        if (sharedName != null) url += $"?sharedName={Uri.EscapeDataString(sharedName)}";
+        await _http.DeleteAsync(url, ct);
+    }
+
+    public async Task ClearPreferencesAsync(string? sharedName = null, CancellationToken ct = default)
+    {
+        var url = "/api/v1/storage/preferences";
+        if (sharedName != null) url += $"?sharedName={Uri.EscapeDataString(sharedName)}";
+        await _http.DeleteAsync(url, ct);
+    }
+
+    public async Task<InspectorSecureStorageEntry?> GetSecureStorageAsync(string key, CancellationToken ct = default)
+    {
+        try
+        {
+            return await _http.GetFromJsonAsync<InspectorSecureStorageEntry>(
+                $"/api/v1/storage/secure/{Uri.EscapeDataString(key)}", JsonOptions, ct);
+        }
+        catch (HttpRequestException) { return null; }
+    }
+
+    public async Task SetSecureStorageAsync(string key, string value, CancellationToken ct = default)
+    {
+        var response = await _http.PutAsJsonAsync(
+            $"/api/v1/storage/secure/{Uri.EscapeDataString(key)}", new { value }, JsonOptions, ct);
+        response.EnsureSuccessStatusCode();
+    }
+
+    public async Task DeleteSecureStorageAsync(string key, CancellationToken ct = default)
+    {
+        await _http.DeleteAsync($"/api/v1/storage/secure/{Uri.EscapeDataString(key)}", ct);
+    }
+
+    public async Task ClearSecureStorageAsync(CancellationToken ct = default)
+    {
+        await _http.DeleteAsync("/api/v1/storage/secure", ct);
+    }
+
+    public void Dispose()
+    {
+        _http.Dispose();
+    }
+}

--- a/src/MauiSherpa/MauiProgram.cs
+++ b/src/MauiSherpa/MauiProgram.cs
@@ -125,6 +125,9 @@ public static class MauiProgram
         builder.Services.AddSingleton<IFirebasePushService, FirebasePushService>();
         builder.Services.AddSingleton<DeviceInspectorService>();
         builder.Services.AddSingleton<DevFlowInspectorService>();
+        // DevFlow v1 spec abstraction — unified client that works with both v1 and legacy agents
+        builder.Services.AddHttpClient();
+        builder.Services.AddSingleton<MauiSherpa.Core.Interfaces.IAppInspectorClientFactory, MauiSherpa.Core.Services.AppInspectorClientFactory>();
         builder.Services.AddSingleton<IDebugFlagService, DebugFlagService>();
         builder.Services.AddSingleton<IDoctorService, DoctorService>();
         builder.Services.AddSingleton<IProfilingContextService, ProfilingContextService>();

--- a/tests/MauiSherpa.Core.Tests/Services/Inspector/AppInspectorClientFactoryTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/Inspector/AppInspectorClientFactoryTests.cs
@@ -1,0 +1,91 @@
+using System.Net;
+using FluentAssertions;
+using MauiSherpa.Core.Interfaces;
+using MauiSherpa.Core.Models.Inspector;
+using MauiSherpa.Core.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Moq.Protected;
+
+namespace MauiSherpa.Core.Tests.Services.Inspector;
+
+/// <summary>
+/// Verifies the factory probes v1 first and falls back to legacy.
+/// </summary>
+public class AppInspectorClientFactoryTests
+{
+    [Fact]
+    public async Task CreateAsync_WhenV1EndpointResponds_ReturnsV1Client()
+    {
+        var handler = new StubHandler(req =>
+            req.RequestUri!.AbsolutePath switch
+            {
+                "/api/v1/agent/status" => new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"running\":true}", System.Text.Encoding.UTF8, "application/json")
+                },
+                _ => new HttpResponseMessage(HttpStatusCode.NotFound)
+            });
+
+        var factory = BuildFactory(handler);
+
+        var client = await factory.CreateAsync("localhost", 9223);
+
+        client.Should().NotBeNull();
+        client.ProtocolVersion.Should().Be(InspectorProtocolVersion.V1);
+    }
+
+    [Fact]
+    public async Task CreateAsync_WhenOnlyLegacyResponds_ReturnsLegacyClient()
+    {
+        var handler = new StubHandler(req =>
+            req.RequestUri!.AbsolutePath switch
+            {
+                "/api/v1/agent/status" => new HttpResponseMessage(HttpStatusCode.NotFound),
+                "/api/status" => new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"running\":true}", System.Text.Encoding.UTF8, "application/json")
+                },
+                _ => new HttpResponseMessage(HttpStatusCode.NotFound)
+            });
+
+        var factory = BuildFactory(handler);
+
+        var client = await factory.CreateAsync("localhost", 9223);
+
+        client.Should().NotBeNull();
+        client.ProtocolVersion.Should().Be(InspectorProtocolVersion.Legacy);
+    }
+
+    [Fact]
+    public async Task CreateAsync_WhenNeitherResponds_DefaultsToV1()
+    {
+        var handler = new StubHandler(_ =>
+            throw new HttpRequestException("connection refused"));
+
+        var factory = BuildFactory(handler);
+
+        var client = await factory.CreateAsync("localhost", 9223);
+
+        client.Should().NotBeNull();
+        client.ProtocolVersion.Should().Be(InspectorProtocolVersion.V1);
+    }
+
+    private static AppInspectorClientFactory BuildFactory(StubHandler handler)
+    {
+        var httpClientFactory = new Mock<IHttpClientFactory>();
+        httpClientFactory
+            .Setup(f => f.CreateClient(It.IsAny<string>()))
+            .Returns(() => new HttpClient(handler, disposeHandler: false));
+        return new AppInspectorClientFactory(httpClientFactory.Object, NullLogger<AppInspectorClientFactory>.Instance);
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _respond;
+        public StubHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) => _respond = respond;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(_respond(request));
+    }
+}

--- a/tests/MauiSherpa.Core.Tests/Services/Inspector/InspectorModelsTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/Inspector/InspectorModelsTests.cs
@@ -1,0 +1,186 @@
+using System.Text.Json;
+using FluentAssertions;
+using MauiSherpa.Core.Models.Inspector;
+
+namespace MauiSherpa.Core.Tests.Services.Inspector;
+
+/// <summary>
+/// Validates that v1 JSON responses deserialize into the common inspector models.
+/// </summary>
+public class InspectorModelsTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+    };
+
+    [Fact]
+    public void Capabilities_HasCapability_MatchesRegisteredNamespaces()
+    {
+        var caps = new InspectorCapabilities
+        {
+            Capabilities = new Dictionary<string, CapabilityDetail>
+            {
+                ["ui.tree"] = new() { Version = 1, Features = ["find", "query"] },
+                ["ui.actions"] = new() { Version = 1, Features = ["tap", "fill"] },
+            }
+        };
+
+        caps.HasCapability("ui.tree").Should().BeTrue();
+        caps.HasCapability("ui.actions").Should().BeTrue();
+        caps.HasCapability("profiler").Should().BeFalse();
+    }
+
+    [Fact]
+    public void Capabilities_HasFeature_MatchesFeatureList()
+    {
+        var caps = new InspectorCapabilities
+        {
+            Capabilities = new Dictionary<string, CapabilityDetail>
+            {
+                ["ui.actions"] = new() { Version = 1, Features = ["tap", "fill", "scroll"] },
+            }
+        };
+
+        caps.HasFeature("ui.actions", "tap").Should().BeTrue();
+        caps.HasFeature("ui.actions", "gesture").Should().BeFalse();
+        caps.HasFeature("unknown", "tap").Should().BeFalse();
+    }
+
+    [Fact]
+    public void ElementState_DeserializesFromV1Json()
+    {
+        const string json = """
+        {
+            "displayed": true,
+            "enabled": false,
+            "selected": false,
+            "focused": true,
+            "opacity": 0.5
+        }
+        """;
+
+        var state = JsonSerializer.Deserialize<ElementState>(json, JsonOptions);
+
+        state.Should().NotBeNull();
+        state!.Displayed.Should().BeTrue();
+        state.Enabled.Should().BeFalse();
+        state.Focused.Should().BeTrue();
+        state.Opacity.Should().Be(0.5);
+    }
+
+    [Fact]
+    public void InspectorElement_DeserializesFromV1Json()
+    {
+        const string json = """
+        {
+            "id": "btn-1",
+            "parentId": "page-1",
+            "type": "Button",
+            "fullType": "Microsoft.Maui.Controls.Button",
+            "framework": "maui",
+            "automationId": "submit",
+            "text": "Submit",
+            "value": null,
+            "role": "button",
+            "traits": ["interactive", "focusable"],
+            "state": {
+                "displayed": true,
+                "enabled": true,
+                "focused": false,
+                "opacity": 1.0
+            },
+            "bounds": {
+                "x": 10,
+                "y": 20,
+                "width": 100,
+                "height": 40,
+                "coordinateSystem": "window"
+            }
+        }
+        """;
+
+        var element = JsonSerializer.Deserialize<InspectorElement>(json, JsonOptions);
+
+        element.Should().NotBeNull();
+        element!.Id.Should().Be("btn-1");
+        element.ParentId.Should().Be("page-1");
+        element.Framework.Should().Be("maui");
+        element.Role.Should().Be("button");
+        element.Traits.Should().BeEquivalentTo(["interactive", "focusable"]);
+        element.State.Displayed.Should().BeTrue();
+        element.State.Opacity.Should().Be(1.0);
+        element.Bounds.Should().NotBeNull();
+        element.Bounds!.X.Should().Be(10);
+        element.Bounds.CoordinateSystem.Should().Be("window");
+    }
+
+    [Fact]
+    public void InspectorError_DeserializesRfc7807ProblemDetails()
+    {
+        const string json = """
+        {
+            "type": "about:blank",
+            "title": "Element not found",
+            "status": 404,
+            "detail": "No element with id 'xyz'",
+            "errorCode": "element-not-found"
+        }
+        """;
+
+        var error = JsonSerializer.Deserialize<InspectorError>(json, JsonOptions);
+
+        error.Should().NotBeNull();
+        error!.Title.Should().Be("Element not found");
+        error.Status.Should().Be(404);
+        error.ErrorCode.Should().Be("element-not-found");
+    }
+
+    [Fact]
+    public void AgentStatus_DeserializesFromV1Json()
+    {
+        const string json = """
+        {
+            "agent": {
+                "name": "devflow-maui",
+                "version": "1.0.0",
+                "framework": "maui",
+                "frameworkVersion": "10.0"
+            },
+            "platform": "MacCatalyst",
+            "device": {
+                "model": "Mac",
+                "manufacturer": "Apple",
+                "osVersion": "15.0",
+                "idiom": "desktop"
+            },
+            "app": {
+                "name": "MyApp",
+                "version": "1.0",
+                "packageId": "com.example.myapp"
+            },
+            "running": true
+        }
+        """;
+
+        var status = JsonSerializer.Deserialize<InspectorAgentStatus>(json, JsonOptions);
+
+        status.Should().NotBeNull();
+        status!.Agent.Name.Should().Be("devflow-maui");
+        status.Agent.Framework.Should().Be("maui");
+        status.Platform.Should().Be("MacCatalyst");
+        status.Device.Model.Should().Be("Mac");
+        status.App.PackageId.Should().Be("com.example.myapp");
+        status.Running.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ProtocolVersion_EnumValues()
+    {
+        Enum.GetValues<InspectorProtocolVersion>().Should().Contain([
+            InspectorProtocolVersion.Legacy,
+            InspectorProtocolVersion.V1,
+        ]);
+    }
+}


### PR DESCRIPTION
## Why

[dotnet/maui-labs#82](https://github.com/dotnet/maui-labs/pull/82) is a `breaking-change` that reshapes the MauiDevFlow protocol into a framework-agnostic v1 spec. All API paths move from `/api/*` to `/api/v1/*`, the `ElementInfo` schema is overhauled (flat `IsVisible`/`IsEnabled` becomes nested `state: {displayed, enabled, ...}`), and v1 agents will not respond to legacy paths. Sherpa needs to support the new spec without breaking existing legacy agent connections, and the abstraction needs to leave room for non-MAUI frameworks (Flutter, React Native, Expo) down the road.

## Approach

This PR introduces the foundation: a single `IAppInspectorClient` interface that UI code programs against, with two implementations selected at runtime by a factory that probes the agent's protocol version.

- **`IAppInspectorClient`** (in `MauiSherpa.Core/Interfaces/`) is the unified contract covering agent status/capabilities, visual tree, actions, webview, network, logs, profiler, device info, sensors, and storage.
- **`InspectorModels`** are framework-agnostic DTOs using v1's richer shape (nested `ElementState`, new `Role`/`Traits`/`Framework`/`FrameworkProperties`, RFC 7807 `InspectorError`). Records with camelCase JSON map cleanly to v1 responses.
- **`DevFlowV1Client`** is the native v1 HTTP client. WebSocket streaming is stubbed and tracked as follow-up work.
- **`DevFlowLegacyClient`** is an adapter that wraps the untouched `DevFlowAgentClient` and maps legacy models onto the common shape. V1-only actions (scroll, gesture, batch, resize, key, back, navigate, clear) return structured `unsupported-capability` errors so the UI can react sensibly.
- **`AppInspectorClientFactory`** probes `/api/v1/agent/status` first, falls back to `/api/status`, and defaults to v1 if both fail. Registered in DI alongside `IHttpClientFactory`.

The existing `DevFlowAgentClient` and all 7 Blazor inspector pages are intentionally untouched - they continue working with legacy agents today. UI migration to the new interface is the next phase and is large enough to warrant its own PRs (every binding like `element.IsVisible` needs to become `element.State.Displayed`). Recommended sequence is documented in the session plan.

## Testing

- 10 new unit tests covering v1 JSON deserialization (`ElementState`, `InspectorElement`, `InspectorAgentStatus`, RFC 7807 `InspectorError`), capability/feature lookups, and factory protocol detection (v1 hit, legacy fallback, default-to-v1 on total failure)
- `MauiSherpa.Core` and the full `MauiSherpa` app build clean on Mac Catalyst

## Notes for Reviewers

- This is foundation only - no user-visible behavior changes. The UI still uses `DevFlowAgentClient` directly.
- The legacy adapter deliberately returns `ActionResult { Success = false, Error.ErrorCode = "unsupported-capability" }` rather than throwing, so the UI can show a clean message when a feature isn't available on the connected agent.
- When the legacy API is eventually sunsetted, deleting `DevFlowLegacyClient` + `DevFlowAgentClient` will not require any UI changes - that is the whole point of the abstraction.

Tracked follow-up work (15 todos):
- v1 WebSocket streaming (new envelope format for `/ws/v1/network`, `/ws/v1/logs`, `/ws/v1/device/sensors`)
- Migrate 7 Blazor inspector pages onto `IAppInspectorClient`
- Capability-driven tab visibility and framework label in inspector header
- UI for new v1 actions (scroll, gesture, batch, etc.), tree layer selector, expanded WebView features
- `CopilotToolsService` update