### PR TITLE
Add Ailoha agent inspector support with dual-protocol DevFlow client

### DIFF
--- a/src/MauiSherpa.Core/Models/DevFlow/DevFlowModels.cs
+++ b/src/MauiSherpa.Core/Models/DevFlow/DevFlowModels.cs
@@ -495,10 +495,34 @@ public class DevFlowNetworkRequest
     public string? ResponseContentType { get; set; }
 
     [JsonPropertyName("requestHeaders")]
-    public Dictionary<string, string[]>? RequestHeaders { get; set; }
+    public JsonElement RequestHeadersRaw { get; set; }
 
     [JsonPropertyName("responseHeaders")]
-    public Dictionary<string, string[]>? ResponseHeaders { get; set; }
+    public JsonElement ResponseHeadersRaw { get; set; }
+
+    [JsonIgnore]
+    public Dictionary<string, string[]>? RequestHeaders => NormalizeHeaders(RequestHeadersRaw);
+
+    [JsonIgnore]
+    public Dictionary<string, string[]>? ResponseHeaders => NormalizeHeaders(ResponseHeadersRaw);
+
+    private static Dictionary<string, string[]>? NormalizeHeaders(JsonElement el)
+    {
+        if (el.ValueKind != JsonValueKind.Object) return null;
+        var dict = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+        foreach (var prop in el.EnumerateObject())
+        {
+            string[] values;
+            if (prop.Value.ValueKind == JsonValueKind.Array)
+                values = prop.Value.EnumerateArray().Select(v => v.GetString() ?? "").ToArray();
+            else if (prop.Value.ValueKind == JsonValueKind.String)
+                values = new[] { prop.Value.GetString() ?? "" };
+            else
+                values = new[] { prop.Value.ToString() };
+            dict[prop.Name] = values;
+        }
+        return dict;
+    }
 
     [JsonPropertyName("requestBody")]
     public string? RequestBody { get; set; }
@@ -520,27 +544,54 @@ public class DevFlowNetworkRequest
 }
 
 /// <summary>
-/// Log entry from /api/logs.
+/// Log entry. Supports v1 (timestamp/level/source/message/category/exception)
+/// and legacy (t/l/s/m/c) field names.
 /// </summary>
 public class DevFlowLogEntry
 {
     [JsonPropertyName("t")]
-    public DateTimeOffset Timestamp { get; set; }
+    public DateTimeOffset? LegacyTimestamp { get; set; }
+
+    [JsonPropertyName("timestamp")]
+    public DateTimeOffset? V1Timestamp { get; set; }
 
     [JsonPropertyName("l")]
-    public string? Level { get; set; }
+    public string? LegacyLevel { get; set; }
+
+    [JsonPropertyName("level")]
+    public string? V1Level { get; set; }
 
     [JsonPropertyName("s")]
-    public string? Source { get; set; }
+    public string? LegacySource { get; set; }
+
+    [JsonPropertyName("source")]
+    public string? V1Source { get; set; }
 
     [JsonPropertyName("m")]
-    public string? Message { get; set; }
+    public string? LegacyMessage { get; set; }
+
+    [JsonPropertyName("message")]
+    public string? V1Message { get; set; }
 
     [JsonPropertyName("c")]
-    public string? Category { get; set; }
+    public string? LegacyCategory { get; set; }
+
+    [JsonPropertyName("category")]
+    public string? V1Category { get; set; }
+
+    [JsonPropertyName("exception")]
+    public string? V1Exception { get; set; }
+
+    [JsonIgnore] public DateTimeOffset Timestamp => V1Timestamp ?? LegacyTimestamp ?? default;
+    [JsonIgnore] public string? Level => V1Level ?? LegacyLevel;
+    [JsonIgnore] public string? Source => V1Source ?? LegacySource;
+    [JsonIgnore] public string? Message => V1Message ?? LegacyMessage;
+    [JsonIgnore] public string? Category => V1Category ?? LegacyCategory;
 
     [JsonPropertyName("e")]
-    public string? Exception { get; set; }
+    public string? LegacyException { get; set; }
+
+    [JsonIgnore] public string? Exception => V1Exception ?? LegacyException;
 }
 
 /// <summary>
@@ -691,17 +742,31 @@ public class DevFlowGeolocation
 
 public class DevFlowSensorStatus
 {
-    [JsonPropertyName("sensor")] public string Sensor { get; set; } = string.Empty;
+    // v1 (Ailoha/DevFlow) uses "name"+"available"; legacy used "sensor"+"supported".
+    [JsonPropertyName("name")] public string Name { get; set; } = string.Empty;
+    [JsonPropertyName("sensor")] public string? LegacySensor { get; set; }
     [JsonPropertyName("active")] public bool Active { get; set; }
-    [JsonPropertyName("supported")] public bool Supported { get; set; }
+    [JsonPropertyName("available")] public bool Available { get; set; } = true;
+    [JsonPropertyName("supported")] public bool? LegacySupported { get; set; }
     [JsonPropertyName("subscribers")] public int Subscribers { get; set; }
+
+    [JsonIgnore]
+    public string Sensor => !string.IsNullOrEmpty(Name) ? Name : (LegacySensor ?? string.Empty);
+    [JsonIgnore]
+    public bool Supported => LegacySupported ?? Available;
 }
 
 public class DevFlowSensorReading
 {
     [JsonPropertyName("sensor")] public string Sensor { get; set; } = string.Empty;
     [JsonPropertyName("timestamp")] public string? Timestamp { get; set; }
-    [JsonPropertyName("data")] public JsonElement Data { get; set; }
+    // v1 uses "values"; legacy used "data".
+    [JsonPropertyName("values")] public JsonElement Values { get; set; }
+    [JsonPropertyName("data")] public JsonElement LegacyData { get; set; }
+
+    [JsonIgnore]
+    public JsonElement Data => Values.ValueKind != JsonValueKind.Undefined && Values.ValueKind != JsonValueKind.Null
+        ? Values : LegacyData;
 }
 
 // ── Storage DTOs ──
@@ -710,6 +775,7 @@ public class DevFlowPreferenceEntry
 {
     [JsonPropertyName("key")] public string Key { get; set; } = string.Empty;
     [JsonPropertyName("value")] public string? Value { get; set; }
+    [JsonPropertyName("type")] public string? Type { get; set; }
     [JsonPropertyName("sharedName")] public string? SharedName { get; set; }
 }
 

--- a/src/MauiSherpa.Core/Services/DevFlowAgentClient.cs
+++ b/src/MauiSherpa.Core/Services/DevFlowAgentClient.cs
@@ -6,6 +6,18 @@ using MauiSherpa.Core.Models.DevFlow;
 namespace MauiSherpa.Core.Services;
 
 /// <summary>
+/// Thrown when the agent returns a non-success HTTP status or an unparseable response body.
+/// Surfaces the agent-reported status code and error message so the inspector UI can show
+/// the real cause (e.g. "Screenshot capture failed" from the Ailoha React Native agent)
+/// instead of a silent failure.
+/// </summary>
+public sealed class DevFlowAgentException : Exception
+{
+    public int StatusCode { get; }
+    public DevFlowAgentException(int statusCode, string message) : base(message) => StatusCode = statusCode;
+}
+
+/// <summary>
 /// HTTP/WebSocket client for communicating with a MAUI DevFlow agent and broker.
 /// </summary>
 public class DevFlowAgentClient : IDisposable
@@ -277,28 +289,45 @@ public class DevFlowAgentClient : IDisposable
 
     public async Task<byte[]?> GetScreenshotAsync(int? window = null, string? elementId = null, CancellationToken ct = default)
     {
+        var parts = new List<string>();
+        if (_useV1)
+        {
+            // v1 query parameter is `elementId` and there is no `window` parameter.
+            if (elementId != null) parts.Add($"elementId={Uri.EscapeDataString(elementId)}");
+        }
+        else
+        {
+            if (window != null) parts.Add($"window={window}");
+            if (elementId != null) parts.Add($"id={Uri.EscapeDataString(elementId)}");
+        }
+        var basePath = V("/api/v1/ui/screenshot", "/api/screenshot");
+        var url = parts.Count > 0
+            ? $"{BaseUrl}{basePath}?{string.Join("&", parts)}"
+            : $"{BaseUrl}{basePath}";
+        var response = await _http.GetAsync(url, ct);
+        if (!response.IsSuccessStatusCode)
+        {
+            var body = await response.Content.ReadAsStringAsync(ct);
+            throw new DevFlowAgentException(
+                (int)response.StatusCode,
+                ExtractError(body) ?? $"Screenshot request failed ({(int)response.StatusCode} {response.StatusCode}).");
+        }
+        return await response.Content.ReadAsByteArrayAsync(ct);
+    }
+
+    private static string? ExtractError(string body)
+    {
+        if (string.IsNullOrWhiteSpace(body)) return null;
         try
         {
-            var parts = new List<string>();
-            if (_useV1)
-            {
-                // v1 query parameter is `elementId` and there is no `window` parameter.
-                if (elementId != null) parts.Add($"elementId={Uri.EscapeDataString(elementId)}");
-            }
-            else
-            {
-                if (window != null) parts.Add($"window={window}");
-                if (elementId != null) parts.Add($"id={Uri.EscapeDataString(elementId)}");
-            }
-            var basePath = V("/api/v1/ui/screenshot", "/api/screenshot");
-            var url = parts.Count > 0
-                ? $"{BaseUrl}{basePath}?{string.Join("&", parts)}"
-                : $"{BaseUrl}{basePath}";
-            var response = await _http.GetAsync(url, ct);
-            if (!response.IsSuccessStatusCode) return null;
-            return await response.Content.ReadAsByteArrayAsync(ct);
+            using var doc = JsonDocument.Parse(body);
+            if (doc.RootElement.ValueKind == JsonValueKind.Object
+                && doc.RootElement.TryGetProperty("error", out var err)
+                && err.ValueKind == JsonValueKind.String)
+                return err.GetString();
         }
-        catch { return null; }
+        catch { }
+        return body.Length > 200 ? body.Substring(0, 200) + "…" : body;
     }
 
     public async Task<bool> TapAsync(string elementId, CancellationToken ct = default)
@@ -716,10 +745,17 @@ public class DevFlowAgentClient : IDisposable
     {
         var query = sharedName != null ? $"?sharedName={Uri.EscapeDataString(sharedName)}" : "";
         var basePath = V("/api/v1/storage/preferences", "/api/preferences");
+        var response = await _http.GetAsync($"{BaseUrl}{basePath}{query}", ct);
+        var json = await response.Content.ReadAsStringAsync(ct);
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new DevFlowAgentException(
+                (int)response.StatusCode,
+                ExtractError(json) ?? $"Preferences request failed ({(int)response.StatusCode} {response.StatusCode}).");
+        }
+        if (string.IsNullOrWhiteSpace(json)) return new();
         try
         {
-            var json = await _http.GetStringAsync($"{BaseUrl}{basePath}{query}", ct);
-            if (string.IsNullOrWhiteSpace(json)) return new();
             using var doc = JsonDocument.Parse(json);
             var root = doc.RootElement;
             var opts = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
@@ -739,7 +775,10 @@ public class DevFlowAgentClient : IDisposable
             }
             return new();
         }
