### PR TITLE
Package sherpa-inspector as a dotnet tool

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,11 +53,13 @@ jobs:
         run: |
           dotnet build tests/MauiSherpa.Core.Tests --configuration Release
           dotnet build tests/MauiSherpa.Workloads.Tests --configuration Release
+          dotnet build tests/MauiSherpa.AppInspector.Cli.Tests --configuration Release
 
       - name: Run tests
         run: |
           dotnet test tests/MauiSherpa.Core.Tests --configuration Release --no-build --verbosity normal --logger "trx;LogFileName=test-results.trx"
           dotnet test tests/MauiSherpa.Workloads.Tests --configuration Release --no-build --verbosity normal --logger "trx;LogFileName=test-results.trx"
+          dotnet test tests/MauiSherpa.AppInspector.Cli.Tests --configuration Release --no-build --verbosity normal --logger "trx;LogFileName=test-results.trx"
 
       - name: Upload test results
         uses: actions/upload-artifact@v4
@@ -683,6 +685,90 @@ jobs:
             -f description="$DESC" \
             -f context="MAUI Sherpa / Download Linux App (${{ matrix.arch }})"
 
+  publish-inspector-tool:
+    name: Publish Inspector Tool
+    runs-on: ubuntu-latest
+    needs: build-test
+    if: >-
+      github.event_name == 'push'
+      || (github.event_name == 'workflow_dispatch' && inputs.publish_artifacts)
+      || (github.event_name == 'pull_request' && (
+        contains(github.event.pull_request.labels.*.name, 'build-artifacts')
+        || contains(github.event.pull_request.labels.*.name, 'build-artifacts-notarized')))
+    permissions:
+      contents: read
+      statuses: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Determine version
+        id: version
+        run: |
+          SHA="${GITHUB_SHA::8}"
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            VER="${GITHUB_REF#refs/tags/v}"
+          else
+            VER=$(grep '<AppVersion>' Directory.Build.props | sed 's/.*<AppVersion>\(.*\)<\/AppVersion>.*/\1/')
+          fi
+          echo "app_version=$VER" >> $GITHUB_OUTPUT
+          echo "commit_sha=$SHA" >> $GITHUB_OUTPUT
+          echo "Version: $VER+$SHA"
+
+      - name: Pack sherpa-inspector dotnet tool
+        run: |
+          dotnet pack src/MauiSherpa.AppInspector.Cli/Sherpa.AppInspector.Cli.csproj \
+            -c Release \
+            -p:AppVersion=${{ steps.version.outputs.app_version }} \
+            -p:AppCommitSha=${{ steps.version.outputs.commit_sha }} \
+            -o ./artifacts/nuget
+
+      - name: Upload sherpa-inspector NuGet package
+        uses: actions/upload-artifact@v4
+        with:
+          name: sherpa-inspector-dotnet-tool
+          path: ./artifacts/nuget/*.nupkg
+          retention-days: 30
+
+      - name: Publish sherpa-inspector to NuGet.org
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: |
+          if [ -z "$NUGET_API_KEY" ]; then
+            echo "::error::NUGET_API_KEY secret is required to publish sherpa-inspector"
+            exit 1
+          fi
+          dotnet nuget push "./artifacts/nuget/*.nupkg" \
+            --api-key "$NUGET_API_KEY" \
+            --source https://api.nuget.org/v3/index.json \
+            --skip-duplicate
+
+      - name: Set commit status with package link
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ARTIFACT_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          if compgen -G "./artifacts/nuget/*.nupkg" > /dev/null; then
+            STATE="success"
+            DESC="sherpa-inspector dotnet tool package built"
+          else
+            STATE="failure"
+            DESC="sherpa-inspector dotnet tool package failed"
+          fi
+          gh api repos/${{ github.repository }}/statuses/${{ github.sha }} \
+            -f state="$STATE" \
+            -f target_url="$ARTIFACT_URL" \
+            -f description="$DESC" \
+            -f context="MAUI Sherpa / sherpa-inspector Tool"
+
   notarize-macos:
     name: Notarize macOS App
     runs-on: macos-26
@@ -812,7 +898,7 @@ jobs:
   create-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: [notarize-macos, publish-windows, publish-linux]
+    needs: [notarize-macos, publish-windows, publish-linux, publish-inspector-tool]
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write
@@ -884,6 +970,12 @@ jobs:
           name: MAUI-Sherpa.linux-flatpak-arm64
           path: ./release
 
+      - name: Download sherpa-inspector dotnet tool package
+        uses: actions/download-artifact@v4
+        with:
+          name: sherpa-inspector-dotnet-tool
+          path: ./release
+
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
@@ -896,6 +988,7 @@ jobs:
             ./release/*.deb
             ./release/*.AppImage
             ./release/*.flatpak
+            ./release/*.nupkg
           generate_release_notes: false
           draft: false
           prerelease: ${{ contains(github.ref, '-') }}

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ MAUI Sherpa is a desktop application for **macOS**, **Windows**, and **Linux** t
 - Application log streaming (native + WebView)
 - Blazor WebView DOM inspection via CDP
 - Live property editing (colors, sizes, brushes)
-- Self-contained `sherpa-inspector` executable for embedding the inspector in external WebViews ([website](website/appinspector.html), [docs](docs/app-inspector-cli.md))
+- `sherpa-inspector` dotnet tool package and self-contained executable for embedding the inspector in external WebViews ([website](website/appinspector.html), [docs](docs/app-inspector-cli.md))
 
 ### 📋 Publish Profiles
 - Bundle Apple + Android signing configs into reusable profiles

--- a/docs/app-inspector-cli.md
+++ b/docs/app-inspector-cli.md
@@ -2,7 +2,15 @@
 
 `sherpa-inspector` hosts only the MAUI Sherpa app inspector as a local web app. It is intended for host applications that want to start an inspector process and point an embedded WebView at the emitted URL.
 
-The primary distribution is a self-contained executable per platform/runtime identifier, so the host machine does not need the .NET runtime installed.
+The primary distribution is a .NET global tool NuGet package. Self-contained runtime-specific executables can still be published when a host app needs to bundle the inspector and avoid a .NET runtime dependency.
+
+## Install
+
+```bash
+dotnet tool install --global Sherpa.AppInspector.Cli
+```
+
+The installed command is `sherpa-inspector`.
 
 ## Usage
 
@@ -65,6 +73,26 @@ The server binds to loopback by default and generates a per-run token. The emitt
 Use `--listen-host` only when the caller intentionally wants a different bind address. The inspector can interact with the target app, so exposing it off-machine is not recommended.
 
 ## Distribution
+
+CI builds `Sherpa.AppInspector.Cli.<version>.nupkg` as a dotnet tool package, uploads it as a workflow artifact, attaches it to tagged GitHub releases, and publishes it to NuGet.org from `v*` tag builds.
+
+Pack the tool locally with:
+
+```bash
+dotnet pack src/MauiSherpa.AppInspector.Cli/Sherpa.AppInspector.Cli.csproj \
+  -c Release \
+  -o artifacts/nuget
+```
+
+Install a local package for testing with:
+
+```bash
+dotnet tool install --tool-path ./.tools/sherpa-inspector \
+  --add-source artifacts/nuget \
+  Sherpa.AppInspector.Cli
+```
+
+### Self-contained executable
 
 Publish self-contained artifacts with a runtime identifier:
 

--- a/src/MauiSherpa.AppInspector.Cli/Sherpa.AppInspector.Cli.csproj
+++ b/src/MauiSherpa.AppInspector.Cli/Sherpa.AppInspector.Cli.csproj
@@ -7,9 +7,19 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Sherpa.AppInspector.Cli</RootNamespace>
     <AssemblyName>sherpa-inspector</AssemblyName>
+
+    <PackAsTool>true</PackAsTool>
+    <IsPackable>true</IsPackable>
+    <ToolCommandName>sherpa-inspector</ToolCommandName>
     <PackageId>Sherpa.AppInspector.Cli</PackageId>
-    <PackageDescription>Self-contained MAUI Sherpa app inspector host for local WebView embedding.</PackageDescription>
+    <PackageDescription>Dotnet tool that hosts the MAUI Sherpa app inspector for local WebView embedding.</PackageDescription>
+    <PackageTags>maui;sherpa;app-inspector;devflow;dotnet-tool;blazor;webview</PackageTags>
+    <Authors>MauiSherpa Contributors</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageProjectUrl>https://github.com/Redth/MAUI.Sherpa/blob/main/docs/app-inspector-cli.md</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/Redth/MAUI.Sherpa</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
     <Version>$(AppVersion)</Version>
 
     <SelfContained Condition="'$(RuntimeIdentifier)' != ''">true</SelfContained>
@@ -20,6 +30,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="../../docs/app-inspector-cli.md" Pack="true" PackagePath="README.md" />
     <InternalsVisibleTo Include="Sherpa.AppInspector.Cli.Tests" />
   </ItemGroup>
 

--- a/website/appinspector.html
+++ b/website/appinspector.html
@@ -96,28 +96,24 @@
             <div class="section-header reveal">
                 <h2 class="text-h2">Install and package</h2>
                 <p class="section-header__desc">
-                    The recommended distribution is a self-contained executable built for each desktop runtime identifier.
+                    The recommended distribution is the <code>Sherpa.AppInspector.Cli</code> dotnet tool NuGet package. Self-contained executables are still available for hosts that need to bundle the inspector.
                 </p>
             </div>
 
             <div class="steps reveal">
                 <div class="step">
-                    <h3 class="step__title">Publish a runtime-specific executable</h3>
+                    <h3 class="step__title">Install the dotnet tool</h3>
                     <div class="step__content">
-                        <p>Publish from the repository using the desired runtime identifier. The output binary is named <code>sherpa-inspector</code> on macOS/Linux and <code>sherpa-inspector.exe</code> on Windows.</p>
+                        <p>Install from NuGet.org. The package ID is <code>Sherpa.AppInspector.Cli</code> and the installed command is <code>sherpa-inspector</code>.</p>
                         <div class="code-block">
                             <div class="code-block__header">
                                 <span class="code-block__lang">Terminal</span>
                                 <button class="code-block__copy">Copy</button>
                             </div>
-                            <pre><code><span class="token-command">dotnet</span> <span class="token-function">publish</span> <span class="token-param">src/MauiSherpa.AppInspector.Cli/Sherpa.AppInspector.Cli.csproj</span> \
-  <span class="token-flag">-c</span> <span class="token-param">Release</span> \
-  <span class="token-flag">-r</span> <span class="token-param">osx-arm64</span> \
-  <span class="token-flag">--self-contained</span> <span class="token-param">true</span> \
-  <span class="token-param">/p:PublishSingleFile=true</span></code></pre>
+                            <pre><code><span class="token-command">dotnet</span> <span class="token-function">tool install</span> <span class="token-flag">--global</span> <span class="token-param">Sherpa.AppInspector.Cli</span></code></pre>
                         </div>
                         <p style="color: var(--ink-secondary); margin-top: var(--space-4);">
-                            Build separate artifacts for <code>osx-arm64</code>, <code>osx-x64</code>, <code>win-x64</code>, <code>win-arm64</code>, <code>linux-x64</code>, or <code>linux-arm64</code> as needed.
+                            Tagged CI builds publish the package to NuGet.org and attach the <code>.nupkg</code> to the GitHub release.
                         </p>
                     </div>
                 </div>
@@ -125,7 +121,7 @@
                 <div class="step">
                     <h3 class="step__title">Bundle with your host app</h3>
                     <div class="step__content">
-                        <p>Include the executable next to your host app or inside your app bundle. At runtime, start it as a child process, read stdout until the <code>INSPECTOR_READY</code> line appears, parse the JSON, then navigate your WebView to <code>url</code>.</p>
+                        <p>Start <code>sherpa-inspector</code> from the tool path, or include a self-contained publish next to your host app. At runtime, read stdout until the <code>INSPECTOR_READY</code> line appears, parse the JSON, then navigate your WebView to <code>url</code>.</p>
                     </div>
                 </div>
             </div>

--- a/website/appinspector.html
+++ b/website/appinspector.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>AppInspector CLI — MAUI Sherpa</title>
-    <meta name="description" content="Install and use sherpa-inspector, the self-contained AppInspector CLI for hosting the MAUI Sherpa inspector in any local WebView.">
+    <meta name="description" content="Install and use sherpa-inspector, the dotnet tool for hosting the MAUI Sherpa inspector in any local WebView.">
     <link rel="icon" type="image/png" href="images/maui.sherpa.logo.png">
     <link rel="stylesheet" href="css/styles.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous">
@@ -42,7 +42,7 @@
                 AppInspector CLI
             </h1>
             <p class="page-header__desc">
-                Host the Sherpa app inspector as a self-contained local web server, then embed it in any desktop WebView or browser.
+                Install the Sherpa app inspector as a dotnet tool, start a local web server, then embed it in any desktop WebView or browser.
             </p>
             <div style="display: flex; gap: var(--space-4); flex-wrap: wrap; margin-top: var(--space-8); justify-content: center;">
                 <a href="#install" class="btn btn--primary">
@@ -69,8 +69,8 @@
                         <div class="feature-card__icon feature-card__icon--purple" style="width: 36px; height: 36px; font-size: 1rem; margin-bottom: var(--space-3);">
                             <i class="fas fa-box"></i>
                         </div>
-                        <strong>Self-contained</strong>
-                        <p style="font-size: 0.85rem; color: var(--ink-tertiary); margin-top: var(--space-2);">Ship a platform executable without requiring users to install a .NET runtime.</p>
+                        <strong>NuGet-distributed</strong>
+                        <p style="font-size: 0.85rem; color: var(--ink-tertiary); margin-top: var(--space-2);">Install from NuGet.org as a global or app-local dotnet tool.</p>
                     </div>
                     <div class="feature-card" style="padding: var(--space-5);">
                         <div class="feature-card__icon feature-card__icon--blue" style="width: 36px; height: 36px; font-size: 1rem; margin-bottom: var(--space-3);">
@@ -96,7 +96,7 @@
             <div class="section-header reveal">
                 <h2 class="text-h2">Install and package</h2>
                 <p class="section-header__desc">
-                    The recommended distribution is the <code>Sherpa.AppInspector.Cli</code> dotnet tool NuGet package. Self-contained executables are still available for hosts that need to bundle the inspector.
+                    The recommended distribution is the <code>Sherpa.AppInspector.Cli</code> dotnet tool NuGet package.
                 </p>
             </div>
 
@@ -119,9 +119,19 @@
                 </div>
 
                 <div class="step">
-                    <h3 class="step__title">Bundle with your host app</h3>
+                    <h3 class="step__title">Install app-local for an embedding host</h3>
                     <div class="step__content">
-                        <p>Start <code>sherpa-inspector</code> from the tool path, or include a self-contained publish next to your host app. At runtime, read stdout until the <code>INSPECTOR_READY</code> line appears, parse the JSON, then navigate your WebView to <code>url</code>.</p>
+                        <p>Use a tool-path install when a host application wants to control exactly where the executable lives.</p>
+                        <div class="code-block">
+                            <div class="code-block__header">
+                                <span class="code-block__lang">Terminal</span>
+                                <button class="code-block__copy">Copy</button>
+                            </div>
+                            <pre><code><span class="token-command">dotnet</span> <span class="token-function">tool install</span> <span class="token-flag">--tool-path</span> <span class="token-param">./tools/appinspector</span> <span class="token-param">Sherpa.AppInspector.Cli</span></code></pre>
+                        </div>
+                        <p style="color: var(--ink-secondary); margin-top: var(--space-4);">
+                            At runtime, start the installed <code>sherpa-inspector</code> command as a child process, read stdout until the <code>INSPECTOR_READY</code> line appears, parse the JSON, then navigate your WebView to <code>url</code>.
+                        </p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
sherpa-inspector needs a NuGet-distributed dotnet tool package so CI can produce a stable installer path in addition to self-contained executable builds.

## Summary
- Configures `Sherpa.AppInspector.Cli` as a packable dotnet tool with the `sherpa-inspector` command, NuGet metadata, and packaged README.
- Adds AppInspector CLI tests to the main build/test workflow.
- Adds a `publish-inspector-tool` CI job that packs the `.nupkg`, uploads it as an artifact, publishes to NuGet.org on `v*` tags, and includes the package in GitHub releases.
- Updates README, docs, and website guidance for `dotnet tool install --global Sherpa.AppInspector.Cli`.

## Testing
- `dotnet test tests/MauiSherpa.AppInspector.Cli.Tests/Sherpa.AppInspector.Cli.Tests.csproj --configuration Release --verbosity minimal`
- `dotnet pack src/MauiSherpa.AppInspector.Cli/Sherpa.AppInspector.Cli.csproj -c Release -o <artifact-dir>`
- `dotnet tool install --tool-path <tool-dir> --add-source <artifact-dir> --no-cache Sherpa.AppInspector.Cli --version 0.8.1`
- `<tool-dir>/sherpa-inspector --help`