### PR TITLE
Add v0.9.1 release notes

### DIFF
--- a/docs/release-notes/v0.9.1.md
+++ b/docs/release-notes/v0.9.1.md
@@ -1,0 +1,28 @@
+## 🏔️ v0.9.1 — "Adjusting the Harness"
+
+Still on the same ridge, but the rope team paused to tighten a few buckles before pushing
+further. A tricky SMS radio glitch that was dropping calls has been sorted, and the team
+standardized how they label their gear caches so every camp uses the same naming convention.
+
+### ✨ Improvements
+
+- **Xcode bundle name normalization** — Managed Xcode bundles now follow a standardized
+  `Xcode<sep><version>.app` naming scheme (e.g. `Xcode_16.2.app`), matching GitHub Actions
+  runner-images out of the box. A new Settings dropdown lets you pick `_` or `-` as the
+  separator, and changing it offers to batch-rename every bundle in `/Applications` — including
+  retargeting `xcode-select` if its symlink moved. A matching `maui-sherpa apple xcode
+  normalize-names` CLI subcommand brings the same capability to scripts. (#156)
+
+### 🐛 Bug Fixes
+
+- **Apple SMS 2FA verification** — Users who receive Apple two-factor codes via SMS instead of
+  a trusted device push were always greeted with "Invalid security code." Four interlocking
+  bugs — wrong endpoint selection, a hidden phone dropdown for single-number accounts, a
+  never-called SMS request method, and missing session headers — conspired to block the route.
+  All four are patched; the 2FA modal now shows phone options when available and actually asks
+  Apple to send the code before you type it in. (#158)
+
+---
+
+*Harness re-threaded, gear re-tagged — time to lean back into the wind and keep moving along
+the ridge.* 🪢


### PR DESCRIPTION
Adds the mountaineering-themed release notes for v0.9.1 to `docs/release-notes/`.

The [GitHub release](https://github.com/Redth/MAUI.Sherpa/releases/tag/v0.9.1) has already been published.