### PR TITLE
Add Sentry integration across all MAUI app flavors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,7 +151,8 @@ jobs:
             -r osx-arm64 \
             -p:CreatePackage=false \
             -p:AppVersion=${{ steps.version.outputs.app_version }} \
-            -p:AppCommitSha=${{ steps.version.outputs.commit_sha }}
+            -p:AppCommitSha=${{ steps.version.outputs.commit_sha }} \
+            -p:SentryDsn=${{ secrets.SENTRY_DSN }}
 
       - name: Publish macOS App (x64)
         run: |
@@ -161,7 +162,8 @@ jobs:
             -r osx-x64 \
             -p:CreatePackage=false \
             -p:AppVersion=${{ steps.version.outputs.app_version }} \
-            -p:AppCommitSha=${{ steps.version.outputs.commit_sha }}
+            -p:AppCommitSha=${{ steps.version.outputs.commit_sha }} \
+            -p:SentryDsn=${{ secrets.SENTRY_DSN }}
 
       - name: Create universal binary
         run: |
@@ -439,7 +441,8 @@ jobs:
             -p:WindowsAppSDKSelfContained=true `
             --self-contained true `
             -p:AppVersion=${{ steps.version.outputs.app_version }} `
-            -p:AppCommitSha=${{ steps.version.outputs.commit_sha }}
+            -p:AppCommitSha=${{ steps.version.outputs.commit_sha }} `
+            -p:SentryDsn=${{ secrets.SENTRY_DSN }}
 
       - name: Publish Windows App (arm64)
         run: |
@@ -451,7 +454,8 @@ jobs:
             -p:WindowsAppSDKSelfContained=true `
             --self-contained true `
             -p:AppVersion=${{ steps.version.outputs.app_version }} `
-            -p:AppCommitSha=${{ steps.version.outputs.commit_sha }}
+            -p:AppCommitSha=${{ steps.version.outputs.commit_sha }} `
+            -p:SentryDsn=${{ secrets.SENTRY_DSN }}
 
       - name: Create ZIP archives
         run: |
@@ -583,6 +587,7 @@ jobs:
             --disable-build-servers \
             -p:AppVersion=${{ steps.version.outputs.app_version }} \
             -p:AppCommitSha=${{ steps.version.outputs.commit_sha }} \
+            -p:SentryDsn=${{ secrets.SENTRY_DSN }} \
             -p:UseSharedCompilation=false \
             -nodeReuse:false \
             -maxcpucount:1 \

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,18 @@
     <AppVersion>0.8.1</AppVersion>
     <AppCommitSha>dev</AppCommitSha>
     <InformationalVersion>$(AppVersion)+$(AppCommitSha)</InformationalVersion>
+
+    <!-- Sentry DSN — CI injects via -p:SentryDsn=... (pulled from a secret).
+         When empty, Sentry is not initialized at runtime. -->
+    <SentryDsn Condition="'$(SentryDsn)' == ''"></SentryDsn>
   </PropertyGroup>
+
+  <!-- Bake SentryDsn into the assembly as metadata when provided. The app
+       reads this attribute at startup to configure Sentry without keeping
+       the DSN in source. -->
+  <ItemGroup Condition="'$(SentryDsn)' != ''">
+    <AssemblyMetadata Include="SentryDsn" Value="$(SentryDsn)" />
+  </ItemGroup>
 
   <!-- Override vulnerable transitive System.Data.SqlClient pulled in by AzDo SDK -->
   <ItemGroup>

--- a/src/MauiSherpa.LinuxGtk/MauiSherpa.LinuxGtk.csproj
+++ b/src/MauiSherpa.LinuxGtk/MauiSherpa.LinuxGtk.csproj
@@ -40,6 +40,7 @@
     <PackageReference Condition="!Exists('$(HOME)/code/Maui.Gtk/src/Platform.Maui.Linux.Gtk4.Essentials/Platform.Maui.Linux.Gtk4.Essentials.csproj')" Include="Platform.Maui.Linux.Gtk4.Essentials" Version="0.6.0" />
     <PackageReference Include="Redth.MauiDevFlow.Agent.Gtk" Version="0.23.0" Condition="'$(Configuration)' == 'Debug'" />
     <PackageReference Include="Redth.MauiDevFlow.Blazor.Gtk" Version="0.23.0" Condition="'$(Configuration)' == 'Debug'" />
+    <PackageReference Include="Sentry.Maui" Version="6.4.0" />
     <PackageReference Include="Shiny.Mediator.Caching.MicrosoftMemoryCache" Version="6.1.1" />
     <PackageReference Include="Shiny.Mediator.Maui" Version="6.1.1" />
   </ItemGroup>

--- a/src/MauiSherpa.MacOS/MacOSMauiProgram.cs
+++ b/src/MauiSherpa.MacOS/MacOSMauiProgram.cs
@@ -8,6 +8,7 @@ using Microsoft.Maui.Platform.MacOS.Hosting;
 using Microsoft.Maui.Platform.MacOS.Handlers;
 using Microsoft.Maui.Essentials.MacOS;
 using Shiny.Mediator;
