### PR TITLE
Fix Apple SMS 2FA verification failing with 'Invalid security code'

### DIFF
--- a/src/MauiSherpa.Core/Services/AppleDownloadAuthService.cs
+++ b/src/MauiSherpa.Core/Services/AppleDownloadAuthService.cs
@@ -284,11 +284,15 @@ public class AppleDownloadAuthService : IAppleDownloadAuthService
 
         try
         {
-            var serviceKey = await GetServiceKeyAsync();
+            var serviceKey = _pendingServiceKey ?? await GetServiceKeyAsync();
             if (serviceKey == null) return false;
 
             var request = new HttpRequestMessage(HttpMethod.Put, $"{AuthUrl}/verify/phone");
             request.Headers.Add("X-Apple-Widget-Key", serviceKey);
+            if (_pendingSessionId != null)
+                request.Headers.Add("X-Apple-ID-Session-Id", _pendingSessionId);
+            if (_pendingScnt != null)
+                request.Headers.Add("scnt", _pendingScnt);
             request.Content = new StringContent(
                 JsonSerializer.Serialize(new
                 {
@@ -298,6 +302,7 @@ public class AppleDownloadAuthService : IAppleDownloadAuthService
                 Encoding.UTF8, "application/json");
 
             var response = await _httpClient.SendAsync(request);
+            _logger.LogInformation($"SMS code request response: {(int)response.StatusCode} {response.StatusCode}");
             return response.IsSuccessStatusCode;
         }
         catch (Exception ex)

--- a/src/MauiSherpa/Pages/Modals/XcodeDownloadAuthModal.razor
+++ b/src/MauiSherpa/Pages/Modals/XcodeDownloadAuthModal.razor
@@ -4,6 +4,7 @@
 @using MauiSherpa.Pages.Forms
 @inject HybridFormBridgeHolder BridgeHolder
 @inject XcodeManagementViewModel ViewModel
+@inject IAppleDownloadAuthService AuthService
 @implements IDisposable
 
 @{
@@ -68,11 +69,11 @@
                         }
                     </p>
 
-                    @if (twoFactorOptions?.TrustedPhoneNumbers.Count > 1)
+                    @if (twoFactorOptions?.TrustedPhoneNumbers.Count > 0)
                     {
                         <div class="form-group">
                             <label>Verification method</label>
-                            <select @bind="selectedPhoneIndex" @bind:after="OnFieldChanged" disabled="@isAuthenticating">
+                            <select @bind="selectedPhoneIndex" @bind:after="OnPhoneSelectionChanged" disabled="@isAuthenticating">
                                 @if (twoFactorOptions.CanUseTrustedDevice)
                                 {
                                     <option value="-1">Trusted Device</option>
@@ -149,6 +150,21 @@
 
     private void OnFieldChanged() => UpdateWizardState();
 
+    private async Task OnPhoneSelectionChanged()
+    {
+        UpdateWizardState();
+        await RequestSmsForSelectedPhone();
+    }
+
+    private async Task RequestSmsForSelectedPhone()
+    {
+        if (selectedPhoneIndex >= 0 && twoFactorOptions?.TrustedPhoneNumbers.Count > selectedPhoneIndex)
+        {
+            var phone = twoFactorOptions.TrustedPhoneNumbers[selectedPhoneIndex];
+            await AuthService.RequestSmsCodeAsync(phone);
+        }
+    }
+
     private void UpdateWizardState()
     {
         var bridge = BridgeHolder.Current;
@@ -211,6 +227,10 @@
                         && twoFactorOptions.TrustedPhoneNumbers.Count > 0
                         ? 0
                         : -1;
+
+                    // If SMS was auto-selected, request the code be sent
+                    if (selectedPhoneIndex >= 0)
+                        await RequestSmsForSelectedPhone();
                 }
                 else
                 {


### PR DESCRIPTION
## Problem

Users who receive Apple 2FA codes via SMS (rather than trusted device push) always get "Invalid security code" when verifying. Reported in #157.

## Root Cause

Four interrelated bugs in the Apple 2FA flow:

1. **SMS codes sent to wrong endpoint** — For hsa2 accounts, `CanUseTrustedDevice` is always `true` (even with no trusted devices), so the code defaulted to the `/verify/trusteddevice/securitycode` endpoint instead of `/verify/phone/securitycode`.

2. **Phone dropdown hidden for single-phone users** — The verification method dropdown only showed when `TrustedPhoneNumbers.Count > 1`, so users with one phone number couldn't switch from "Trusted Device" to SMS.

3. **`RequestSmsCodeAsync` never called from UI** — When SMS was selected (or auto-selected), the app never called `PUT /verify/phone` to trigger Apple to actually send the SMS. The method existed but was unused.

4. **`RequestSmsCodeAsync` missing session headers** — Even if called, it didn't include the required `X-Apple-ID-Session-Id` / `scnt` headers, so Apple would reject the request.

## Fix

- Show the verification method dropdown whenever there are any phone numbers (≥ 1, not > 1)
- Call `RequestSmsCodeAsync` when a phone is selected (either auto-selected on transition to 2FA step, or manually switched by user)
- Add session headers and use cached service key in `RequestSmsCodeAsync`

## Files Changed

- `src/MauiSherpa.Core/Services/AppleDownloadAuthService.cs` — Fix `RequestSmsCodeAsync` session headers
- `src/MauiSherpa/Pages/Modals/XcodeDownloadAuthModal.razor` — Fix dropdown visibility, trigger SMS delivery

Fixes #157