-        catch { return new(); }
+        catch (JsonException ex)
+        {
+            throw new DevFlowAgentException(0, $"Failed to parse preferences response: {ex.Message}");
+        }
     }
 
     public async Task<DevFlowPreferenceEntry?> GetPreferenceAsync(string key, string type = "string", string? sharedName = null, CancellationToken ct = default)

--- a/src/MauiSherpa.Core/Services/DevFlowAgentClient.cs
+++ b/src/MauiSherpa.Core/Services/DevFlowAgentClient.cs
@@ -17,7 +17,18 @@ public class DevFlowAgentClient : IDisposable
     private CancellationTokenSource? _logsWsCts;
     private readonly Dictionary<string, (ClientWebSocket Ws, CancellationTokenSource Cts)> _sensorStreams = new();
     private string? _currentProfilerSessionId;
+    // Default to v1 (modern DevFlow + Ailoha). GetStatusAsync probes both protocols
+    // and switches to legacy if only /api/status is reachable.
+    private bool _useV1 = true;
+    private bool _protocolDetected;
     private bool _disposed;
+
+    /// <summary>
+    /// Protocol the client is using once detection has run. Null until the first
+    /// successful <see cref="GetStatusAsync"/> call.
+    /// </summary>
+    public DevFlowAgentProtocol? Protocol
+        => _protocolDetected ? (_useV1 ? DevFlowAgentProtocol.V1 : DevFlowAgentProtocol.Legacy) : null;
 
     public string AgentHost { get; }
     public int AgentPort { get; }