+using Sentry.Maui;
 #if DEBUG
 using MauiDevFlow.Agent;
 using MauiDevFlow.Blazor;
@@ -32,6 +33,28 @@ public static class MacOSMauiProgram
                 fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
                 fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
             });
+
+        // Sentry — DSN is injected at build time via -p:SentryDsn=... (see Directory.Build.props).
+        // When no DSN is configured (e.g. local dev without the env var), Sentry is skipped.
+        var sentryDsn = SentryConfig.GetDsn();
+        if (!string.IsNullOrWhiteSpace(sentryDsn))
+        {
+            builder.UseSentry(options =>
+            {
+                options.Dsn = sentryDsn;
+                options.TracesSampleRate = 1.0;
+                options.EnableLogs = true;
+#if DEBUG
+                options.Debug = true;
+                options.Environment = "debug";
+#else
+                options.Environment = "release";
+#endif
+                options.Release = typeof(MacOSMauiProgram).Assembly
+                    .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+                    ?.InformationalVersion;
+            });
+        }
 
         // Use native sidebar for FlyoutPage
         builder.ConfigureMauiHandlers(handlers =>

--- a/src/MauiSherpa.MacOS/MauiSherpa.MacOS.csproj
+++ b/src/MauiSherpa.MacOS/MauiSherpa.MacOS.csproj
@@ -39,6 +39,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
     <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.31" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
+    <PackageReference Include="Sentry.Maui" Version="6.4.0" />
     <PackageReference Include="Shiny.Mediator.Caching.MicrosoftMemoryCache" Version="6.1.1" />
     <PackageReference Include="Shiny.Mediator.Maui" Version="6.1.1" />
     <PackageReference Include="Redth.MauiDevFlow.Agent" Version="0.23.0" Condition="'$(Configuration)' == 'Debug'" />

--- a/src/MauiSherpa/MauiProgram.cs
+++ b/src/MauiSherpa/MauiProgram.cs
@@ -21,6 +21,7 @@ using MauiIcons.Fluent;
 using MauiIcons.FontAwesome.Brand;
 #endif
 using Shiny.Mediator;
+using Sentry.Maui;
 
 namespace MauiSherpa;
 
@@ -52,6 +53,28 @@ public static class MauiProgram
                 fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
             });
 #endif
+
+        // Sentry — DSN is injected at build time via -p:SentryDsn=... (see Directory.Build.props).
+        // When no DSN is configured (e.g. local dev without the env var), Sentry is skipped.
+        var sentryDsn = SentryConfig.GetDsn();
+        if (!string.IsNullOrWhiteSpace(sentryDsn))
+        {
+            builder.UseSentry(options =>
+            {
+                options.Dsn = sentryDsn;
+                options.TracesSampleRate = 1.0;
+                options.EnableLogs = true;
+#if DEBUG
+                options.Debug = true;
+                options.Environment = "debug";
+#else
+                options.Environment = "release";
+#endif
+                options.Release = typeof(MauiProgram).Assembly
+                    .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+                    ?.InformationalVersion;
+            });
+        }
 
 #if LINUXGTK
         builder.Services.AddBlazorWebView();

--- a/src/MauiSherpa/MauiSherpa.csproj
+++ b/src/MauiSherpa/MauiSherpa.csproj
@@ -55,6 +55,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
     <PackageReference Include="Redth.MauiDevFlow.Agent" Version="0.23.0" Condition="'$(Configuration)' == 'Debug'" />
     <PackageReference Include="Redth.MauiDevFlow.Blazor" Version="0.23.0" Condition="'$(Configuration)' == 'Debug'" />
+    <PackageReference Include="Sentry.Maui" Version="6.4.0" />
     <PackageReference Include="Shiny.Mediator.Caching.MicrosoftMemoryCache" Version="6.1.1" />
     <PackageReference Include="Shiny.Mediator.Maui" Version="6.1.1" />
   </ItemGroup>

--- a/src/MauiSherpa/Services/SentryConfig.cs
+++ b/src/MauiSherpa/Services/SentryConfig.cs
@@ -1,0 +1,27 @@
+using System.Reflection;
+
+namespace MauiSherpa.Services;
+
+/// <summary>
+/// Resolves the Sentry DSN without hardcoding it in source.
+/// Resolution order:
+///   1. SENTRY_DSN environment variable (useful for local development)
+///   2. Assembly metadata "SentryDsn" (baked in by CI via -p:SentryDsn=... in Directory.Build.props)
+/// Returns null when neither is set, in which case Sentry should not be initialized.
+/// </summary>
+internal static class SentryConfig
+{
+    public static string? GetDsn()
+    {
+        var fromEnv = Environment.GetEnvironmentVariable("SENTRY_DSN");
+        if (!string.IsNullOrWhiteSpace(fromEnv))
+            return fromEnv.Trim();
+
+        var fromAssembly = typeof(SentryConfig).Assembly
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .FirstOrDefault(a => string.Equals(a.Key, "SentryDsn", StringComparison.Ordinal))
+            ?.Value;
+
+        return string.IsNullOrWhiteSpace(fromAssembly) ? null : fromAssembly.Trim();
+    }
+}


