### PR TITLE
Migrate Linux GTK4 packages from Maui.Gtk to dotnet/maui-labs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -420,3 +420,4 @@ FodyWeavers.xsd
 *.msix
 *.msm
 *.msp
+nohup.out

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 - [.NET MAUI](https://github.com/dotnet/maui) - Cross-platform UI framework
 - [Platform.Maui.MacOS](https://github.com/nicoleeldridge/mauiplatforms) - macOS AppKit backend for .NET MAUI
-- [Platform.Maui.Linux.Gtk4](https://github.com/nicoleeldridge/Maui.Gtk) - Linux GTK4 backend for .NET MAUI
+- [Microsoft.Maui.Platforms.Linux.Gtk4](https://github.com/dotnet/maui-labs) - Linux GTK4 backend for .NET MAUI
 - [Shiny.Mediator](https://github.com/shinyorg/mediator) - Mediator pattern with caching
 - [AndroidSdk](https://github.com/redth/androidsdk.tool) - Android SDK management APIs
 - [AppleDev.Tools](https://github.com/redth/appledev.tools) - Apple Developer Tools APIs and AppStoreConnect API client

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/src/MauiSherpa.LinuxGtk/MauiSherpa.LinuxGtk.csproj
+++ b/src/MauiSherpa.LinuxGtk/MauiSherpa.LinuxGtk.csproj
@@ -20,9 +20,6 @@
     <DebSection>devel</DebSection>
     <DebMaintainer>Jon Dick &lt;redth@users.noreply.github.com&gt;</DebMaintainer>
     <FlatpakFinishArgs>--socket=wayland --socket=fallback-x11 --share=ipc --device=dri --share=network --filesystem=home</FlatpakFinishArgs>
-    <LocalGtkNugetSource>$(MSBuildThisFileDirectory)..\..\.nuget\local-packages</LocalGtkNugetSource>
-    <RestoreSources>$(RestoreSources);https://api.nuget.org/v3/index.json</RestoreSources>
-    <RestoreSources Condition="Exists('$(LocalGtkNugetSource)')">$(RestoreSources);$(LocalGtkNugetSource)</RestoreSources>
   </PropertyGroup>
 
   <ItemGroup>
@@ -31,15 +28,14 @@
     <PackageReference Include="Markdig" Version="0.44.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
-    <!-- Use local ProjectReference when Maui.Gtk repo is cloned, otherwise NuGet -->
-    <ProjectReference Condition="Exists('$(HOME)/code/Maui.Gtk/src/Platform.Maui.Linux.Gtk4/Platform.Maui.Linux.Gtk4.csproj')" Include="$(HOME)/code/Maui.Gtk/src/Platform.Maui.Linux.Gtk4/Platform.Maui.Linux.Gtk4.csproj" />
-    <ProjectReference Condition="Exists('$(HOME)/code/Maui.Gtk/src/Platform.Maui.Linux.Gtk4.BlazorWebView/Platform.Maui.Linux.Gtk4.BlazorWebView.csproj')" Include="$(HOME)/code/Maui.Gtk/src/Platform.Maui.Linux.Gtk4.BlazorWebView/Platform.Maui.Linux.Gtk4.BlazorWebView.csproj" />
-    <ProjectReference Condition="Exists('$(HOME)/code/Maui.Gtk/src/Platform.Maui.Linux.Gtk4.Essentials/Platform.Maui.Linux.Gtk4.Essentials.csproj')" Include="$(HOME)/code/Maui.Gtk/src/Platform.Maui.Linux.Gtk4.Essentials/Platform.Maui.Linux.Gtk4.Essentials.csproj" />
-    <PackageReference Condition="!Exists('$(HOME)/code/Maui.Gtk/src/Platform.Maui.Linux.Gtk4/Platform.Maui.Linux.Gtk4.csproj')" Include="Platform.Maui.Linux.Gtk4" Version="0.6.0" />
-    <PackageReference Condition="!Exists('$(HOME)/code/Maui.Gtk/src/Platform.Maui.Linux.Gtk4.BlazorWebView/Platform.Maui.Linux.Gtk4.BlazorWebView.csproj')" Include="Platform.Maui.Linux.Gtk4.BlazorWebView" Version="0.6.0" />
-    <PackageReference Condition="!Exists('$(HOME)/code/Maui.Gtk/src/Platform.Maui.Linux.Gtk4.Essentials/Platform.Maui.Linux.Gtk4.Essentials.csproj')" Include="Platform.Maui.Linux.Gtk4.Essentials" Version="0.6.0" />
-    <PackageReference Include="Redth.MauiDevFlow.Agent.Gtk" Version="0.23.0" Condition="'$(Configuration)' == 'Debug'" />
-    <PackageReference Include="Redth.MauiDevFlow.Blazor.Gtk" Version="0.23.0" Condition="'$(Configuration)' == 'Debug'" />
+    <PackageReference Include="Microsoft.Maui.Platforms.Linux.Gtk4" Version="0.1.0-preview.*" />
+    <PackageReference Include="Microsoft.Maui.Platforms.Linux.Gtk4.BlazorWebView" Version="0.1.0-preview.*" />
+    <PackageReference Include="Microsoft.Maui.Platforms.Linux.Gtk4.Essentials" Version="0.1.0-preview.*" />
+    <!-- DevFlow GTK packages temporarily removed — they depend on old Platform.Maui.Linux.Gtk4
+         and conflict with the new Microsoft.Maui.Platforms.Linux.Gtk4 packages.
+         Restore once DevFlow is updated to reference the new package names. -->
+    <!-- <PackageReference Include="Redth.MauiDevFlow.Agent.Gtk" Version="0.23.0" Condition="'$(Configuration)' == 'Debug'" /> -->
+    <!-- <PackageReference Include="Redth.MauiDevFlow.Blazor.Gtk" Version="0.23.0" Condition="'$(Configuration)' == 'Debug'" /> -->
     <PackageReference Include="Sentry.Maui" Version="6.4.0" />
     <PackageReference Include="Shiny.Mediator.Caching.MicrosoftMemoryCache" Version="6.1.1" />
     <PackageReference Include="Shiny.Mediator.Maui" Version="6.1.1" />

--- a/src/MauiSherpa.LinuxGtk/MauiSherpa.LinuxGtk.csproj
+++ b/src/MauiSherpa.LinuxGtk/MauiSherpa.LinuxGtk.csproj
@@ -28,9 +28,9 @@
     <PackageReference Include="Markdig" Version="0.44.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Maui.Platforms.Linux.Gtk4" Version="0.1.0-preview.*" />
-    <PackageReference Include="Microsoft.Maui.Platforms.Linux.Gtk4.BlazorWebView" Version="0.1.0-preview.*" />
-    <PackageReference Include="Microsoft.Maui.Platforms.Linux.Gtk4.Essentials" Version="0.1.0-preview.*" />
+    <PackageReference Include="Microsoft.Maui.Platforms.Linux.Gtk4" Version="0.1.0-preview.5.26222.2" />
+    <PackageReference Include="Microsoft.Maui.Platforms.Linux.Gtk4.BlazorWebView" Version="0.1.0-preview.5.26222.2" />
+    <PackageReference Include="Microsoft.Maui.Platforms.Linux.Gtk4.Essentials" Version="0.1.0-preview.5.26222.2" />
     <!-- DevFlow GTK packages temporarily removed — they depend on old Platform.Maui.Linux.Gtk4
          and conflict with the new Microsoft.Maui.Platforms.Linux.Gtk4 packages.
          Restore once DevFlow is updated to reference the new package names. -->

--- a/src/MauiSherpa.LinuxGtk/Program.cs
+++ b/src/MauiSherpa.LinuxGtk/Program.cs
@@ -1,11 +1,8 @@
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Hosting;
-#if DEBUG
-using MauiDevFlow.Agent.Gtk;
-#endif
 using MauiSherpa.Core.Interfaces;
 using MauiSherpa.Services;
-using Platform.Maui.Linux.Gtk4.Platform;
+using Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
 
 namespace MauiSherpa;
 
@@ -56,9 +53,7 @@ public class Program : GtkMauiApplication
         // to context events before the Blazor app loads or user clicks Copilot button.
         Services.GetService<ICopilotModalService>();
 
-#if DEBUG
-        Microsoft.Maui.Controls.Application.Current?.StartDevFlowAgent();
-#endif
+// DevFlow GTK agent removed temporarily (package conflict with new Microsoft.Maui.Platforms.Linux.Gtk4)
     }
 
     /// <summary>

--- a/src/MauiSherpa/CopilotPage.cs
+++ b/src/MauiSherpa/CopilotPage.cs
@@ -4,7 +4,7 @@ using MauiSherpa.Core.Interfaces;
 using Microsoft.Maui.Platform.MacOS;
 using Microsoft.Maui.Platform.MacOS.Controls;
 #elif LINUXGTK
-using Platform.Maui.Linux.Gtk4.Platform;
+using Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
 using Microsoft.AspNetCore.Components.WebView.Maui;
 #else
 using Microsoft.AspNetCore.Components.WebView.Maui;

--- a/src/MauiSherpa/MauiProgram.cs
+++ b/src/MauiSherpa/MauiProgram.cs
@@ -5,13 +5,10 @@ using MauiSherpa.Core.ViewModels;
 using MauiSherpa.Core.Interfaces;
 using MauiSherpa.Core.Services;
 #if LINUXGTK
-#if DEBUG
-using MauiDevFlow.Agent.Gtk;
-using MauiDevFlow.Blazor.Gtk;
-#endif
-using Platform.Maui.Linux.Gtk4.BlazorWebView;
-using Platform.Maui.Linux.Gtk4.Essentials.Hosting;
-using Platform.Maui.Linux.Gtk4.Hosting;
+// DevFlow GTK usings removed temporarily (package conflict with new Microsoft.Maui.Platforms.Linux.Gtk4)
+using Microsoft.Maui.Platforms.Linux.Gtk4.BlazorWebView;
+using Microsoft.Maui.Platforms.Linux.Gtk4.Essentials.Hosting;
+using Microsoft.Maui.Platforms.Linux.Gtk4.Hosting;
 #else
 #if DEBUG
 using MauiDevFlow.Agent;
@@ -288,9 +285,9 @@ public static class MauiProgram
 #if DEBUG
 #if !LINUXGTK
         builder.Services.AddBlazorWebViewDeveloperTools();
-#endif
         builder.AddMauiDevFlowAgent();
         builder.AddMauiBlazorDevFlowTools();
+#endif
         builder.Logging.AddDebug();
 #endif
 

--- a/src/MauiSherpa/Pages/Forms/FormPage.cs
+++ b/src/MauiSherpa/Pages/Forms/FormPage.cs
@@ -1,7 +1,7 @@
 using Microsoft.Maui.Controls;
 using MauiSherpa.Core.Interfaces;
 #if LINUXGTK
-using Platform.Maui.Linux.Gtk4.Platform;
+using Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
 #endif
 
 namespace MauiSherpa.Pages.Forms;

--- a/src/MauiSherpa/Pages/Forms/HybridFormPage.cs
+++ b/src/MauiSherpa/Pages/Forms/HybridFormPage.cs
@@ -7,7 +7,7 @@ using Microsoft.Maui.Platform.MacOS.Controls;
 using Microsoft.AspNetCore.Components.WebView.Maui;
 #endif
 #if LINUXGTK
-using Platform.Maui.Linux.Gtk4.Platform;
+using Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
 #endif
 
 namespace MauiSherpa.Pages.Forms;

--- a/src/MauiSherpa/Pages/Forms/HybridProgressPage.cs
+++ b/src/MauiSherpa/Pages/Forms/HybridProgressPage.cs
@@ -6,7 +6,7 @@ using Microsoft.Maui.Platform.MacOS.Controls;
 using Microsoft.AspNetCore.Components.WebView.Maui;
 #endif
 #if LINUXGTK
-using Platform.Maui.Linux.Gtk4.Platform;
+using Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
 #endif
 
 namespace MauiSherpa.Pages.Forms;

--- a/src/MauiSherpa/Pages/Forms/HybridViewPage.cs
+++ b/src/MauiSherpa/Pages/Forms/HybridViewPage.cs
@@ -6,7 +6,7 @@ using Microsoft.Maui.Platform.MacOS.Controls;
 using Microsoft.AspNetCore.Components.WebView.Maui;
 #endif
 #if LINUXGTK
-using Platform.Maui.Linux.Gtk4.Platform;
+using Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
 #endif
 
 namespace MauiSherpa.Pages.Forms;

--- a/src/MauiSherpa/Pages/Forms/ProgressModalPage.cs
+++ b/src/MauiSherpa/Pages/Forms/ProgressModalPage.cs
@@ -6,7 +6,7 @@ using Microsoft.Maui.Platform.MacOS.Controls;
 using Microsoft.AspNetCore.Components.WebView.Maui;
 #endif
 #if LINUXGTK
-using Platform.Maui.Linux.Gtk4.Platform;
+using Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
 #endif
 
 namespace MauiSherpa.Pages.Forms;

--- a/src/MauiSherpa/Pages/Forms/SettingsPage.cs
+++ b/src/MauiSherpa/Pages/Forms/SettingsPage.cs
@@ -7,7 +7,7 @@ using Microsoft.Maui.Platform.MacOS.Controls;
 using Microsoft.AspNetCore.Components.WebView.Maui;
 #endif
 #if LINUXGTK
-using Platform.Maui.Linux.Gtk4.Platform;
+using Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
 #endif
 
 namespace MauiSherpa.Pages.Forms;

--- a/src/MauiSherpa/Pages/Forms/WizardFormPage.cs
+++ b/src/MauiSherpa/Pages/Forms/WizardFormPage.cs
@@ -7,7 +7,7 @@ using Microsoft.Maui.Platform.MacOS.Controls;
 using Microsoft.AspNetCore.Components.WebView.Maui;
 #endif
 #if LINUXGTK
-using Platform.Maui.Linux.Gtk4.Platform;
+using Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
 #endif
 
 namespace MauiSherpa.Pages.Forms;

--- a/src/MauiSherpa/Pages/Modals/AddPublisherPage.cs
+++ b/src/MauiSherpa/Pages/Modals/AddPublisherPage.cs
@@ -4,7 +4,7 @@ using MauiSherpa.Pages.Forms;
 using Microsoft.Maui.Platform.MacOS;
 #endif
 #if LINUXGTK
-using Platform.Maui.Linux.Gtk4.Platform;
+using Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
 #endif
 
 namespace MauiSherpa.Pages.Modals;

--- a/src/MauiSherpa/Pages/Modals/AppleConfigWizardPage.cs
+++ b/src/MauiSherpa/Pages/Modals/AppleConfigWizardPage.cs
@@ -4,7 +4,7 @@ using MauiSherpa.Pages.Forms;
 using Microsoft.Maui.Platform.MacOS;
 #endif
 #if LINUXGTK
-using Platform.Maui.Linux.Gtk4.Platform;
+using Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
 #endif
 
 namespace MauiSherpa.Pages.Modals;

--- a/src/MauiSherpa/Pages/Modals/AppleIdentityPage.cs
+++ b/src/MauiSherpa/Pages/Modals/AppleIdentityPage.cs
@@ -4,7 +4,7 @@ using MauiSherpa.Pages.Forms;
 using Microsoft.Maui.Platform.MacOS;
 #endif
 #if LINUXGTK
-using Platform.Maui.Linux.Gtk4.Platform;
+using Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
 #endif
 
 namespace MauiSherpa.Pages.Modals;

--- a/src/MauiSherpa/Pages/Modals/CISecretsWizardPage.cs
+++ b/src/MauiSherpa/Pages/Modals/CISecretsWizardPage.cs
@@ -3,7 +3,7 @@ using MauiSherpa.Pages.Forms;
 using Microsoft.Maui.Platform.MacOS;
 #endif
 #if LINUXGTK
-using Platform.Maui.Linux.Gtk4.Platform;
+using Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
 #endif
 
 namespace MauiSherpa.Pages.Modals;

--- a/src/MauiSherpa/Pages/Modals/CloudProviderPage.cs
+++ b/src/MauiSherpa/Pages/Modals/CloudProviderPage.cs
@@ -4,7 +4,7 @@ using MauiSherpa.Pages.Forms;
 using Microsoft.Maui.Platform.MacOS;
 #endif
 #if LINUXGTK
-using Platform.Maui.Linux.Gtk4.Platform;
+using Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
 #endif
 
 namespace MauiSherpa.Pages.Modals;

--- a/src/MauiSherpa/Pages/Modals/CreateProfilePage.cs
+++ b/src/MauiSherpa/Pages/Modals/CreateProfilePage.cs
@@ -4,7 +4,7 @@ using MauiSherpa.Pages.Forms;
 using Microsoft.Maui.Platform.MacOS;
 #endif
 #if LINUXGTK
-using Platform.Maui.Linux.Gtk4.Platform;
+using Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
 #endif
 
 namespace MauiSherpa.Pages.Modals;

--- a/src/MauiSherpa/Pages/Modals/EditProfilePage.cs
+++ b/src/MauiSherpa/Pages/Modals/EditProfilePage.cs
@@ -4,7 +4,7 @@ using MauiSherpa.Pages.Forms;
 using Microsoft.Maui.Platform.MacOS;
 #endif
 #if LINUXGTK
-using Platform.Maui.Linux.Gtk4.Platform;
+using Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
 #endif
 
 namespace MauiSherpa.Pages.Modals;

--- a/src/MauiSherpa/Pages/Modals/ExportCertificatePage.cs
+++ b/src/MauiSherpa/Pages/Modals/ExportCertificatePage.cs
@@ -4,7 +4,7 @@ using MauiSherpa.Pages.Forms;
 using Microsoft.Maui.Platform.MacOS;
 #endif
 #if LINUXGTK
-using Platform.Maui.Linux.Gtk4.Platform;
+using Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
 #endif
 
 namespace MauiSherpa.Pages.Modals;

--- a/src/MauiSherpa/Pages/Modals/ExportSettingsPage.cs
+++ b/src/MauiSherpa/Pages/Modals/ExportSettingsPage.cs
@@ -3,7 +3,7 @@ using MauiSherpa.Pages.Forms;
 using Microsoft.Maui.Platform.MacOS;
 #endif
 #if LINUXGTK
-using Platform.Maui.Linux.Gtk4.Platform;
+using Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
 #endif
 
 namespace MauiSherpa.Pages.Modals;

--- a/src/MauiSherpa/Pages/Modals/GoogleIdentityPage.cs
+++ b/src/MauiSherpa/Pages/Modals/GoogleIdentityPage.cs
@@ -4,7 +4,7 @@ using MauiSherpa.Pages.Forms;
 using Microsoft.Maui.Platform.MacOS;
 #endif
 #if LINUXGTK
-using Platform.Maui.Linux.Gtk4.Platform;
+using Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
 #endif
 
 namespace MauiSherpa.Pages.Modals;

--- a/src/MauiSherpa/Pages/Modals/ImportSettingsPage.cs
+++ b/src/MauiSherpa/Pages/Modals/ImportSettingsPage.cs
@@ -4,7 +4,7 @@ using MauiSherpa.Pages.Forms;
 using Microsoft.Maui.Platform.MacOS;
 #endif
 #if LINUXGTK
-using Platform.Maui.Linux.Gtk4.Platform;
+using Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
 #endif
 
 namespace MauiSherpa.Pages.Modals;

--- a/src/MauiSherpa/Pages/Modals/KeystoreSignaturesPage.cs
+++ b/src/MauiSherpa/Pages/Modals/KeystoreSignaturesPage.cs
@@ -4,7 +4,7 @@ using MauiSherpa.Pages.Forms;
 using Microsoft.Maui.Platform.MacOS;
 #endif
 #if LINUXGTK
-using Platform.Maui.Linux.Gtk4.Platform;
+using Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
 #endif
 
 namespace MauiSherpa.Pages.Modals;

--- a/src/MauiSherpa/Pages/Modals/ManageCapabilitiesPage.cs
+++ b/src/MauiSherpa/Pages/Modals/ManageCapabilitiesPage.cs
@@ -4,7 +4,7 @@ using MauiSherpa.Pages.Forms;
 using Microsoft.Maui.Platform.MacOS;
 #endif
 #if LINUXGTK
-using Platform.Maui.Linux.Gtk4.Platform;
+using Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
 #endif
 
 namespace MauiSherpa.Pages.Modals;

--- a/src/MauiSherpa/Pages/Modals/PepkExportPage.cs
+++ b/src/MauiSherpa/Pages/Modals/PepkExportPage.cs
@@ -3,7 +3,7 @@ using MauiSherpa.Pages.Forms;
 using Microsoft.Maui.Platform.MacOS;
 #endif
 #if LINUXGTK
-using Platform.Maui.Linux.Gtk4.Platform;
+using Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
 #endif
 
 namespace MauiSherpa.Pages.Modals;

--- a/src/MauiSherpa/Pages/Modals/ProfilingCaptureWizardPage.cs
+++ b/src/MauiSherpa/Pages/Modals/ProfilingCaptureWizardPage.cs
@@ -4,7 +4,7 @@ using MauiSherpa.Pages.Forms;
 using Microsoft.Maui.Platform.MacOS;
 #endif
 #if LINUXGTK
-using Platform.Maui.Linux.Gtk4.Platform;
+using Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
 #endif
 
 namespace MauiSherpa.Pages.Modals;

--- a/src/MauiSherpa/Pages/Modals/PublishProfileEditorPage.cs
+++ b/src/MauiSherpa/Pages/Modals/PublishProfileEditorPage.cs
@@ -4,7 +4,7 @@ using MauiSherpa.Pages.Forms;
 using Microsoft.Maui.Platform.MacOS;
 #endif
 #if LINUXGTK
-using Platform.Maui.Linux.Gtk4.Platform;
+using Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
 #endif
 
 namespace MauiSherpa.Pages.Modals;

--- a/src/MauiSherpa/Pages/Modals/PublishReviewPage.cs
+++ b/src/MauiSherpa/Pages/Modals/PublishReviewPage.cs
@@ -4,7 +4,7 @@ using MauiSherpa.Pages.Forms;
 using Microsoft.Maui.Platform.MacOS;
 #endif
 #if LINUXGTK
-using Platform.Maui.Linux.Gtk4.Platform;
+using Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
 #endif
 
 namespace MauiSherpa.Pages.Modals;

--- a/src/MauiSherpa/Pages/Modals/PublishSecretsPage.cs
+++ b/src/MauiSherpa/Pages/Modals/PublishSecretsPage.cs
@@ -3,7 +3,7 @@ using MauiSherpa.Pages.Forms;
 using Microsoft.Maui.Platform.MacOS;
 #endif
 #if LINUXGTK
-using Platform.Maui.Linux.Gtk4.Platform;
+using Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
 #endif
 
 namespace MauiSherpa.Pages.Modals;

--- a/src/MauiSherpa/Pages/Modals/PublisherPage.cs
+++ b/src/MauiSherpa/Pages/Modals/PublisherPage.cs
@@ -4,7 +4,7 @@ using MauiSherpa.Pages.Forms;
 using Microsoft.Maui.Platform.MacOS;
 #endif
 #if LINUXGTK
-using Platform.Maui.Linux.Gtk4.Platform;
+using Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
 #endif
 
 namespace MauiSherpa.Pages.Modals;

--- a/src/MauiSherpa/Pages/Modals/RuntimePickerPage.cs
+++ b/src/MauiSherpa/Pages/Modals/RuntimePickerPage.cs
@@ -4,7 +4,7 @@ using MauiSherpa.Pages.Forms;
 using Microsoft.Maui.Platform.MacOS;
 #endif
 #if LINUXGTK
-using Platform.Maui.Linux.Gtk4.Platform;
+using Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
 #endif
 
 namespace MauiSherpa.Pages.Modals;

--- a/src/MauiSherpa/Pages/Modals/SecretPickerPage.cs
+++ b/src/MauiSherpa/Pages/Modals/SecretPickerPage.cs
@@ -4,7 +4,7 @@ using MauiSherpa.Pages.Forms;
 using Microsoft.Maui.Platform.MacOS;
 #endif
 #if LINUXGTK
-using Platform.Maui.Linux.Gtk4.Platform;
+using Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
 #endif
 
 namespace MauiSherpa.Pages.Modals;

--- a/src/MauiSherpa/Pages/Modals/XcodeDownloadAuthPage.cs
+++ b/src/MauiSherpa/Pages/Modals/XcodeDownloadAuthPage.cs
@@ -3,7 +3,7 @@ using MauiSherpa.Pages.Forms;
 using Microsoft.Maui.Platform.MacOS;
 #endif
 #if LINUXGTK
-using Platform.Maui.Linux.Gtk4.Platform;
+using Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
 #endif
 
 namespace MauiSherpa.Pages.Modals;


### PR DESCRIPTION
## Summary

Migrate Linux GTK4 support from community packages (`Platform.Maui.Linux.Gtk4` from redth/Maui.Gtk) to official packages (`Microsoft.Maui.Platforms.Linux.Gtk4` from dotnet/maui-labs).

## Changes

- **nuget.config**: Added dotnet10 Azure DevOps NuGet feed
- **MauiSherpa.LinuxGtk.csproj**: Updated 3 package references to new names with floating preview versions
- **~34 source files**: Updated namespaces (`Platform.Maui.Linux.Gtk4` → `Microsoft.Maui.Platforms.Linux.Gtk4`)
- **README.md**: Updated acknowledgment link to dotnet/maui-labs
- **.gitignore**: Added nohup.out

## Package Mapping

| Old | New |
|-----|-----|
| `Platform.Maui.Linux.Gtk4` | `Microsoft.Maui.Platforms.Linux.Gtk4` |
| `Platform.Maui.Linux.Gtk4.BlazorWebView` | `Microsoft.Maui.Platforms.Linux.Gtk4.BlazorWebView` |
| `Platform.Maui.Linux.Gtk4.Essentials` | `Microsoft.Maui.Platforms.Linux.Gtk4.Essentials` |

## Known Issue

The current preview packages have a heap corruption bug caused by premature `Graphene.Point.Free()` calls in `GtkLayoutPanel.cs` and `GtkViewHandler.cs`. Fix submitted as dotnet/maui-labs#132.

The app will crash at launch until that fix is included in a new package version. DevFlow GTK packages are also commented out pending an update to the new package names.

## Notes

- DevFlow GTK packages temporarily disabled (need update for new namespaces)
- NuGet feed URL: `https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json`