@@ -109,12 +120,60 @@ public class DevFlowAgentClient : IDisposable
 
     public async Task<DevFlowAgentStatus?> GetStatusAsync(CancellationToken ct = default)
     {
-        // v1 status returns nested objects: { agent:{name,version,…}, device:{model,idiom,…},
-        // app:{name,packageId,…}, platform, running, cdpReady, cdpWebViewCount }
-        // Map to the flat legacy shape so existing UI keeps working unchanged.
+        // Two wire shapes exist:
+        //   v1  (/api/v1/agent/status): { agent:{name,version,…}, device:{model,idiom,…},
+        //                                 app:{name,packageId,…}, platform, running, … }
+        //   legacy (/api/status):       flat { agent, version, platform, deviceType, idiom,
+        //                                     appName, running, cdpReady, cdpWebViewCount }
+        // Probe v1 first; if 404/network-error, fall back to legacy. Cache the result so
+        // every other endpoint dispatches to the matching URL family.
+        if (!_protocolDetected)
+        {
+            try
+            {
+                var v1 = await _http.GetAsync($"{BaseUrl}/api/v1/agent/status", ct);
+                if (v1.IsSuccessStatusCode)
+                {
+                    _useV1 = true;
+                    _protocolDetected = true;
+                    var body = await v1.Content.ReadAsStringAsync(ct);
+                    return ParseV1Status(body);
+                }
+
+                if (v1.StatusCode == System.Net.HttpStatusCode.NotFound)
+                {
+                    var legacy = await _http.GetAsync($"{BaseUrl}/api/status", ct);
+                    if (legacy.IsSuccessStatusCode)
+                    {
+                        _useV1 = false;
+                        _protocolDetected = true;
+                        var body = await legacy.Content.ReadAsStringAsync(ct);
+                        return JsonSerializer.Deserialize<DevFlowAgentStatus>(body,
+                            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                    }
+                }
+            }
+            catch { return null; }
+            return null;
+        }
+
+        // Protocol already detected — just call the right endpoint.
         try
         {
-            var json = await _http.GetStringAsync($"{BaseUrl}/api/v1/agent/status", ct);
+            if (_useV1)
+            {
+                var json = await _http.GetStringAsync($"{BaseUrl}/api/v1/agent/status", ct);
+                return ParseV1Status(json);
+            }
+            return await GetAsync<DevFlowAgentStatus>("/api/status", ct);
+        }
+        catch { return null; }
+    }
+
+    private static DevFlowAgentStatus? ParseV1Status(string json)
+    {
+        try
+        {
             using var doc = JsonDocument.Parse(json);
             var root = doc.RootElement;
 
@@ -161,13 +220,15 @@ public class DevFlowAgentClient : IDisposable
         var parts = new List<string>();
         if (maxDepth > 0) parts.Add($"depth={maxDepth}");
         if (window != null) parts.Add($"window={window}");
-        var url = parts.Count > 0 ? $"/api/v1/ui/tree?{string.Join("&", parts)}" : "/api/v1/ui/tree";
+        var basePath = V("/api/v1/ui/tree", "/api/tree");
+        var url = parts.Count > 0 ? $"{basePath}?{string.Join("&", parts)}" : basePath;
         return await GetAsync<List<DevFlowElementInfo>>(url, ct) ?? new();
     }
 
     public async Task<DevFlowElementInfo?> GetElementAsync(string id, CancellationToken ct = default)
     {
-        return await GetAsync<DevFlowElementInfo>($"/api/v1/ui/elements/{Uri.EscapeDataString(id)}", ct);
+        var path = V($"/api/v1/ui/elements/{Uri.EscapeDataString(id)}", $"/api/element/{Uri.EscapeDataString(id)}");
+        return await GetAsync<DevFlowElementInfo>(path, ct);
     }
 
     public async Task<List<DevFlowElementInfo>> QueryAsync(
@@ -178,7 +239,8 @@ public class DevFlowAgentClient : IDisposable
         if (automationId != null) parts.Add($"automationId={Uri.EscapeDataString(automationId)}");
         if (text != null) parts.Add($"text={Uri.EscapeDataString(text)}");
         if (selector != null) parts.Add($"selector={Uri.EscapeDataString(selector)}");
-        var url = $"/api/v1/ui/elements?{string.Join("&", parts)}";
+        var basePath = V("/api/v1/ui/elements", "/api/query");
+        var url = $"{basePath}?{string.Join("&", parts)}";
         return await GetAsync<List<DevFlowElementInfo>>(url, ct) ?? new();
     }
 
@@ -186,7 +248,10 @@ public class DevFlowAgentClient : IDisposable
     {
         try
         {
-            var json = await _http.GetStringAsync($"{BaseUrl}/api/v1/ui/elements/{Uri.EscapeDataString(elementId)}/properties/{Uri.EscapeDataString(propertyName)}", ct);
+            var path = V(
+                $"/api/v1/ui/elements/{Uri.EscapeDataString(elementId)}/properties/{Uri.EscapeDataString(propertyName)}",
+                $"/api/property/{Uri.EscapeDataString(elementId)}/{Uri.EscapeDataString(propertyName)}");
+            var json = await _http.GetStringAsync($"{BaseUrl}{path}", ct);
             var result = JsonSerializer.Deserialize<JsonElement>(json);
             if (result.TryGetProperty("value", out var val))
                 return val.GetString();
@@ -201,9 +266,10 @@ public class DevFlowAgentClient : IDisposable
         {
             var json = JsonSerializer.Serialize(new { value });
             var content = new StringContent(json, Encoding.UTF8, "application/json");
-            var response = await _http.PostAsync(
-                $"{BaseUrl}/api/v1/ui/elements/{Uri.EscapeDataString(elementId)}/properties/{Uri.EscapeDataString(propertyName)}",
-                content, ct);
+            var path = V(
+                $"/api/v1/ui/elements/{Uri.EscapeDataString(elementId)}/properties/{Uri.EscapeDataString(propertyName)}",
+                $"/api/property/{Uri.EscapeDataString(elementId)}/{Uri.EscapeDataString(propertyName)}");
+            var response = await _http.PostAsync($"{BaseUrl}{path}", content, ct);
             return response.IsSuccessStatusCode;
         }
         catch { return false; }
@@ -216,9 +282,10 @@ public class DevFlowAgentClient : IDisposable
             var parts = new List<string>();
             if (window != null) parts.Add($"window={window}");
             if (elementId != null) parts.Add($"id={Uri.EscapeDataString(elementId)}");
+            var basePath = V("/api/v1/ui/screenshot", "/api/screenshot");
             var url = parts.Count > 0
-                ? $"{BaseUrl}/api/v1/ui/screenshot?{string.Join("&", parts)}"
-                : $"{BaseUrl}/api/v1/ui/screenshot";
+                ? $"{BaseUrl}{basePath}?{string.Join("&", parts)}"
+                : $"{BaseUrl}{basePath}";
             var response = await _http.GetAsync(url, ct);
             if (!response.IsSuccessStatusCode) return null;
             return await response.Content.ReadAsByteArrayAsync(ct);
@@ -227,13 +294,13 @@ public class DevFlowAgentClient : IDisposable
     }
 
     public async Task<bool> TapAsync(string elementId, CancellationToken ct = default)
-        => await PostActionAsync("/api/v1/ui/actions/tap", new { elementId }, ct);
+        => await PostActionAsync(V("/api/v1/ui/actions/tap", "/api/action/tap"), new { elementId }, ct);
 
     public async Task<bool> FillAsync(string elementId, string text, CancellationToken ct = default)
-        => await PostActionAsync("/api/v1/ui/actions/fill", new { elementId, text }, ct);
+        => await PostActionAsync(V("/api/v1/ui/actions/fill", "/api/action/fill"), new { elementId, text }, ct);
 
     public async Task<bool> FocusAsync(string elementId, CancellationToken ct = default)
-        => await PostActionAsync("/api/v1/ui/actions/focus", new { elementId }, ct);
+        => await PostActionAsync(V("/api/v1/ui/actions/focus", "/api/action/focus"), new { elementId }, ct);
 
     // --- Hit Test ---
 
@@ -241,7 +308,8 @@ public class DevFlowAgentClient : IDisposable
     {
         var parts = new List<string> { $"x={x}", $"y={y}" };
         if (window != null) parts.Add($"window={window}");
-        var url = $"/api/v1/ui/hit-test?{string.Join("&", parts)}";
+        var basePath = V("/api/v1/ui/hit-test", "/api/hittest");
+        var url = $"{basePath}?{string.Join("&", parts)}";
         return await GetAsync<DevFlowHitTestResult>(url, ct);
     }
 
@@ -252,7 +320,8 @@ public class DevFlowAgentClient : IDisposable
         var parts = new List<string> { $"limit={limit}" };
         if (skip > 0) parts.Add($"skip={skip}");
         if (source != null) parts.Add($"source={Uri.EscapeDataString(source)}");
-        var url = $"/api/v1/logs?{string.Join("&", parts)}";
+        var basePath = V("/api/v1/logs", "/api/logs");
+        var url = $"{basePath}?{string.Join("&", parts)}";
         return await GetAsync<List<DevFlowLogEntry>>(url, ct) ?? new();
     }
 
@@ -260,13 +329,24 @@ public class DevFlowAgentClient : IDisposable
 
     public async Task<DevFlowProfilerCapabilities?> GetProfilerCapabilitiesAsync(CancellationToken ct = default)
     {
-        return await GetAsync<DevFlowProfilerCapabilities>("/api/v1/profiler/capabilities", ct);
+        return await GetAsync<DevFlowProfilerCapabilities>(
+            V("/api/v1/profiler/capabilities", "/api/profiler/capabilities"), ct);
     }
 
     public async Task<DevFlowProfilerStartResponse?> StartProfilerAsync(int? sampleIntervalMs = null, CancellationToken ct = default)
     {
-        // v1 returns the session object directly (not wrapped). Wrap it for the legacy API,
-        // and remember the session id for subsequent samples/stop calls.
+        // Legacy: POST /api/profiler/start returns { session, capabilities }.
+        // v1: POST /api/v1/profiler/sessions returns the session directly. We track the
+        // session id internally so stop/samples can target it.
+        if (!_useV1)
+        {
+            object body = sampleIntervalMs.HasValue ? new { sampleIntervalMs = sampleIntervalMs.Value } : (object)new { };
+            var legacyResp = await PostAsync<DevFlowProfilerStartResponse>("/api/profiler/start", body, ct);
+            if (legacyResp?.Session?.SessionId is { Length: > 0 } id)
+                _currentProfilerSessionId = id;
+            return legacyResp;
+        }
+
         try
         {
             object? body = sampleIntervalMs.HasValue ? new { sampleIntervalMs = sampleIntervalMs.Value } : new { };
@@ -280,8 +360,6 @@ public class DevFlowAgentClient : IDisposable
             if (session != null && !string.IsNullOrEmpty(session.SessionId))
                 _currentProfilerSessionId = session.SessionId;
 
-            // capabilities come from a separate endpoint in v1; fetch them so callers that read
-            // .Capabilities still see the data.
             var caps = await GetProfilerCapabilitiesAsync(ct);
 
             return new DevFlowProfilerStartResponse
@@ -295,6 +373,13 @@ public class DevFlowAgentClient : IDisposable
 
     public async Task<DevFlowProfilerStopResponse?> StopProfilerAsync(CancellationToken ct = default)
     {
+        if (!_useV1)
+        {
+            var resp = await PostAsync<DevFlowProfilerStopResponse>("/api/profiler/stop", new { }, ct);
+            _currentProfilerSessionId = null;
+            return resp;
+        }
+
         var sessionId = _currentProfilerSessionId;
         if (string.IsNullOrEmpty(sessionId)) return null;
 
@@ -332,11 +417,18 @@ public class DevFlowAgentClient : IDisposable
         int limit = 200,
         CancellationToken ct = default)
     {
-        var sessionId = _currentProfilerSessionId;
-        if (string.IsNullOrEmpty(sessionId)) return null;
-
         var safeLimit = Math.Clamp(limit, 1, 5000);
-        var url = $"/api/v1/profiler/sessions/{Uri.EscapeDataString(sessionId)}/samples?sampleCursor={sampleCursor}&markerCursor={markerCursor}&spanCursor={spanCursor}&limit={safeLimit}";
+        string url;
+        if (_useV1)
+        {
+            var sessionId = _currentProfilerSessionId;
+            if (string.IsNullOrEmpty(sessionId)) return null;
+            url = $"/api/v1/profiler/sessions/{Uri.EscapeDataString(sessionId)}/samples?sampleCursor={sampleCursor}&markerCursor={markerCursor}&spanCursor={spanCursor}&limit={safeLimit}";
+        }
+        else
+        {
+            url = $"/api/profiler/samples?sampleCursor={sampleCursor}&markerCursor={markerCursor}&spanCursor={spanCursor}&limit={safeLimit}";
+        }
         return await GetAsync<DevFlowProfilerBatch>(url, ct);
     }
 
@@ -348,7 +440,8 @@ public class DevFlowAgentClient : IDisposable
     {
         limit = Math.Clamp(limit, 1, 200);
         minDurationMs = Math.Clamp(minDurationMs, 0, 60_000);
-        var url = $"/api/v1/profiler/hotspots?limit={limit}&minDurationMs={minDurationMs}";
+        var basePath = V("/api/v1/profiler/hotspots", "/api/profiler/hotspots");
+        var url = $"{basePath}?limit={limit}&minDurationMs={minDurationMs}";
         if (!string.IsNullOrWhiteSpace(kind))
             url += $"&kind={Uri.EscapeDataString(kind)}";
         return await GetAsync<List<DevFlowProfilerHotspot>>(url, ct) ?? new();
@@ -363,7 +456,9 @@ public class DevFlowAgentClient : IDisposable
         if (string.IsNullOrWhiteSpace(name))
             return false;
 
-        return await PostActionAsync("/api/v1/profiler/markers", new { name, type, payloadJson }, ct);
+        return await PostActionAsync(
+            V("/api/v1/profiler/markers", "/api/profiler/marker"),
+            new { name, type, payloadJson }, ct);
     }
 
     // --- CDP ---
@@ -383,7 +478,8 @@ public class DevFlowAgentClient : IDisposable
 
             var json = JsonSerializer.Serialize(bodyObj);
             var content = new StringContent(json, Encoding.UTF8, "application/json");
-            var response = await _http.PostAsync($"{BaseUrl}/api/v1/webview/evaluate", content, ct);
+            var path = V("/api/v1/webview/evaluate", "/api/cdp");
+            var response = await _http.PostAsync($"{BaseUrl}{path}", content, ct);
             var responseBody = await response.Content.ReadAsStringAsync(ct);
             return JsonSerializer.Deserialize<CdpResponse>(responseBody);
         }
@@ -392,26 +488,30 @@ public class DevFlowAgentClient : IDisposable
 
     public async Task<List<CdpTarget>> GetCdpTargetsAsync(CancellationToken ct = default)
     {
-        return await GetAsync<List<CdpTarget>>("/api/v1/webview/contexts", ct) ?? new();
+        return await GetAsync<List<CdpTarget>>(V("/api/v1/webview/contexts", "/api/cdp/targets"), ct) ?? new();
     }
 
     // --- Network ---
 
     public async Task<List<DevFlowNetworkRequest>> GetNetworkRequestsAsync(CancellationToken ct = default)
     {
-        return await GetAsync<List<DevFlowNetworkRequest>>("/api/v1/network/requests", ct) ?? new();
+        return await GetAsync<List<DevFlowNetworkRequest>>(V("/api/v1/network/requests", "/api/network"), ct) ?? new();
     }
 
     public async Task<DevFlowNetworkRequest?> GetNetworkRequestDetailAsync(string id, CancellationToken ct = default)
     {
-        return await GetAsync<DevFlowNetworkRequest>($"/api/v1/network/requests/{Uri.EscapeDataString(id)}", ct);
+        var path = V($"/api/v1/network/requests/{Uri.EscapeDataString(id)}", $"/api/network/{Uri.EscapeDataString(id)}");
+        return await GetAsync<DevFlowNetworkRequest>(path, ct);
     }
 
     public async Task<bool> ClearNetworkRequestsAsync(CancellationToken ct = default)
     {
         try
         {
-            var response = await _http.DeleteAsync($"{BaseUrl}/api/v1/network/requests", ct);
+            // v1: DELETE /api/v1/network/requests   |   legacy: POST /api/network/clear
+            HttpResponseMessage response = _useV1
+                ? await _http.DeleteAsync($"{BaseUrl}/api/v1/network/requests", ct)
+                : await _http.PostAsync($"{BaseUrl}/api/network/clear", null, ct);
             return response.IsSuccessStatusCode;
         }
         catch { return false; }
@@ -433,7 +533,9 @@ public class DevFlowAgentClient : IDisposable
 
         try
         {
-            var wsUrl = $"ws://{AgentHost}:{AgentPort}/ws/v1/network";
+            var wsUrl = _useV1
+                ? $"ws://{AgentHost}:{AgentPort}/ws/v1/network"
+                : $"ws://{AgentHost}:{AgentPort}/ws/network";
             await _networkWs.ConnectAsync(new Uri(wsUrl), token);
 
             var buffer = new byte[64 * 1024];
@@ -503,7 +605,10 @@ public class DevFlowAgentClient : IDisposable
             if (source != null) parts.Add($"source={Uri.EscapeDataString(source)}");
             parts.Add($"replay={replay}");
             var query = string.Join("&", parts);
-            var wsUrl = $"ws://{AgentHost}:{AgentPort}/ws/v1/logs?{query}";
+            var wsBase = _useV1
+                ? $"ws://{AgentHost}:{AgentPort}/ws/v1/logs"
+                : $"ws://{AgentHost}:{AgentPort}/ws/logs";
+            var wsUrl = $"{wsBase}?{query}";
             await _logsWs.ConnectAsync(new Uri(wsUrl), token);
 
             var buffer = new byte[64 * 1024];
@@ -563,41 +668,47 @@ public class DevFlowAgentClient : IDisposable
     // --- Platform Info ---
 
     public async Task<DevFlowAppInfo?> GetAppInfoAsync(CancellationToken ct = default)
-        => await GetAsync<DevFlowAppInfo>("/api/v1/device/app", ct);
+        => await GetAsync<DevFlowAppInfo>(V("/api/v1/device/app", "/api/platform/app-info"), ct);
 
     public async Task<DevFlowDeviceInfo?> GetDeviceInfoAsync(CancellationToken ct = default)
-        => await GetAsync<DevFlowDeviceInfo>("/api/v1/device/info", ct);
+        => await GetAsync<DevFlowDeviceInfo>(V("/api/v1/device/info", "/api/platform/device-info"), ct);
 
     public async Task<DevFlowDisplayInfo?> GetDisplayInfoAsync(CancellationToken ct = default)
-        => await GetAsync<DevFlowDisplayInfo>("/api/v1/device/display", ct);
+        => await GetAsync<DevFlowDisplayInfo>(V("/api/v1/device/display", "/api/platform/device-display"), ct);
 
     public async Task<DevFlowBatteryInfo?> GetBatteryInfoAsync(CancellationToken ct = default)
-        => await GetAsync<DevFlowBatteryInfo>("/api/v1/device/battery", ct);
+        => await GetAsync<DevFlowBatteryInfo>(V("/api/v1/device/battery", "/api/platform/battery"), ct);
 
     public async Task<DevFlowConnectivityInfo?> GetConnectivityAsync(CancellationToken ct = default)
-        => await GetAsync<DevFlowConnectivityInfo>("/api/v1/device/connectivity", ct);
+        => await GetAsync<DevFlowConnectivityInfo>(V("/api/v1/device/connectivity", "/api/platform/connectivity"), ct);
 
     public async Task<DevFlowVersionTracking?> GetVersionTrackingAsync(CancellationToken ct = default)
-        => await GetAsync<DevFlowVersionTracking>("/api/v1/device/version-tracking", ct);
+        => await GetAsync<DevFlowVersionTracking>(V("/api/v1/device/version-tracking", "/api/platform/version-tracking"), ct);
 
     public async Task<List<DevFlowPermissionStatus>> GetPermissionsAsync(CancellationToken ct = default)
     {
-        var result = await GetAsync<DevFlowPermissionsResponse>("/api/v1/device/permissions", ct);
+        var result = await GetAsync<DevFlowPermissionsResponse>(V("/api/v1/device/permissions", "/api/platform/permissions"), ct);
         return result?.Permissions ?? new();
     }
 
     public async Task<DevFlowPermissionStatus?> CheckPermissionAsync(string permission, CancellationToken ct = default)
-        => await GetAsync<DevFlowPermissionStatus>($"/api/v1/device/permissions/{Uri.EscapeDataString(permission)}", ct);
+        => await GetAsync<DevFlowPermissionStatus>(
+            V($"/api/v1/device/permissions/{Uri.EscapeDataString(permission)}",
+              $"/api/platform/permissions/{Uri.EscapeDataString(permission)}"), ct);
 
     public async Task<DevFlowGeolocation?> GetGeolocationAsync(string accuracy = "Medium", int timeoutSeconds = 10, CancellationToken ct = default)
-        => await GetAsync<DevFlowGeolocation>($"/api/v1/device/geolocation?accuracy={Uri.EscapeDataString(accuracy)}&timeout={timeoutSeconds}", ct);
+    {
+        var basePath = V("/api/v1/device/geolocation", "/api/platform/geolocation");
+        return await GetAsync<DevFlowGeolocation>($"{basePath}?accuracy={Uri.EscapeDataString(accuracy)}&timeout={timeoutSeconds}", ct);
+    }
 
     // --- Preferences ---
 
     public async Task<List<DevFlowPreferenceEntry>> GetPreferencesAsync(string? sharedName = null, CancellationToken ct = default)
     {
         var query = sharedName != null ? $"?sharedName={Uri.EscapeDataString(sharedName)}" : "";
-        var result = await GetAsync<DevFlowPreferencesListResponse>($"/api/v1/storage/preferences{query}", ct);
+        var basePath = V("/api/v1/storage/preferences", "/api/preferences");
+        var result = await GetAsync<DevFlowPreferencesListResponse>($"{basePath}{query}", ct);
         return result?.Keys ?? new();
     }
 
@@ -605,20 +716,29 @@ public class DevFlowAgentClient : IDisposable
     {
         var query = $"?type={Uri.EscapeDataString(type)}";
         if (sharedName != null) query += $"&sharedName={Uri.EscapeDataString(sharedName)}";
-        return await GetAsync<DevFlowPreferenceEntry>($"/api/v1/storage/preferences/{Uri.EscapeDataString(key)}{query}", ct);
+        var path = V(
+            $"/api/v1/storage/preferences/{Uri.EscapeDataString(key)}",
+            $"/api/preferences/{Uri.EscapeDataString(key)}");
+        return await GetAsync<DevFlowPreferenceEntry>($"{path}{query}", ct);
     }
 
     public async Task<bool> SetPreferenceAsync(string key, object? value, string? type = null, string? sharedName = null, CancellationToken ct = default)
     {
         var body = new DevFlowPreferenceSetRequest { Value = value, Type = type ?? "string", SharedName = sharedName };
-        var result = await PostAsync<DevFlowPreferenceEntry>($"/api/v1/storage/preferences/{Uri.EscapeDataString(key)}", body, ct);
+        var path = V(
+            $"/api/v1/storage/preferences/{Uri.EscapeDataString(key)}",
+            $"/api/preferences/{Uri.EscapeDataString(key)}");
+        var result = await PostAsync<DevFlowPreferenceEntry>(path, body, ct);
         return result != null;
     }
 
     public async Task<bool> DeletePreferenceAsync(string key, string? sharedName = null, CancellationToken ct = default)
     {
         var query = sharedName != null ? $"?sharedName={Uri.EscapeDataString(sharedName)}" : "";
-        return await DeleteAsync($"/api/v1/storage/preferences/{Uri.EscapeDataString(key)}{query}", ct);
+        var path = V(
+            $"/api/v1/storage/preferences/{Uri.EscapeDataString(key)}",
+            $"/api/preferences/{Uri.EscapeDataString(key)}");
+        return await DeleteAsync($"{path}{query}", ct);
     }
 
     public async Task<bool> ClearPreferencesAsync(string? sharedName = null, CancellationToken ct = default)
@@ -626,8 +746,10 @@ public class DevFlowAgentClient : IDisposable
         var query = sharedName != null ? $"?sharedName={Uri.EscapeDataString(sharedName)}" : "";
         try
         {
-            // v1 uses DELETE on the collection to clear it.
-            var response = await _http.DeleteAsync($"{BaseUrl}/api/v1/storage/preferences{query}", ct);
+            // v1: DELETE collection. Legacy: POST /api/preferences/clear.
+            HttpResponseMessage response = _useV1
+                ? await _http.DeleteAsync($"{BaseUrl}/api/v1/storage/preferences{query}", ct)
+                : await _http.PostAsync($"{BaseUrl}/api/preferences/clear{query}", null, ct);
             return response.IsSuccessStatusCode;
         }
         catch { return false; }
@@ -636,23 +758,32 @@ public class DevFlowAgentClient : IDisposable
     // --- Secure Storage ---
 
     public async Task<DevFlowSecureStorageEntry?> GetSecureStorageAsync(string key, CancellationToken ct = default)
-        => await GetAsync<DevFlowSecureStorageEntry>($"/api/v1/storage/secure/{Uri.EscapeDataString(key)}", ct);
+        => await GetAsync<DevFlowSecureStorageEntry>(
+            V($"/api/v1/storage/secure/{Uri.EscapeDataString(key)}",
+              $"/api/secure-storage/{Uri.EscapeDataString(key)}"), ct);
 
     public async Task<bool> SetSecureStorageAsync(string key, string value, CancellationToken ct = default)
     {
         var body = new { value };
-        var result = await PostAsync<DevFlowSecureStorageEntry>($"/api/v1/storage/secure/{Uri.EscapeDataString(key)}", body, ct);
+        var path = V(
+            $"/api/v1/storage/secure/{Uri.EscapeDataString(key)}",
+            $"/api/secure-storage/{Uri.EscapeDataString(key)}");
+        var result = await PostAsync<DevFlowSecureStorageEntry>(path, body, ct);
         return result != null;
     }
 
     public async Task<bool> DeleteSecureStorageAsync(string key, CancellationToken ct = default)
-        => await DeleteAsync($"/api/v1/storage/secure/{Uri.EscapeDataString(key)}", ct);
+        => await DeleteAsync(
+            V($"/api/v1/storage/secure/{Uri.EscapeDataString(key)}",
+              $"/api/secure-storage/{Uri.EscapeDataString(key)}"), ct);
 
     public async Task<bool> ClearSecureStorageAsync(CancellationToken ct = default)
     {
         try
         {
-            var response = await _http.DeleteAsync($"{BaseUrl}/api/v1/storage/secure", ct);
+            HttpResponseMessage response = _useV1
+                ? await _http.DeleteAsync($"{BaseUrl}/api/v1/storage/secure", ct)
+                : await _http.PostAsync($"{BaseUrl}/api/secure-storage/clear", null, ct);
             return response.IsSuccessStatusCode;
         }
         catch { return false; }
@@ -661,13 +792,16 @@ public class DevFlowAgentClient : IDisposable
     // --- Sensors ---
 
     public async Task<List<DevFlowSensorStatus>> GetSensorsAsync(CancellationToken ct = default)
-        => await GetAsync<List<DevFlowSensorStatus>>("/api/v1/device/sensors", ct) ?? new();
+        => await GetAsync<List<DevFlowSensorStatus>>(V("/api/v1/device/sensors", "/api/sensors"), ct) ?? new();
 
     public async Task<bool> StartSensorAsync(string sensor, string speed = "UI", CancellationToken ct = default)
     {
         try
         {
-            var response = await _http.PostAsync($"{BaseUrl}/api/v1/device/sensors/{Uri.EscapeDataString(sensor)}/start?speed={Uri.EscapeDataString(speed)}", null, ct);
+            var path = V(
+                $"/api/v1/device/sensors/{Uri.EscapeDataString(sensor)}/start",
+                $"/api/sensors/{Uri.EscapeDataString(sensor)}/start");
+            var response = await _http.PostAsync($"{BaseUrl}{path}?speed={Uri.EscapeDataString(speed)}", null, ct);
             return response.IsSuccessStatusCode;
         }
         catch { return false; }
@@ -677,7 +811,10 @@ public class DevFlowAgentClient : IDisposable
     {
         try
         {
-            var response = await _http.PostAsync($"{BaseUrl}/api/v1/device/sensors/{Uri.EscapeDataString(sensor)}/stop", null, ct);
+            var path = V(
+                $"/api/v1/device/sensors/{Uri.EscapeDataString(sensor)}/stop",
+                $"/api/sensors/{Uri.EscapeDataString(sensor)}/stop");
+            var response = await _http.PostAsync($"{BaseUrl}{path}", null, ct);
             return response.IsSuccessStatusCode;
         }
         catch { return false; }
@@ -694,7 +831,10 @@ public class DevFlowAgentClient : IDisposable
         var token = cts.Token;
         try
         {
-            var wsUrl = $"ws://{AgentHost}:{AgentPort}/ws/v1/sensors?sensor={Uri.EscapeDataString(sensor)}&speed={Uri.EscapeDataString(speed)}&throttleMs={throttleMs}";
+            var wsBase = _useV1
+                ? $"ws://{AgentHost}:{AgentPort}/ws/v1/sensors"
+                : $"ws://{AgentHost}:{AgentPort}/ws/sensors";
+            var wsUrl = $"{wsBase}?sensor={Uri.EscapeDataString(sensor)}&speed={Uri.EscapeDataString(speed)}&throttleMs={throttleMs}";
             await ws.ConnectAsync(new Uri(wsUrl), token);
 
             var buffer = new byte[16 * 1024];
@@ -770,6 +910,9 @@ public class DevFlowAgentClient : IDisposable
 
     // --- Helpers ---
 
+    /// <summary>Pick the v1 or legacy URL based on the detected protocol.</summary>
+    private string V(string v1Path, string legacyPath) => _useV1 ? v1Path : legacyPath;
+
     private async Task<T?> GetAsync<T>(string path, CancellationToken ct = default) where T : class
     {
         try
@@ -832,4 +975,13 @@ public class DevFlowAgentClient : IDisposable
         StopAllSensorStreams();
         _http.Dispose();
     }
+}
+
+/// <summary>Protocol exposed by a MAUI DevFlow / Ailoha agent.</summary>
+public enum DevFlowAgentProtocol
+{
+    /// <summary>Modern <c>/api/v1/*</c> + <c>/ws/v1/*</c> surface (DevFlow preview.7+, Ailoha).</summary>
+    V1,
+    /// <summary>Legacy <c>/api/*</c> + <c>/ws/*</c> surface (DevFlow preview.6 and earlier).</summary>
+    Legacy,
 }

--- a/src/MauiSherpa.Core/Services/DevFlowAgentClient.cs
+++ b/src/MauiSherpa.Core/Services/DevFlowAgentClient.cs
@@ -280,8 +280,16 @@ public class DevFlowAgentClient : IDisposable
         try
         {
             var parts = new List<string>();
-            if (window != null) parts.Add($"window={window}");
-            if (elementId != null) parts.Add($"id={Uri.EscapeDataString(elementId)}");
+            if (_useV1)
+            {
+                // v1 query parameter is `elementId` and there is no `window` parameter.
+                if (elementId != null) parts.Add($"elementId={Uri.EscapeDataString(elementId)}");
+            }
+            else
+            {
+                if (window != null) parts.Add($"window={window}");
+                if (elementId != null) parts.Add($"id={Uri.EscapeDataString(elementId)}");
+            }
             var basePath = V("/api/v1/ui/screenshot", "/api/screenshot");
             var url = parts.Count > 0
                 ? $"{BaseUrl}{basePath}?{string.Join("&", parts)}"
@@ -708,8 +716,30 @@ public class DevFlowAgentClient : IDisposable
     {
         var query = sharedName != null ? $"?sharedName={Uri.EscapeDataString(sharedName)}" : "";
         var basePath = V("/api/v1/storage/preferences", "/api/preferences");
-        var result = await GetAsync<DevFlowPreferencesListResponse>($"{basePath}{query}", ct);
-        return result?.Keys ?? new();
+        try
+        {
+            var json = await _http.GetStringAsync($"{BaseUrl}{basePath}{query}", ct);
+            if (string.IsNullOrWhiteSpace(json)) return new();
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            var opts = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+
+            // Bare array (DevFlow v1 reference shape)
+            if (root.ValueKind == JsonValueKind.Array)
+                return JsonSerializer.Deserialize<List<DevFlowPreferenceEntry>>(root.GetRawText(), opts) ?? new();
+
+            // Wrapped: {keys:[...]} (legacy MAUI DevFlow) or {preferences:[...]} (Ailoha)
+            if (root.ValueKind == JsonValueKind.Object)
+            {
+                foreach (var name in new[] { "keys", "preferences", "items", "entries" })
+                {
+                    if (root.TryGetProperty(name, out var arr) && arr.ValueKind == JsonValueKind.Array)
+                        return JsonSerializer.Deserialize<List<DevFlowPreferenceEntry>>(arr.GetRawText(), opts) ?? new();
+                }
+            }
+            return new();
+        }
+        catch { return new(); }
     }
 
     public async Task<DevFlowPreferenceEntry?> GetPreferenceAsync(string key, string type = "string", string? sharedName = null, CancellationToken ct = default)
@@ -728,8 +758,10 @@ public class DevFlowAgentClient : IDisposable
         var path = V(
             $"/api/v1/storage/preferences/{Uri.EscapeDataString(key)}",
             $"/api/preferences/{Uri.EscapeDataString(key)}");
-        var result = await PostAsync<DevFlowPreferenceEntry>(path, body, ct);
-        return result != null;
+        // v1 uses PUT for set; legacy uses POST.
+        return _useV1
+            ? await PutAsync(path, body, ct)
+            : await PostAsync<DevFlowPreferenceEntry>(path, body, ct) != null;
     }
 
     public async Task<bool> DeletePreferenceAsync(string key, string? sharedName = null, CancellationToken ct = default)
@@ -768,8 +800,10 @@ public class DevFlowAgentClient : IDisposable
         var path = V(
             $"/api/v1/storage/secure/{Uri.EscapeDataString(key)}",
             $"/api/secure-storage/{Uri.EscapeDataString(key)}");
-        var result = await PostAsync<DevFlowSecureStorageEntry>(path, body, ct);
-        return result != null;
+        // v1 uses PUT for set; legacy uses POST.
+        return _useV1
+            ? await PutAsync(path, body, ct)
+            : await PostAsync<DevFlowSecureStorageEntry>(path, body, ct) != null;
     }
 
     public async Task<bool> DeleteSecureStorageAsync(string key, CancellationToken ct = default)
@@ -792,7 +826,29 @@ public class DevFlowAgentClient : IDisposable
     // --- Sensors ---
 
     public async Task<List<DevFlowSensorStatus>> GetSensorsAsync(CancellationToken ct = default)
-        => await GetAsync<List<DevFlowSensorStatus>>(V("/api/v1/device/sensors", "/api/sensors"), ct) ?? new();
+    {
+        var basePath = V("/api/v1/device/sensors", "/api/sensors");
+        try
+        {
+            var json = await _http.GetStringAsync($"{BaseUrl}{basePath}", ct);
+            if (string.IsNullOrWhiteSpace(json)) return new();
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            var opts = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+
+            if (root.ValueKind == JsonValueKind.Array)
+                return JsonSerializer.Deserialize<List<DevFlowSensorStatus>>(root.GetRawText(), opts) ?? new();
+
+            if (root.ValueKind == JsonValueKind.Object &&
+                root.TryGetProperty("sensors", out var arr) &&
+                arr.ValueKind == JsonValueKind.Array)
+            {
+                return JsonSerializer.Deserialize<List<DevFlowSensorStatus>>(arr.GetRawText(), opts) ?? new();
+            }
+            return new();
+        }
+        catch { return new(); }
+    }
 
     public async Task<bool> StartSensorAsync(string sensor, string speed = "UI", CancellationToken ct = default)
     {
@@ -832,7 +888,7 @@ public class DevFlowAgentClient : IDisposable
         try
         {
             var wsBase = _useV1
-                ? $"ws://{AgentHost}:{AgentPort}/ws/v1/sensors"
+                ? $"ws://{AgentHost}:{AgentPort}/ws/v1/device/sensors"
                 : $"ws://{AgentHost}:{AgentPort}/ws/sensors";
             var wsUrl = $"{wsBase}?sensor={Uri.EscapeDataString(sensor)}&speed={Uri.EscapeDataString(speed)}&throttleMs={throttleMs}";
             await ws.ConnectAsync(new Uri(wsUrl), token);
@@ -853,8 +909,26 @@ public class DevFlowAgentClient : IDisposable
                     sb.Clear();
                     try
                     {
-                        var reading = JsonSerializer.Deserialize<DevFlowSensorReading>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-                        if (reading != null) onReading(reading);
+                        using var doc = JsonDocument.Parse(json);
+                        var root = doc.RootElement;
+                        var opts = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+
+                        // v1 envelope: {type:"reading", timestamp, reading:{sensor, timestamp, values}}
+                        if (root.ValueKind == JsonValueKind.Object &&
+                            root.TryGetProperty("type", out var typeProp) &&
+                            typeProp.GetString() == "reading" &&
+                            root.TryGetProperty("reading", out var readingProp))
+                        {
+                            var reading = JsonSerializer.Deserialize<DevFlowSensorReading>(readingProp.GetRawText(), opts);
+                            if (reading != null) onReading(reading);
+                        }
+                        else
+                        {
+                            // Legacy: bare reading object
+                            var reading = JsonSerializer.Deserialize<DevFlowSensorReading>(json, opts);
+                            if (reading != null && (!string.IsNullOrEmpty(reading.Sensor) || reading.Data.ValueKind != JsonValueKind.Undefined))
+                                onReading(reading);
+                        }
                     }
                     catch { }
                 }
@@ -959,6 +1033,18 @@ public class DevFlowAgentClient : IDisposable
         try
         {
             var response = await _http.DeleteAsync($"{BaseUrl}{path}", ct);
+            return response.IsSuccessStatusCode;
+        }
+        catch { return false; }
+    }
+
+    private async Task<bool> PutAsync(string path, object body, CancellationToken ct = default)
+    {
+        try
+        {
+            var json = JsonSerializer.Serialize(body);
+            var content = new StringContent(json, Encoding.UTF8, "application/json");
+            var response = await _http.PutAsync($"{BaseUrl}{path}", content, ct);
             return response.IsSuccessStatusCode;
         }
         catch { return false; }

--- a/src/MauiSherpa.Core/Services/DevFlowAgentClient.cs
+++ b/src/MauiSherpa.Core/Services/DevFlowAgentClient.cs
@@ -16,6 +16,7 @@ public class DevFlowAgentClient : IDisposable
     private ClientWebSocket? _logsWs;
     private CancellationTokenSource? _logsWsCts;
     private readonly Dictionary<string, (ClientWebSocket Ws, CancellationTokenSource Cts)> _sensorStreams = new();
+    private string? _currentProfilerSessionId;
     private bool _disposed;
 
     public string AgentHost { get; }
@@ -31,11 +32,20 @@ public class DevFlowAgentClient : IDisposable
 
     // --- Broker API ---
 
+    /// <summary>Default broker port for the MAUI DevFlow CLI.</summary>
+    public const int DevFlowBrokerPort = 19223;
+
+    /// <summary>Default broker port for the Ailoha CLI.</summary>
+    public const int AilohaBrokerPort = 19323;
+
+    /// <summary>Standard broker ports we probe when the user accepts the default.</summary>
+    public static readonly IReadOnlyList<int> DefaultBrokerPorts = new[] { DevFlowBrokerPort, AilohaBrokerPort };
+
     /// <summary>
     /// Fetch agents from the broker at the given host/port.
     /// </summary>
     public static async Task<List<BrokerAgent>> GetBrokerAgentsAsync(
-        string brokerHost = "localhost", int brokerPort = 19223, CancellationToken ct = default)
+        string brokerHost = "localhost", int brokerPort = DevFlowBrokerPort, CancellationToken ct = default)
     {
         using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
         try
@@ -54,7 +64,7 @@ public class DevFlowAgentClient : IDisposable
     /// Check if the broker is healthy.
     /// </summary>
     public static async Task<bool> IsBrokerHealthyAsync(
-        string brokerHost = "localhost", int brokerPort = 19223, CancellationToken ct = default)
+        string brokerHost = "localhost", int brokerPort = DevFlowBrokerPort, CancellationToken ct = default)
     {
         using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(3) };
         try
@@ -69,11 +79,81 @@ public class DevFlowAgentClient : IDisposable
         }
     }
 
+    /// <summary>
+    /// Find the first reachable broker on <paramref name="brokerHost"/> from the provided
+    /// candidate ports. Returns <c>null</c> if none are reachable. Probes run in parallel.
+    /// </summary>
+    public static async Task<int?> FindReachableBrokerPortAsync(
+        string brokerHost,
+        IEnumerable<int> candidatePorts,
+        CancellationToken ct = default)
+    {
+        var ports = candidatePorts?.Distinct().ToArray() ?? Array.Empty<int>();
+        if (ports.Length == 0) return null;
+
+        var tasks = ports
+            .Select(async port => (port, healthy: await IsBrokerHealthyAsync(brokerHost, port, ct)))
+            .ToList();
+
+        var results = await Task.WhenAll(tasks);
+        // Preserve candidate ordering — pick the first port in the input order that's healthy.
+        foreach (var port in ports)
+        {
+            var match = results.FirstOrDefault(r => r.port == port && r.healthy);
+            if (match.healthy) return port;
+        }
+        return null;
+    }
+
     // --- Agent API ---
 
     public async Task<DevFlowAgentStatus?> GetStatusAsync(CancellationToken ct = default)
     {
-        return await GetAsync<DevFlowAgentStatus>("/api/status", ct);
+        // v1 status returns nested objects: { agent:{name,version,…}, device:{model,idiom,…},
+        // app:{name,packageId,…}, platform, running, cdpReady, cdpWebViewCount }
+        // Map to the flat legacy shape so existing UI keeps working unchanged.
+        try
+        {
+            var json = await _http.GetStringAsync($"{BaseUrl}/api/v1/agent/status", ct);
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            string? readNested(string parent, string child)
+                => root.TryGetProperty(parent, out var p)
+                   && p.ValueKind == JsonValueKind.Object
+                   && p.TryGetProperty(child, out var c)
+                   && c.ValueKind == JsonValueKind.String
+                    ? c.GetString()
+                    : null;
+
+            string? readString(string name)
+                => root.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.String
+                    ? v.GetString() : null;
+
+            bool getBool(string name)
+                => root.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.True;
+
+            int getInt(string name)
+                => root.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.Number
+                   && v.TryGetInt32(out var n) ? n : 0;
+
+            return new DevFlowAgentStatus
+            {
+                Agent = readNested("agent", "name") ?? readString("agent"),
+                Version = readNested("agent", "version") ?? readString("version"),
+                Platform = readString("platform") ?? readNested("device", "platform"),
+                DeviceType = readNested("device", "model") ?? readString("deviceType"),
+                Idiom = readNested("device", "idiom") ?? readString("idiom"),
+                AppName = readNested("app", "name") ?? readString("appName"),
+                Running = getBool("running"),
+                CdpReady = getBool("cdpReady"),
+                CdpWebViewCount = getInt("cdpWebViewCount"),
+            };
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     public async Task<List<DevFlowElementInfo>> GetTreeAsync(int maxDepth = 0, int? window = null, CancellationToken ct = default)
@@ -81,13 +161,13 @@ public class DevFlowAgentClient : IDisposable
         var parts = new List<string>();
         if (maxDepth > 0) parts.Add($"depth={maxDepth}");
         if (window != null) parts.Add($"window={window}");
-        var url = parts.Count > 0 ? $"/api/tree?{string.Join("&", parts)}" : "/api/tree";
+        var url = parts.Count > 0 ? $"/api/v1/ui/tree?{string.Join("&", parts)}" : "/api/v1/ui/tree";
         return await GetAsync<List<DevFlowElementInfo>>(url, ct) ?? new();
     }
 
     public async Task<DevFlowElementInfo?> GetElementAsync(string id, CancellationToken ct = default)
     {
-        return await GetAsync<DevFlowElementInfo>($"/api/element/{Uri.EscapeDataString(id)}", ct);
+        return await GetAsync<DevFlowElementInfo>($"/api/v1/ui/elements/{Uri.EscapeDataString(id)}", ct);
     }
 
     public async Task<List<DevFlowElementInfo>> QueryAsync(
@@ -98,7 +178,7 @@ public class DevFlowAgentClient : IDisposable
         if (automationId != null) parts.Add($"automationId={Uri.EscapeDataString(automationId)}");
         if (text != null) parts.Add($"text={Uri.EscapeDataString(text)}");
         if (selector != null) parts.Add($"selector={Uri.EscapeDataString(selector)}");
-        var url = $"/api/query?{string.Join("&", parts)}";
+        var url = $"/api/v1/ui/elements?{string.Join("&", parts)}";
         return await GetAsync<List<DevFlowElementInfo>>(url, ct) ?? new();
     }
 
@@ -106,7 +186,7 @@ public class DevFlowAgentClient : IDisposable
     {
         try
         {
-            var json = await _http.GetStringAsync($"{BaseUrl}/api/property/{Uri.EscapeDataString(elementId)}/{Uri.EscapeDataString(propertyName)}", ct);
+            var json = await _http.GetStringAsync($"{BaseUrl}/api/v1/ui/elements/{Uri.EscapeDataString(elementId)}/properties/{Uri.EscapeDataString(propertyName)}", ct);
             var result = JsonSerializer.Deserialize<JsonElement>(json);
             if (result.TryGetProperty("value", out var val))
                 return val.GetString();
@@ -122,7 +202,7 @@ public class DevFlowAgentClient : IDisposable
             var json = JsonSerializer.Serialize(new { value });
             var content = new StringContent(json, Encoding.UTF8, "application/json");
             var response = await _http.PostAsync(
-                $"{BaseUrl}/api/property/{Uri.EscapeDataString(elementId)}/{Uri.EscapeDataString(propertyName)}",
+                $"{BaseUrl}/api/v1/ui/elements/{Uri.EscapeDataString(elementId)}/properties/{Uri.EscapeDataString(propertyName)}",
                 content, ct);
             return response.IsSuccessStatusCode;
         }
@@ -137,8 +217,8 @@ public class DevFlowAgentClient : IDisposable
             if (window != null) parts.Add($"window={window}");
             if (elementId != null) parts.Add($"id={Uri.EscapeDataString(elementId)}");
             var url = parts.Count > 0
-                ? $"{BaseUrl}/api/screenshot?{string.Join("&", parts)}"
-                : $"{BaseUrl}/api/screenshot";
+                ? $"{BaseUrl}/api/v1/ui/screenshot?{string.Join("&", parts)}"
+                : $"{BaseUrl}/api/v1/ui/screenshot";
             var response = await _http.GetAsync(url, ct);
             if (!response.IsSuccessStatusCode) return null;
             return await response.Content.ReadAsByteArrayAsync(ct);
@@ -147,13 +227,13 @@ public class DevFlowAgentClient : IDisposable
     }
 
     public async Task<bool> TapAsync(string elementId, CancellationToken ct = default)
-        => await PostActionAsync("/api/action/tap", new { elementId }, ct);
+        => await PostActionAsync("/api/v1/ui/actions/tap", new { elementId }, ct);
 
     public async Task<bool> FillAsync(string elementId, string text, CancellationToken ct = default)
-        => await PostActionAsync("/api/action/fill", new { elementId, text }, ct);
+        => await PostActionAsync("/api/v1/ui/actions/fill", new { elementId, text }, ct);
 
     public async Task<bool> FocusAsync(string elementId, CancellationToken ct = default)
-        => await PostActionAsync("/api/action/focus", new { elementId }, ct);
+        => await PostActionAsync("/api/v1/ui/actions/focus", new { elementId }, ct);
 
     // --- Hit Test ---
 
@@ -161,7 +241,7 @@ public class DevFlowAgentClient : IDisposable
     {
         var parts = new List<string> { $"x={x}", $"y={y}" };
         if (window != null) parts.Add($"window={window}");
-        var url = $"/api/hittest?{string.Join("&", parts)}";
+        var url = $"/api/v1/ui/hit-test?{string.Join("&", parts)}";
         return await GetAsync<DevFlowHitTestResult>(url, ct);
     }
 
@@ -172,7 +252,7 @@ public class DevFlowAgentClient : IDisposable
         var parts = new List<string> { $"limit={limit}" };
         if (skip > 0) parts.Add($"skip={skip}");
         if (source != null) parts.Add($"source={Uri.EscapeDataString(source)}");
-        var url = $"/api/logs?{string.Join("&", parts)}";
+        var url = $"/api/v1/logs?{string.Join("&", parts)}";
         return await GetAsync<List<DevFlowLogEntry>>(url, ct) ?? new();
     }
 
@@ -180,20 +260,69 @@ public class DevFlowAgentClient : IDisposable
 
     public async Task<DevFlowProfilerCapabilities?> GetProfilerCapabilitiesAsync(CancellationToken ct = default)
     {
-        return await GetAsync<DevFlowProfilerCapabilities>("/api/profiler/capabilities", ct);
+        return await GetAsync<DevFlowProfilerCapabilities>("/api/v1/profiler/capabilities", ct);
     }
 
     public async Task<DevFlowProfilerStartResponse?> StartProfilerAsync(int? sampleIntervalMs = null, CancellationToken ct = default)
     {
-        if (sampleIntervalMs.HasValue)
-            return await PostAsync<DevFlowProfilerStartResponse>("/api/profiler/start", new { sampleIntervalMs = sampleIntervalMs.Value }, ct);
+        // v1 returns the session object directly (not wrapped). Wrap it for the legacy API,
+        // and remember the session id for subsequent samples/stop calls.
+        try
+        {
+            object? body = sampleIntervalMs.HasValue ? new { sampleIntervalMs = sampleIntervalMs.Value } : new { };
+            var json = JsonSerializer.Serialize(body);
+            var content = new StringContent(json, Encoding.UTF8, "application/json");
+            var response = await _http.PostAsync($"{BaseUrl}/api/v1/profiler/sessions", content, ct);
+            if (!response.IsSuccessStatusCode) return null;
 
-        return await PostAsync<DevFlowProfilerStartResponse>("/api/profiler/start", new { }, ct);
+            var responseBody = await response.Content.ReadAsStringAsync(ct);
+            var session = JsonSerializer.Deserialize<DevFlowProfilerSessionInfo>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            if (session != null && !string.IsNullOrEmpty(session.SessionId))
+                _currentProfilerSessionId = session.SessionId;
+
+            // capabilities come from a separate endpoint in v1; fetch them so callers that read
+            // .Capabilities still see the data.
+            var caps = await GetProfilerCapabilitiesAsync(ct);
+
+            return new DevFlowProfilerStartResponse
+            {
+                Session = session,
+                Capabilities = caps,
+            };
+        }
+        catch { return null; }
     }
 
     public async Task<DevFlowProfilerStopResponse?> StopProfilerAsync(CancellationToken ct = default)
     {
-        return await PostAsync<DevFlowProfilerStopResponse>("/api/profiler/stop", new { }, ct);
+        var sessionId = _currentProfilerSessionId;
+        if (string.IsNullOrEmpty(sessionId)) return null;
+
+        try
+        {
+            var response = await _http.DeleteAsync($"{BaseUrl}/api/v1/profiler/sessions/{Uri.EscapeDataString(sessionId)}", ct);
+            if (!response.IsSuccessStatusCode) return null;
+
+            DevFlowProfilerSessionInfo? session = null;
+            var responseBody = await response.Content.ReadAsStringAsync(ct);
+            if (!string.IsNullOrWhiteSpace(responseBody))
+            {
+                try
+                {
+                    session = JsonSerializer.Deserialize<DevFlowProfilerSessionInfo>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                }
+                catch { }
+            }
+
+            _currentProfilerSessionId = null;
+
+            return new DevFlowProfilerStopResponse
+            {
+                Session = session ?? new DevFlowProfilerSessionInfo { SessionId = sessionId, IsActive = false },
+                StoppedAtUtc = DateTimeOffset.UtcNow,
+            };
+        }
+        catch { return null; }
     }
 
     public async Task<DevFlowProfilerBatch?> GetProfilerSamplesAsync(
@@ -203,8 +332,11 @@ public class DevFlowAgentClient : IDisposable
         int limit = 200,
         CancellationToken ct = default)
     {
+        var sessionId = _currentProfilerSessionId;
+        if (string.IsNullOrEmpty(sessionId)) return null;
+
         var safeLimit = Math.Clamp(limit, 1, 5000);
-        var url = $"/api/profiler/samples?sampleCursor={sampleCursor}&markerCursor={markerCursor}&spanCursor={spanCursor}&limit={safeLimit}";
+        var url = $"/api/v1/profiler/sessions/{Uri.EscapeDataString(sessionId)}/samples?sampleCursor={sampleCursor}&markerCursor={markerCursor}&spanCursor={spanCursor}&limit={safeLimit}";
         return await GetAsync<DevFlowProfilerBatch>(url, ct);
     }
 
@@ -216,7 +348,7 @@ public class DevFlowAgentClient : IDisposable
     {
         limit = Math.Clamp(limit, 1, 200);
         minDurationMs = Math.Clamp(minDurationMs, 0, 60_000);
-        var url = $"/api/profiler/hotspots?limit={limit}&minDurationMs={minDurationMs}";
+        var url = $"/api/v1/profiler/hotspots?limit={limit}&minDurationMs={minDurationMs}";
         if (!string.IsNullOrWhiteSpace(kind))
             url += $"&kind={Uri.EscapeDataString(kind)}";
         return await GetAsync<List<DevFlowProfilerHotspot>>(url, ct) ?? new();
@@ -231,7 +363,7 @@ public class DevFlowAgentClient : IDisposable
         if (string.IsNullOrWhiteSpace(name))
             return false;
 
-        return await PostActionAsync("/api/profiler/marker", new { name, type, payloadJson }, ct);
+        return await PostActionAsync("/api/v1/profiler/markers", new { name, type, payloadJson }, ct);
     }
 
     // --- CDP ---
@@ -251,7 +383,7 @@ public class DevFlowAgentClient : IDisposable
 
             var json = JsonSerializer.Serialize(bodyObj);
             var content = new StringContent(json, Encoding.UTF8, "application/json");
-            var response = await _http.PostAsync($"{BaseUrl}/api/cdp", content, ct);
+            var response = await _http.PostAsync($"{BaseUrl}/api/v1/webview/evaluate", content, ct);
             var responseBody = await response.Content.ReadAsStringAsync(ct);
             return JsonSerializer.Deserialize<CdpResponse>(responseBody);
         }
@@ -260,26 +392,26 @@ public class DevFlowAgentClient : IDisposable
 
     public async Task<List<CdpTarget>> GetCdpTargetsAsync(CancellationToken ct = default)
     {
-        return await GetAsync<List<CdpTarget>>("/api/cdp/targets", ct) ?? new();
+        return await GetAsync<List<CdpTarget>>("/api/v1/webview/contexts", ct) ?? new();
     }
 
     // --- Network ---
 
     public async Task<List<DevFlowNetworkRequest>> GetNetworkRequestsAsync(CancellationToken ct = default)
     {
-        return await GetAsync<List<DevFlowNetworkRequest>>("/api/network", ct) ?? new();
+        return await GetAsync<List<DevFlowNetworkRequest>>("/api/v1/network/requests", ct) ?? new();
     }
 
     public async Task<DevFlowNetworkRequest?> GetNetworkRequestDetailAsync(string id, CancellationToken ct = default)
     {
-        return await GetAsync<DevFlowNetworkRequest>($"/api/network/{Uri.EscapeDataString(id)}", ct);
+        return await GetAsync<DevFlowNetworkRequest>($"/api/v1/network/requests/{Uri.EscapeDataString(id)}", ct);
     }
 
     public async Task<bool> ClearNetworkRequestsAsync(CancellationToken ct = default)
     {
         try
         {
-            var response = await _http.PostAsync($"{BaseUrl}/api/network/clear", null, ct);
+            var response = await _http.DeleteAsync($"{BaseUrl}/api/v1/network/requests", ct);
             return response.IsSuccessStatusCode;
         }
         catch { return false; }
@@ -301,7 +433,7 @@ public class DevFlowAgentClient : IDisposable
 
         try
         {
-            var wsUrl = $"ws://{AgentHost}:{AgentPort}/ws/network";
+            var wsUrl = $"ws://{AgentHost}:{AgentPort}/ws/v1/network";
             await _networkWs.ConnectAsync(new Uri(wsUrl), token);
 
             var buffer = new byte[64 * 1024];
@@ -371,7 +503,7 @@ public class DevFlowAgentClient : IDisposable
             if (source != null) parts.Add($"source={Uri.EscapeDataString(source)}");
             parts.Add($"replay={replay}");
             var query = string.Join("&", parts);
-            var wsUrl = $"ws://{AgentHost}:{AgentPort}/ws/logs?{query}";
+            var wsUrl = $"ws://{AgentHost}:{AgentPort}/ws/v1/logs?{query}";
             await _logsWs.ConnectAsync(new Uri(wsUrl), token);
 
             var buffer = new byte[64 * 1024];
@@ -431,41 +563,41 @@ public class DevFlowAgentClient : IDisposable
     // --- Platform Info ---
 
     public async Task<DevFlowAppInfo?> GetAppInfoAsync(CancellationToken ct = default)
-        => await GetAsync<DevFlowAppInfo>("/api/platform/app-info", ct);
+        => await GetAsync<DevFlowAppInfo>("/api/v1/device/app", ct);
 
     public async Task<DevFlowDeviceInfo?> GetDeviceInfoAsync(CancellationToken ct = default)
-        => await GetAsync<DevFlowDeviceInfo>("/api/platform/device-info", ct);
+        => await GetAsync<DevFlowDeviceInfo>("/api/v1/device/info", ct);
 
     public async Task<DevFlowDisplayInfo?> GetDisplayInfoAsync(CancellationToken ct = default)
-        => await GetAsync<DevFlowDisplayInfo>("/api/platform/device-display", ct);
+        => await GetAsync<DevFlowDisplayInfo>("/api/v1/device/display", ct);
 
     public async Task<DevFlowBatteryInfo?> GetBatteryInfoAsync(CancellationToken ct = default)
-        => await GetAsync<DevFlowBatteryInfo>("/api/platform/battery", ct);
+        => await GetAsync<DevFlowBatteryInfo>("/api/v1/device/battery", ct);
 
     public async Task<DevFlowConnectivityInfo?> GetConnectivityAsync(CancellationToken ct = default)
-        => await GetAsync<DevFlowConnectivityInfo>("/api/platform/connectivity", ct);
+        => await GetAsync<DevFlowConnectivityInfo>("/api/v1/device/connectivity", ct);
 
     public async Task<DevFlowVersionTracking?> GetVersionTrackingAsync(CancellationToken ct = default)
-        => await GetAsync<DevFlowVersionTracking>("/api/platform/version-tracking", ct);
+        => await GetAsync<DevFlowVersionTracking>("/api/v1/device/version-tracking", ct);
 
     public async Task<List<DevFlowPermissionStatus>> GetPermissionsAsync(CancellationToken ct = default)
     {
-        var result = await GetAsync<DevFlowPermissionsResponse>("/api/platform/permissions", ct);
+        var result = await GetAsync<DevFlowPermissionsResponse>("/api/v1/device/permissions", ct);
         return result?.Permissions ?? new();
     }
 
     public async Task<DevFlowPermissionStatus?> CheckPermissionAsync(string permission, CancellationToken ct = default)
-        => await GetAsync<DevFlowPermissionStatus>($"/api/platform/permissions/{Uri.EscapeDataString(permission)}", ct);
+        => await GetAsync<DevFlowPermissionStatus>($"/api/v1/device/permissions/{Uri.EscapeDataString(permission)}", ct);
 
     public async Task<DevFlowGeolocation?> GetGeolocationAsync(string accuracy = "Medium", int timeoutSeconds = 10, CancellationToken ct = default)
-        => await GetAsync<DevFlowGeolocation>($"/api/platform/geolocation?accuracy={Uri.EscapeDataString(accuracy)}&timeout={timeoutSeconds}", ct);
+        => await GetAsync<DevFlowGeolocation>($"/api/v1/device/geolocation?accuracy={Uri.EscapeDataString(accuracy)}&timeout={timeoutSeconds}", ct);
 
     // --- Preferences ---
 
     public async Task<List<DevFlowPreferenceEntry>> GetPreferencesAsync(string? sharedName = null, CancellationToken ct = default)
     {
         var query = sharedName != null ? $"?sharedName={Uri.EscapeDataString(sharedName)}" : "";
-        var result = await GetAsync<DevFlowPreferencesListResponse>($"/api/preferences{query}", ct);
+        var result = await GetAsync<DevFlowPreferencesListResponse>($"/api/v1/storage/preferences{query}", ct);
         return result?.Keys ?? new();
     }
 
@@ -473,20 +605,20 @@ public class DevFlowAgentClient : IDisposable
     {
         var query = $"?type={Uri.EscapeDataString(type)}";
         if (sharedName != null) query += $"&sharedName={Uri.EscapeDataString(sharedName)}";
-        return await GetAsync<DevFlowPreferenceEntry>($"/api/preferences/{Uri.EscapeDataString(key)}{query}", ct);
+        return await GetAsync<DevFlowPreferenceEntry>($"/api/v1/storage/preferences/{Uri.EscapeDataString(key)}{query}", ct);
     }
 
     public async Task<bool> SetPreferenceAsync(string key, object? value, string? type = null, string? sharedName = null, CancellationToken ct = default)
     {
         var body = new DevFlowPreferenceSetRequest { Value = value, Type = type ?? "string", SharedName = sharedName };
-        var result = await PostAsync<DevFlowPreferenceEntry>($"/api/preferences/{Uri.EscapeDataString(key)}", body, ct);
+        var result = await PostAsync<DevFlowPreferenceEntry>($"/api/v1/storage/preferences/{Uri.EscapeDataString(key)}", body, ct);
         return result != null;
     }
 
     public async Task<bool> DeletePreferenceAsync(string key, string? sharedName = null, CancellationToken ct = default)
     {
         var query = sharedName != null ? $"?sharedName={Uri.EscapeDataString(sharedName)}" : "";
-        return await DeleteAsync($"/api/preferences/{Uri.EscapeDataString(key)}{query}", ct);
+        return await DeleteAsync($"/api/v1/storage/preferences/{Uri.EscapeDataString(key)}{query}", ct);
     }
 
     public async Task<bool> ClearPreferencesAsync(string? sharedName = null, CancellationToken ct = default)
@@ -494,7 +626,8 @@ public class DevFlowAgentClient : IDisposable
         var query = sharedName != null ? $"?sharedName={Uri.EscapeDataString(sharedName)}" : "";
         try
         {
-            var response = await _http.PostAsync($"{BaseUrl}/api/preferences/clear{query}", null, ct);
+            // v1 uses DELETE on the collection to clear it.
+            var response = await _http.DeleteAsync($"{BaseUrl}/api/v1/storage/preferences{query}", ct);
             return response.IsSuccessStatusCode;
         }
         catch { return false; }
@@ -503,23 +636,23 @@ public class DevFlowAgentClient : IDisposable
     // --- Secure Storage ---
 
     public async Task<DevFlowSecureStorageEntry?> GetSecureStorageAsync(string key, CancellationToken ct = default)
-        => await GetAsync<DevFlowSecureStorageEntry>($"/api/secure-storage/{Uri.EscapeDataString(key)}", ct);
+        => await GetAsync<DevFlowSecureStorageEntry>($"/api/v1/storage/secure/{Uri.EscapeDataString(key)}", ct);
 
     public async Task<bool> SetSecureStorageAsync(string key, string value, CancellationToken ct = default)
     {
         var body = new { value };
-        var result = await PostAsync<DevFlowSecureStorageEntry>($"/api/secure-storage/{Uri.EscapeDataString(key)}", body, ct);
+        var result = await PostAsync<DevFlowSecureStorageEntry>($"/api/v1/storage/secure/{Uri.EscapeDataString(key)}", body, ct);
         return result != null;
     }
 
     public async Task<bool> DeleteSecureStorageAsync(string key, CancellationToken ct = default)
-        => await DeleteAsync($"/api/secure-storage/{Uri.EscapeDataString(key)}", ct);
+        => await DeleteAsync($"/api/v1/storage/secure/{Uri.EscapeDataString(key)}", ct);
 
     public async Task<bool> ClearSecureStorageAsync(CancellationToken ct = default)
     {
         try
         {
-            var response = await _http.PostAsync($"{BaseUrl}/api/secure-storage/clear", null, ct);
+            var response = await _http.DeleteAsync($"{BaseUrl}/api/v1/storage/secure", ct);
             return response.IsSuccessStatusCode;
         }
         catch { return false; }
@@ -528,13 +661,13 @@ public class DevFlowAgentClient : IDisposable
     // --- Sensors ---
 
     public async Task<List<DevFlowSensorStatus>> GetSensorsAsync(CancellationToken ct = default)
-        => await GetAsync<List<DevFlowSensorStatus>>("/api/sensors", ct) ?? new();
+        => await GetAsync<List<DevFlowSensorStatus>>("/api/v1/device/sensors", ct) ?? new();
 
     public async Task<bool> StartSensorAsync(string sensor, string speed = "UI", CancellationToken ct = default)
     {
         try
         {
-            var response = await _http.PostAsync($"{BaseUrl}/api/sensors/{Uri.EscapeDataString(sensor)}/start?speed={Uri.EscapeDataString(speed)}", null, ct);
+            var response = await _http.PostAsync($"{BaseUrl}/api/v1/device/sensors/{Uri.EscapeDataString(sensor)}/start?speed={Uri.EscapeDataString(speed)}", null, ct);
             return response.IsSuccessStatusCode;
         }
         catch { return false; }
@@ -544,7 +677,7 @@ public class DevFlowAgentClient : IDisposable
     {
         try
         {
-            var response = await _http.PostAsync($"{BaseUrl}/api/sensors/{Uri.EscapeDataString(sensor)}/stop", null, ct);
+            var response = await _http.PostAsync($"{BaseUrl}/api/v1/device/sensors/{Uri.EscapeDataString(sensor)}/stop", null, ct);
             return response.IsSuccessStatusCode;
         }
         catch { return false; }
@@ -561,7 +694,7 @@ public class DevFlowAgentClient : IDisposable
         var token = cts.Token;
         try
         {
-            var wsUrl = $"ws://{AgentHost}:{AgentPort}/ws/sensors?sensor={Uri.EscapeDataString(sensor)}&speed={Uri.EscapeDataString(speed)}&throttleMs={throttleMs}";
+            var wsUrl = $"ws://{AgentHost}:{AgentPort}/ws/v1/sensors?sensor={Uri.EscapeDataString(sensor)}&speed={Uri.EscapeDataString(speed)}&throttleMs={throttleMs}";
             await ws.ConnectAsync(new Uri(wsUrl), token);
 
             var buffer = new byte[16 * 1024];

--- a/src/MauiSherpa.MacOS/MauiSherpa.MacOS.csproj
+++ b/src/MauiSherpa.MacOS/MauiSherpa.MacOS.csproj
@@ -68,6 +68,12 @@
     <BundleResource Include="Resources\ghcp_icon_white.png" />
   </ItemGroup>
 
+  <!-- Inject required Info.plist privacy usage descriptions (e.g. Bluetooth for the
+       MAUI DevFlow Sensors API). Without these, macOS TCC will SIGKILL the app. -->
+  <ItemGroup>
+    <PartialAppManifest Include="Resources\PrivacyInfo.plist" />
+  </ItemGroup>
+
   <!-- Shared resources -->
   <ItemGroup>
     <MauiIcon Include="..\MauiSherpa\Resources\AppIcon\appicon.png" />

--- a/src/MauiSherpa.MacOS/Resources/PrivacyInfo.plist
+++ b/src/MauiSherpa.MacOS/Resources/PrivacyInfo.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSBluetoothAlwaysUsageDescription</key>
+    <string>MAUI Sherpa uses Bluetooth to inspect Bluetooth sensors on connected devices via the MAUI DevFlow agent.</string>
+    <key>NSBluetoothPeripheralUsageDescription</key>
+    <string>MAUI Sherpa uses Bluetooth to inspect Bluetooth sensors on connected devices via the MAUI DevFlow agent.</string>
+    <key>NSLocalNetworkUsageDescription</key>
+    <string>MAUI Sherpa connects to MAUI DevFlow and Ailoha agents running on your local network to inspect MAUI apps.</string>
+</dict>
+</plist>

--- a/src/MauiSherpa/Pages/DevFlow.razor
+++ b/src/MauiSherpa/Pages/DevFlow.razor
@@ -34,7 +34,7 @@
         }
         else if (brokerConnected == false)
         {
-            <span class="status-badge status-disconnected"><i class="fas fa-circle"></i> Broker not reachable at @brokerHost:@brokerPort</span>
+            <span class="status-badge status-disconnected"><i class="fas fa-circle"></i> No broker reachable on @brokerHost (tried @brokerPort, 19223, 19323)</span>
         }
     </div>
 </div>
@@ -171,12 +171,25 @@
 
         try
         {
-            var healthy = await DevFlowAgentClient.IsBrokerHealthyAsync(brokerHost, brokerPort);
-            brokerConnected = healthy;
+            // Probe the user-entered port plus both standard broker ports (DevFlow 19223,
+            // Ailoha 19323) so users don't have to change the field for either toolchain.
+            var portsToTry = new List<int> { brokerPort };
+            foreach (var p in DevFlowAgentClient.DefaultBrokerPorts)
+                if (!portsToTry.Contains(p)) portsToTry.Add(p);
 
-            if (healthy)
+            var probes = portsToTry
+                .Select(async port => (port, healthy: await DevFlowAgentClient.IsBrokerHealthyAsync(brokerHost, port)))
+                .ToList();
+            var probeResults = await Task.WhenAll(probes);
+            var healthyPorts = probeResults.Where(r => r.healthy).Select(r => r.port).ToList();
+
+            brokerConnected = healthyPorts.Count > 0;
+
+            if (healthyPorts.Count > 0)
             {
-                agents = await DevFlowAgentClient.GetBrokerAgentsAsync(brokerHost, brokerPort);
+                var agentLists = await Task.WhenAll(healthyPorts.Select(p =>
+                    DevFlowAgentClient.GetBrokerAgentsAsync(brokerHost, p)));
+                agents = agentLists.SelectMany(a => a).ToList();
 
                 // Fetch version from each agent's status endpoint (parallel)
                 var tasks = agents.Select(async agent =>

--- a/src/MauiSherpa/Pages/Inspector/DevFlowTreeTab.razor
+++ b/src/MauiSherpa/Pages/Inspector/DevFlowTreeTab.razor
@@ -42,6 +42,13 @@
                     }
                 </div>
             }
+            else if (!string.IsNullOrEmpty(screenshotError))
+            {
+                <div class="screenshot-placeholder" style="color: var(--text-error, #c0392b);">
+                    <i class="fas fa-triangle-exclamation"></i>
+                    <span>@screenshotError</span>
+                </div>
+            }
             else
             {
                 <div class="screenshot-placeholder">
@@ -269,6 +276,7 @@
     private HashSet<string> expandedNodes = new();
     private string searchQuery = "";
     private string? screenshotData;
+    private string? screenshotError;
     private bool isLoadingTree;
     private bool isLoadingProps;
     private int autoRefreshInterval;
@@ -504,12 +512,26 @@
     {
         try
         {
+            screenshotError = null;
             var bytes = await Client.GetScreenshotAsync(window: window ?? selectedWindowIndex);
             screenshotData = bytes != null ? Convert.ToBase64String(bytes) : null;
             StateHasChanged();
             await UpdateOverlayAsync();
         }
-        catch { }
+        catch (DevFlowAgentException ex)
+        {
+            screenshotData = null;
+            screenshotError = ex.StatusCode > 0
+                ? $"Agent returned {ex.StatusCode}: {ex.Message}"
+                : ex.Message;
+            StateHasChanged();
+        }
+        catch (Exception ex)
+        {
+            screenshotData = null;
+            screenshotError = $"Screenshot failed: {ex.Message}";
+            StateHasChanged();
+        }
 
         // Keep tree in sync with screenshot (avoid recursion via flag)
         if (!_syncingRefresh)


### PR DESCRIPTION
The app inspector previously only spoke the legacy MAUI DevFlow `/api/*` endpoints, so connecting to an Ailoha agent (or any modern DevFlow preview.7+ agent that only exposes `/api/v1/*`) hung at "Connecting…". This adds Ailoha support without dropping legacy DevFlow agents.

## Approach

- **Dual broker discovery** in `DevFlow.razor`: `RefreshAgents` now probes the user-entered port plus both standard broker ports in parallel (DevFlow `19223` + Ailoha `19323`) and merges the agent lists.
- **Protocol-aware `DevFlowAgentClient`**: `GetStatusAsync` probes `/api/v1/agent/status` first and falls back to `/api/status` on 404. The detected protocol is cached in `_useV1` and exposed via a new `Protocol` property + `DevFlowAgentProtocol` enum. Every endpoint dispatches through a small `V(v1Path, legacyPath)` helper.
- **Per-endpoint semantics** are handled where v1 and legacy diverge: profiler start/stop/samples (sessionId in URL vs wrapped `{session, capabilities}` response), clear endpoints (`DELETE` collection vs `POST .../clear`), and WebSocket paths (`/ws/v1/*` vs `/ws/*`).
- **Status mapping**: `ParseV1Status` flattens the v1 nested `{agent, device, app}` shape into the existing `DevFlowAgentStatus` model so the inspector tabs don't change.

## Notes for review

- I kept the dual-protocol logic inside `DevFlowAgentClient` itself rather than wiring up the existing `IAppInspectorClient` + `AppInspectorClientFactory` abstraction. The factory does the right thing, but the inspector tabs still consume concrete `DevFlow*` models, so migrating to it would require swapping all 6 tabs + both host pages over to `Inspector*` types. Captured as future work.
- WS message envelopes and v1 response shapes for tree/network/sensors are assumed to match legacy because v1 is mostly a URL refactor of the same handlers. Highly likely correct but only confirmed by runtime testing.
- Tested that the build is clean (`dotnet build src/MauiSherpa -f net10.0-maccatalyst` -> 0 errors). Live agent validation against both DevFlow preview.7 and Ailoha is the next step.