### PR DESCRIPTION
Wires up Sentry error and performance reporting for every MAUI Sherpa app flavor (Mac Catalyst, Windows, standalone macOS/AppKit, and Linux GTK) so we actually have visibility into crashes and exceptions happening in the wild.

## Approach

The DSN is never hardcoded. It's injected at build time via a `SentryDsn` MSBuild property (see `Directory.Build.props`), which emits an `AssemblyMetadata("SentryDsn", ...)` attribute only when a value is supplied. A small `SentryConfig` helper resolves the DSN at startup in this order:

1. `SENTRY_DSN` environment variable (handy for local development)
2. Assembly metadata baked in by CI
3. Otherwise null, and Sentry initialization is skipped entirely

Both `MauiProgram.CreateMauiApp` (shared by MauiSherpa head and MauiSherpa.LinuxGtk) and `MacOSMauiProgram.CreateMauiApp` call `builder.UseSentry(...)` only when a DSN is present. Config matches the Sentry docs snippet (`TracesSampleRate = 1.0`, `EnableLogs = true`), with `Debug = true` only in DEBUG builds, and `Release` / `Environment` populated from `AssemblyInformationalVersionAttribute` so events are tagged with the app version and commit.

## Action required: CI workflow change

The OAuth app used by this session lacks `workflow` scope, so I couldn't push the companion edits to `.github/workflows/build.yml`. Please apply this patch manually (it just appends `-p:SentryDsn=${{ secrets.SENTRY_DSN }}` to the 5 publish steps) and add a `SENTRY_DSN` repository secret:

```diff
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,7 +151,8 @@ jobs:
             -r osx-arm64 \
             -p:CreatePackage=false \
             -p:AppVersion=${{ steps.version.outputs.app_version }} \
-            -p:AppCommitSha=${{ steps.version.outputs.commit_sha }}
+            -p:AppCommitSha=${{ steps.version.outputs.commit_sha }} \
+            -p:SentryDsn=${{ secrets.SENTRY_DSN }}
 
       - name: Publish macOS App (x64)
         run: |
@@ -161,7 +162,8 @@ jobs:
             -r osx-x64 \
             -p:CreatePackage=false \
             -p:AppVersion=${{ steps.version.outputs.app_version }} \
-            -p:AppCommitSha=${{ steps.version.outputs.commit_sha }}
+            -p:AppCommitSha=${{ steps.version.outputs.commit_sha }} \
+            -p:SentryDsn=${{ secrets.SENTRY_DSN }}
 
       - name: Create universal binary
         run: |
@@ -439,7 +441,8 @@ jobs:
             -p:WindowsAppSDKSelfContained=true `
             --self-contained true `
             -p:AppVersion=${{ steps.version.outputs.app_version }} `
-            -p:AppCommitSha=${{ steps.version.outputs.commit_sha }}
+            -p:AppCommitSha=${{ steps.version.outputs.commit_sha }} `
+            -p:SentryDsn=${{ secrets.SENTRY_DSN }}
 
       - name: Publish Windows App (arm64)
         run: |
@@ -451,7 +454,8 @@ jobs:
             -p:WindowsAppSDKSelfContained=true `
             --self-contained true `
             -p:AppVersion=${{ steps.version.outputs.app_version }} `
-            -p:AppCommitSha=${{ steps.version.outputs.commit_sha }}
+            -p:AppCommitSha=${{ steps.version.outputs.commit_sha }} `
+            -p:SentryDsn=${{ secrets.SENTRY_DSN }}
 
       - name: Create ZIP archives
         run: |
@@ -583,6 +587,7 @@ jobs:
             --disable-build-servers \
             -p:AppVersion=${{ steps.version.outputs.app_version }} \
             -p:AppCommitSha=${{ steps.version.outputs.commit_sha }} \
+            -p:SentryDsn=${{ secrets.SENTRY_DSN }} \
             -p:UseSharedCompilation=false \
             -nodeReuse:false \
             -maxcpucount:1 \
```

Without the secret, builds still succeed and Sentry simply stays disabled.

## Notes for review

- `Sentry.Maui` 6.4.0 is added to all three app csprojs (MauiSherpa, MauiSherpa.MacOS, MauiSherpa.LinuxGtk).
- `SentryConfig.cs` lives in `src/MauiSherpa/Services/` and is picked up by the standalone macOS project (via its linked `Compile Include`) and by the Linux GTK project (via its shared file glob), so there's only one copy.
- Verified Mac Catalyst and standalone macOS builds pass with 0 errors, and confirmed with `strings` that the DSN lands in the assembly metadata when `-p:SentryDsn=...` is passed, and is absent otherwise.