### PR TITLE
Add centralized secrets vault architecture

### DIFF
--- a/docs/secrets-storage.md
+++ b/docs/secrets-storage.md
@@ -8,7 +8,7 @@ MAUI Sherpa stores credentials, signing material, provider configuration, and ap
 | --- | --- | --- | --- |
 | SQLCipher root key | `ILocalVaultKeyStore`, `LocalSecretsKeyStore` | Local vault encryption key | OS secure storage entry `MAUI Sherpa Local Vault`. This is the only long-term OS secure-storage dependency for migrated app-owned data. |
 | Central local vault | `ILocalVaultStore`, `SqlCipherLocalVaultStore` | Generic app-owned secrets, metadata, settings, and provider data | Shiny DocumentDB over SQLCipher in `local-vault.db`. Records use a generic scope/path/key envelope. |
-| Local secrets provider | `LocalSqlCipherSecretsProvider` | Managed secrets, local copies of synced certs/keystores, publish profile payloads | Built-in default provider and logical provider view over the central local vault under `local-provider-secret`. It is always present in Settings so users can switch back to local-only storage while leaving cloud providers configured. Existing flat keys are preserved in metadata for compatibility. |
+| Local secrets provider | `LocalSqlCipherSecretsProvider` | Managed secrets, local copies of synced certs/keystores, publish profile payloads | Built-in provider and logical provider view over the central local vault under `local-provider-secret`. It is created and offered as a default only after the user opts in to the Local Vault introduction. Existing flat keys are preserved in metadata for compatibility. |
 | Legacy Local provider DB | first-pass `local-secrets.db` | Local-provider secret values | Lazily migrated into the central vault on Local provider use, then deleted after successful verification/write. |
 | Secure-storage compatibility | `VaultSecureStorageService` | Existing app-owned key/value secrets | Reads/writes the central vault under `secure`. On first read, legacy OS/fallback secure-storage values are copied into the vault and removed from the old store. |
 | Encrypted settings | `EncryptedSettingsService` | Settings snapshots that may include sensitive config | Vault-backed settings document under `settings`. Existing `settings.enc`, `.bak`, `.unreadable`, and `MauiSherpa_MasterKey` are removed after successful migration. |
@@ -55,6 +55,22 @@ flowchart LR
     Vault --> KeyStore[ILocalVaultKeyStore]
     KeyStore --> OS[OS secure storage: MAUI Sherpa Local Vault]
 ```
+
+## First-run Local Vault introduction
+
+The app does not create or activate the Local provider until the user has seen the Local Vault introduction and explicitly enables it. `ILocalVaultIntroductionService` persists the current introduction version and decision in preferences:
+
+- `NotSet`: the current introduction has not been answered. The app shows the introduction on startup and treats Local Vault as disabled.
+- `Enabled`: the user approved Local Vault. Sherpa may request OS secure-storage access for the root key, create the built-in Local provider, migrate legacy local values into the vault, and make Local the default provider when requested.
+- `Declined`: the user chose not to use Local Vault for now. Sherpa does not show the introduction repeatedly and does not auto-create or auto-select Local.
+
+While the decision is `NotSet` or `Declined`, compatibility adapters intentionally stay on legacy storage:
+
+- `VaultSecureStorageService` reads and writes the legacy `ILegacySecureStorageService` instead of touching `ILocalVaultStore`.
+- `EncryptedSettingsService` reads and writes `settings.enc` instead of opening the vault.
+- `CloudSecretsService` stores provider metadata/settings in the legacy JSON files, hides Local from provider lists, and chooses a remote provider as the implicit default if one exists.
+
+The startup flow shows the Local Vault introduction before update prompts, and the modal's enable action calls `ILocalVaultAccessService.RequestAccessAsync()` before marking Local Vault as enabled. If the OS secure-storage prompt is denied or unavailable, Sherpa leaves the decision unset so the user can retry or decline without leaving a half-enabled Local provider.
 
 ## Canonical secret paths
 
@@ -110,11 +126,11 @@ Sherpa-managed secrets still keep their typed metadata (`Type`, `Description`, `
 
 ## Compatibility adapters
 
-`VaultSecureStorageService` keeps the existing `ISecureStorageService` contract while changing its persistence boundary. Consumers such as Apple identities, Google identities, Firebase push, publisher config, and keystore passwords do not need immediate rewrites; their values are stored as vault records in the `secure` scope. Legacy secure-storage values are migrated on first read and deleted from the legacy store after the vault write succeeds.
+`VaultSecureStorageService` keeps the existing `ISecureStorageService` contract while changing its persistence boundary. Consumers such as Apple identities, Google identities, Firebase push, publisher config, and keystore passwords do not need immediate rewrites; after Local Vault is enabled, their values are stored as vault records in the `secure` scope. Legacy secure-storage values are migrated on first read and deleted from the legacy store after the vault write succeeds. Before Local Vault is enabled, the facade deliberately delegates to legacy secure storage so startup can run without prompting for the vault key.
 
-`EncryptedSettingsService` is also a compatibility facade. It reads the vault first, migrates an existing `settings.enc` file when needed, and writes new settings directly to the `settings` scope. After a successful migration, it deletes `settings.enc`, `settings.enc.bak`, `settings.enc.unreadable`, and the old `MauiSherpa_MasterKey`.
+`EncryptedSettingsService` is also a compatibility facade. After Local Vault is enabled, it reads the vault first, migrates an existing `settings.enc` file when needed, and writes new settings directly to the `settings` scope. After a successful migration, it deletes `settings.enc`, `settings.enc.bak`, `settings.enc.unreadable`, and the old `MauiSherpa_MasterKey`. Before Local Vault is enabled, it keeps using `settings.enc`.
 
-`CloudSecretsService` stores provider metadata and non-secret provider settings in the `cloud-provider` scope. If legacy `cloud-secrets-providers.json` or `cloud-secrets-{id}.json` files exist, they are imported into the vault and deleted after successful writes. Provider secret settings continue to use `ISecureStorageService`, which now maps them to the vault.
+`CloudSecretsService` stores provider metadata and non-secret provider settings in the `cloud-provider` scope after Local Vault is enabled. If legacy `cloud-secrets-providers.json` or `cloud-secrets-{id}.json` files exist, they are imported into the vault and deleted after successful writes. Provider secret settings continue to use `ISecureStorageService`, which maps them to the vault only after the Local Vault introduction has been enabled.
 
 ## Export/import impact
 

--- a/docs/secrets-storage.md
+++ b/docs/secrets-storage.md
@@ -89,6 +89,25 @@ Recommended mappings for Sherpa-managed keys:
 
 Remote provider migrations should rewrite Sherpa-managed legacy keys into canonical paths only after the local vault migration has completed and the provider can verify all rewritten values.
 
+## Per-secret metadata
+
+`ICloudSecretsProvider` supports arbitrary string key/value metadata for each secret through `StoreSecretAsync(..., metadata)`, `GetSecretMetadataAsync`, and `SetSecretMetadataAsync`. `ICloudSecretsService` forwards the same operations to the active provider.
+
+The metadata contract is intentionally exact: metadata keys and values are serialized as one JSON dictionary instead of spreading individual metadata keys into provider-native tag, label, or variable names. That avoids data loss in providers that restrict tag characters, force lower-case labels, or sanitize variable names.
+
+Provider mapping:
+
+| Provider | Metadata storage |
+| --- | --- |
+| Local | Inline `LocalVaultItem.Metadata` in the SQLCipher vault item. Value updates preserve existing metadata unless replacement metadata is provided. |
+| Azure Key Vault, AWS Secrets Manager, Google Secret Manager, Infisical | Reserved companion secret containing the metadata JSON. The companion name is derived from the provider's actual storage key and hidden from `ListSecretsAsync`. |
+| 1Password, Vaultwarden / Bitwarden | Reserved companion field on the same secure note/cipher item. The field is hidden from `ListSecretsAsync`. |
+| Azure DevOps variable groups | One reserved non-secret companion variable containing the metadata JSON. Legacy per-key `__meta__` variables are still cleaned up on delete. |
+
+`GetSecretMetadataAsync` returns `null` when the primary secret does not exist and an empty dictionary when the secret exists but has no metadata. `SetSecretMetadataAsync` replaces the complete metadata dictionary without changing the secret value; an empty dictionary clears the metadata companion where a companion store is used. Deleting a primary secret also attempts to remove its metadata companion.
+
+Sherpa-managed secrets still keep their typed metadata (`Type`, `Description`, `OriginalFileName`, timestamps, and arbitrary user metadata) in the existing `sherpa-secrets-meta/` JSON record. That remains the source of truth for the managed-secrets UI and avoids creating two independent metadata records for the same Sherpa-managed secret.
+
 ## Compatibility adapters
 
 `VaultSecureStorageService` keeps the existing `ISecureStorageService` contract while changing its persistence boundary. Consumers such as Apple identities, Google identities, Firebase push, publisher config, and keystore passwords do not need immediate rewrites; their values are stored as vault records in the `secure` scope. Legacy secure-storage values are migrated on first read and deleted from the legacy store after the vault write succeeds.

--- a/docs/secrets-storage.md
+++ b/docs/secrets-storage.md
@@ -1,0 +1,130 @@
+# Secrets storage architecture
+
+MAUI Sherpa stores credentials, signing material, provider configuration, and app-managed secrets. The target architecture is a single SQLCipher-backed local vault for app-owned sensitive data, with OS secure storage used only for the SQLCipher root key.
+
+## Current storage audit
+
+| Area | Code surface | Sensitive data | Current / target storage |
+| --- | --- | --- | --- |
+| SQLCipher root key | `ILocalVaultKeyStore`, `LocalSecretsKeyStore` | Local vault encryption key | OS secure storage entry `MAUI Sherpa Local Vault`. This is the only long-term OS secure-storage dependency for migrated app-owned data. |
+| Central local vault | `ILocalVaultStore`, `SqlCipherLocalVaultStore` | Generic app-owned secrets, metadata, settings, and provider data | Shiny DocumentDB over SQLCipher in `local-vault.db`. Records use a generic scope/path/key envelope. |
+| Local secrets provider | `LocalSqlCipherSecretsProvider` | Managed secrets, local copies of synced certs/keystores, publish profile payloads | Built-in default provider and logical provider view over the central local vault under `local-provider-secret`. It is always present in Settings so users can switch back to local-only storage while leaving cloud providers configured. Existing flat keys are preserved in metadata for compatibility. |
+| Legacy Local provider DB | first-pass `local-secrets.db` | Local-provider secret values | Lazily migrated into the central vault on Local provider use, then deleted after successful verification/write. |
+| Secure-storage compatibility | `VaultSecureStorageService` | Existing app-owned key/value secrets | Reads/writes the central vault under `secure`. On first read, legacy OS/fallback secure-storage values are copied into the vault and removed from the old store. |
+| Encrypted settings | `EncryptedSettingsService` | Settings snapshots that may include sensitive config | Vault-backed settings document under `settings`. Existing `settings.enc`, `.bak`, `.unreadable`, and `MauiSherpa_MasterKey` are removed after successful migration. |
+| Apple identities | `AppleIdentityService` | P8 private key content | Secret values now flow through vault-backed `ISecureStorageService`; metadata remains in `apple-identities.json` until the identity metadata adapter is migrated. |
+| Google identities | `GoogleIdentityService` | Service account JSON/private key | Secret values now flow through vault-backed `ISecureStorageService`; metadata remains in `google-identities.json` until the identity metadata adapter is migrated. |
+| Apple Developer download auth | `AppleDownloadAuthService` | Session cookies and Apple ID | Values now flow through vault-backed `ISecureStorageService`. Password is not persisted. |
+| Firebase push credentials | `FirebasePushService` | FCM service account JSON/private key | Value now flows through vault-backed `ISecureStorageService`. |
+| Android keystores | `KeystoreService`, `KeystoreSyncService` | Keystore password and keystore file | Passwords now flow through vault-backed `ISecureStorageService`; metadata remains in `android-keystores.json` until the keystore metadata adapter is migrated. User-selected keystore files remain at their file paths. |
+| Secrets provider config | `CloudSecretsService`, `CloudSecretsProviderFactory` | Client secrets, tokens, service account JSON, vault passwords | Provider metadata and non-secret settings are vault-backed under `cloud-provider`. Secret settings use vault-backed `ISecureStorageService`. Legacy JSON files are removed after migration. |
+| Managed remote secrets | `ManagedSecretsService`, `CertificateSyncService`, `KeystoreSyncService`, `PublishProfileService` | User-managed bytes, P12 payloads/passwords, JKS payloads/passwords, publish profiles | Active `ICloudSecretsService` provider. Remote providers keep remote data; Local provider stores in the central vault. |
+| Publisher config | `SecretsPublisherService` | GitHub/Gitea/GitLab/Azure DevOps PATs and publisher settings | Existing `secrets_publishers` blob now flows through vault-backed `ISecureStorageService`; a typed publisher metadata adapter can split it later. |
+| Push projects | `PushProjectService` | Device tokens, APNs config paths, payloads, send history | Legacy `push-projects.json`; planned vault adapter because operational data can be sensitive. |
+| Platform certificate/private-key stores | `LocalCertificateService`, platform APIs | Installed signing identities | Remain in macOS Keychain, Windows certificate store, or Linux user X509 store. The vault stores Sherpa metadata and Local-provider sync copies, not installed platform private-key material. |
+| Non-sensitive caches/artifacts | logs, profiling artifacts, Apple root cert cache, downloaded tools, update temp files, Copilot caches, window size/basic UI prefs | Non-secret operational data | Outside the vault unless a future feature makes the data secret-bearing. |
+
+## Local vault model
+
+The central vault is intentionally migration-light. It uses one generic document envelope rather than feature-specific SQL tables:
+
+```csharp
+public sealed class LocalVaultItem
+{
+    public string Id { get; set; } = "";
+    public string Scope { get; set; } = "";
+    public string Path { get; set; } = "/";
+    public string Key { get; set; } = "";
+    public string ContentType { get; set; } = "";
+    public byte[] Value { get; set; } = [];
+    public Dictionary<string, string> Metadata { get; set; } = new();
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}
+```
+
+`Id` is a deterministic SHA-256 hash of normalized `scope + path + key`, so callers can upsert and retrieve records without a separate index table. `Scope` separates feature domains such as `settings`, `secure`, `cloud-provider`, `local-provider-secret`, and `migration`. `Path` and `Key` provide hierarchy while allowing values to remain JSON, text, or binary.
+
+```mermaid
+flowchart LR
+    Services[Feature services] --> Vault[ILocalVaultStore]
+    SecureFacade[VaultSecureStorageService] --> Vault
+    Settings[EncryptedSettingsService] --> Vault
+    LocalProvider[Local ICloudSecretsProvider] --> Vault
+    Vault --> SqlCipher[Shiny DocumentDB SQLCipher local-vault.db]
+    Vault --> KeyStore[ILocalVaultKeyStore]
+    KeyStore --> OS[OS secure storage: MAUI Sherpa Local Vault]
+```
+
+## Canonical secret paths
+
+New path-aware code should use:
+
+```csharp
+public readonly record struct SecretPath(string FolderPath, string Key);
+```
+
+Normalization rules:
+
+- Empty or null folder paths normalize to `/`.
+- `/` is the logical separator on every platform.
+- Folder paths are normalized to leading slash, no trailing slash, and no duplicate separators.
+- `.` and `..` path segments are rejected.
+- Secret leaf keys cannot be empty or contain path separators.
+- Existing flat provider APIs remain supported by encoding a `SecretPath` as `folder/key` and decoding flat keys on the last `/`.
+
+Managed-secret folders are first-class metadata records so the UI can create and select empty folders before any secret exists in them. `ManagedSecretsService` persists those records under `sherpa-secret-folders/` while continuing to infer folders from legacy slash-delimited secret keys for backward compatibility. It also writes a hidden `sherpa-folder-marker` placeholder under the folder's own secret path so providers that only materialize folders when a child secret exists can still represent empty folders. Creating a secret no longer asks the user to type a folder path; the user creates folders with an explicit gesture and chooses an existing folder when adding the secret. Editing a secret can move it to another folder by writing the value and metadata under the new key, then deleting the old key after the new write succeeds. Existing folders can be renamed, which moves managed secrets, child folders, and folder markers under the new path, or deleted when empty.
+
+Recommended mappings for Sherpa-managed keys:
+
+| Legacy key pattern | Canonical path |
+| --- | --- |
+| `sherpa-secrets/api-key` | path `/managed`, key `api-key` |
+| `sherpa-secrets-meta/api-key` | metadata on `/managed/api-key` or companion metadata record |
+| `CERT_{serial}_P12` | path `/certificates/{serial}`, key `p12` |
+| `CERT_{serial}_PWD` | path `/certificates/{serial}`, key `password` |
+| `KEYSTORE_{alias}_JKS` | path `/keystores/{alias}`, key `jks` |
+| `KEYSTORE_{alias}_PWD` | path `/keystores/{alias}`, key `password` |
+| `sherpa-publish-profiles/{id}` | path `/publish-profiles`, key `{id}` |
+
+Remote provider migrations should rewrite Sherpa-managed legacy keys into canonical paths only after the local vault migration has completed and the provider can verify all rewritten values.
+
+## Compatibility adapters
+
+`VaultSecureStorageService` keeps the existing `ISecureStorageService` contract while changing its persistence boundary. Consumers such as Apple identities, Google identities, Firebase push, publisher config, and keystore passwords do not need immediate rewrites; their values are stored as vault records in the `secure` scope. Legacy secure-storage values are migrated on first read and deleted from the legacy store after the vault write succeeds.
+
+`EncryptedSettingsService` is also a compatibility facade. It reads the vault first, migrates an existing `settings.enc` file when needed, and writes new settings directly to the `settings` scope. After a successful migration, it deletes `settings.enc`, `settings.enc.bak`, `settings.enc.unreadable`, and the old `MauiSherpa_MasterKey`.
+
+`CloudSecretsService` stores provider metadata and non-secret provider settings in the `cloud-provider` scope. If legacy `cloud-secrets-providers.json` or `cloud-secrets-{id}.json` files exist, they are imported into the vault and deleted after successful writes. Provider secret settings continue to use `ISecureStorageService`, which now maps them to the vault.
+
+## Export/import impact
+
+The existing `BackupService` continues to export password-protected settings snapshots, but those snapshots now hydrate through services backed by the local vault:
+
+- Settings are read from the `settings` vault scope.
+- Provider metadata and non-secret provider settings are read from the `cloud-provider` vault scope through `CloudSecretsService`.
+- Provider secret settings, publisher config, identity private keys, Firebase credentials, and keystore passwords are read through vault-backed `ISecureStorageService`.
+- Local-provider secrets remain available through `ICloudSecretsService` and can be included by feature-specific export flows without opening a separate database.
+
+A future raw vault package can export selected `scope/path/key` records directly for advanced backup or migration scenarios, but the user-facing backup path does not need a schema-specific database migration to pick up the vault-backed adapters added here.
+
+## Migration and cleanup
+
+Migrations must be explicit, idempotent, and cleanup-aware:
+
+1. Open or create `local-vault.db` with the OS secure-storage root key.
+2. Detect a legacy source and acquire a migration lock for that step.
+3. Write migrated records into the vault and re-read representative records.
+4. Record a migration marker under the `migration` scope.
+5. Delete migrated secret-bearing legacy storage only after successful vault writes.
+6. Leave legacy storage intact on failure so the migration can be retried.
+
+The implemented Local-provider bridge migrates `local-secrets.db` into `local-vault.db`, preserves each original flat key in metadata, and deletes the old SQLite file and sidecars after successful migration. The secure-storage, encrypted-settings, and secrets-provider configuration adapters follow the same cleanup rule for the data they migrate.
+
+## Guidance for new code
+
+- Store app-owned secret-bearing data through `ILocalVaultStore` or higher-level services backed by it.
+- Use `ICloudSecretsService` or `IManagedSecretsService` for values that may sync to Local or remote providers.
+- Do not add new feature-specific encrypted files or secure-storage keys for app-owned data.
+- Keep OS secure storage limited to root encryption keys or platform tokens that cannot safely move yet.
+- Keep installed certificates/private keys in platform stores; put only Sherpa metadata, references, and Local-provider sync copies in the vault.

--- a/src/MauiSherpa.Core/Interfaces.cs
+++ b/src/MauiSherpa.Core/Interfaces.cs
@@ -2838,6 +2838,20 @@ public interface ICloudSecretsProvider
     /// <param name="key">The secret key/name</param>
     /// <returns>The secret value, or null if not found</returns>
     Task<byte[]?> GetSecretAsync(string key, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets arbitrary key/value metadata stored for a secret.
+    /// </summary>
+    /// <param name="key">The secret key/name</param>
+    /// <returns>The metadata dictionary, null if the secret is not found, or an empty dictionary if no metadata exists</returns>
+    Task<Dictionary<string, string>?> GetSecretMetadataAsync(string key, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Replaces arbitrary key/value metadata for a secret without changing the secret value.
+    /// </summary>
+    /// <param name="key">The secret key/name</param>
+    /// <param name="metadata">The complete metadata dictionary to store</param>
+    Task<bool> SetSecretMetadataAsync(string key, Dictionary<string, string> metadata, CancellationToken cancellationToken = default);
     
     /// <summary>
     /// Deletes a secret
@@ -2902,8 +2916,14 @@ public record ManagedSecret(
     string? Description,
     string? OriginalFileName,
     DateTime CreatedAt,
-    DateTime UpdatedAt
-);
+    DateTime UpdatedAt,
+    Dictionary<string, string>? Metadata = null
+)
+{
+    public Dictionary<string, string> Metadata { get; init; } = Metadata is null
+        ? new Dictionary<string, string>(StringComparer.Ordinal)
+        : new Dictionary<string, string>(Metadata, StringComparer.Ordinal);
+}
 
 /// <summary>
 /// A logical folder for Sherpa-managed secrets.
@@ -2962,17 +2982,17 @@ public interface IManagedSecretsService
     /// <summary>
     /// Creates a new managed secret
     /// </summary>
-    Task<bool> CreateAsync(string key, byte[] value, ManagedSecretType type, string? description = null, string? originalFileName = null, CancellationToken cancellationToken = default);
+    Task<bool> CreateAsync(string key, byte[] value, ManagedSecretType type, string? description = null, string? originalFileName = null, Dictionary<string, string>? metadata = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Updates an existing managed secret's value and/or metadata
     /// </summary>
-    Task<bool> UpdateAsync(string key, byte[]? value = null, string? description = null, CancellationToken cancellationToken = default);
+    Task<bool> UpdateAsync(string key, byte[]? value = null, string? description = null, Dictionary<string, string>? metadata = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Moves an existing managed secret to a new key and optionally updates value/metadata.
     /// </summary>
-    Task<bool> MoveAsync(string key, string newKey, byte[]? value = null, string? description = null, CancellationToken cancellationToken = default);
+    Task<bool> MoveAsync(string key, string newKey, byte[]? value = null, string? description = null, Dictionary<string, string>? metadata = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Deletes a managed secret and its metadata
@@ -3040,6 +3060,16 @@ public interface ICloudSecretsService
     /// Retrieves a secret from the active provider
     /// </summary>
     Task<byte[]?> GetSecretAsync(string key, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets arbitrary key/value metadata stored for a secret from the active provider.
+    /// </summary>
+    Task<Dictionary<string, string>?> GetSecretMetadataAsync(string key, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Replaces arbitrary key/value metadata for a secret in the active provider.
+    /// </summary>
+    Task<bool> SetSecretMetadataAsync(string key, Dictionary<string, string> metadata, CancellationToken cancellationToken = default);
     
     /// <summary>
     /// Deletes a secret from the active provider

--- a/src/MauiSherpa.Core/Interfaces.cs
+++ b/src/MauiSherpa.Core/Interfaces.cs
@@ -118,6 +118,42 @@ public interface ILocalVaultAccessService
     event Action? StateChanged;
 }
 
+public enum LocalVaultIntroductionDecision
+{
+    NotSet,
+    Enabled,
+    Declined
+}
+
+public enum LocalVaultIntroductionResult
+{
+    EnableLocal,
+    DeclineLocal
+}
+
+public sealed record LocalVaultIntroductionState(
+    int Version,
+    LocalVaultIntroductionDecision Decision,
+    DateTime? DecidedAtUtc = null)
+{
+    public const int CurrentVersion = 1;
+
+    public bool HasSeenCurrentVersion => Version == CurrentVersion && Decision != LocalVaultIntroductionDecision.NotSet;
+    public bool IsLocalVaultEnabled => Version == CurrentVersion && Decision == LocalVaultIntroductionDecision.Enabled;
+    public bool HasDeclined => Version == CurrentVersion && Decision == LocalVaultIntroductionDecision.Declined;
+
+    public static LocalVaultIntroductionState NotShown { get; } =
+        new(CurrentVersion, LocalVaultIntroductionDecision.NotSet);
+}
+
+public interface ILocalVaultIntroductionService
+{
+    LocalVaultIntroductionState GetState();
+    Task MarkEnabledAsync(CancellationToken cancellationToken = default);
+    Task MarkDeclinedAsync(CancellationToken cancellationToken = default);
+    event Action? StateChanged;
+}
+
 public interface ILocalVaultStore
 {
     string DatabasePath { get; }
@@ -3052,6 +3088,11 @@ public interface ICloudSecretsService
     /// Saves (adds or updates) a provider configuration
     /// </summary>
     Task SaveProviderAsync(CloudSecretsProviderConfig provider);
+
+    /// <summary>
+    /// Enables the built-in Local provider after the user opts in to the local vault.
+    /// </summary>
+    Task EnableDefaultLocalProviderAsync(bool setActiveProvider = true);
     
     /// <summary>
     /// Deletes a provider configuration

--- a/src/MauiSherpa.Core/Interfaces.cs
+++ b/src/MauiSherpa.Core/Interfaces.cs
@@ -74,6 +74,57 @@ public interface ISecureStorageService
     Task RemoveAsync(string key);
 }
 
+public interface ILegacySecureStorageService : ISecureStorageService
+{
+}
+
+public interface ILocalVaultKeyStore
+{
+    Task<string> GetOrCreateKeyAsync(CancellationToken cancellationToken = default);
+}
+
+public interface ILocalSecretsKeyStore : ILocalVaultKeyStore
+{
+}
+
+public interface ILocalVaultStore
+{
+    string DatabasePath { get; }
+
+    Task<LocalVaultItem> PutAsync(
+        string scope,
+        string path,
+        string key,
+        byte[] value,
+        string contentType,
+        Dictionary<string, string>? metadata = null,
+        CancellationToken cancellationToken = default);
+
+    Task<LocalVaultItem?> GetAsync(
+        string scope,
+        string path,
+        string key,
+        CancellationToken cancellationToken = default);
+
+    Task<bool> RemoveAsync(
+        string scope,
+        string path,
+        string key,
+        CancellationToken cancellationToken = default);
+
+    Task<bool> ExistsAsync(
+        string scope,
+        string path,
+        string key,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<LocalVaultItem>> ListAsync(
+        string scope,
+        string? path = null,
+        string? keyPrefix = null,
+        CancellationToken cancellationToken = default);
+}
+
 public interface IPlatformService
 {
     bool IsWindows { get; }
@@ -2673,7 +2724,8 @@ public enum CloudSecretsProviderType
     Infisical,
     OnePassword,
     Vaultwarden,
-    AzureDevOps
+    AzureDevOps,
+    Local
 }
 
 /// <summary>
@@ -2854,6 +2906,15 @@ public record ManagedSecret(
 );
 
 /// <summary>
+/// A logical folder for Sherpa-managed secrets.
+/// </summary>
+public record ManagedSecretFolder(
+    string Path,
+    string Name,
+    DateTime CreatedAt
+);
+
+/// <summary>
 /// Service for managing Sherpa-owned secrets in cloud storage.
 /// Uses key prefixes to distinguish Sherpa-managed secrets from others.
 /// </summary>
@@ -2861,11 +2922,32 @@ public interface IManagedSecretsService
 {
     const string SecretPrefix = "sherpa-secrets/";
     const string MetadataPrefix = "sherpa-secrets-meta/";
+    const string FolderPrefix = "sherpa-secret-folders/";
 
     /// <summary>
     /// Lists all Sherpa-managed secrets
     /// </summary>
     Task<IReadOnlyList<ManagedSecret>> ListAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists explicitly created Sherpa-managed secret folders.
+    /// </summary>
+    Task<IReadOnlyList<ManagedSecretFolder>> ListFoldersAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates a logical folder for Sherpa-managed secrets.
+    /// </summary>
+    Task<bool> CreateFolderAsync(string folderPath, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Renames a logical folder and moves any managed secrets and child folders under it.
+    /// </summary>
+    Task<bool> RenameFolderAsync(string folderPath, string newFolderPath, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes an empty logical folder.
+    /// </summary>
+    Task<bool> DeleteFolderAsync(string folderPath, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets metadata for a specific managed secret
@@ -2886,6 +2968,11 @@ public interface IManagedSecretsService
     /// Updates an existing managed secret's value and/or metadata
     /// </summary>
     Task<bool> UpdateAsync(string key, byte[]? value = null, string? description = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Moves an existing managed secret to a new key and optionally updates value/metadata.
+    /// </summary>
+    Task<bool> MoveAsync(string key, string newKey, byte[]? value = null, string? description = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Deletes a managed secret and its metadata

--- a/src/MauiSherpa.Core/Interfaces.cs
+++ b/src/MauiSherpa.Core/Interfaces.cs
@@ -87,6 +87,37 @@ public interface ILocalSecretsKeyStore : ILocalVaultKeyStore
 {
 }
 
+public enum LocalVaultAccessProblem
+{
+    None,
+    AccessDenied
+}
+
+public sealed record LocalVaultAccessState(
+    LocalVaultAccessProblem Problem,
+    string? Message = null,
+    DateTime? LastFailureUtc = null)
+{
+    public bool RequiresUserAction => Problem != LocalVaultAccessProblem.None;
+
+    public static LocalVaultAccessState Available { get; } = new(LocalVaultAccessProblem.None);
+}
+
+public sealed class LocalVaultUnavailableException : InvalidOperationException
+{
+    public LocalVaultUnavailableException(string message, Exception? innerException = null)
+        : base(message, innerException)
+    {
+    }
+}
+
+public interface ILocalVaultAccessService
+{
+    LocalVaultAccessState GetState();
+    Task<LocalVaultAccessState> RequestAccessAsync(CancellationToken cancellationToken = default);
+    event Action? StateChanged;
+}
+
 public interface ILocalVaultStore
 {
     string DatabasePath { get; }

--- a/src/MauiSherpa.Core/MauiSherpa.Core.csproj
+++ b/src/MauiSherpa.Core/MauiSherpa.Core.csproj
@@ -45,6 +45,7 @@
     <PackageReference Include="NGitLab" Version="11.3.1" />
     <PackageReference Include="Octokit" Version="14.0.0" />
     <PackageReference Include="SharpKml.Core" Version="6.1.0" />
+    <PackageReference Include="Shiny.DocumentDb.Sqlite.SqlCipher" Version="5.0.1" />
     <PackageReference Include="Shiny.Mediator" Version="6.1.1" />
     <PackageReference Include="Shiny.Mediator.AppSupport" Version="6.1.1" />
     <PackageReference Include="Sodium.Core" Version="1.4.0" />

--- a/src/MauiSherpa.Core/Services/AwsSecretsManagerProvider.cs
+++ b/src/MauiSherpa.Core/Services/AwsSecretsManagerProvider.cs
@@ -108,14 +108,11 @@ public class AwsSecretsManagerProvider : ICloudSecretsProvider
                     SecretBinary = new MemoryStream(value)
                 };
                 
-                // Add tags if metadata provided
-                if (metadata != null && metadata.Count > 0)
-                {
-                    createRequest.Tags = metadata.Select(kv => new Tag { Key = kv.Key, Value = kv.Value }).ToList();
-                }
-                
                 await client.CreateSecretAsync(createRequest, cancellationToken);
             }
+
+            if (metadata is not null && !await SetSecretMetadataAsync(key, metadata, cancellationToken))
+                return false;
 
             _logger.LogInformation($"Stored secret: {key}");
             return true;
@@ -173,6 +170,49 @@ public class AwsSecretsManagerProvider : ICloudSecretsProvider
         }
     }
 
+    public async Task<Dictionary<string, string>?> GetSecretMetadataAsync(string key, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var secretName = GetSecretName(key);
+            if (!await SecretExistsInternalAsync(secretName, cancellationToken))
+                return null;
+
+            var metadataBytes = await GetSecretAsync(CloudSecretMetadata.GetMetadataKey(secretName), cancellationToken);
+            return metadataBytes is null
+                ? new Dictionary<string, string>(StringComparer.Ordinal)
+                : CloudSecretMetadata.Deserialize(metadataBytes);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"AWS Secrets Manager get secret metadata error: {ex.Message}", ex);
+            return null;
+        }
+    }
+
+    public async Task<bool> SetSecretMetadataAsync(
+        string key,
+        Dictionary<string, string> metadata,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var secretName = GetSecretName(key);
+            if (!await SecretExistsInternalAsync(secretName, cancellationToken))
+                return false;
+
+            var metadataKey = CloudSecretMetadata.GetMetadataKey(secretName);
+            return metadata.Count == 0
+                ? await DeleteSecretAsync(metadataKey, cancellationToken)
+                : await StoreSecretAsync(metadataKey, CloudSecretMetadata.Serialize(metadata), cancellationToken: cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"AWS Secrets Manager set secret metadata error: {ex.Message}", ex);
+            return false;
+        }
+    }
+
     public async Task<bool> DeleteSecretAsync(string key, CancellationToken cancellationToken = default)
     {
         try
@@ -187,12 +227,16 @@ public class AwsSecretsManagerProvider : ICloudSecretsProvider
             };
             
             await client.DeleteSecretAsync(request, cancellationToken);
+            if (!CloudSecretMetadata.IsMetadataKey(key))
+                await DeleteSecretAsync(CloudSecretMetadata.GetMetadataKey(secretName), cancellationToken);
             
             _logger.LogInformation($"Deleted secret: {key}");
             return true;
         }
         catch (ResourceNotFoundException)
         {
+            if (!CloudSecretMetadata.IsMetadataKey(key))
+                await DeleteSecretAsync(CloudSecretMetadata.GetMetadataKey(GetSecretName(key)), cancellationToken);
             _logger.LogInformation($"Secret already deleted or not found: {key}");
             return true;
         }
@@ -261,7 +305,8 @@ public class AwsSecretsManagerProvider : ICloudSecretsProvider
                         continue;
 
                     // Filter by prefix if specified
-                    if (!string.IsNullOrEmpty(effectivePrefix) && !secret.Name.StartsWith(effectivePrefix, StringComparison.OrdinalIgnoreCase))
+                    if (CloudSecretMetadata.IsMetadataKey(RemoveSecretPrefix(secret.Name)) ||
+                        (!string.IsNullOrEmpty(effectivePrefix) && !secret.Name.StartsWith(effectivePrefix, StringComparison.OrdinalIgnoreCase)))
                         continue;
 
                     // Remove our prefix to get the original key

--- a/src/MauiSherpa.Core/Services/AzureDevOpsProvider.cs
+++ b/src/MauiSherpa.Core/Services/AzureDevOpsProvider.cs
@@ -2,6 +2,7 @@ using MauiSherpa.Core.Interfaces;
 using Microsoft.VisualStudio.Services.Common;
 using Microsoft.VisualStudio.Services.WebApi;
 using Microsoft.TeamFoundation.DistributedTask.WebApi;
+using System.Text;
 
 namespace MauiSherpa.Core.Services;
 
@@ -146,17 +147,9 @@ public class AzureDevOpsProvider : ICloudSecretsProvider
 
             group.Variables[sanitizedKey] = new VariableValue { Value = base64Value, IsSecret = true };
 
-            // Store metadata as companion variables if provided
-            if (metadata != null)
-            {
-                foreach (var kvp in metadata)
-                {
-                    var metaKey = $"{sanitizedKey}__meta__{SanitizeKey(kvp.Key)}";
-                    group.Variables[metaKey] = new VariableValue { Value = kvp.Value, IsSecret = false };
-                }
-            }
-
             await UpdateVariableGroupAsync(client, group, cancellationToken);
+            if (metadata is not null && !await SetSecretMetadataAsync(key, metadata, cancellationToken))
+                return false;
 
             _logger.LogInformation($"Stored secret in Azure DevOps: {key}");
             return true;
@@ -197,6 +190,71 @@ public class AzureDevOpsProvider : ICloudSecretsProvider
         }
     }
 
+    public async Task<Dictionary<string, string>?> GetSecretMetadataAsync(string key, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var client = await GetTaskClientAsync(cancellationToken);
+            var group = await GetVariableGroupAsync(client, cancellationToken);
+            if (group == null)
+                return null;
+
+            var sanitizedKey = SanitizeKey(key);
+            if (!group.Variables.ContainsKey(sanitizedKey))
+                return null;
+
+            var metadataKey = GetMetadataVariableKey(sanitizedKey);
+            return group.Variables.TryGetValue(metadataKey, out var variable) && variable.Value is not null
+                ? CloudSecretMetadata.Deserialize(Encoding.UTF8.GetBytes(variable.Value))
+                : new Dictionary<string, string>(StringComparer.Ordinal);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"Azure DevOps get secret metadata error: {ex.Message}", ex);
+            return null;
+        }
+    }
+
+    public async Task<bool> SetSecretMetadataAsync(
+        string key,
+        Dictionary<string, string> metadata,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var client = await GetTaskClientAsync(cancellationToken);
+            var group = await GetVariableGroupAsync(client, cancellationToken);
+            if (group == null)
+                return false;
+
+            var sanitizedKey = SanitizeKey(key);
+            if (!group.Variables.ContainsKey(sanitizedKey))
+                return false;
+
+            var metadataKey = GetMetadataVariableKey(sanitizedKey);
+            if (metadata.Count == 0)
+            {
+                group.Variables.Remove(metadataKey);
+            }
+            else
+            {
+                group.Variables[metadataKey] = new VariableValue
+                {
+                    Value = Encoding.UTF8.GetString(CloudSecretMetadata.Serialize(metadata)),
+                    IsSecret = false
+                };
+            }
+
+            await UpdateVariableGroupAsync(client, group, cancellationToken);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"Azure DevOps set secret metadata error: {ex.Message}", ex);
+            return false;
+        }
+    }
+
     public async Task<bool> DeleteSecretAsync(string key, CancellationToken cancellationToken = default)
     {
         try
@@ -215,7 +273,11 @@ public class AzureDevOpsProvider : ICloudSecretsProvider
 
             // Also remove any companion metadata variables
             var metaPrefix = $"{sanitizedKey}__meta__";
-            var metaKeys = group.Variables.Keys.Where(k => k.StartsWith(metaPrefix)).ToList();
+            var metadataKey = GetMetadataVariableKey(sanitizedKey);
+            var metaKeys = group.Variables.Keys
+                .Where(k => k.StartsWith(metaPrefix, StringComparison.Ordinal) ||
+                    string.Equals(k, metadataKey, StringComparison.Ordinal))
+                .ToList();
             foreach (var metaKey in metaKeys)
             {
                 group.Variables.Remove(metaKey);
@@ -270,6 +332,7 @@ public class AzureDevOpsProvider : ICloudSecretsProvider
 
             var secrets = group.Variables.Keys
                 .Where(k => !k.Contains("__meta__")) // Exclude metadata companion variables
+                .Where(k => !CloudSecretMetadata.IsMetadataKey(k))
                 .Where(k => sanitizedPrefix == null || k.StartsWith(sanitizedPrefix, StringComparison.OrdinalIgnoreCase))
                 .ToList()
                 .AsReadOnly();
@@ -284,4 +347,9 @@ public class AzureDevOpsProvider : ICloudSecretsProvider
     }
 
     #endregion
+
+    private static string GetMetadataVariableKey(string sanitizedKey)
+    {
+        return SanitizeKey(CloudSecretMetadata.GetMetadataKey(sanitizedKey));
+    }
 }

--- a/src/MauiSherpa.Core/Services/AzureKeyVaultProvider.cs
+++ b/src/MauiSherpa.Core/Services/AzureKeyVaultProvider.cs
@@ -93,17 +93,9 @@ public class AzureKeyVaultProvider : ICloudSecretsProvider
             var base64Value = Convert.ToBase64String(value);
             
             var secret = new KeyVaultSecret(sanitizedKey, base64Value);
-            
-            // Add metadata as tags
-            if (metadata != null)
-            {
-                foreach (var kvp in metadata)
-                {
-                    secret.Properties.Tags[kvp.Key] = kvp.Value;
-                }
-            }
-
             await client.SetSecretAsync(secret, cancellationToken);
+            if (metadata is not null && !await SetSecretMetadataAsync(key, metadata, cancellationToken))
+                return false;
             
             _logger.LogInformation($"Stored secret: {key}");
             return true;
@@ -151,6 +143,49 @@ public class AzureKeyVaultProvider : ICloudSecretsProvider
         }
     }
 
+    public async Task<Dictionary<string, string>?> GetSecretMetadataAsync(string key, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var sanitizedKey = SanitizeKey(key);
+            if (!await SecretExistsAsync(key, cancellationToken))
+                return null;
+
+            var metadataBytes = await GetSecretAsync(CloudSecretMetadata.GetMetadataKey(sanitizedKey), cancellationToken);
+            return metadataBytes is null
+                ? new Dictionary<string, string>(StringComparer.Ordinal)
+                : CloudSecretMetadata.Deserialize(metadataBytes);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"Azure Key Vault get secret metadata error: {ex.Message}", ex);
+            return null;
+        }
+    }
+
+    public async Task<bool> SetSecretMetadataAsync(
+        string key,
+        Dictionary<string, string> metadata,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var sanitizedKey = SanitizeKey(key);
+            if (!await SecretExistsAsync(key, cancellationToken))
+                return false;
+
+            var metadataKey = CloudSecretMetadata.GetMetadataKey(sanitizedKey);
+            return metadata.Count == 0
+                ? await DeleteSecretAsync(metadataKey, cancellationToken)
+                : await StoreSecretAsync(metadataKey, CloudSecretMetadata.Serialize(metadata), cancellationToken: cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"Azure Key Vault set secret metadata error: {ex.Message}", ex);
+            return false;
+        }
+    }
+
     public async Task<bool> DeleteSecretAsync(string key, CancellationToken cancellationToken = default)
     {
         try
@@ -162,12 +197,16 @@ public class AzureKeyVaultProvider : ICloudSecretsProvider
             
             // Wait for deletion to complete
             await operation.WaitForCompletionAsync(cancellationToken);
+            if (!CloudSecretMetadata.IsMetadataKey(key))
+                await DeleteSecretAsync(CloudSecretMetadata.GetMetadataKey(sanitizedKey), cancellationToken);
             
             _logger.LogInformation($"Deleted secret: {key}");
             return true;
         }
         catch (RequestFailedException ex) when (ex.Status == 404)
         {
+            if (!CloudSecretMetadata.IsMetadataKey(key))
+                await DeleteSecretAsync(CloudSecretMetadata.GetMetadataKey(SanitizeKey(key)), cancellationToken);
             _logger.LogInformation($"Secret already deleted or not found: {key}");
             return true;
         }
@@ -218,7 +257,8 @@ public class AzureKeyVaultProvider : ICloudSecretsProvider
             {
                 var secretName = secretProperties.Name;
 
-                if (sanitizedPrefix == null || secretName.StartsWith(sanitizedPrefix, StringComparison.OrdinalIgnoreCase))
+                if (!CloudSecretMetadata.IsMetadataKey(secretName) &&
+                    (sanitizedPrefix == null || secretName.StartsWith(sanitizedPrefix, StringComparison.OrdinalIgnoreCase)))
                 {
                     allSecrets.Add(secretName);
                 }

--- a/src/MauiSherpa.Core/Services/CloudSecretMetadata.cs
+++ b/src/MauiSherpa.Core/Services/CloudSecretMetadata.cs
@@ -1,0 +1,40 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace MauiSherpa.Core.Services;
+
+internal static class CloudSecretMetadata
+{
+    public const string ReservedKeyPrefix = "maui-sherpa-metadata-";
+    private const string ReservedKeyPrefixUnderscore = "maui_sherpa_metadata_";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = false
+    };
+
+    public static string GetMetadataKey(string providerStorageKey)
+    {
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(providerStorageKey));
+        return ReservedKeyPrefix + Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    public static bool IsMetadataKey(string key)
+    {
+        return key.StartsWith(ReservedKeyPrefix, StringComparison.OrdinalIgnoreCase) ||
+            key.StartsWith(ReservedKeyPrefixUnderscore, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static byte[] Serialize(Dictionary<string, string> metadata)
+    {
+        return Encoding.UTF8.GetBytes(JsonSerializer.Serialize(metadata, JsonOptions));
+    }
+
+    public static Dictionary<string, string> Deserialize(byte[] bytes)
+    {
+        var json = Encoding.UTF8.GetString(bytes);
+        return JsonSerializer.Deserialize<Dictionary<string, string>>(json, JsonOptions) ??
+            new Dictionary<string, string>(StringComparer.Ordinal);
+    }
+}

--- a/src/MauiSherpa.Core/Services/CloudSecretsProviderFactory.cs
+++ b/src/MauiSherpa.Core/Services/CloudSecretsProviderFactory.cs
@@ -8,14 +8,22 @@ namespace MauiSherpa.Core.Services;
 public class CloudSecretsProviderFactory : ICloudSecretsProviderFactory
 {
     private readonly ILoggingService _logger;
+    private readonly ILocalSecretsKeyStore? _localSecretsKeyStore;
+    private readonly ILocalVaultStore? _localVaultStore;
 
-    public CloudSecretsProviderFactory(ILoggingService logger)
+    public CloudSecretsProviderFactory(
+        ILoggingService logger,
+        ILocalSecretsKeyStore? localSecretsKeyStore = null,
+        ILocalVaultStore? localVaultStore = null)
     {
         _logger = logger;
+        _localSecretsKeyStore = localSecretsKeyStore;
+        _localVaultStore = localVaultStore;
     }
 
     public IReadOnlyList<CloudSecretsProviderType> SupportedProviders => new[]
     {
+        CloudSecretsProviderType.Local,
         CloudSecretsProviderType.Infisical,
         CloudSecretsProviderType.AzureKeyVault,
         CloudSecretsProviderType.AwsSecretsManager,
@@ -29,6 +37,7 @@ public class CloudSecretsProviderFactory : ICloudSecretsProviderFactory
     {
         return config.ProviderType switch
         {
+            CloudSecretsProviderType.Local => CreateLocalProvider(config),
             CloudSecretsProviderType.Infisical => new InfisicalProvider(config, _logger),
             CloudSecretsProviderType.AzureKeyVault => new AzureKeyVaultProvider(config, _logger),
             CloudSecretsProviderType.AwsSecretsManager => new AwsSecretsManagerProvider(config, _logger),
@@ -44,6 +53,7 @@ public class CloudSecretsProviderFactory : ICloudSecretsProviderFactory
     {
         return providerType switch
         {
+            CloudSecretsProviderType.Local => Array.Empty<CloudProviderSettingInfo>(),
             CloudSecretsProviderType.Infisical => GetInfisicalSettings(),
             CloudSecretsProviderType.AzureKeyVault => GetAzureKeyVaultSettings(),
             CloudSecretsProviderType.AwsSecretsManager => GetAwsSecretsManagerSettings(),
@@ -59,6 +69,7 @@ public class CloudSecretsProviderFactory : ICloudSecretsProviderFactory
     {
         return providerType switch
         {
+            CloudSecretsProviderType.Local => "Local",
             CloudSecretsProviderType.Infisical => "Infisical",
             CloudSecretsProviderType.AzureKeyVault => "Azure Key Vault",
             CloudSecretsProviderType.AwsSecretsManager => "AWS Secrets Manager",
@@ -69,6 +80,17 @@ public class CloudSecretsProviderFactory : ICloudSecretsProviderFactory
             CloudSecretsProviderType.None => "None",
             _ => providerType.ToString()
         };
+    }
+
+    private ICloudSecretsProvider CreateLocalProvider(CloudSecretsProviderConfig config)
+    {
+        if (_localVaultStore is not null)
+            return new LocalSqlCipherSecretsProvider(config, _logger, _localVaultStore, _localSecretsKeyStore);
+
+        if (_localSecretsKeyStore is not null)
+            return new LocalSqlCipherSecretsProvider(config, _logger, _localSecretsKeyStore);
+
+        throw new InvalidOperationException("Local secrets key storage is not configured.");
     }
 
     private static IReadOnlyList<CloudProviderSettingInfo> GetInfisicalSettings() => new[]

--- a/src/MauiSherpa.Core/Services/CloudSecretsProviderPathExtensions.cs
+++ b/src/MauiSherpa.Core/Services/CloudSecretsProviderPathExtensions.cs
@@ -1,0 +1,50 @@
+using MauiSherpa.Core.Interfaces;
+
+namespace MauiSherpa.Core.Services;
+
+public static class CloudSecretsProviderPathExtensions
+{
+    public static Task<bool> StoreSecretAsync(
+        this ICloudSecretsProvider provider,
+        SecretPath path,
+        byte[] value,
+        Dictionary<string, string>? metadata = null,
+        CancellationToken cancellationToken = default)
+    {
+        return provider.StoreSecretAsync(path.ToFlatKey(), value, metadata, cancellationToken);
+    }
+
+    public static Task<byte[]?> GetSecretAsync(
+        this ICloudSecretsProvider provider,
+        SecretPath path,
+        CancellationToken cancellationToken = default)
+    {
+        return provider.GetSecretAsync(path.ToFlatKey(), cancellationToken);
+    }
+
+    public static Task<bool> DeleteSecretAsync(
+        this ICloudSecretsProvider provider,
+        SecretPath path,
+        CancellationToken cancellationToken = default)
+    {
+        return provider.DeleteSecretAsync(path.ToFlatKey(), cancellationToken);
+    }
+
+    public static Task<bool> SecretExistsAsync(
+        this ICloudSecretsProvider provider,
+        SecretPath path,
+        CancellationToken cancellationToken = default)
+    {
+        return provider.SecretExistsAsync(path.ToFlatKey(), cancellationToken);
+    }
+
+    public static Task<IReadOnlyList<string>> ListSecretsAsync(
+        this ICloudSecretsProvider provider,
+        string folderPath,
+        CancellationToken cancellationToken = default)
+    {
+        var normalized = SecretPath.NormalizeFolderPath(folderPath);
+        var prefix = normalized == "/" ? null : normalized.TrimStart('/') + "/";
+        return provider.ListSecretsAsync(prefix, cancellationToken);
+    }
+}

--- a/src/MauiSherpa.Core/Services/CloudSecretsProviderPathExtensions.cs
+++ b/src/MauiSherpa.Core/Services/CloudSecretsProviderPathExtensions.cs
@@ -22,6 +22,23 @@ public static class CloudSecretsProviderPathExtensions
         return provider.GetSecretAsync(path.ToFlatKey(), cancellationToken);
     }
 
+    public static Task<Dictionary<string, string>?> GetSecretMetadataAsync(
+        this ICloudSecretsProvider provider,
+        SecretPath path,
+        CancellationToken cancellationToken = default)
+    {
+        return provider.GetSecretMetadataAsync(path.ToFlatKey(), cancellationToken);
+    }
+
+    public static Task<bool> SetSecretMetadataAsync(
+        this ICloudSecretsProvider provider,
+        SecretPath path,
+        Dictionary<string, string> metadata,
+        CancellationToken cancellationToken = default)
+    {
+        return provider.SetSecretMetadataAsync(path.ToFlatKey(), metadata, cancellationToken);
+    }
+
     public static Task<bool> DeleteSecretAsync(
         this ICloudSecretsProvider provider,
         SecretPath path,

--- a/src/MauiSherpa.Core/Services/CloudSecretsService.cs
+++ b/src/MauiSherpa.Core/Services/CloudSecretsService.cs
@@ -15,6 +15,7 @@ public class CloudSecretsService : ICloudSecretsService
     private readonly ICloudSecretsProviderFactory _providerFactory;
     private readonly ILocalVaultStore? _vaultStore;
     private readonly ILocalVaultAccessService? _localVaultAccess;
+    private readonly ILocalVaultIntroductionService? _localVaultIntroduction;
     private readonly string _settingsPath;
     
     private List<CloudSecretsProviderMetadata> _providerMetadata = new();
@@ -43,7 +44,8 @@ public class CloudSecretsService : ICloudSecretsService
         ILoggingService logger,
         ICloudSecretsProviderFactory providerFactory,
         ILocalVaultStore? vaultStore = null,
-        ILocalVaultAccessService? localVaultAccess = null)
+        ILocalVaultAccessService? localVaultAccess = null,
+        ILocalVaultIntroductionService? localVaultIntroduction = null)
     {
         _secureStorage = secureStorage;
         _fileSystem = fileSystem;
@@ -51,6 +53,7 @@ public class CloudSecretsService : ICloudSecretsService
         _providerFactory = providerFactory;
         _vaultStore = vaultStore;
         _localVaultAccess = localVaultAccess;
+        _localVaultIntroduction = localVaultIntroduction;
         _settingsPath = Path.Combine(
             AppDataPath.GetAppDataDirectory(),
             "cloud-secrets-providers.json");
@@ -65,12 +68,16 @@ public class CloudSecretsService : ICloudSecretsService
     public async Task<IReadOnlyList<CloudSecretsProviderConfig>> GetProvidersAsync()
     {
         await LoadMetadataAsync();
-        await EnsureDefaultLocalProviderMetadataAsync();
+        if (IsLocalProviderEnabled())
+            await EnsureDefaultLocalProviderMetadataAsync();
 
         var result = new List<CloudSecretsProviderConfig>();
 
         foreach (var meta in _providerMetadata)
         {
+            if (meta.Id == DefaultLocalProviderId && !IsLocalProviderEnabled())
+                continue;
+
             var config = await LoadProviderConfigAsync(meta);
             if (config != null)
                 result.Add(config);
@@ -133,11 +140,20 @@ public class CloudSecretsService : ICloudSecretsService
         }
     }
 
+    public async Task EnableDefaultLocalProviderAsync(bool setActiveProvider = true)
+    {
+        await EnsureDefaultLocalProviderAsync();
+
+        if (setActiveProvider)
+            await SetActiveProviderAsync(DefaultLocalProviderId);
+    }
+
     public async Task DeleteProviderAsync(string providerId)
     {
         if (providerId == DefaultLocalProviderId)
         {
-            await EnsureDefaultLocalProviderAsync();
+            if (IsLocalProviderEnabled())
+                await EnsureDefaultLocalProviderAsync();
             _logger.LogInformation("The default Local secrets provider cannot be deleted.");
             return;
         }
@@ -151,7 +167,7 @@ public class CloudSecretsService : ICloudSecretsService
         var nonSecretPath = GetNonSecretSettingsPath(providerId);
         if (await _fileSystem.FileExistsAsync(nonSecretPath))
             await _fileSystem.DeleteFileAsync(nonSecretPath);
-        if (_vaultStore is not null)
+        if (CanUseLocalVault())
             await _vaultStore.RemoveAsync(LocalVaultScopes.CloudProvider, ProviderSettingsVaultPath, GetProviderSettingsVaultKey(providerId));
 
         var removed = _providerMetadata.RemoveAll(m => m.Id == providerId);
@@ -231,8 +247,6 @@ public class CloudSecretsService : ICloudSecretsService
     /// </summary>
     public async Task InitializeAsync()
     {
-        await EnsureDefaultLocalProviderAsync();
-
         _activeProviderId = await TryGetSecureStorageAsync(ActiveProviderKey);
         if (!string.IsNullOrEmpty(_activeProviderId))
         {
@@ -250,7 +264,8 @@ public class CloudSecretsService : ICloudSecretsService
         {
             var providers = await GetProvidersAsync();
             var defaultProviderId = ChooseDefaultProviderId(providers);
-            await SetActiveProviderAsync(defaultProviderId);
+            if (defaultProviderId is not null)
+                await SetActiveProviderAsync(defaultProviderId);
         }
     }
 
@@ -401,7 +416,7 @@ public class CloudSecretsService : ICloudSecretsService
 
     private async Task LoadMetadataAsync()
     {
-        if (_vaultStore is not null)
+        if (CanUseLocalVault())
         {
             try
             {
@@ -427,7 +442,7 @@ public class CloudSecretsService : ICloudSecretsService
                 if (!string.IsNullOrEmpty(json))
                 {
                     _providerMetadata = JsonSerializer.Deserialize<List<CloudSecretsProviderMetadata>>(json) ?? new();
-                    if (_vaultStore is not null && await TryPersistMetadataToVaultAsync(json))
+                    if (CanUseLocalVault() && await TryPersistMetadataToVaultAsync(json))
                         await _fileSystem.DeleteFileAsync(_settingsPath);
                     return;
                 }
@@ -468,7 +483,7 @@ public class CloudSecretsService : ICloudSecretsService
             WriteIndented = true
         });
 
-        if (_vaultStore is not null && await TryPersistMetadataToVaultAsync(json))
+        if (CanUseLocalVault() && await TryPersistMetadataToVaultAsync(json))
         {
             if (await _fileSystem.FileExistsAsync(_settingsPath))
                 await _fileSystem.DeleteFileAsync(_settingsPath);
@@ -513,7 +528,7 @@ public class CloudSecretsService : ICloudSecretsService
 
     private async Task<Dictionary<string, string>> LoadNonSecretSettingsAsync(string providerId)
     {
-        if (_vaultStore is not null)
+        if (CanUseLocalVault())
         {
             try
             {
@@ -543,7 +558,7 @@ public class CloudSecretsService : ICloudSecretsService
             return new();
 
         var legacySettings = JsonSerializer.Deserialize<Dictionary<string, string>>(legacyJson) ?? new();
-        if (_vaultStore is not null)
+        if (CanUseLocalVault())
         {
             var legacySettingsJson = JsonSerializer.Serialize(legacySettings);
             if (await TryPersistNonSecretSettingsToVaultAsync(providerId, legacySettingsJson))
@@ -557,7 +572,7 @@ public class CloudSecretsService : ICloudSecretsService
     {
         var json = JsonSerializer.Serialize(settings);
 
-        if (_vaultStore is not null && await TryPersistNonSecretSettingsToVaultAsync(providerId, json))
+        if (CanUseLocalVault() && await TryPersistNonSecretSettingsToVaultAsync(providerId, json))
         {
             var legacyPath = GetNonSecretSettingsPath(providerId);
             if (await _fileSystem.FileExistsAsync(legacyPath))
@@ -596,7 +611,7 @@ public class CloudSecretsService : ICloudSecretsService
         }
     }
 
-    private string ChooseDefaultProviderId(IReadOnlyList<CloudSecretsProviderConfig> providers)
+    private string? ChooseDefaultProviderId(IReadOnlyList<CloudSecretsProviderConfig> providers)
     {
         var localUnavailable = _localVaultAccess?.GetState().RequiresUserAction == true;
         if (localUnavailable)
@@ -606,10 +621,20 @@ public class CloudSecretsService : ICloudSecretsService
                 return nonLocal.Id;
         }
 
-        return providers.FirstOrDefault(p => p.Id == DefaultLocalProviderId)?.Id
-            ?? providers.FirstOrDefault()?.Id
-            ?? DefaultLocalProviderId;
+        if (IsLocalProviderEnabled())
+        {
+            return providers.FirstOrDefault(p => p.Id == DefaultLocalProviderId)?.Id
+                ?? providers.FirstOrDefault()?.Id;
+        }
+
+        return providers.FirstOrDefault(p => p.ProviderType != CloudSecretsProviderType.Local)?.Id;
     }
+
+    private bool IsLocalProviderEnabled() =>
+        _localVaultIntroduction?.GetState().IsLocalVaultEnabled != false;
+
+    private bool CanUseLocalVault() =>
+        _vaultStore is not null && IsLocalProviderEnabled();
 
     private async Task<string?> TryGetSecureStorageAsync(string key)
     {

--- a/src/MauiSherpa.Core/Services/CloudSecretsService.cs
+++ b/src/MauiSherpa.Core/Services/CloudSecretsService.cs
@@ -14,6 +14,7 @@ public class CloudSecretsService : ICloudSecretsService
     private readonly ILoggingService _logger;
     private readonly ICloudSecretsProviderFactory _providerFactory;
     private readonly ILocalVaultStore? _vaultStore;
+    private readonly ILocalVaultAccessService? _localVaultAccess;
     private readonly string _settingsPath;
     
     private List<CloudSecretsProviderMetadata> _providerMetadata = new();
@@ -41,13 +42,15 @@ public class CloudSecretsService : ICloudSecretsService
         IFileSystemService fileSystem,
         ILoggingService logger,
         ICloudSecretsProviderFactory providerFactory,
-        ILocalVaultStore? vaultStore = null)
+        ILocalVaultStore? vaultStore = null,
+        ILocalVaultAccessService? localVaultAccess = null)
     {
         _secureStorage = secureStorage;
         _fileSystem = fileSystem;
         _logger = logger;
         _providerFactory = providerFactory;
         _vaultStore = vaultStore;
+        _localVaultAccess = localVaultAccess;
         _settingsPath = Path.Combine(
             AppDataPath.GetAppDataDirectory(),
             "cloud-secrets-providers.json");
@@ -90,11 +93,11 @@ public class CloudSecretsService : ICloudSecretsService
         if (secretSettings.Count > 0)
         {
             var secretJson = JsonSerializer.Serialize(secretSettings);
-            await _secureStorage.SetAsync(SecureKeyPrefix + provider.Id, secretJson);
+            await TrySetSecureStorageAsync(SecureKeyPrefix + provider.Id, secretJson);
         }
         else
         {
-            await _secureStorage.RemoveAsync(SecureKeyPrefix + provider.Id);
+            await TryRemoveSecureStorageAsync(SecureKeyPrefix + provider.Id);
         }
         
         // Store non-secret settings in metadata
@@ -142,7 +145,7 @@ public class CloudSecretsService : ICloudSecretsService
         await LoadMetadataAsync();
 
         // Remove from secure storage
-        await _secureStorage.RemoveAsync(SecureKeyPrefix + providerId);
+        await TryRemoveSecureStorageAsync(SecureKeyPrefix + providerId);
         
         // Remove non-secret settings file
         var nonSecretPath = GetNonSecretSettingsPath(providerId);
@@ -201,7 +204,7 @@ public class CloudSecretsService : ICloudSecretsService
             _activeProviderId = null;
             ActiveProvider = null;
             _activeProviderInstance = null;
-            await _secureStorage.RemoveAsync(ActiveProviderKey);
+            await TryRemoveSecureStorageAsync(ActiveProviderKey);
         }
         else
         {
@@ -216,7 +219,7 @@ public class CloudSecretsService : ICloudSecretsService
             _activeProviderId = providerId;
             ActiveProvider = config;
             _activeProviderInstance = null; // Force re-creation on next use
-            await _secureStorage.SetAsync(ActiveProviderKey, providerId);
+            await TrySetSecureStorageAsync(ActiveProviderKey, providerId);
         }
         
         OnActiveProviderChanged?.Invoke();
@@ -230,7 +233,7 @@ public class CloudSecretsService : ICloudSecretsService
     {
         await EnsureDefaultLocalProviderAsync();
 
-        _activeProviderId = await _secureStorage.GetAsync(ActiveProviderKey);
+        _activeProviderId = await TryGetSecureStorageAsync(ActiveProviderKey);
         if (!string.IsNullOrEmpty(_activeProviderId))
         {
             var providers = await GetProvidersAsync();
@@ -239,13 +242,15 @@ public class CloudSecretsService : ICloudSecretsService
             {
                 // Provider was deleted, clear the active provider
                 _activeProviderId = null;
-                await _secureStorage.RemoveAsync(ActiveProviderKey);
+                await TryRemoveSecureStorageAsync(ActiveProviderKey);
             }
         }
 
         if (ActiveProvider is null)
         {
-            await SetActiveProviderAsync(DefaultLocalProviderId);
+            var providers = await GetProvidersAsync();
+            var defaultProviderId = ChooseDefaultProviderId(providers);
+            await SetActiveProviderAsync(defaultProviderId);
         }
     }
 
@@ -369,7 +374,7 @@ public class CloudSecretsService : ICloudSecretsService
                 settings[kvp.Key] = kvp.Value;
             
             // Load secret settings from secure storage
-            var secretJson = await _secureStorage.GetAsync(SecureKeyPrefix + metadata.Id);
+            var secretJson = await TryGetSecureStorageAsync(SecureKeyPrefix + metadata.Id);
             if (!string.IsNullOrEmpty(secretJson))
             {
                 var secretSettings = JsonSerializer.Deserialize<Dictionary<string, string>>(secretJson);
@@ -396,9 +401,9 @@ public class CloudSecretsService : ICloudSecretsService
 
     private async Task LoadMetadataAsync()
     {
-        try
+        if (_vaultStore is not null)
         {
-            if (_vaultStore is not null)
+            try
             {
                 var item = await _vaultStore.GetAsync(LocalVaultScopes.CloudProvider, "/", ProviderMetadataVaultKey);
                 if (item is not null)
@@ -408,18 +413,22 @@ public class CloudSecretsService : ICloudSecretsService
                     return;
                 }
             }
+            catch (Exception ex)
+            {
+                _logger.LogWarning($"Failed to read cloud secrets metadata from local vault: {ex.Message}");
+            }
+        }
 
+        try
+        {
             if (await _fileSystem.FileExistsAsync(_settingsPath))
             {
                 var json = await _fileSystem.ReadFileAsync(_settingsPath);
                 if (!string.IsNullOrEmpty(json))
                 {
                     _providerMetadata = JsonSerializer.Deserialize<List<CloudSecretsProviderMetadata>>(json) ?? new();
-                    if (_vaultStore is not null)
-                    {
-                        await PersistMetadataAsync();
+                    if (_vaultStore is not null && await TryPersistMetadataToVaultAsync(json))
                         await _fileSystem.DeleteFileAsync(_settingsPath);
-                    }
                     return;
                 }
             }
@@ -454,24 +463,20 @@ public class CloudSecretsService : ICloudSecretsService
 
     private async Task PersistMetadataAsync()
     {
+        var json = JsonSerializer.Serialize(_providerMetadata, new JsonSerializerOptions
+        {
+            WriteIndented = true
+        });
+
+        if (_vaultStore is not null && await TryPersistMetadataToVaultAsync(json))
+        {
+            if (await _fileSystem.FileExistsAsync(_settingsPath))
+                await _fileSystem.DeleteFileAsync(_settingsPath);
+            return;
+        }
+
         try
         {
-            var json = JsonSerializer.Serialize(_providerMetadata, new JsonSerializerOptions
-            {
-                WriteIndented = true
-            });
-
-            if (_vaultStore is not null)
-            {
-                await _vaultStore.PutAsync(
-                    LocalVaultScopes.CloudProvider,
-                    "/",
-                    ProviderMetadataVaultKey,
-                    System.Text.Encoding.UTF8.GetBytes(json),
-                    LocalVaultContentTypes.Json);
-                return;
-            }
-
             var directory = Path.GetDirectoryName(_settingsPath);
             if (!string.IsNullOrEmpty(directory))
                 await _fileSystem.CreateDirectoryAsync(directory);
@@ -484,19 +489,48 @@ public class CloudSecretsService : ICloudSecretsService
         }
     }
 
+    private async Task<bool> TryPersistMetadataToVaultAsync(string json)
+    {
+        if (_vaultStore is null)
+            return false;
+
+        try
+        {
+            await _vaultStore.PutAsync(
+                LocalVaultScopes.CloudProvider,
+                "/",
+                ProviderMetadataVaultKey,
+                System.Text.Encoding.UTF8.GetBytes(json),
+                LocalVaultContentTypes.Json);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning($"Failed to persist cloud secrets metadata in local vault: {ex.Message}");
+            return false;
+        }
+    }
+
     private async Task<Dictionary<string, string>> LoadNonSecretSettingsAsync(string providerId)
     {
         if (_vaultStore is not null)
         {
-            var item = await _vaultStore.GetAsync(
-                LocalVaultScopes.CloudProvider,
-                ProviderSettingsVaultPath,
-                GetProviderSettingsVaultKey(providerId));
-
-            if (item is not null)
+            try
             {
-                var json = System.Text.Encoding.UTF8.GetString(item.Value);
-                return JsonSerializer.Deserialize<Dictionary<string, string>>(json) ?? new();
+                var item = await _vaultStore.GetAsync(
+                    LocalVaultScopes.CloudProvider,
+                    ProviderSettingsVaultPath,
+                    GetProviderSettingsVaultKey(providerId));
+
+                if (item is not null)
+                {
+                    var json = System.Text.Encoding.UTF8.GetString(item.Value);
+                    return JsonSerializer.Deserialize<Dictionary<string, string>>(json) ?? new();
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning($"Failed to read provider settings from local vault for {providerId}: {ex.Message}");
             }
         }
 
@@ -511,8 +545,9 @@ public class CloudSecretsService : ICloudSecretsService
         var legacySettings = JsonSerializer.Deserialize<Dictionary<string, string>>(legacyJson) ?? new();
         if (_vaultStore is not null)
         {
-            await PersistNonSecretSettingsAsync(providerId, legacySettings);
-            await _fileSystem.DeleteFileAsync(nonSecretPath);
+            var legacySettingsJson = JsonSerializer.Serialize(legacySettings);
+            if (await TryPersistNonSecretSettingsToVaultAsync(providerId, legacySettingsJson))
+                await _fileSystem.DeleteFileAsync(nonSecretPath);
         }
 
         return legacySettings;
@@ -522,7 +557,25 @@ public class CloudSecretsService : ICloudSecretsService
     {
         var json = JsonSerializer.Serialize(settings);
 
-        if (_vaultStore is not null)
+        if (_vaultStore is not null && await TryPersistNonSecretSettingsToVaultAsync(providerId, json))
+        {
+            var legacyPath = GetNonSecretSettingsPath(providerId);
+            if (await _fileSystem.FileExistsAsync(legacyPath))
+                await _fileSystem.DeleteFileAsync(legacyPath);
+            return;
+        }
+
+        await _fileSystem.WriteFileAsync(GetNonSecretSettingsPath(providerId), json);
+    }
+
+    private static string GetProviderSettingsVaultKey(string providerId) => ProviderSettingsKeyPrefix + providerId;
+
+    private async Task<bool> TryPersistNonSecretSettingsToVaultAsync(string providerId, string json)
+    {
+        if (_vaultStore is null)
+            return false;
+
+        try
         {
             await _vaultStore.PutAsync(
                 LocalVaultScopes.CloudProvider,
@@ -534,17 +587,66 @@ public class CloudSecretsService : ICloudSecretsService
                 {
                     ["ProviderId"] = providerId
                 });
-
-            var legacyPath = GetNonSecretSettingsPath(providerId);
-            if (await _fileSystem.FileExistsAsync(legacyPath))
-                await _fileSystem.DeleteFileAsync(legacyPath);
-            return;
+            return true;
         }
-
-        await _fileSystem.WriteFileAsync(GetNonSecretSettingsPath(providerId), json);
+        catch (Exception ex)
+        {
+            _logger.LogWarning($"Failed to persist provider settings in local vault for {providerId}: {ex.Message}");
+            return false;
+        }
     }
 
-    private static string GetProviderSettingsVaultKey(string providerId) => ProviderSettingsKeyPrefix + providerId;
+    private string ChooseDefaultProviderId(IReadOnlyList<CloudSecretsProviderConfig> providers)
+    {
+        var localUnavailable = _localVaultAccess?.GetState().RequiresUserAction == true;
+        if (localUnavailable)
+        {
+            var nonLocal = providers.FirstOrDefault(p => p.ProviderType != CloudSecretsProviderType.Local);
+            if (nonLocal is not null)
+                return nonLocal.Id;
+        }
+
+        return providers.FirstOrDefault(p => p.Id == DefaultLocalProviderId)?.Id
+            ?? providers.FirstOrDefault()?.Id
+            ?? DefaultLocalProviderId;
+    }
+
+    private async Task<string?> TryGetSecureStorageAsync(string key)
+    {
+        try
+        {
+            return await _secureStorage.GetAsync(key);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning($"Failed to read secure storage key {key}: {ex.Message}");
+            return null;
+        }
+    }
+
+    private async Task TrySetSecureStorageAsync(string key, string value)
+    {
+        try
+        {
+            await _secureStorage.SetAsync(key, value);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning($"Failed to persist secure storage key {key}: {ex.Message}");
+        }
+    }
+
+    private async Task TryRemoveSecureStorageAsync(string key)
+    {
+        try
+        {
+            await _secureStorage.RemoveAsync(key);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning($"Failed to remove secure storage key {key}: {ex.Message}");
+        }
+    }
 
     #endregion
 }

--- a/src/MauiSherpa.Core/Services/CloudSecretsService.cs
+++ b/src/MauiSherpa.Core/Services/CloudSecretsService.cs
@@ -13,6 +13,7 @@ public class CloudSecretsService : ICloudSecretsService
     private readonly IFileSystemService _fileSystem;
     private readonly ILoggingService _logger;
     private readonly ICloudSecretsProviderFactory _providerFactory;
+    private readonly ILocalVaultStore? _vaultStore;
     private readonly string _settingsPath;
     
     private List<CloudSecretsProviderMetadata> _providerMetadata = new();
@@ -30,17 +31,23 @@ public class CloudSecretsService : ICloudSecretsService
 
     private const string SecureKeyPrefix = "cloud_secrets_provider_";
     private const string ActiveProviderKey = "cloud_secrets_active_provider";
+    public const string DefaultLocalProviderId = "local";
+    private const string ProviderMetadataVaultKey = "providers";
+    private const string ProviderSettingsVaultPath = "/providers";
+    private const string ProviderSettingsKeyPrefix = "settings-";
 
     public CloudSecretsService(
         ISecureStorageService secureStorage,
         IFileSystemService fileSystem,
         ILoggingService logger,
-        ICloudSecretsProviderFactory providerFactory)
+        ICloudSecretsProviderFactory providerFactory,
+        ILocalVaultStore? vaultStore = null)
     {
         _secureStorage = secureStorage;
         _fileSystem = fileSystem;
         _logger = logger;
         _providerFactory = providerFactory;
+        _vaultStore = vaultStore;
         _settingsPath = Path.Combine(
             AppDataPath.GetAppDataDirectory(),
             "cloud-secrets-providers.json");
@@ -55,6 +62,8 @@ public class CloudSecretsService : ICloudSecretsService
     public async Task<IReadOnlyList<CloudSecretsProviderConfig>> GetProvidersAsync()
     {
         await LoadMetadataAsync();
+        await EnsureDefaultLocalProviderMetadataAsync();
+
         var result = new List<CloudSecretsProviderConfig>();
 
         foreach (var meta in _providerMetadata)
@@ -83,6 +92,10 @@ public class CloudSecretsService : ICloudSecretsService
             var secretJson = JsonSerializer.Serialize(secretSettings);
             await _secureStorage.SetAsync(SecureKeyPrefix + provider.Id, secretJson);
         }
+        else
+        {
+            await _secureStorage.RemoveAsync(SecureKeyPrefix + provider.Id);
+        }
         
         // Store non-secret settings in metadata
         var metadata = new CloudSecretsProviderMetadata(
@@ -101,10 +114,10 @@ public class CloudSecretsService : ICloudSecretsService
         await PersistMetadataAsync();
         
         // Store non-secret settings separately (since they're not in the metadata)
-        var nonSecretSettingsJson = JsonSerializer.Serialize(
-            provider.Settings.Where(kvp => !secretKeys.Contains(kvp.Key))
-                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
-        await _fileSystem.WriteFileAsync(GetNonSecretSettingsPath(provider.Id), nonSecretSettingsJson);
+        var nonSecretSettings = provider.Settings
+            .Where(kvp => !secretKeys.Contains(kvp.Key))
+            .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+        await PersistNonSecretSettingsAsync(provider.Id, nonSecretSettings);
         
         _logger.LogInformation($"Saved cloud secrets provider: {provider.Name}");
         
@@ -119,6 +132,13 @@ public class CloudSecretsService : ICloudSecretsService
 
     public async Task DeleteProviderAsync(string providerId)
     {
+        if (providerId == DefaultLocalProviderId)
+        {
+            await EnsureDefaultLocalProviderAsync();
+            _logger.LogInformation("The default Local secrets provider cannot be deleted.");
+            return;
+        }
+
         await LoadMetadataAsync();
 
         // Remove from secure storage
@@ -128,6 +148,8 @@ public class CloudSecretsService : ICloudSecretsService
         var nonSecretPath = GetNonSecretSettingsPath(providerId);
         if (await _fileSystem.FileExistsAsync(nonSecretPath))
             await _fileSystem.DeleteFileAsync(nonSecretPath);
+        if (_vaultStore is not null)
+            await _vaultStore.RemoveAsync(LocalVaultScopes.CloudProvider, ProviderSettingsVaultPath, GetProviderSettingsVaultKey(providerId));
 
         var removed = _providerMetadata.RemoveAll(m => m.Id == providerId);
         if (removed > 0)
@@ -206,6 +228,8 @@ public class CloudSecretsService : ICloudSecretsService
     /// </summary>
     public async Task InitializeAsync()
     {
+        await EnsureDefaultLocalProviderAsync();
+
         _activeProviderId = await _secureStorage.GetAsync(ActiveProviderKey);
         if (!string.IsNullOrEmpty(_activeProviderId))
         {
@@ -217,6 +241,11 @@ public class CloudSecretsService : ICloudSecretsService
                 _activeProviderId = null;
                 await _secureStorage.RemoveAsync(ActiveProviderKey);
             }
+        }
+
+        if (ActiveProvider is null)
+        {
+            await SetActiveProviderAsync(DefaultLocalProviderId);
         }
     }
 
@@ -311,21 +340,9 @@ public class CloudSecretsService : ICloudSecretsService
         {
             var settings = new Dictionary<string, string>();
             
-            // Load non-secret settings
-            var nonSecretPath = GetNonSecretSettingsPath(metadata.Id);
-            if (await _fileSystem.FileExistsAsync(nonSecretPath))
-            {
-                var json = await _fileSystem.ReadFileAsync(nonSecretPath);
-                if (!string.IsNullOrEmpty(json))
-                {
-                    var nonSecretSettings = JsonSerializer.Deserialize<Dictionary<string, string>>(json);
-                    if (nonSecretSettings != null)
-                    {
-                        foreach (var kvp in nonSecretSettings)
-                            settings[kvp.Key] = kvp.Value;
-                    }
-                }
-            }
+            var nonSecretSettings = await LoadNonSecretSettingsAsync(metadata.Id);
+            foreach (var kvp in nonSecretSettings)
+                settings[kvp.Key] = kvp.Value;
             
             // Load secret settings from secure storage
             var secretJson = await _secureStorage.GetAsync(SecureKeyPrefix + metadata.Id);
@@ -357,12 +374,28 @@ public class CloudSecretsService : ICloudSecretsService
     {
         try
         {
+            if (_vaultStore is not null)
+            {
+                var item = await _vaultStore.GetAsync(LocalVaultScopes.CloudProvider, "/", ProviderMetadataVaultKey);
+                if (item is not null)
+                {
+                    var json = System.Text.Encoding.UTF8.GetString(item.Value);
+                    _providerMetadata = JsonSerializer.Deserialize<List<CloudSecretsProviderMetadata>>(json) ?? new();
+                    return;
+                }
+            }
+
             if (await _fileSystem.FileExistsAsync(_settingsPath))
             {
                 var json = await _fileSystem.ReadFileAsync(_settingsPath);
                 if (!string.IsNullOrEmpty(json))
                 {
                     _providerMetadata = JsonSerializer.Deserialize<List<CloudSecretsProviderMetadata>>(json) ?? new();
+                    if (_vaultStore is not null)
+                    {
+                        await PersistMetadataAsync();
+                        await _fileSystem.DeleteFileAsync(_settingsPath);
+                    }
                     return;
                 }
             }
@@ -374,18 +407,51 @@ public class CloudSecretsService : ICloudSecretsService
         _providerMetadata = new();
     }
 
+    private async Task EnsureDefaultLocalProviderAsync()
+    {
+        await LoadMetadataAsync();
+        await EnsureDefaultLocalProviderMetadataAsync();
+    }
+
+    private async Task EnsureDefaultLocalProviderMetadataAsync()
+    {
+        if (_providerMetadata.Any(p => p.Id == DefaultLocalProviderId))
+            return;
+
+        var localProvider = new CloudSecretsProviderMetadata(
+            DefaultLocalProviderId,
+            "Local",
+            CloudSecretsProviderType.Local,
+            new List<string>());
+
+        _providerMetadata.Insert(0, localProvider);
+        await PersistMetadataAsync();
+    }
+
     private async Task PersistMetadataAsync()
     {
         try
         {
-            var directory = Path.GetDirectoryName(_settingsPath);
-            if (!string.IsNullOrEmpty(directory))
-                await _fileSystem.CreateDirectoryAsync(directory);
-
             var json = JsonSerializer.Serialize(_providerMetadata, new JsonSerializerOptions
             {
                 WriteIndented = true
             });
+
+            if (_vaultStore is not null)
+            {
+                await _vaultStore.PutAsync(
+                    LocalVaultScopes.CloudProvider,
+                    "/",
+                    ProviderMetadataVaultKey,
+                    System.Text.Encoding.UTF8.GetBytes(json),
+                    LocalVaultContentTypes.Json);
+                return;
+            }
+
+            var directory = Path.GetDirectoryName(_settingsPath);
+            if (!string.IsNullOrEmpty(directory))
+                await _fileSystem.CreateDirectoryAsync(directory);
+
             await _fileSystem.WriteFileAsync(_settingsPath, json);
         }
         catch (Exception ex)
@@ -393,6 +459,68 @@ public class CloudSecretsService : ICloudSecretsService
             _logger.LogError($"Failed to persist cloud secrets metadata: {ex.Message}", ex);
         }
     }
+
+    private async Task<Dictionary<string, string>> LoadNonSecretSettingsAsync(string providerId)
+    {
+        if (_vaultStore is not null)
+        {
+            var item = await _vaultStore.GetAsync(
+                LocalVaultScopes.CloudProvider,
+                ProviderSettingsVaultPath,
+                GetProviderSettingsVaultKey(providerId));
+
+            if (item is not null)
+            {
+                var json = System.Text.Encoding.UTF8.GetString(item.Value);
+                return JsonSerializer.Deserialize<Dictionary<string, string>>(json) ?? new();
+            }
+        }
+
+        var nonSecretPath = GetNonSecretSettingsPath(providerId);
+        if (!await _fileSystem.FileExistsAsync(nonSecretPath))
+            return new();
+
+        var legacyJson = await _fileSystem.ReadFileAsync(nonSecretPath);
+        if (string.IsNullOrEmpty(legacyJson))
+            return new();
+
+        var legacySettings = JsonSerializer.Deserialize<Dictionary<string, string>>(legacyJson) ?? new();
+        if (_vaultStore is not null)
+        {
+            await PersistNonSecretSettingsAsync(providerId, legacySettings);
+            await _fileSystem.DeleteFileAsync(nonSecretPath);
+        }
+
+        return legacySettings;
+    }
+
+    private async Task PersistNonSecretSettingsAsync(string providerId, Dictionary<string, string> settings)
+    {
+        var json = JsonSerializer.Serialize(settings);
+
+        if (_vaultStore is not null)
+        {
+            await _vaultStore.PutAsync(
+                LocalVaultScopes.CloudProvider,
+                ProviderSettingsVaultPath,
+                GetProviderSettingsVaultKey(providerId),
+                System.Text.Encoding.UTF8.GetBytes(json),
+                LocalVaultContentTypes.Json,
+                new Dictionary<string, string>
+                {
+                    ["ProviderId"] = providerId
+                });
+
+            var legacyPath = GetNonSecretSettingsPath(providerId);
+            if (await _fileSystem.FileExistsAsync(legacyPath))
+                await _fileSystem.DeleteFileAsync(legacyPath);
+            return;
+        }
+
+        await _fileSystem.WriteFileAsync(GetNonSecretSettingsPath(providerId), json);
+    }
+
+    private static string GetProviderSettingsVaultKey(string providerId) => ProviderSettingsKeyPrefix + providerId;
 
     #endregion
 }

--- a/src/MauiSherpa.Core/Services/CloudSecretsService.cs
+++ b/src/MauiSherpa.Core/Services/CloudSecretsService.cs
@@ -277,6 +277,30 @@ public class CloudSecretsService : ICloudSecretsService
         return await provider.GetSecretAsync(key, cancellationToken);
     }
 
+    public async Task<Dictionary<string, string>?> GetSecretMetadataAsync(string key, CancellationToken cancellationToken = default)
+    {
+        var provider = await GetActiveProviderInstanceAsync();
+        if (provider == null)
+        {
+            _logger.LogWarning("No active cloud secrets provider configured");
+            return null;
+        }
+
+        return await provider.GetSecretMetadataAsync(key, cancellationToken);
+    }
+
+    public async Task<bool> SetSecretMetadataAsync(string key, Dictionary<string, string> metadata, CancellationToken cancellationToken = default)
+    {
+        var provider = await GetActiveProviderInstanceAsync();
+        if (provider == null)
+        {
+            _logger.LogWarning("No active cloud secrets provider configured");
+            return false;
+        }
+
+        return await provider.SetSecretMetadataAsync(key, metadata, cancellationToken);
+    }
+
     public async Task<bool> DeleteSecretAsync(string key, CancellationToken cancellationToken = default)
     {
         var provider = await GetActiveProviderInstanceAsync();

--- a/src/MauiSherpa.Core/Services/EncryptedSettingsService.cs
+++ b/src/MauiSherpa.Core/Services/EncryptedSettingsService.cs
@@ -12,25 +12,43 @@ public class EncryptedSettingsService : IEncryptedSettingsService
 {
     private const string MasterKeyStorageKey = "MauiSherpa_MasterKey";
     private const string SettingsFileName = "settings.enc";
+    private const string VaultSettingsPath = "/";
+    private const string VaultSettingsKey = "maui-sherpa-settings";
     private const int NonceSize = 12;
     private const int TagSize = 16;
     private const int KeySize = 32; // 256 bits
     
     private readonly IFileSystemService _fileSystem;
     private readonly ISecureStorageService _secureStorage;
+    private readonly ILocalVaultStore? _vaultStore;
     private readonly string _settingsPath;
     private MauiSherpaSettings? _cachedSettings;
     private readonly SemaphoreSlim _lock = new(1, 1);
     
     public event Action? OnSettingsChanged;
 
-    public EncryptedSettingsService(IFileSystemService fileSystem, ISecureStorageService secureStorage)
+    public EncryptedSettingsService(
+        IFileSystemService fileSystem,
+        ISecureStorageService secureStorage,
+        ILocalVaultStore? vaultStore = null)
+        : this(
+            fileSystem,
+            secureStorage,
+            vaultStore,
+            Path.Combine(AppDataPath.GetAppDataDirectory(), SettingsFileName))
+    {
+    }
+
+    internal EncryptedSettingsService(
+        IFileSystemService fileSystem,
+        ISecureStorageService secureStorage,
+        ILocalVaultStore? vaultStore,
+        string settingsPath)
     {
         _fileSystem = fileSystem;
         _secureStorage = secureStorage;
-        _settingsPath = Path.Combine(
-            AppDataPath.GetAppDataDirectory(),
-            SettingsFileName);
+        _vaultStore = vaultStore;
+        _settingsPath = settingsPath;
     }
 
     // Protected constructor for testing
@@ -38,6 +56,7 @@ public class EncryptedSettingsService : IEncryptedSettingsService
     {
         _fileSystem = null!;
         _secureStorage = null!;
+        _vaultStore = null;
         _settingsPath = "";
     }
 
@@ -49,7 +68,17 @@ public class EncryptedSettingsService : IEncryptedSettingsService
             if (_cachedSettings != null)
                 return _cachedSettings;
 
-            if (!await SettingsExistAsync())
+            if (_vaultStore is not null)
+            {
+                var vaultSettings = await LoadVaultSettingsAsync();
+                if (vaultSettings is not null)
+                {
+                    _cachedSettings = vaultSettings;
+                    return _cachedSettings;
+                }
+            }
+
+            if (!LegacySettingsFileExists())
             {
                 _cachedSettings = new MauiSherpaSettings();
                 return _cachedSettings;
@@ -62,6 +91,11 @@ public class EncryptedSettingsService : IEncryptedSettingsService
             {
                 var json = Decrypt(encryptedData, masterKey);
                 _cachedSettings = JsonSerializer.Deserialize<MauiSherpaSettings>(json) ?? new MauiSherpaSettings();
+                if (_vaultStore is not null)
+                {
+                    await SaveVaultSettingsAsync(_cachedSettings);
+                    await CleanupLegacySettingsAsync();
+                }
             }
             catch (CryptographicException)
             {
@@ -88,23 +122,34 @@ public class EncryptedSettingsService : IEncryptedSettingsService
         await _lock.WaitAsync();
         try
         {
+            var settingsToSave = settings with { LastModified = DateTime.UtcNow };
+
+            if (_vaultStore is not null)
+            {
+                await SaveVaultSettingsAsync(settingsToSave);
+                _cachedSettings = settingsToSave;
+                await CleanupLegacySettingsAsync();
+                OnSettingsChanged?.Invoke();
+                return;
+            }
+
+            // Create backup before saving
             var directory = Path.GetDirectoryName(_settingsPath);
             if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
                 Directory.CreateDirectory(directory);
 
-            // Create backup before saving
             if (File.Exists(_settingsPath))
             {
                 var backupPath = _settingsPath + ".bak";
                 File.Copy(_settingsPath, backupPath, overwrite: true);
             }
 
-            var json = JsonSerializer.Serialize(settings with { LastModified = DateTime.UtcNow });
+            var json = JsonSerializer.Serialize(settingsToSave);
             var masterKey = await GetOrCreateMasterKeyAsync();
             var encrypted = Encrypt(json, masterKey);
             await File.WriteAllBytesAsync(_settingsPath, encrypted);
             
-            _cachedSettings = settings;
+            _cachedSettings = settingsToSave;
             OnSettingsChanged?.Invoke();
         }
         finally
@@ -122,7 +167,67 @@ public class EncryptedSettingsService : IEncryptedSettingsService
 
     public Task<bool> SettingsExistAsync()
     {
-        return Task.FromResult(File.Exists(_settingsPath));
+        return SettingsExistCoreAsync();
+    }
+
+    private async Task<bool> SettingsExistCoreAsync()
+    {
+        if (_vaultStore is not null &&
+            await _vaultStore.ExistsAsync(LocalVaultScopes.Settings, VaultSettingsPath, VaultSettingsKey))
+        {
+            return true;
+        }
+
+        return LegacySettingsFileExists();
+    }
+
+    private bool LegacySettingsFileExists() => File.Exists(_settingsPath);
+
+    private async Task<MauiSherpaSettings?> LoadVaultSettingsAsync()
+    {
+        if (_vaultStore is null)
+            return null;
+
+        var item = await _vaultStore.GetAsync(LocalVaultScopes.Settings, VaultSettingsPath, VaultSettingsKey);
+        if (item is null)
+            return null;
+
+        var json = Encoding.UTF8.GetString(item.Value);
+        return JsonSerializer.Deserialize<MauiSherpaSettings>(json) ?? new MauiSherpaSettings();
+    }
+
+    private async Task SaveVaultSettingsAsync(MauiSherpaSettings settings)
+    {
+        if (_vaultStore is null)
+            return;
+
+        var json = JsonSerializer.Serialize(settings);
+        await _vaultStore.PutAsync(
+            LocalVaultScopes.Settings,
+            VaultSettingsPath,
+            VaultSettingsKey,
+            Encoding.UTF8.GetBytes(json),
+            LocalVaultContentTypes.Json,
+            new Dictionary<string, string>
+            {
+                ["LegacyFileName"] = SettingsFileName
+            });
+    }
+
+    private async Task CleanupLegacySettingsAsync()
+    {
+        foreach (var path in new[]
+        {
+            _settingsPath,
+            _settingsPath + ".bak",
+            _settingsPath + ".unreadable"
+        })
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+
+        await _secureStorage.RemoveAsync(MasterKeyStorageKey);
     }
 
     protected virtual async Task<byte[]> GetOrCreateMasterKeyAsync()

--- a/src/MauiSherpa.Core/Services/EncryptedSettingsService.cs
+++ b/src/MauiSherpa.Core/Services/EncryptedSettingsService.cs
@@ -21,6 +21,7 @@ public class EncryptedSettingsService : IEncryptedSettingsService
     private readonly IFileSystemService _fileSystem;
     private readonly ISecureStorageService _secureStorage;
     private readonly ILocalVaultStore? _vaultStore;
+    private readonly ILocalVaultIntroductionService? _localVaultIntroduction;
     private readonly string _settingsPath;
     private MauiSherpaSettings? _cachedSettings;
     private readonly SemaphoreSlim _lock = new(1, 1);
@@ -30,11 +31,13 @@ public class EncryptedSettingsService : IEncryptedSettingsService
     public EncryptedSettingsService(
         IFileSystemService fileSystem,
         ISecureStorageService secureStorage,
-        ILocalVaultStore? vaultStore = null)
+        ILocalVaultStore? vaultStore = null,
+        ILocalVaultIntroductionService? localVaultIntroduction = null)
         : this(
             fileSystem,
             secureStorage,
             vaultStore,
+            localVaultIntroduction,
             Path.Combine(AppDataPath.GetAppDataDirectory(), SettingsFileName))
     {
     }
@@ -44,10 +47,21 @@ public class EncryptedSettingsService : IEncryptedSettingsService
         ISecureStorageService secureStorage,
         ILocalVaultStore? vaultStore,
         string settingsPath)
+        : this(fileSystem, secureStorage, vaultStore, null, settingsPath)
+    {
+    }
+
+    internal EncryptedSettingsService(
+        IFileSystemService fileSystem,
+        ISecureStorageService secureStorage,
+        ILocalVaultStore? vaultStore,
+        ILocalVaultIntroductionService? localVaultIntroduction,
+        string settingsPath)
     {
         _fileSystem = fileSystem;
         _secureStorage = secureStorage;
         _vaultStore = vaultStore;
+        _localVaultIntroduction = localVaultIntroduction;
         _settingsPath = settingsPath;
     }
 
@@ -68,7 +82,7 @@ public class EncryptedSettingsService : IEncryptedSettingsService
             if (_cachedSettings != null)
                 return _cachedSettings;
 
-            if (_vaultStore is not null)
+            if (CanUseLocalVault())
             {
                 var vaultSettings = await LoadVaultSettingsAsync();
                 if (vaultSettings is not null)
@@ -91,7 +105,7 @@ public class EncryptedSettingsService : IEncryptedSettingsService
             {
                 var json = Decrypt(encryptedData, masterKey);
                 _cachedSettings = JsonSerializer.Deserialize<MauiSherpaSettings>(json) ?? new MauiSherpaSettings();
-                if (_vaultStore is not null)
+                if (CanUseLocalVault())
                 {
                     await SaveVaultSettingsAsync(_cachedSettings);
                     await CleanupLegacySettingsAsync();
@@ -124,7 +138,7 @@ public class EncryptedSettingsService : IEncryptedSettingsService
         {
             var settingsToSave = settings with { LastModified = DateTime.UtcNow };
 
-            if (_vaultStore is not null)
+            if (CanUseLocalVault())
             {
                 await SaveVaultSettingsAsync(settingsToSave);
                 _cachedSettings = settingsToSave;
@@ -172,7 +186,7 @@ public class EncryptedSettingsService : IEncryptedSettingsService
 
     private async Task<bool> SettingsExistCoreAsync()
     {
-        if (_vaultStore is not null &&
+        if (CanUseLocalVault() &&
             await _vaultStore.ExistsAsync(LocalVaultScopes.Settings, VaultSettingsPath, VaultSettingsKey))
         {
             return true;
@@ -182,6 +196,10 @@ public class EncryptedSettingsService : IEncryptedSettingsService
     }
 
     private bool LegacySettingsFileExists() => File.Exists(_settingsPath);
+
+    private bool CanUseLocalVault() =>
+        _vaultStore is not null &&
+        _localVaultIntroduction?.GetState().IsLocalVaultEnabled != false;
 
     private async Task<MauiSherpaSettings?> LoadVaultSettingsAsync()
     {

--- a/src/MauiSherpa.Core/Services/GoogleSecretManagerProvider.cs
+++ b/src/MauiSherpa.Core/Services/GoogleSecretManagerProvider.cs
@@ -109,15 +109,6 @@ public class GoogleSecretManagerProvider : ICloudSecretsProvider
                     Replication = new Replication { Automatic = new Replication.Types.Automatic() }
                 };
                 
-                // Add labels if metadata provided
-                if (metadata != null)
-                {
-                    foreach (var kvp in metadata)
-                    {
-                        secret.Labels[SanitizeLabel(kvp.Key)] = SanitizeLabel(kvp.Value);
-                    }
-                }
-                
                 var createRequest = new CreateSecretRequest
                 {
                     Parent = parent,
@@ -141,6 +132,8 @@ public class GoogleSecretManagerProvider : ICloudSecretsProvider
             };
             
             await client.AddSecretVersionAsync(addVersionRequest, cancellationToken);
+            if (metadata is not null && !await SetSecretMetadataAsync(key, metadata, cancellationToken))
+                return false;
 
             _logger.LogInformation($"Stored secret: {key}");
             return true;
@@ -186,6 +179,49 @@ public class GoogleSecretManagerProvider : ICloudSecretsProvider
         }
     }
 
+    public async Task<Dictionary<string, string>?> GetSecretMetadataAsync(string key, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var secretId = GetSecretId(key);
+            if (!await SecretExistsInternalAsync(secretId, cancellationToken))
+                return null;
+
+            var metadataBytes = await GetSecretAsync(CloudSecretMetadata.GetMetadataKey(secretId), cancellationToken);
+            return metadataBytes is null
+                ? new Dictionary<string, string>(StringComparer.Ordinal)
+                : CloudSecretMetadata.Deserialize(metadataBytes);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"Google Secret Manager get secret metadata error: {ex.Message}", ex);
+            return null;
+        }
+    }
+
+    public async Task<bool> SetSecretMetadataAsync(
+        string key,
+        Dictionary<string, string> metadata,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var secretId = GetSecretId(key);
+            if (!await SecretExistsInternalAsync(secretId, cancellationToken))
+                return false;
+
+            var metadataKey = CloudSecretMetadata.GetMetadataKey(secretId);
+            return metadata.Count == 0
+                ? await DeleteSecretAsync(metadataKey, cancellationToken)
+                : await StoreSecretAsync(metadataKey, CloudSecretMetadata.Serialize(metadata), cancellationToken: cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"Google Secret Manager set secret metadata error: {ex.Message}", ex);
+            return false;
+        }
+    }
+
     public async Task<bool> DeleteSecretAsync(string key, CancellationToken cancellationToken = default)
     {
         try
@@ -196,12 +232,16 @@ public class GoogleSecretManagerProvider : ICloudSecretsProvider
             
             var request = new DeleteSecretRequest { Name = secretName };
             await client.DeleteSecretAsync(request, cancellationToken);
+            if (!CloudSecretMetadata.IsMetadataKey(key))
+                await DeleteSecretAsync(CloudSecretMetadata.GetMetadataKey(secretId), cancellationToken);
             
             _logger.LogInformation($"Deleted secret: {key}");
             return true;
         }
         catch (Grpc.Core.RpcException ex) when (ex.StatusCode == Grpc.Core.StatusCode.NotFound)
         {
+            if (!CloudSecretMetadata.IsMetadataKey(key))
+                await DeleteSecretAsync(CloudSecretMetadata.GetMetadataKey(GetSecretId(key)), cancellationToken);
             _logger.LogInformation($"Secret already deleted or not found: {key}");
             return true;
         }
@@ -274,6 +314,9 @@ public class GoogleSecretManagerProvider : ICloudSecretsProvider
 
                 // Remove our prefix to get the original key
                 var originalKey = RemoveSecretPrefix(secretId);
+                if (CloudSecretMetadata.IsMetadataKey(originalKey))
+                    continue;
+
                 allSecrets.Add(originalKey);
             }
 
@@ -333,33 +376,6 @@ public class GoogleSecretManagerProvider : ICloudSecretsProvider
         // Limit to 255 characters
         if (result.Length > 255)
             result = result[..255];
-        
-        return result;
-    }
-
-    /// <summary>
-    /// Sanitize label key/value for Google Cloud
-    /// </summary>
-    private static string SanitizeLabel(string value)
-    {
-        var sanitized = new StringBuilder();
-        foreach (var c in value.ToLowerInvariant())
-        {
-            if (char.IsLetterOrDigit(c) || c == '-' || c == '_')
-                sanitized.Append(c);
-            else
-                sanitized.Append('-');
-        }
-        
-        var result = sanitized.ToString();
-        
-        // Must start with a letter
-        if (result.Length > 0 && !char.IsLetter(result[0]))
-            result = "l" + result;
-        
-        // Limit to 63 characters
-        if (result.Length > 63)
-            result = result[..63];
         
         return result;
     }

--- a/src/MauiSherpa.Core/Services/InfisicalProvider.cs
+++ b/src/MauiSherpa.Core/Services/InfisicalProvider.cs
@@ -143,6 +143,9 @@ public class InfisicalProvider : ICloudSecretsProvider
                 await client.Secrets().CreateAsync(createOptions);
             }
 
+            if (metadata is not null && !await SetSecretMetadataAsync(key, metadata, cancellationToken))
+                return false;
+
             _logger.LogInformation($"Stored secret: {key}");
             return true;
         }
@@ -200,6 +203,55 @@ public class InfisicalProvider : ICloudSecretsProvider
         }
     }
 
+    public async Task<Dictionary<string, string>?> GetSecretMetadataAsync(string key, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var secretName = SanitizeSecretName(key);
+            var client = await GetClientAsync(cancellationToken);
+            if (client == null)
+                return null;
+            if (!await SecretExistsInternalAsync(client, secretName, cancellationToken))
+                return null;
+
+            var metadataBytes = await GetSecretAsync(CloudSecretMetadata.GetMetadataKey(secretName), cancellationToken);
+            return metadataBytes is null
+                ? new Dictionary<string, string>(StringComparer.Ordinal)
+                : CloudSecretMetadata.Deserialize(metadataBytes);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"Infisical get secret metadata error: {ex.Message}", ex);
+            return null;
+        }
+    }
+
+    public async Task<bool> SetSecretMetadataAsync(
+        string key,
+        Dictionary<string, string> metadata,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var secretName = SanitizeSecretName(key);
+            var client = await GetClientAsync(cancellationToken);
+            if (client == null)
+                return false;
+            if (!await SecretExistsInternalAsync(client, secretName, cancellationToken))
+                return false;
+
+            var metadataKey = CloudSecretMetadata.GetMetadataKey(secretName);
+            return metadata.Count == 0
+                ? await DeleteSecretAsync(metadataKey, cancellationToken)
+                : await StoreSecretAsync(metadataKey, CloudSecretMetadata.Serialize(metadata), cancellationToken: cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"Infisical set secret metadata error: {ex.Message}", ex);
+            return false;
+        }
+    }
+
     public async Task<bool> DeleteSecretAsync(string key, CancellationToken cancellationToken = default)
     {
         try
@@ -219,6 +271,8 @@ public class InfisicalProvider : ICloudSecretsProvider
             };
             
             await client.Secrets().DeleteAsync(options);
+            if (!CloudSecretMetadata.IsMetadataKey(key))
+                await DeleteSecretAsync(CloudSecretMetadata.GetMetadataKey(secretName), cancellationToken);
             
             _logger.LogInformation($"Deleted secret: {key}");
             return true;
@@ -227,6 +281,8 @@ public class InfisicalProvider : ICloudSecretsProvider
             ex.Message.Contains("not found", StringComparison.OrdinalIgnoreCase) ||
             ex.InnerException?.Message?.Contains("not found", StringComparison.OrdinalIgnoreCase) == true)
         {
+            if (!CloudSecretMetadata.IsMetadataKey(key))
+                await DeleteSecretAsync(CloudSecretMetadata.GetMetadataKey(SanitizeSecretName(key)), cancellationToken);
             _logger.LogInformation($"Secret already deleted or not found: {key}");
             return true;
         }
@@ -321,6 +377,8 @@ public class InfisicalProvider : ICloudSecretsProvider
                 
                 // Filter by sanitized prefix if specified
                 if (sanitizedPrefix != null && !secretKey.StartsWith(sanitizedPrefix, StringComparison.OrdinalIgnoreCase))
+                    continue;
+                if (CloudSecretMetadata.IsMetadataKey(secretKey))
                     continue;
                 
                 result.Add(secretKey);

--- a/src/MauiSherpa.Core/Services/LocalSqlCipherSecretsProvider.cs
+++ b/src/MauiSherpa.Core/Services/LocalSqlCipherSecretsProvider.cs
@@ -1,0 +1,342 @@
+using System.Text;
+using System.Text.Json;
+using MauiSherpa.Core.Interfaces;
+using Shiny.DocumentDb;
+using Shiny.DocumentDb.Sqlite.SqlCipher;
+
+namespace MauiSherpa.Core.Services;
+
+public class LocalSqlCipherSecretsProvider : ICloudSecretsProvider
+{
+    public const string DefaultDatabaseFileName = LocalVaultOptions.DefaultDatabaseFileName;
+    public const string LegacyDatabaseFileName = "local-secrets.db";
+    public const string DatabasePathSettingKey = "DatabasePath";
+
+    private const string OriginalFlatKeyMetadataName = "OriginalFlatKey";
+    private const string LegacyMigrationStepId = "local-provider-legacy-db";
+
+    private readonly ILoggingService _logger;
+    private readonly ILocalVaultStore _vaultStore;
+    private readonly ILocalVaultKeyStore? _keyStore;
+    private readonly string _legacyDatabasePath;
+    private readonly SemaphoreSlim _migrationLock = new(1, 1);
+    private bool _legacyMigrationChecked;
+
+    public LocalSqlCipherSecretsProvider(
+        CloudSecretsProviderConfig config,
+        ILoggingService logger,
+        ILocalVaultStore vaultStore,
+        ILocalVaultKeyStore? keyStore = null)
+    {
+        _logger = logger;
+        _vaultStore = vaultStore;
+        _keyStore = keyStore;
+        _legacyDatabasePath = GetLegacyDatabasePath(config);
+    }
+
+    public LocalSqlCipherSecretsProvider(
+        CloudSecretsProviderConfig config,
+        ILoggingService logger,
+        ILocalSecretsKeyStore keyStore)
+        : this(
+            config,
+            logger,
+            new SqlCipherLocalVaultStore(keyStore, logger, new LocalVaultOptions(GetVaultDatabasePath(config))),
+            keyStore)
+    {
+    }
+
+    public CloudSecretsProviderType ProviderType => CloudSecretsProviderType.Local;
+
+    public string DisplayName => "Local";
+
+    public async Task<bool> TestConnectionAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await EnsureLegacyDatabaseMigratedAsync(cancellationToken);
+            await _vaultStore.ListAsync(LocalVaultScopes.LocalProviderSecret, cancellationToken: cancellationToken);
+            _logger.LogInformation($"Local secrets provider is available in vault {_vaultStore.DatabasePath}");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"Local secrets provider connection test failed: {ex.Message}", ex);
+            return false;
+        }
+    }
+
+    public async Task<bool> StoreSecretAsync(
+        string key,
+        byte[] value,
+        Dictionary<string, string>? metadata = null,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await EnsureLegacyDatabaseMigratedAsync(cancellationToken);
+            var path = SecretPath.FromFlatKey(key);
+            var itemMetadata = metadata is null
+                ? new Dictionary<string, string>(StringComparer.Ordinal)
+                : new Dictionary<string, string>(metadata, StringComparer.Ordinal);
+            itemMetadata[OriginalFlatKeyMetadataName] = key;
+
+            await _vaultStore.PutAsync(
+                LocalVaultScopes.LocalProviderSecret,
+                path.FolderPath,
+                path.Key,
+                value,
+                LocalVaultContentTypes.Binary,
+                itemMetadata,
+                cancellationToken);
+
+            _logger.LogInformation($"Stored local secret: {key}");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"Local secrets provider store error: {ex.Message}", ex);
+            return false;
+        }
+    }
+
+    public async Task<byte[]?> GetSecretAsync(string key, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await EnsureLegacyDatabaseMigratedAsync(cancellationToken);
+            var item = await FindItemByFlatKeyAsync(key, cancellationToken);
+            return item?.Value;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"Local secrets provider get error: {ex.Message}", ex);
+            return null;
+        }
+    }
+
+    public async Task<bool> DeleteSecretAsync(string key, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await EnsureLegacyDatabaseMigratedAsync(cancellationToken);
+            var item = await FindItemByFlatKeyAsync(key, cancellationToken);
+            if (item is null)
+                return true;
+
+            await _vaultStore.RemoveAsync(
+                LocalVaultScopes.LocalProviderSecret,
+                item.Path,
+                item.Key,
+                cancellationToken);
+
+            _logger.LogInformation($"Deleted local secret: {key}");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"Local secrets provider delete error: {ex.Message}", ex);
+            return false;
+        }
+    }
+
+    public async Task<bool> SecretExistsAsync(string key, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await EnsureLegacyDatabaseMigratedAsync(cancellationToken);
+            return await FindItemByFlatKeyAsync(key, cancellationToken) is not null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"Local secrets provider exists check error: {ex.Message}", ex);
+            return false;
+        }
+    }
+
+    public async Task<IReadOnlyList<string>> ListSecretsAsync(string? prefix = null, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await EnsureLegacyDatabaseMigratedAsync(cancellationToken);
+            var documents = await _vaultStore.ListAsync(
+                LocalVaultScopes.LocalProviderSecret,
+                cancellationToken: cancellationToken);
+
+            var keys = documents
+                .Select(GetFlatKey)
+                .Where(x => string.IsNullOrEmpty(prefix) || x.StartsWith(prefix, StringComparison.Ordinal))
+                .OrderBy(x => x, StringComparer.Ordinal)
+                .ToList();
+
+            return keys.AsReadOnly();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"Local secrets provider list error: {ex.Message}", ex);
+            return Array.Empty<string>();
+        }
+    }
+
+    private async Task<LocalVaultItem?> FindItemByFlatKeyAsync(string key, CancellationToken cancellationToken)
+    {
+        var path = SecretPath.FromFlatKey(key);
+        var item = await _vaultStore.GetAsync(
+            LocalVaultScopes.LocalProviderSecret,
+            path.FolderPath,
+            path.Key,
+            cancellationToken);
+
+        if (item is not null)
+            return item;
+
+        var allItems = await _vaultStore.ListAsync(
+            LocalVaultScopes.LocalProviderSecret,
+            cancellationToken: cancellationToken);
+
+        return allItems.FirstOrDefault(x =>
+            x.Metadata.TryGetValue(OriginalFlatKeyMetadataName, out var originalKey) &&
+            string.Equals(originalKey, key, StringComparison.Ordinal));
+    }
+
+    private async Task EnsureLegacyDatabaseMigratedAsync(CancellationToken cancellationToken)
+    {
+        if (_legacyMigrationChecked)
+            return;
+
+        await _migrationLock.WaitAsync(cancellationToken);
+        try
+        {
+            if (_legacyMigrationChecked)
+                return;
+
+            if (_keyStore is null ||
+                string.Equals(_legacyDatabasePath, _vaultStore.DatabasePath, StringComparison.Ordinal) ||
+                !File.Exists(_legacyDatabasePath) ||
+                await IsMigrationStepCompleteAsync(cancellationToken))
+            {
+                _legacyMigrationChecked = true;
+                return;
+            }
+
+            var key = await _keyStore.GetOrCreateKeyAsync(cancellationToken);
+            var legacyStore = new DocumentStore(new DocumentStoreOptions
+            {
+                DatabaseProvider = new SqlCipherDatabaseProvider(_legacyDatabasePath, key)
+            });
+
+            var legacyDocuments = await legacyStore.Query<LocalSecretDocument>().ToList();
+            foreach (var document in legacyDocuments.Where(x => !string.IsNullOrWhiteSpace(x.Key)))
+            {
+                var metadata = document.Metadata is null
+                    ? new Dictionary<string, string>(StringComparer.Ordinal)
+                    : new Dictionary<string, string>(document.Metadata, StringComparer.Ordinal);
+                metadata[OriginalFlatKeyMetadataName] = document.Key;
+                metadata["MigratedFrom"] = LegacyDatabaseFileName;
+
+                var path = SecretPath.FromFlatKey(document.Key);
+                await _vaultStore.PutAsync(
+                    LocalVaultScopes.LocalProviderSecret,
+                    path.FolderPath,
+                    path.Key,
+                    document.Value,
+                    LocalVaultContentTypes.Binary,
+                    metadata,
+                    cancellationToken);
+            }
+
+            await MarkMigrationStepCompleteAsync(legacyDocuments.Count, cancellationToken);
+            DeleteLegacyDatabaseFiles(_legacyDatabasePath);
+            _logger.LogInformation($"Migrated {legacyDocuments.Count} local secrets into the shared local vault.");
+            _legacyMigrationChecked = true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning($"Local secrets legacy database migration was skipped: {ex.Message}");
+        }
+        finally
+        {
+            _migrationLock.Release();
+        }
+    }
+
+    private async Task<bool> IsMigrationStepCompleteAsync(CancellationToken cancellationToken)
+    {
+        return await _vaultStore.ExistsAsync(
+            LocalVaultScopes.Migration,
+            "/",
+            LegacyMigrationStepId,
+            cancellationToken);
+    }
+
+    private async Task MarkMigrationStepCompleteAsync(int migratedCount, CancellationToken cancellationToken)
+    {
+        var payload = JsonSerializer.Serialize(new
+        {
+            Step = LegacyMigrationStepId,
+            MigratedCount = migratedCount,
+            CompletedAt = DateTime.UtcNow
+        });
+
+        await _vaultStore.PutAsync(
+            LocalVaultScopes.Migration,
+            "/",
+            LegacyMigrationStepId,
+            Encoding.UTF8.GetBytes(payload),
+            LocalVaultContentTypes.Json,
+            cancellationToken: cancellationToken);
+    }
+
+    private static string GetFlatKey(LocalVaultItem item)
+    {
+        return item.Metadata.TryGetValue(OriginalFlatKeyMetadataName, out var originalKey)
+            ? originalKey
+            : new SecretPath(item.Path, item.Key).ToFlatKey();
+    }
+
+    private static void DeleteLegacyDatabaseFiles(string legacyDatabasePath)
+    {
+        foreach (var path in new[]
+        {
+            legacyDatabasePath,
+            legacyDatabasePath + "-wal",
+            legacyDatabasePath + "-shm"
+        })
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+    }
+
+    private static string GetVaultDatabasePath(CloudSecretsProviderConfig config)
+    {
+        if (config.Settings.TryGetValue(DatabasePathSettingKey, out var configuredPath) &&
+            !string.IsNullOrWhiteSpace(configuredPath))
+        {
+            return configuredPath;
+        }
+
+        return Path.Combine(AppDataPath.GetAppDataDirectory(), DefaultDatabaseFileName);
+    }
+
+    private static string GetLegacyDatabasePath(CloudSecretsProviderConfig config)
+    {
+        if (config.Settings.TryGetValue(DatabasePathSettingKey, out var configuredPath) &&
+            !string.IsNullOrWhiteSpace(configuredPath))
+        {
+            return configuredPath;
+        }
+
+        return Path.Combine(AppDataPath.GetAppDataDirectory(), LegacyDatabaseFileName);
+    }
+
+    internal sealed class LocalSecretDocument
+    {
+        public string Id { get; set; } = "";
+        public string Key { get; set; } = "";
+        public byte[] Value { get; set; } = [];
+        public Dictionary<string, string> Metadata { get; set; } = new();
+        public DateTime CreatedAt { get; set; }
+        public DateTime UpdatedAt { get; set; }
+    }
+}

--- a/src/MauiSherpa.Core/Services/LocalSqlCipherSecretsProvider.cs
+++ b/src/MauiSherpa.Core/Services/LocalSqlCipherSecretsProvider.cs
@@ -76,9 +76,12 @@ public class LocalSqlCipherSecretsProvider : ICloudSecretsProvider
         {
             await EnsureLegacyDatabaseMigratedAsync(cancellationToken);
             var path = SecretPath.FromFlatKey(key);
-            var itemMetadata = metadata is null
-                ? new Dictionary<string, string>(StringComparer.Ordinal)
-                : new Dictionary<string, string>(metadata, StringComparer.Ordinal);
+            var existing = await FindItemByFlatKeyAsync(key, cancellationToken);
+            var itemMetadata = metadata is null && existing is not null
+                ? new Dictionary<string, string>(existing.Metadata, StringComparer.Ordinal)
+                : metadata is null
+                    ? new Dictionary<string, string>(StringComparer.Ordinal)
+                    : new Dictionary<string, string>(metadata, StringComparer.Ordinal);
             itemMetadata[OriginalFlatKeyMetadataName] = key;
 
             await _vaultStore.PutAsync(
@@ -112,6 +115,62 @@ public class LocalSqlCipherSecretsProvider : ICloudSecretsProvider
         {
             _logger.LogError($"Local secrets provider get error: {ex.Message}", ex);
             return null;
+        }
+    }
+
+    public async Task<Dictionary<string, string>?> GetSecretMetadataAsync(string key, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await EnsureLegacyDatabaseMigratedAsync(cancellationToken);
+            var item = await FindItemByFlatKeyAsync(key, cancellationToken);
+            if (item is null)
+                return null;
+
+            var metadata = new Dictionary<string, string>(item.Metadata, StringComparer.Ordinal);
+            metadata.Remove(OriginalFlatKeyMetadataName);
+            return metadata;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"Local secrets provider metadata get error: {ex.Message}", ex);
+            return null;
+        }
+    }
+
+    public async Task<bool> SetSecretMetadataAsync(
+        string key,
+        Dictionary<string, string> metadata,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await EnsureLegacyDatabaseMigratedAsync(cancellationToken);
+            var item = await FindItemByFlatKeyAsync(key, cancellationToken);
+            if (item is null)
+                return false;
+
+            var itemMetadata = new Dictionary<string, string>(metadata, StringComparer.Ordinal)
+            {
+                [OriginalFlatKeyMetadataName] = GetFlatKey(item)
+            };
+
+            await _vaultStore.PutAsync(
+                LocalVaultScopes.LocalProviderSecret,
+                item.Path,
+                item.Key,
+                item.Value,
+                item.ContentType,
+                itemMetadata,
+                cancellationToken);
+
+            _logger.LogInformation($"Updated local secret metadata: {key}");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"Local secrets provider metadata set error: {ex.Message}", ex);
+            return false;
         }
     }
 

--- a/src/MauiSherpa.Core/Services/LocalVaultItem.cs
+++ b/src/MauiSherpa.Core/Services/LocalVaultItem.cs
@@ -1,0 +1,63 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace MauiSherpa.Core.Services;
+
+public sealed class LocalVaultItem
+{
+    public string Id { get; set; } = "";
+    public string Scope { get; set; } = "";
+    public string Path { get; set; } = "/";
+    public string Key { get; set; } = "";
+    public string ContentType { get; set; } = "";
+    public byte[] Value { get; set; } = [];
+    public Dictionary<string, string> Metadata { get; set; } = new();
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+
+    public static string CreateId(string scope, string path, string key)
+    {
+        var normalizedScope = LocalVaultNames.NormalizeScope(scope);
+        var normalizedPath = SecretPath.NormalizeFolderPath(path);
+        var normalizedKey = SecretPath.NormalizeKey(key);
+        var identity = $"v1\n{normalizedScope}\n{normalizedPath}\n{normalizedKey}";
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(identity));
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+}
+
+public static class LocalVaultContentTypes
+{
+    public const string Json = "application/json";
+    public const string Text = "text/plain";
+    public const string Binary = "application/octet-stream";
+}
+
+public static class LocalVaultScopes
+{
+    public const string LocalProviderSecret = "local-provider-secret";
+    public const string LocalProviderMetadata = "local-provider-metadata";
+    public const string Settings = "settings";
+    public const string SecureStorage = "secure";
+    public const string CloudProvider = "cloud-provider";
+    public const string Migration = "migration";
+}
+
+public static class LocalVaultNames
+{
+    public static string NormalizeScope(string scope)
+    {
+        if (string.IsNullOrWhiteSpace(scope))
+            throw new ArgumentException("Vault scope cannot be empty.", nameof(scope));
+
+        return scope.Trim().ToLowerInvariant();
+    }
+}
+
+public sealed record LocalVaultOptions(string DatabasePath)
+{
+    public const string DefaultDatabaseFileName = "local-vault.db";
+
+    public static LocalVaultOptions Default =>
+        new(Path.Combine(AppDataPath.GetAppDataDirectory(), DefaultDatabaseFileName));
+}

--- a/src/MauiSherpa.Core/Services/ManagedSecretsService.cs
+++ b/src/MauiSherpa.Core/Services/ManagedSecretsService.cs
@@ -1,12 +1,16 @@
 using System.Text.Json;
+using System.Text;
 using MauiSherpa.Core.Interfaces;
 
 namespace MauiSherpa.Core.Services;
 
 public class ManagedSecretsService : IManagedSecretsService
 {
+    public const string FolderPlaceholderKey = "sherpa-folder-marker";
+
     readonly ICloudSecretsService _cloudService;
     readonly ILoggingService _logger;
+    static readonly byte[] FolderPlaceholderValue = Encoding.UTF8.GetBytes("""{"kind":"maui-sherpa-folder"}""");
 
     static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -51,6 +55,173 @@ public class ManagedSecretsService : IManagedSecretsService
         return secrets;
     }
 
+    public async Task<IReadOnlyList<ManagedSecretFolder>> ListFoldersAsync(CancellationToken cancellationToken = default)
+    {
+        if (_cloudService.ActiveProvider is null)
+            return Array.Empty<ManagedSecretFolder>();
+
+        var folderKeys = await _cloudService.ListSecretsAsync(IManagedSecretsService.FolderPrefix, cancellationToken);
+        var folders = new List<ManagedSecretFolder>();
+
+        foreach (var fullFolderKey in folderKeys)
+        {
+            try
+            {
+                var folderBytes = await _cloudService.GetSecretAsync(fullFolderKey, cancellationToken);
+                if (folderBytes is null)
+                    continue;
+
+                var json = System.Text.Encoding.UTF8.GetString(folderBytes);
+                var folder = JsonSerializer.Deserialize<ManagedSecretFolder>(json, JsonOptions);
+                if (folder is not null)
+                    folders.Add(folder);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning($"Failed to load folder metadata for '{fullFolderKey}': {ex.Message}");
+            }
+        }
+
+        return folders
+            .GroupBy(f => f.Path, StringComparer.Ordinal)
+            .Select(g => g.First())
+            .OrderBy(f => f.Path, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    public async Task<bool> CreateFolderAsync(string folderPath, CancellationToken cancellationToken = default)
+    {
+        if (_cloudService.ActiveProvider is null)
+            throw new InvalidOperationException("No active cloud secrets provider configured.");
+
+        var normalizedPath = SecretPath.NormalizeFolderPath(folderPath);
+        if (normalizedPath == "/")
+            throw new ArgumentException("Root folder already exists.", nameof(folderPath));
+
+        var folder = new ManagedSecretFolder(
+            normalizedPath,
+            GetFolderName(normalizedPath),
+            DateTime.UtcNow);
+        var stored = await StoreFolderAsync(folder, cancellationToken);
+
+        if (stored)
+            _logger.LogInformation($"Created managed secrets folder: {normalizedPath}");
+
+        return stored;
+    }
+
+    public async Task<bool> RenameFolderAsync(string folderPath, string newFolderPath, CancellationToken cancellationToken = default)
+    {
+        if (_cloudService.ActiveProvider is null)
+            throw new InvalidOperationException("No active cloud secrets provider configured.");
+
+        var oldPath = SecretPath.NormalizeFolderPath(folderPath);
+        var normalizedNewPath = SecretPath.NormalizeFolderPath(newFolderPath);
+        if (oldPath == "/" || normalizedNewPath == "/")
+            throw new ArgumentException("Root folder cannot be renamed.");
+        if (oldPath == normalizedNewPath)
+            return true;
+        if (normalizedNewPath.StartsWith(oldPath + "/", StringComparison.Ordinal))
+            throw new ArgumentException("A folder cannot be moved inside itself.", nameof(newFolderPath));
+
+        var secrets = await ListAsync(cancellationToken);
+        var affectedSecrets = secrets
+            .Where(secret => IsInFolderTree(GetSecretFolder(secret.Key), oldPath))
+            .ToList();
+        var movedKeys = affectedSecrets
+            .Select(secret => MoveKey(secret.Key, oldPath, normalizedNewPath))
+            .ToHashSet(StringComparer.Ordinal);
+        if (secrets.Any(secret => !affectedSecrets.Any(affected => affected.Key == secret.Key) && movedKeys.Contains(secret.Key)))
+            return false;
+
+        var secretMoves = new List<(ManagedSecret Existing, ManagedSecret Moved, byte[] Value)>();
+        foreach (var secret in affectedSecrets)
+        {
+            var value = await GetValueAsync(secret.Key, cancellationToken);
+            if (value is null)
+                return false;
+
+            var moved = secret with
+            {
+                Key = MoveKey(secret.Key, oldPath, normalizedNewPath),
+                UpdatedAt = DateTime.UtcNow
+            };
+            secretMoves.Add((secret, moved, value));
+        }
+
+        var folders = await ListFoldersAsync(cancellationToken);
+        var affectedFolders = folders
+            .Where(folder => folder.Path == oldPath || folder.Path.StartsWith(oldPath + "/", StringComparison.Ordinal))
+            .ToList();
+        if (!affectedFolders.Any(folder => folder.Path == oldPath))
+            affectedFolders.Insert(0, new ManagedSecretFolder(oldPath, GetFolderName(oldPath), DateTime.UtcNow));
+
+        var folderMoves = affectedFolders
+            .Select(folder =>
+            {
+                var movedPath = MoveFolderPath(folder.Path, oldPath, normalizedNewPath);
+                return (Existing: folder, Moved: new ManagedSecretFolder(movedPath, GetFolderName(movedPath), DateTime.UtcNow));
+            })
+            .ToList();
+
+        foreach (var (_, moved, value) in secretMoves)
+        {
+            var stored = await _cloudService.StoreSecretAsync(
+                IManagedSecretsService.SecretPrefix + moved.Key,
+                value,
+                cancellationToken: cancellationToken);
+            if (!stored)
+                return false;
+
+            await SaveMetadataAsync(moved, cancellationToken);
+        }
+
+        foreach (var (_, moved) in folderMoves)
+        {
+            var stored = await StoreFolderAsync(moved, cancellationToken);
+            if (!stored)
+                return false;
+        }
+
+        foreach (var (existing, _, _) in secretMoves)
+            await DeleteAsync(existing.Key, cancellationToken);
+
+        foreach (var (existing, _) in folderMoves)
+        {
+            await _cloudService.DeleteSecretAsync(GetFolderMetadataKey(existing.Path), cancellationToken);
+            await _cloudService.DeleteSecretAsync(GetFolderPlaceholderKey(existing.Path), cancellationToken);
+        }
+
+        _logger.LogInformation($"Renamed managed secrets folder: {oldPath} -> {normalizedNewPath}");
+        return true;
+    }
+
+    public async Task<bool> DeleteFolderAsync(string folderPath, CancellationToken cancellationToken = default)
+    {
+        if (_cloudService.ActiveProvider is null)
+            throw new InvalidOperationException("No active cloud secrets provider configured.");
+
+        var normalizedPath = SecretPath.NormalizeFolderPath(folderPath);
+        if (normalizedPath == "/")
+            throw new ArgumentException("Root folder cannot be deleted.", nameof(folderPath));
+
+        var secrets = await ListAsync(cancellationToken);
+        if (secrets.Any(secret => IsInFolderTree(GetSecretFolder(secret.Key), normalizedPath)))
+            return false;
+
+        var folders = await ListFoldersAsync(cancellationToken);
+        if (folders.Any(folder => folder.Path != normalizedPath && folder.Path.StartsWith(normalizedPath + "/", StringComparison.Ordinal)))
+            return false;
+
+        var metadataDeleted = await _cloudService.DeleteSecretAsync(GetFolderMetadataKey(normalizedPath), cancellationToken);
+        var placeholderDeleted = await _cloudService.DeleteSecretAsync(GetFolderPlaceholderKey(normalizedPath), cancellationToken);
+        var deleted = metadataDeleted && placeholderDeleted;
+        if (deleted)
+            _logger.LogInformation($"Deleted managed secrets folder: {normalizedPath}");
+
+        return deleted;
+    }
+
     public async Task<ManagedSecret?> GetAsync(string key, CancellationToken cancellationToken = default)
     {
         if (_cloudService.ActiveProvider is null)
@@ -78,6 +249,9 @@ public class ManagedSecretsService : IManagedSecretsService
         if (string.IsNullOrWhiteSpace(key))
             throw new ArgumentException("Secret key cannot be empty.", nameof(key));
 
+        if (SecretPath.FromFlatKey(key).Key.Equals(FolderPlaceholderKey, StringComparison.OrdinalIgnoreCase))
+            throw new ArgumentException("Secret key is reserved for folder metadata.", nameof(key));
+
         var fullKey = IManagedSecretsService.SecretPrefix + key;
         var now = DateTime.UtcNow;
 
@@ -86,7 +260,11 @@ public class ManagedSecretsService : IManagedSecretsService
             return false;
 
         var meta = new ManagedSecret(key, type, description, originalFileName, now, now);
-        await SaveMetadataAsync(meta, cancellationToken);
+        if (!await SaveMetadataAsync(meta, cancellationToken))
+        {
+            await _cloudService.DeleteSecretAsync(fullKey, cancellationToken);
+            return false;
+        }
 
         _logger.LogInformation($"Created managed secret: {key} (type: {type})");
         return true;
@@ -115,9 +293,71 @@ public class ManagedSecretsService : IManagedSecretsService
             Description = description ?? existing.Description,
             UpdatedAt = DateTime.UtcNow
         };
-        await SaveMetadataAsync(updated, cancellationToken);
+        if (!await SaveMetadataAsync(updated, cancellationToken))
+            return false;
 
         _logger.LogInformation($"Updated managed secret: {key}");
+        return true;
+    }
+
+    public async Task<bool> MoveAsync(string key, string newKey, byte[]? value = null, string? description = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (_cloudService.ActiveProvider is null)
+            throw new InvalidOperationException("No active cloud secrets provider configured.");
+
+        if (string.IsNullOrWhiteSpace(key))
+            throw new ArgumentException("Secret key cannot be empty.", nameof(key));
+        if (string.IsNullOrWhiteSpace(newKey))
+            throw new ArgumentException("Secret key cannot be empty.", nameof(newKey));
+
+        var oldPath = SecretPath.FromFlatKey(key);
+        var newPath = SecretPath.FromFlatKey(newKey);
+        if (newPath.Key.Equals(FolderPlaceholderKey, StringComparison.OrdinalIgnoreCase))
+            throw new ArgumentException("Secret key is reserved for folder metadata.", nameof(newKey));
+
+        if (oldPath.ToFlatKey() == newPath.ToFlatKey())
+            return await UpdateAsync(key, value, description, cancellationToken);
+
+        var existing = await LoadMetadataAsync(key, cancellationToken);
+        if (existing is null)
+            return false;
+
+        if (await LoadMetadataAsync(newKey, cancellationToken) is not null ||
+            await _cloudService.SecretExistsAsync(IManagedSecretsService.SecretPrefix + newKey, cancellationToken))
+        {
+            return false;
+        }
+
+        var valueToStore = value ?? await GetValueAsync(key, cancellationToken);
+        if (valueToStore is null)
+            return false;
+
+        var stored = await _cloudService.StoreSecretAsync(
+            IManagedSecretsService.SecretPrefix + newKey,
+            valueToStore,
+            cancellationToken: cancellationToken);
+        if (!stored)
+            return false;
+
+        var moved = existing with
+        {
+            Key = newKey,
+            Description = description ?? existing.Description,
+            UpdatedAt = DateTime.UtcNow
+        };
+        var metadataStored = await SaveMetadataAsync(moved, cancellationToken);
+        if (!metadataStored)
+        {
+            await _cloudService.DeleteSecretAsync(IManagedSecretsService.SecretPrefix + newKey, cancellationToken);
+            return false;
+        }
+
+        var deleted = await DeleteAsync(key, cancellationToken);
+        if (!deleted)
+            return false;
+
+        _logger.LogInformation($"Moved managed secret: {key} -> {newKey}");
         return true;
     }
 
@@ -164,11 +404,80 @@ public class ManagedSecretsService : IManagedSecretsService
         }
     }
 
-    async Task SaveMetadataAsync(ManagedSecret meta, CancellationToken cancellationToken)
+    async Task<bool> SaveMetadataAsync(ManagedSecret meta, CancellationToken cancellationToken)
     {
         var metaKey = IManagedSecretsService.MetadataPrefix + meta.Key;
         var json = JsonSerializer.Serialize(meta, JsonOptions);
         var bytes = System.Text.Encoding.UTF8.GetBytes(json);
-        await _cloudService.StoreSecretAsync(metaKey, bytes, cancellationToken: cancellationToken);
+        return await _cloudService.StoreSecretAsync(metaKey, bytes, cancellationToken: cancellationToken);
+    }
+
+    async Task<bool> StoreFolderAsync(ManagedSecretFolder folder, CancellationToken cancellationToken)
+    {
+        var placeholderStored = await _cloudService.StoreSecretAsync(
+            GetFolderPlaceholderKey(folder.Path),
+            FolderPlaceholderValue,
+            new Dictionary<string, string>
+            {
+                ["SherpaKind"] = "FolderPlaceholder",
+                ["FolderPath"] = folder.Path
+            },
+            cancellationToken);
+        if (!placeholderStored)
+            return false;
+
+        var json = JsonSerializer.Serialize(folder, JsonOptions);
+        var metadataStored = await _cloudService.StoreSecretAsync(
+            GetFolderMetadataKey(folder.Path),
+            Encoding.UTF8.GetBytes(json),
+            cancellationToken: cancellationToken);
+        if (!metadataStored)
+        {
+            await _cloudService.DeleteSecretAsync(GetFolderPlaceholderKey(folder.Path), cancellationToken);
+            return false;
+        }
+
+        return true;
+    }
+
+    static string GetFolderMetadataKey(string folderPath) =>
+        IManagedSecretsService.FolderPrefix + SecretPath.NormalizeFolderPath(folderPath).TrimStart('/');
+
+    static string GetFolderPlaceholderKey(string folderPath) =>
+        IManagedSecretsService.SecretPrefix + new SecretPath(folderPath, FolderPlaceholderKey).ToFlatKey();
+
+    static string GetFolderName(string folderPath)
+    {
+        var normalized = SecretPath.NormalizeFolderPath(folderPath);
+        var lastSeparator = normalized.LastIndexOf('/');
+        return lastSeparator < 0 ? normalized : normalized[(lastSeparator + 1)..];
+    }
+
+    static string GetSecretFolder(string key)
+    {
+        var lastSeparator = key.LastIndexOf('/');
+        return lastSeparator < 0 ? "/" : SecretPath.NormalizeFolderPath(key[..lastSeparator]);
+    }
+
+    static bool IsInFolderTree(string secretFolder, string folder)
+    {
+        return secretFolder == folder ||
+            (folder != "/" && secretFolder.StartsWith(folder + "/", StringComparison.Ordinal));
+    }
+
+    static string MoveKey(string key, string oldFolderPath, string newFolderPath)
+    {
+        var relativeKey = key[(oldFolderPath.TrimStart('/').Length + 1)..];
+        return newFolderPath.TrimStart('/') + "/" + relativeKey;
+    }
+
+    static string MoveFolderPath(string folderPath, string oldFolderPath, string newFolderPath)
+    {
+        var relativePath = folderPath == oldFolderPath
+            ? ""
+            : folderPath[(oldFolderPath.Length + 1)..];
+        return SecretPath.NormalizeFolderPath(string.IsNullOrEmpty(relativePath)
+            ? newFolderPath
+            : newFolderPath + "/" + relativePath);
     }
 }

--- a/src/MauiSherpa.Core/Services/ManagedSecretsService.cs
+++ b/src/MauiSherpa.Core/Services/ManagedSecretsService.cs
@@ -240,7 +240,7 @@ public class ManagedSecretsService : IManagedSecretsService
     }
 
     public async Task<bool> CreateAsync(string key, byte[] value, ManagedSecretType type,
-        string? description = null, string? originalFileName = null,
+        string? description = null, string? originalFileName = null, Dictionary<string, string>? metadata = null,
         CancellationToken cancellationToken = default)
     {
         if (_cloudService.ActiveProvider is null)
@@ -259,7 +259,7 @@ public class ManagedSecretsService : IManagedSecretsService
         if (!stored)
             return false;
 
-        var meta = new ManagedSecret(key, type, description, originalFileName, now, now);
+        var meta = new ManagedSecret(key, type, description, originalFileName, now, now, metadata);
         if (!await SaveMetadataAsync(meta, cancellationToken))
         {
             await _cloudService.DeleteSecretAsync(fullKey, cancellationToken);
@@ -271,6 +271,7 @@ public class ManagedSecretsService : IManagedSecretsService
     }
 
     public async Task<bool> UpdateAsync(string key, byte[]? value = null, string? description = null,
+        Dictionary<string, string>? metadata = null,
         CancellationToken cancellationToken = default)
     {
         if (_cloudService.ActiveProvider is null)
@@ -291,6 +292,9 @@ public class ManagedSecretsService : IManagedSecretsService
         var updated = existing with
         {
             Description = description ?? existing.Description,
+            Metadata = metadata is null
+                ? existing.Metadata
+                : new Dictionary<string, string>(metadata, StringComparer.Ordinal),
             UpdatedAt = DateTime.UtcNow
         };
         if (!await SaveMetadataAsync(updated, cancellationToken))
@@ -301,6 +305,7 @@ public class ManagedSecretsService : IManagedSecretsService
     }
 
     public async Task<bool> MoveAsync(string key, string newKey, byte[]? value = null, string? description = null,
+        Dictionary<string, string>? metadata = null,
         CancellationToken cancellationToken = default)
     {
         if (_cloudService.ActiveProvider is null)
@@ -317,7 +322,7 @@ public class ManagedSecretsService : IManagedSecretsService
             throw new ArgumentException("Secret key is reserved for folder metadata.", nameof(newKey));
 
         if (oldPath.ToFlatKey() == newPath.ToFlatKey())
-            return await UpdateAsync(key, value, description, cancellationToken);
+            return await UpdateAsync(key, value, description, metadata, cancellationToken);
 
         var existing = await LoadMetadataAsync(key, cancellationToken);
         if (existing is null)
@@ -344,6 +349,9 @@ public class ManagedSecretsService : IManagedSecretsService
         {
             Key = newKey,
             Description = description ?? existing.Description,
+            Metadata = metadata is null
+                ? existing.Metadata
+                : new Dictionary<string, string>(metadata, StringComparer.Ordinal),
             UpdatedAt = DateTime.UtcNow
         };
         var metadataStored = await SaveMetadataAsync(moved, cancellationToken);

--- a/src/MauiSherpa.Core/Services/OnePasswordProvider.cs
+++ b/src/MauiSherpa.Core/Services/OnePasswordProvider.cs
@@ -103,6 +103,9 @@ public class OnePasswordProvider : ICloudSecretsProvider
                 return false;
             }
 
+            if (metadata is not null && !await SetSecretMetadataAsync(key, metadata, cancellationToken))
+                return false;
+
             _logger.LogInformation($"Stored secret: {key}");
             return true;
         }
@@ -139,6 +142,47 @@ public class OnePasswordProvider : ICloudSecretsProvider
         }
     }
 
+    public async Task<Dictionary<string, string>?> GetSecretMetadataAsync(string key, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (!await SecretExistsAsync(key, cancellationToken))
+                return null;
+
+            var metadataBytes = await GetSecretAsync(GetMetadataFieldLabel(key), cancellationToken);
+            return metadataBytes is null
+                ? new Dictionary<string, string>(StringComparer.Ordinal)
+                : CloudSecretMetadata.Deserialize(metadataBytes);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"1Password get secret metadata error: {ex.Message}", ex);
+            return null;
+        }
+    }
+
+    public async Task<bool> SetSecretMetadataAsync(
+        string key,
+        Dictionary<string, string> metadata,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (!await SecretExistsAsync(key, cancellationToken))
+                return false;
+
+            var metadataKey = GetMetadataFieldLabel(key);
+            return metadata.Count == 0
+                ? await DeleteSecretAsync(metadataKey, cancellationToken)
+                : await StoreSecretAsync(metadataKey, CloudSecretMetadata.Serialize(metadata), cancellationToken: cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"1Password set secret metadata error: {ex.Message}", ex);
+            return false;
+        }
+    }
+
     public async Task<bool> DeleteSecretAsync(string key, CancellationToken cancellationToken = default)
     {
         try
@@ -153,6 +197,8 @@ public class OnePasswordProvider : ICloudSecretsProvider
                 if (output.Contains("isn't a field", StringComparison.OrdinalIgnoreCase) ||
                     output.Contains("not found", StringComparison.OrdinalIgnoreCase))
                 {
+                    if (!CloudSecretMetadata.IsMetadataKey(key))
+                        await DeleteSecretAsync(GetMetadataFieldLabel(key), cancellationToken);
                     _logger.LogInformation($"Secret already deleted or not found: {key}");
                     return true;
                 }
@@ -160,6 +206,9 @@ public class OnePasswordProvider : ICloudSecretsProvider
                 _logger.LogError($"1Password delete secret failed (exit code {exitCode}): {output}");
                 return false;
             }
+
+            if (!CloudSecretMetadata.IsMetadataKey(key))
+                await DeleteSecretAsync(GetMetadataFieldLabel(key), cancellationToken);
 
             _logger.LogInformation($"Deleted secret: {key}");
             return true;
@@ -197,6 +246,10 @@ public class OnePasswordProvider : ICloudSecretsProvider
                 return Array.Empty<string>();
 
             var labels = GetCustomFieldLabels(item.Value);
+
+            labels = labels
+                .Where(l => !CloudSecretMetadata.IsMetadataKey(l))
+                .ToList();
 
             if (!string.IsNullOrEmpty(prefix))
                 labels = labels.Where(l => l.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)).ToList();
@@ -414,6 +467,11 @@ public class OnePasswordProvider : ICloudSecretsProvider
             sb.Append(c);
         }
         return sb.ToString();
+    }
+
+    private static string GetMetadataFieldLabel(string key)
+    {
+        return CloudSecretMetadata.GetMetadataKey(SanitizeFieldLabel(key));
     }
 
     #endregion

--- a/src/MauiSherpa.Core/Services/SecretPath.cs
+++ b/src/MauiSherpa.Core/Services/SecretPath.cs
@@ -1,0 +1,91 @@
+using System.Text.RegularExpressions;
+
+namespace MauiSherpa.Core.Services;
+
+public readonly record struct SecretPath
+{
+    private static readonly Regex InvalidSegmentCharacters = new(@"[\u0000-\u001F]", RegexOptions.Compiled);
+
+    public SecretPath(string folderPath, string key)
+    {
+        FolderPath = NormalizeFolderPath(folderPath);
+        Key = NormalizeKey(key);
+    }
+
+    public string FolderPath { get; }
+
+    public string Key { get; }
+
+    public static SecretPath FromFlatKey(string key)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+            throw new ArgumentException("Secret key cannot be empty.", nameof(key));
+
+        var trimmed = key.Trim();
+        var lastSeparator = trimmed.LastIndexOf('/');
+        if (lastSeparator < 0)
+            return new SecretPath("/", trimmed);
+
+        if (lastSeparator == trimmed.Length - 1)
+            throw new ArgumentException("Secret key cannot end with a path separator.", nameof(key));
+
+        var folder = lastSeparator == 0 ? "/" : trimmed[..lastSeparator];
+        var leaf = trimmed[(lastSeparator + 1)..];
+        return new SecretPath(folder, leaf);
+    }
+
+    public string ToFlatKey()
+    {
+        return FolderPath == "/"
+            ? Key
+            : $"{FolderPath.TrimStart('/')}/{Key}";
+    }
+
+    public static string NormalizeFolderPath(string? folderPath)
+    {
+        if (string.IsNullOrWhiteSpace(folderPath) || folderPath == "/")
+            return "/";
+
+        var normalized = folderPath.Trim().Replace('\\', '/');
+        if (!normalized.StartsWith('/'))
+            normalized = "/" + normalized;
+
+        if (normalized.EndsWith('/') && normalized.Length > 1)
+            normalized = normalized.TrimEnd('/');
+
+        if (normalized.Contains("//", StringComparison.Ordinal))
+            throw new ArgumentException("Secret folder paths cannot contain duplicate separators.", nameof(folderPath));
+
+        foreach (var segment in normalized.Split('/', StringSplitOptions.RemoveEmptyEntries))
+        {
+            ValidateSegment(segment, "Secret folder paths cannot contain empty, '.', '..', or control-character segments.");
+        }
+
+        return normalized;
+    }
+
+    public static string NormalizeKey(string key)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+            throw new ArgumentException("Secret key cannot be empty.", nameof(key));
+
+        var normalized = key.Trim();
+        ValidateSegment(normalized, "Secret keys cannot be '.', '..', or contain control characters.");
+
+        if (normalized.Contains('/', StringComparison.Ordinal) || normalized.Contains('\\', StringComparison.Ordinal))
+            throw new ArgumentException("Secret keys cannot contain path separators. Put hierarchy in the folder path.", nameof(key));
+
+        return normalized;
+    }
+
+    private static void ValidateSegment(string segment, string message)
+    {
+        if (segment.Length == 0 ||
+            segment == "." ||
+            segment == ".." ||
+            InvalidSegmentCharacters.IsMatch(segment))
+        {
+            throw new ArgumentException(message);
+        }
+    }
+}

--- a/src/MauiSherpa.Core/Services/SqlCipherLocalVaultStore.cs
+++ b/src/MauiSherpa.Core/Services/SqlCipherLocalVaultStore.cs
@@ -1,0 +1,184 @@
+using MauiSherpa.Core.Interfaces;
+using Shiny.DocumentDb;
+using Shiny.DocumentDb.Sqlite.SqlCipher;
+
+namespace MauiSherpa.Core.Services;
+
+public sealed class SqlCipherLocalVaultStore : ILocalVaultStore
+{
+    private readonly ILocalVaultKeyStore _keyStore;
+    private readonly ILoggingService _logger;
+    private readonly SemaphoreSlim _openLock = new(1, 1);
+    private readonly SemaphoreSlim _operationLock = new(1, 1);
+    private IDocumentStore? _store;
+
+    public SqlCipherLocalVaultStore(
+        ILocalVaultKeyStore keyStore,
+        ILoggingService logger)
+        : this(keyStore, logger, LocalVaultOptions.Default)
+    {
+    }
+
+    public SqlCipherLocalVaultStore(
+        ILocalVaultKeyStore keyStore,
+        ILoggingService logger,
+        LocalVaultOptions options)
+    {
+        _keyStore = keyStore;
+        _logger = logger;
+        DatabasePath = options.DatabasePath;
+    }
+
+    public string DatabasePath { get; }
+
+    public async Task<LocalVaultItem> PutAsync(
+        string scope,
+        string path,
+        string key,
+        byte[] value,
+        string contentType,
+        Dictionary<string, string>? metadata = null,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var normalizedScope = LocalVaultNames.NormalizeScope(scope);
+        var secretPath = new SecretPath(path, key);
+        var id = LocalVaultItem.CreateId(normalizedScope, secretPath.FolderPath, secretPath.Key);
+        var now = DateTime.UtcNow;
+
+        await _operationLock.WaitAsync(cancellationToken);
+        try
+        {
+            var store = await GetStoreAsync(cancellationToken);
+            var existing = await store.Get<LocalVaultItem>(id);
+            var item = new LocalVaultItem
+            {
+                Id = id,
+                Scope = normalizedScope,
+                Path = secretPath.FolderPath,
+                Key = secretPath.Key,
+                ContentType = string.IsNullOrWhiteSpace(contentType)
+                    ? LocalVaultContentTypes.Binary
+                    : contentType,
+                Value = value,
+                Metadata = metadata is null
+                    ? new Dictionary<string, string>()
+                    : new Dictionary<string, string>(metadata, StringComparer.Ordinal),
+                CreatedAt = existing?.CreatedAt ?? now,
+                UpdatedAt = now
+            };
+
+            if (existing is null)
+                await store.Insert(item);
+            else
+                await store.Update(item);
+
+            return item;
+        }
+        finally
+        {
+            _operationLock.Release();
+        }
+    }
+
+    public async Task<LocalVaultItem?> GetAsync(
+        string scope,
+        string path,
+        string key,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var id = LocalVaultItem.CreateId(scope, path, key);
+        var store = await GetStoreAsync(cancellationToken);
+        return await store.Get<LocalVaultItem>(id);
+    }
+
+    public async Task<bool> RemoveAsync(
+        string scope,
+        string path,
+        string key,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var id = LocalVaultItem.CreateId(scope, path, key);
+
+        await _operationLock.WaitAsync(cancellationToken);
+        try
+        {
+            var store = await GetStoreAsync(cancellationToken);
+            var existing = await store.Get<LocalVaultItem>(id);
+            if (existing is null)
+                return false;
+
+            await store.Remove<LocalVaultItem>(id);
+            return true;
+        }
+        finally
+        {
+            _operationLock.Release();
+        }
+    }
+
+    public async Task<bool> ExistsAsync(
+        string scope,
+        string path,
+        string key,
+        CancellationToken cancellationToken = default)
+    {
+        return await GetAsync(scope, path, key, cancellationToken) is not null;
+    }
+
+    public async Task<IReadOnlyList<LocalVaultItem>> ListAsync(
+        string scope,
+        string? path = null,
+        string? keyPrefix = null,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var normalizedScope = LocalVaultNames.NormalizeScope(scope);
+        var normalizedPath = path is null ? null : SecretPath.NormalizeFolderPath(path);
+        var store = await GetStoreAsync(cancellationToken);
+        var items = await store.Query<LocalVaultItem>().ToList();
+
+        return items
+            .Where(x => string.Equals(x.Scope, normalizedScope, StringComparison.Ordinal))
+            .Where(x => normalizedPath is null || string.Equals(x.Path, normalizedPath, StringComparison.Ordinal))
+            .Where(x => string.IsNullOrEmpty(keyPrefix) || x.Key.StartsWith(keyPrefix, StringComparison.Ordinal))
+            .OrderBy(x => x.Path, StringComparer.Ordinal)
+            .ThenBy(x => x.Key, StringComparer.Ordinal)
+            .ToList()
+            .AsReadOnly();
+    }
+
+    private async Task<IDocumentStore> GetStoreAsync(CancellationToken cancellationToken)
+    {
+        if (_store is not null)
+            return _store;
+
+        await _openLock.WaitAsync(cancellationToken);
+        try
+        {
+            if (_store is not null)
+                return _store;
+
+            var directory = Path.GetDirectoryName(DatabasePath);
+            if (!string.IsNullOrEmpty(directory))
+                Directory.CreateDirectory(directory);
+
+            var key = await _keyStore.GetOrCreateKeyAsync(cancellationToken);
+            _store = new DocumentStore(new DocumentStoreOptions
+            {
+                DatabaseProvider = new SqlCipherDatabaseProvider(DatabasePath, key)
+            });
+
+            _logger.LogInformation($"Opened local vault database at {DatabasePath}");
+            return _store;
+        }
+        finally
+        {
+            _openLock.Release();
+        }
+    }
+}

--- a/src/MauiSherpa.Core/Services/VaultSecureStorageService.cs
+++ b/src/MauiSherpa.Core/Services/VaultSecureStorageService.cs
@@ -10,20 +10,26 @@ public sealed class VaultSecureStorageService : ISecureStorageService
     private readonly ILocalVaultStore _vaultStore;
     private readonly ILegacySecureStorageService _legacySecureStorage;
     private readonly ILoggingService _logger;
+    private readonly ILocalVaultIntroductionService? _localVaultIntroduction;
 
     public VaultSecureStorageService(
         ILocalVaultStore vaultStore,
         ILegacySecureStorageService legacySecureStorage,
-        ILoggingService logger)
+        ILoggingService logger,
+        ILocalVaultIntroductionService? localVaultIntroduction = null)
     {
         _vaultStore = vaultStore;
         _legacySecureStorage = legacySecureStorage;
         _logger = logger;
+        _localVaultIntroduction = localVaultIntroduction;
     }
 
     public async Task<string?> GetAsync(string key)
     {
         ValidateKey(key);
+
+        if (!IsLocalVaultEnabled())
+            return await _legacySecureStorage.GetAsync(key);
 
         var vaultKey = EncodeKey(key);
         var item = await _vaultStore.GetAsync(LocalVaultScopes.SecureStorage, "/", vaultKey);
@@ -44,6 +50,12 @@ public sealed class VaultSecureStorageService : ISecureStorageService
     {
         ValidateKey(key);
 
+        if (!IsLocalVaultEnabled())
+        {
+            await _legacySecureStorage.SetAsync(key, value);
+            return;
+        }
+
         var vaultKey = EncodeKey(key);
         await _vaultStore.PutAsync(
             LocalVaultScopes.SecureStorage,
@@ -63,9 +75,18 @@ public sealed class VaultSecureStorageService : ISecureStorageService
     {
         ValidateKey(key);
 
+        if (!IsLocalVaultEnabled())
+        {
+            await _legacySecureStorage.RemoveAsync(key);
+            return;
+        }
+
         await _vaultStore.RemoveAsync(LocalVaultScopes.SecureStorage, "/", EncodeKey(key));
         await _legacySecureStorage.RemoveAsync(key);
     }
+
+    private bool IsLocalVaultEnabled() =>
+        _localVaultIntroduction?.GetState().IsLocalVaultEnabled != false;
 
     private static void ValidateKey(string key)
     {

--- a/src/MauiSherpa.Core/Services/VaultSecureStorageService.cs
+++ b/src/MauiSherpa.Core/Services/VaultSecureStorageService.cs
@@ -1,0 +1,83 @@
+using System.Text;
+using MauiSherpa.Core.Interfaces;
+
+namespace MauiSherpa.Core.Services;
+
+public sealed class VaultSecureStorageService : ISecureStorageService
+{
+    private const string OriginalKeyMetadataName = "OriginalKey";
+
+    private readonly ILocalVaultStore _vaultStore;
+    private readonly ILegacySecureStorageService _legacySecureStorage;
+    private readonly ILoggingService _logger;
+
+    public VaultSecureStorageService(
+        ILocalVaultStore vaultStore,
+        ILegacySecureStorageService legacySecureStorage,
+        ILoggingService logger)
+    {
+        _vaultStore = vaultStore;
+        _legacySecureStorage = legacySecureStorage;
+        _logger = logger;
+    }
+
+    public async Task<string?> GetAsync(string key)
+    {
+        ValidateKey(key);
+
+        var vaultKey = EncodeKey(key);
+        var item = await _vaultStore.GetAsync(LocalVaultScopes.SecureStorage, "/", vaultKey);
+        if (item is not null)
+            return Encoding.UTF8.GetString(item.Value);
+
+        var legacyValue = await _legacySecureStorage.GetAsync(key);
+        if (legacyValue is null)
+            return null;
+
+        await SetAsync(key, legacyValue);
+        await _legacySecureStorage.RemoveAsync(key);
+        _logger.LogInformation($"Migrated secure storage key into local vault: {key}");
+        return legacyValue;
+    }
+
+    public async Task SetAsync(string key, string value)
+    {
+        ValidateKey(key);
+
+        var vaultKey = EncodeKey(key);
+        await _vaultStore.PutAsync(
+            LocalVaultScopes.SecureStorage,
+            "/",
+            vaultKey,
+            Encoding.UTF8.GetBytes(value),
+            LocalVaultContentTypes.Text,
+            new Dictionary<string, string>
+            {
+                [OriginalKeyMetadataName] = key
+            });
+
+        await _legacySecureStorage.RemoveAsync(key);
+    }
+
+    public async Task RemoveAsync(string key)
+    {
+        ValidateKey(key);
+
+        await _vaultStore.RemoveAsync(LocalVaultScopes.SecureStorage, "/", EncodeKey(key));
+        await _legacySecureStorage.RemoveAsync(key);
+    }
+
+    private static void ValidateKey(string key)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+            throw new ArgumentException("Secure storage key cannot be empty.", nameof(key));
+    }
+
+    private static string EncodeKey(string key)
+    {
+        return Convert.ToBase64String(Encoding.UTF8.GetBytes(key))
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+    }
+}

--- a/src/MauiSherpa.Core/Services/VaultwardenProvider.cs
+++ b/src/MauiSherpa.Core/Services/VaultwardenProvider.cs
@@ -116,6 +116,9 @@ public class VaultwardenProvider : ICloudSecretsProvider
             SetField(fields, key, base64Value);
 
             await UpdateCipherFieldsAsync(cipherId, cipher.Value, fields, cancellationToken);
+            if (metadata is not null && !await SetSecretMetadataAsync(key, metadata, cancellationToken))
+                return false;
+
             _logger.LogInformation($"Stored secret: {key}");
             return true;
         }
@@ -152,6 +155,47 @@ public class VaultwardenProvider : ICloudSecretsProvider
         }
     }
 
+    public async Task<Dictionary<string, string>?> GetSecretMetadataAsync(string key, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (!await SecretExistsAsync(key, cancellationToken))
+                return null;
+
+            var metadataBytes = await GetSecretAsync(GetMetadataFieldName(key), cancellationToken);
+            return metadataBytes is null
+                ? new Dictionary<string, string>(StringComparer.Ordinal)
+                : CloudSecretMetadata.Deserialize(metadataBytes);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"Vaultwarden get secret metadata error: {ex.Message}", ex);
+            return null;
+        }
+    }
+
+    public async Task<bool> SetSecretMetadataAsync(
+        string key,
+        Dictionary<string, string> metadata,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (!await SecretExistsAsync(key, cancellationToken))
+                return false;
+
+            var metadataKey = GetMetadataFieldName(key);
+            return metadata.Count == 0
+                ? await DeleteSecretAsync(metadataKey, cancellationToken)
+                : await StoreSecretAsync(metadataKey, CloudSecretMetadata.Serialize(metadata), cancellationToken: cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"Vaultwarden set secret metadata error: {ex.Message}", ex);
+            return false;
+        }
+    }
+
     public async Task<bool> DeleteSecretAsync(string key, CancellationToken cancellationToken = default)
     {
         try
@@ -171,11 +215,16 @@ public class VaultwardenProvider : ICloudSecretsProvider
             var fields = GetFieldsList(cipher.Value);
             if (!RemoveField(fields, key))
             {
+                if (!CloudSecretMetadata.IsMetadataKey(key) && RemoveField(fields, GetMetadataFieldName(key)))
+                    await UpdateCipherFieldsAsync(cipherId, cipher.Value, fields, cancellationToken);
                 _logger.LogInformation($"Secret field not found: {key}");
                 return true;
             }
 
             await UpdateCipherFieldsAsync(cipherId, cipher.Value, fields, cancellationToken);
+            if (!CloudSecretMetadata.IsMetadataKey(key))
+                await DeleteSecretAsync(GetMetadataFieldName(key), cancellationToken);
+
             _logger.LogInformation($"Deleted secret: {key}");
             return true;
         }
@@ -214,6 +263,10 @@ public class VaultwardenProvider : ICloudSecretsProvider
             if (cipher == null) return Array.Empty<string>();
 
             var labels = GetCustomFieldNames(cipher.Value);
+
+            labels = labels
+                .Where(l => !CloudSecretMetadata.IsMetadataKey(l))
+                .ToList();
 
             if (!string.IsNullOrEmpty(prefix))
                 labels = labels.Where(l => l.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)).ToList();
@@ -793,6 +846,11 @@ public class VaultwardenProvider : ICloudSecretsProvider
 
         fields.Remove(existing);
         return true;
+    }
+
+    private static string GetMetadataFieldName(string key)
+    {
+        return CloudSecretMetadata.GetMetadataKey(key);
     }
 
     #endregion

--- a/src/MauiSherpa.MacOS/BlazorContentPage.cs
+++ b/src/MauiSherpa.MacOS/BlazorContentPage.cs
@@ -252,6 +252,14 @@ public class BlazorContentPage : ContentPage
         }
     }
 
+    static string GetFilterMenuTitle(IReadOnlyList<ToolbarFilter> filters)
+    {
+        if (filters.Count == 1)
+            return filters[0].Label;
+
+        return "Filters";
+    }
+
     private void HideSplash()
     {
         if (_loadingOverlay == null) return;
@@ -369,6 +377,7 @@ public class BlazorContentPage : ContentPage
     // Toolbar caching: create items once, then show/hide natively
     bool _toolbarInitialized;
     bool _toolbarVisibilityApplied;
+    string _lastFilterSignature = "";
     Dictionary<string, ToolbarItem> _actionItemMap = new();
     List<NSObject> _nativeMenuTargets = new();
 
@@ -379,10 +388,21 @@ public class BlazorContentPage : ContentPage
     {
         Dispatcher.Dispatch(() =>
         {
+            var filterSignature = GetFilterSignature(_toolbarService.CurrentFilters);
+            if (_toolbarInitialized && !string.Equals(_lastFilterSignature, filterSignature, StringComparison.Ordinal))
+            {
+                _toolbarInitialized = false;
+                _toolbarVisibilityApplied = false;
+                _nativeIdentityMenu = null;
+                _nativeFilterMenu = null;
+                _nativePublishMenu = null;
+            }
+
             if (!_toolbarInitialized)
             {
                 // First time: build with all possible items (superset)
                 _toolbarInitialized = true;
+                _lastFilterSignature = filterSignature;
                 FullRebuildToolbar();
             }
 
@@ -392,6 +412,15 @@ public class BlazorContentPage : ContentPage
             if (!TryUpdateToolbarVisibility())
                 ScheduleToolbarVisibilityRetry();
         });
+    }
+
+    static string GetFilterSignature(IReadOnlyList<ToolbarFilter> filters)
+    {
+        if (filters.Count == 0)
+            return "";
+
+        return string.Join("|", filters.Select(f =>
+            $"{f.Id}:{f.Label}:{f.SelectedIndex}:{string.Join('\u001f', f.Options)}"));
     }
 
     /// <summary>
@@ -506,8 +535,9 @@ public class BlazorContentPage : ContentPage
     }
 
     /// <summary>
-    /// Finds and caches native NSMenuToolbarItem references by MauiMenu_ identifier.
-    /// Menu order: 0=Identity, 1=Publish, 2=Backup, 3=Filter
+    /// Finds and caches native NSMenuToolbarItem references.
+    /// Menu identifiers can shift when the content layout changes, so prefer
+    /// stable labels/menu contents over positional MauiMenu_* assumptions.
     /// </summary>
     void CacheNativeMenuItems(NSToolbar toolbar)
     {
@@ -515,9 +545,50 @@ public class BlazorContentPage : ContentPage
         foreach (var nsItem in toolbar.Items)
         {
             if (nsItem is not NSMenuToolbarItem m) continue;
-            if (nsItem.Identifier == "MauiMenu_0") _nativeIdentityMenu = m;
-            else if (nsItem.Identifier == "MauiMenu_1") _nativePublishMenu = m;
-            else if (nsItem.Identifier == "MauiMenu_3") _nativeFilterMenu = m;
+            if (IsFilterMenuItem(m))
+                _nativeFilterMenu = m;
+            else if (IsPublishMenuItem(m))
+                _nativePublishMenu = m;
+            else if (IsIdentityMenuItem(m))
+                _nativeIdentityMenu = m;
+        }
+    }
+
+    static bool IsFilterMenuItem(NSMenuToolbarItem item)
+    {
+        var label = item.Label ?? "";
+        return label.Equals("Filters", StringComparison.OrdinalIgnoreCase) ||
+            label.Equals("Providers", StringComparison.OrdinalIgnoreCase) ||
+            label.Equals("Provider", StringComparison.OrdinalIgnoreCase) ||
+            EnumerateMenuItems(item.Menu).Any(i =>
+                (i.Title ?? "").Equals("Providers", StringComparison.OrdinalIgnoreCase) ||
+                (i.Submenu?.Title ?? "").Equals("Providers", StringComparison.OrdinalIgnoreCase));
+    }
+
+    static bool IsPublishMenuItem(NSMenuToolbarItem item)
+    {
+        var label = item.Label ?? "";
+        return label.Equals("Publish", StringComparison.OrdinalIgnoreCase) ||
+            EnumerateMenuItems(item.Menu).Any(i => (i.Title ?? "").Contains("Publish", StringComparison.OrdinalIgnoreCase));
+    }
+
+    static bool IsIdentityMenuItem(NSMenuToolbarItem item)
+    {
+        var label = item.Label ?? "";
+        return label.Equals("Identity", StringComparison.OrdinalIgnoreCase) ||
+            EnumerateMenuItems(item.Menu).Any(i => (i.Title ?? "").Equals("Settings…", StringComparison.OrdinalIgnoreCase));
+    }
+
+    static IEnumerable<NSMenuItem> EnumerateMenuItems(NSMenu? menu)
+    {
+        if (menu == null)
+            yield break;
+
+        for (nint i = 0; i < menu.Count; i++)
+        {
+            var item = menu.ItemAt(i);
+            if (item != null)
+                yield return item;
         }
     }
 
@@ -580,8 +651,35 @@ public class BlazorContentPage : ContentPage
         var filterNative = _nativeFilterMenu;
         if (filterNative?.Menu == null) return;
 
+        filterNative.Label = GetFilterMenuTitle(filters);
+        filterNative.PaletteLabel = filterNative.Label;
+
         var menu = filterNative.Menu;
         menu.RemoveAllItems();
+
+        if (filters.Count == 1)
+        {
+            var filter = filters[0];
+            var filterId = filter.Id;
+            if (filter.Options.Length > 0)
+                menu.AddItem(NSMenuItem.SeparatorItem);
+
+            for (int oi = 0; oi < filter.Options.Length; oi++)
+            {
+                var optIndex = oi;
+                var optionItem = new NSMenuItem(filter.Options[oi]);
+                optionItem.State = oi == filter.SelectedIndex ? NSCellStateValue.On : NSCellStateValue.Off;
+
+                var target = new MenuActionTarget(filterId, optIndex,
+                    (fid, idx) => _toolbarService.NotifyFilterChanged(fid, idx));
+                optionItem.Target = target;
+                optionItem.Action = new ObjCRuntime.Selector("menuItemClicked:");
+                _nativeMenuTargets.Add(target);
+
+                menu.AddItem(optionItem);
+            }
+            return;
+        }
 
         for (int fi = 0; fi < filters.Count; fi++)
         {
@@ -878,10 +976,14 @@ public class BlazorContentPage : ContentPage
             MacOSToolbarItem.SetPlacement(settingsItem, MacOSToolbarItemPlacement.SidebarTrailing);
 
             // Create SUPERSET of all possible action items (hidden ones toggled later)
-            // Order matters for layout: [create/import] ← flex → [refresh]
+            // Order matters for layout: [create/import/folder actions] ← flex → [refresh]
             var supersetActions = new[]
             {
-                ("create", "Create", "plus"),
+                ("create", "New Secret", "plus"),
+                ("create-folder", "New Folder", "folder.badge.plus"),
+                ("rename-folder", "Rename Folder", "pencil"),
+                ("delete-folder", "Delete Folder", "trash"),
+                ("up-folder", "Up Folder", "arrow.up"),
                 ("import", "Import", "square.and.arrow.down"),
                 ("install-missing", "Install Missing", "arrow.down.circle"),
                 ("save", "Save", "checkmark"),
@@ -946,17 +1048,20 @@ public class BlazorContentPage : ContentPage
             _filterMenu = new MacOSMenuToolbarItem
             {
                 Icon = "line.3.horizontal.decrease",
-                Text = "Filters",
+                Text = GetFilterMenuTitle(_toolbarService.CurrentFilters),
+                ShowsTitle = true,
                 ShowsIndicator = true,
             };
             var filters = _toolbarService.CurrentFilters;
             if (filters.Count > 0)
             {
-                for (int fi = 0; fi < filters.Count; fi++)
+                if (filters.Count == 1)
                 {
-                    var filter = filters[fi];
+                    var filter = filters[0];
                     var filterId = filter.Id;
-                    var submenuItem = new MacOSMenuItem { Text = filter.Label };
+                    if (filter.Options.Length > 0)
+                        _filterMenu.Items.Add(new MacOSMenuItem { IsSeparator = true });
+
                     for (int oi = 0; oi < filter.Options.Length; oi++)
                     {
                         var optIndex = oi;
@@ -966,11 +1071,31 @@ public class BlazorContentPage : ContentPage
                             IsChecked = oi == filter.SelectedIndex,
                         };
                         option.Clicked += (s, e) => _toolbarService.NotifyFilterChanged(filterId, optIndex);
-                        submenuItem.SubItems.Add(option);
+                        _filterMenu.Items.Add(option);
                     }
-                    if (fi > 0)
-                        _filterMenu.Items.Add(new MacOSMenuItem { IsSeparator = true });
-                    _filterMenu.Items.Add(submenuItem);
+                }
+                else
+                {
+                    for (int fi = 0; fi < filters.Count; fi++)
+                    {
+                        var filter = filters[fi];
+                        var filterId = filter.Id;
+                        var submenuItem = new MacOSMenuItem { Text = filter.Label };
+                        for (int oi = 0; oi < filter.Options.Length; oi++)
+                        {
+                            var optIndex = oi;
+                            var option = new MacOSMenuItem
+                            {
+                                Text = filter.Options[oi],
+                                IsChecked = oi == filter.SelectedIndex,
+                            };
+                            option.Clicked += (s, e) => _toolbarService.NotifyFilterChanged(filterId, optIndex);
+                            submenuItem.SubItems.Add(option);
+                        }
+                        if (fi > 0)
+                            _filterMenu.Items.Add(new MacOSMenuItem { IsSeparator = true });
+                        _filterMenu.Items.Add(submenuItem);
+                    }
                 }
             }
 
@@ -999,14 +1124,14 @@ public class BlazorContentPage : ContentPage
             _publishMenu.Items.Add(publishSelectedAction);
 
             // Build explicit content layout with ALL items:
-            // [Identity] [Publish] [Create] [Import] ← FlexibleSpace → [Filter] [Search] [Refresh]
+            // [Filter/Provider] [Identity] [Publish] [Create] [Import] ← FlexibleSpace → [Search] [Refresh]
             var layout = new List<MacOSToolbarLayoutItem>();
+            layout.Add(MacOSToolbarLayoutItem.Menu(_filterMenu));
             layout.Add(MacOSToolbarLayoutItem.Menu(_identityMenu));
             layout.Add(MacOSToolbarLayoutItem.Menu(_publishMenu));
             foreach (var item in leadingItems)
                 layout.Add(MacOSToolbarLayoutItem.Item(item));
             layout.Add(MacOSToolbarLayoutItem.FlexibleSpace);
-            layout.Add(MacOSToolbarLayoutItem.Menu(_filterMenu));
             layout.Add(MacOSToolbarLayoutItem.Search(_searchItem));
             if (refreshItem != null)
                 layout.Add(MacOSToolbarLayoutItem.Item(refreshItem));
@@ -1143,6 +1268,20 @@ public class BlazorContentPage : ContentPage
                 if (filters[i].Id == filterId) { filterIndex = i; break; }
             }
             if (filterIndex < 0) return;
+
+            if (filters.Count == 1)
+            {
+                var directMenu = filterNative.Menu;
+                for (int i = 0; i < directMenu.Count; i++)
+                {
+                    var mi = directMenu.ItemAt(i);
+                    if (mi != null)
+                        mi.State = i == selectedIndex + 1 ? NSCellStateValue.On : NSCellStateValue.Off;
+                }
+                filterNative.Label = GetFilterMenuTitle(filters);
+                filterNative.PaletteLabel = filterNative.Label;
+                return;
+            }
 
             // Account for separator items between filter submenus
             int menuItemIndex = 0;

--- a/src/MauiSherpa.MacOS/Info.plist
+++ b/src/MauiSherpa.MacOS/Info.plist
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-    <dict>
-        <key>NSBluetoothAlwaysUsageDescription</key>
-        <string>MAUI Sherpa uses Bluetooth to detect device connectivity status.</string>
-    </dict>
+    <dict/>
 </plist>

--- a/src/MauiSherpa.MacOS/MacOSMauiProgram.cs
+++ b/src/MauiSherpa.MacOS/MacOSMauiProgram.cs
@@ -81,7 +81,13 @@ public static class MacOSMauiProgram
         builder.Services.AddScoped<INavigationService, NavigationService>();
         builder.Services.AddSingleton<IDialogService, DialogService>();
         builder.Services.AddSingleton<IFileSystemService, FileSystemService>();
-        builder.Services.AddSingleton<ISecureStorageService, SecureStorageService>();
+        builder.Services.AddSingleton<SecureStorageService>();
+        builder.Services.AddSingleton<ILegacySecureStorageService>(sp => sp.GetRequiredService<SecureStorageService>());
+        builder.Services.AddSingleton<ISecureStorageService, VaultSecureStorageService>();
+        builder.Services.AddSingleton<LocalSecretsKeyStore>();
+        builder.Services.AddSingleton<ILocalSecretsKeyStore>(sp => sp.GetRequiredService<LocalSecretsKeyStore>());
+        builder.Services.AddSingleton<ILocalVaultKeyStore>(sp => sp.GetRequiredService<LocalSecretsKeyStore>());
+        builder.Services.AddSingleton<ILocalVaultStore, SqlCipherLocalVaultStore>();
         builder.Services.AddSingleton<IThemeService, MacOSThemeService>();
 
         // macOS Essentials — AddMacOSEssentials() sets the .Default statics via reflection,
@@ -264,13 +270,25 @@ public static class MacOSMauiProgram
 
 #if DEBUG
         builder.Services.AddBlazorWebViewDeveloperTools();
-        builder.AddMauiDevFlowAgent();
-        builder.AddMauiBlazorDevFlowTools();
+        if (IsDevFlowEnabled())
+        {
+            builder.AddMauiDevFlowAgent();
+            builder.AddMauiBlazorDevFlowTools();
+        }
         builder.Logging.AddDebug();
 #endif
 
         return builder.Build();
     }
+
+#if DEBUG
+    static bool IsDevFlowEnabled()
+    {
+        var value = Environment.GetEnvironmentVariable("MAUI_SHERPA_ENABLE_DEVFLOW");
+        return string.Equals(value, "1", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(value, "true", StringComparison.OrdinalIgnoreCase);
+    }
+#endif
 
     static void MigrateAppData()
     {

--- a/src/MauiSherpa.MacOS/MacOSMauiProgram.cs
+++ b/src/MauiSherpa.MacOS/MacOSMauiProgram.cs
@@ -87,6 +87,7 @@ public static class MacOSMauiProgram
         builder.Services.AddSingleton<LocalSecretsKeyStore>();
         builder.Services.AddSingleton<ILocalSecretsKeyStore>(sp => sp.GetRequiredService<LocalSecretsKeyStore>());
         builder.Services.AddSingleton<ILocalVaultKeyStore>(sp => sp.GetRequiredService<LocalSecretsKeyStore>());
+        builder.Services.AddSingleton<ILocalVaultAccessService>(sp => sp.GetRequiredService<LocalSecretsKeyStore>());
         builder.Services.AddSingleton<ILocalVaultStore, SqlCipherLocalVaultStore>();
         builder.Services.AddSingleton<IThemeService, MacOSThemeService>();
 

--- a/src/MauiSherpa.MacOS/MacOSMauiProgram.cs
+++ b/src/MauiSherpa.MacOS/MacOSMauiProgram.cs
@@ -98,6 +98,7 @@ public static class MacOSMauiProgram
         builder.Services.AddSingleton<ILauncher>(_ => Launcher.Default);
         builder.Services.AddSingleton<IClipboard>(_ => Clipboard.Default);
         builder.Services.AddSingleton<ISecureStorage>(_ => SecureStorage.Default);
+        builder.Services.AddSingleton<ILocalVaultIntroductionService, LocalVaultIntroductionService>();
 
         // Toolbar service for native macOS toolbar integration
         builder.Services.AddSingleton<IToolbarService, ToolbarService>();
@@ -150,6 +151,7 @@ public static class MacOSMauiProgram
         builder.Services.AddSingleton<IFormModalService, MauiSherpa.Services.FormModalService>();
         builder.Services.AddSingleton<MauiSherpa.Pages.Forms.HybridFormBridgeHolder>();
         builder.Services.AddSingleton<MauiSherpa.Pages.Forms.ModalParameterService>();
+        builder.Services.AddSingleton<LocalVaultIntroModalService>();
 
         // Apple services
         builder.Services.AddSingleton<IAppleIdentityService, AppleIdentityService>();

--- a/src/MauiSherpa.MacOS/MauiSherpa.MacOS.csproj
+++ b/src/MauiSherpa.MacOS/MauiSherpa.MacOS.csproj
@@ -69,8 +69,7 @@
     <BundleResource Include="Resources\ghcp_icon_white.png" />
   </ItemGroup>
 
-  <!-- Inject required Info.plist privacy usage descriptions (e.g. Bluetooth for the
-       MAUI DevFlow Sensors API). Without these, macOS TCC will SIGKILL the app. -->
+  <!-- Inject Info.plist privacy usage descriptions needed by debug-local inspection tools. -->
   <ItemGroup>
     <PartialAppManifest Include="Resources\PrivacyInfo.plist" />
   </ItemGroup>

--- a/src/MauiSherpa.MacOS/Resources/PrivacyInfo.plist
+++ b/src/MauiSherpa.MacOS/Resources/PrivacyInfo.plist
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>NSBluetoothAlwaysUsageDescription</key>
-    <string>MAUI Sherpa uses Bluetooth to inspect Bluetooth sensors on connected devices via the MAUI DevFlow agent.</string>
-    <key>NSBluetoothPeripheralUsageDescription</key>
-    <string>MAUI Sherpa uses Bluetooth to inspect Bluetooth sensors on connected devices via the MAUI DevFlow agent.</string>
     <key>NSLocalNetworkUsageDescription</key>
     <string>MAUI Sherpa connects to MAUI DevFlow and Ailoha agents running on your local network to inspect MAUI apps.</string>
 </dict>

--- a/src/MauiSherpa/Components/App.razor
+++ b/src/MauiSherpa/Components/App.razor
@@ -1,8 +1,10 @@
 @using Microsoft.AspNetCore.Components.Routing
 @using MauiSherpa.Core.Interfaces
+@using MauiSherpa.Services
 @inject IUpdateService UpdateService
 @inject ILoggingService Logger
 @inject MauiSherpa.Pages.Forms.ModalParameterService ModalParams
+@inject LocalVaultIntroModalService LocalVaultIntroModal
 @implements IDisposable
 
 <Router AppAssembly="@typeof(App).Assembly">
@@ -24,16 +26,31 @@
     protected override async Task OnInitializedAsync()
     {
         await base.OnInitializedAsync();
+        _ = RunStartupDialogsAsync();
+    }
+
+    private async Task RunStartupDialogsAsync()
+    {
+        try
+        {
+            await Task.Delay(1000, _cts.Token);
+            await InvokeAsync(async () => await LocalVaultIntroModal.ShowIfNeededAsync());
 #if !DEBUG
-        _ = CheckForUpdatesWithDelayAsync();
+            await CheckForUpdatesWithDelayAsync();
 #endif
+        }
+        catch (OperationCanceledException) { }
+        catch (Exception ex)
+        {
+            Logger.LogError("Failed to run startup dialogs", ex);
+        }
     }
 
     private async Task CheckForUpdatesWithDelayAsync()
     {
         try
         {
-            await Task.Delay(3000, _cts.Token);
+            await Task.Delay(2000, _cts.Token);
             var result = await UpdateService.CheckForUpdateAsync(_cts.Token);
 
             if (result.UpdateAvailable && result.LatestRelease != null)

--- a/src/MauiSherpa/MauiProgram.cs
+++ b/src/MauiSherpa/MauiProgram.cs
@@ -113,6 +113,7 @@ public static class MauiProgram
         builder.Services.AddSingleton<LocalSecretsKeyStore>();
         builder.Services.AddSingleton<ILocalSecretsKeyStore>(sp => sp.GetRequiredService<LocalSecretsKeyStore>());
         builder.Services.AddSingleton<ILocalVaultKeyStore>(sp => sp.GetRequiredService<LocalSecretsKeyStore>());
+        builder.Services.AddSingleton<ILocalVaultAccessService>(sp => sp.GetRequiredService<LocalSecretsKeyStore>());
         builder.Services.AddSingleton<ILocalVaultStore, SqlCipherLocalVaultStore>();
         builder.Services.AddSingleton<IThemeService, ThemeService>();
         builder.Services.AddSingleton<IToolbarService, MauiSherpa.Core.Services.ToolbarService>();

--- a/src/MauiSherpa/MauiProgram.cs
+++ b/src/MauiSherpa/MauiProgram.cs
@@ -107,6 +107,7 @@ public static class MauiProgram
         builder.Services.AddSingleton<ILauncher>(_ => Launcher.Default);
         builder.Services.AddSingleton<IClipboard>(_ => Clipboard.Default);
         builder.Services.AddSingleton<ISecureStorage>(_ => SecureStorage.Default);
+        builder.Services.AddSingleton<ILocalVaultIntroductionService, LocalVaultIntroductionService>();
         builder.Services.AddSingleton<SecureStorageService>();
         builder.Services.AddSingleton<ILegacySecureStorageService>(sp => sp.GetRequiredService<SecureStorageService>());
         builder.Services.AddSingleton<ISecureStorageService, VaultSecureStorageService>();
@@ -167,6 +168,7 @@ public static class MauiProgram
         builder.Services.AddSingleton<MauiSherpa.Pages.Forms.HybridFormBridgeHolder>();
         builder.Services.AddSingleton<MauiSherpa.Pages.Forms.ProgressBridgeHolder>();
         builder.Services.AddSingleton<MauiSherpa.Pages.Forms.ModalParameterService>();
+        builder.Services.AddSingleton<LocalVaultIntroModalService>();
         
         // Apple services
         builder.Services.AddSingleton<IXcodeService>(sp =>

--- a/src/MauiSherpa/MauiProgram.cs
+++ b/src/MauiSherpa/MauiProgram.cs
@@ -107,7 +107,13 @@ public static class MauiProgram
         builder.Services.AddSingleton<ILauncher>(_ => Launcher.Default);
         builder.Services.AddSingleton<IClipboard>(_ => Clipboard.Default);
         builder.Services.AddSingleton<ISecureStorage>(_ => SecureStorage.Default);
-        builder.Services.AddSingleton<ISecureStorageService, SecureStorageService>();
+        builder.Services.AddSingleton<SecureStorageService>();
+        builder.Services.AddSingleton<ILegacySecureStorageService>(sp => sp.GetRequiredService<SecureStorageService>());
+        builder.Services.AddSingleton<ISecureStorageService, VaultSecureStorageService>();
+        builder.Services.AddSingleton<LocalSecretsKeyStore>();
+        builder.Services.AddSingleton<ILocalSecretsKeyStore>(sp => sp.GetRequiredService<LocalSecretsKeyStore>());
+        builder.Services.AddSingleton<ILocalVaultKeyStore>(sp => sp.GetRequiredService<LocalSecretsKeyStore>());
+        builder.Services.AddSingleton<ILocalVaultStore, SqlCipherLocalVaultStore>();
         builder.Services.AddSingleton<IThemeService, ThemeService>();
         builder.Services.AddSingleton<IToolbarService, MauiSherpa.Core.Services.ToolbarService>();
 

--- a/src/MauiSherpa/Pages/Certificates.razor
+++ b/src/MauiSherpa/Pages/Certificates.razor
@@ -60,7 +60,7 @@
                 <i class="fas fa-cloud info-icon"></i>
                 <div>
                     <strong>Sync certificates across machines</strong>
-                    <p>Configure a cloud secrets provider (like Infisical) in Settings to securely sync your signing certificates and private keys across all your development machines.</p>
+                    <p>Configure a secrets provider in Settings to securely store signing certificates and private keys. Use a cloud provider to sync across machines.</p>
                 </div>
             </div>
             <button type="button" class="btn-close" @onclick="DismissSyncHint" title="Dismiss">×</button>

--- a/src/MauiSherpa/Pages/Debug.razor
+++ b/src/MauiSherpa/Pages/Debug.razor
@@ -11,6 +11,7 @@
 @inject MauiSherpa.Pages.Forms.ModalParameterService ModalParams
 @inject IAndroidSdkService AndroidSdkService
 @inject IDebugFlagService DebugFlags
+@inject LocalVaultIntroModalService LocalVaultIntroModal
 
 <div class="page-header">
     <div class="page-title-row">
@@ -168,6 +169,19 @@
             <div class="button-grid">
                 <button class="btn btn-primary" @onclick="ShowUpdateModal">
                     <i class="fa-solid fa-arrow-up"></i> Show Update Modal
+                </button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Local Vault Intro Modal -->
+    <div class="debug-section">
+        <h2><i class="fa-solid fa-vault"></i> Local Vault Intro Modal</h2>
+        <p class="section-description">Preview the first-run Local Vault introduction dialog. Actions are not saved in preview mode.</p>
+        <div class="debug-card">
+            <div class="button-grid">
+                <button class="btn btn-primary" @onclick="ShowLocalVaultIntroModal">
+                    <i class="fa-solid fa-vault"></i> Show Local Vault Intro
                 </button>
             </div>
         </div>
@@ -398,6 +412,13 @@
         await nav.PushModalAsync(page, animated: true);
         await resultTask;
         await nav.PopModalAsync(animated: true);
+    }
+
+    // === Local Vault Intro Modal ===
+
+    private async Task ShowLocalVaultIntroModal()
+    {
+        await LocalVaultIntroModal.ShowPreviewAsync();
     }
 
     // === Process Execution Modal ===

--- a/src/MauiSherpa/Pages/Forms/CreateSecretPage.cs
+++ b/src/MauiSherpa/Pages/Forms/CreateSecretPage.cs
@@ -4,7 +4,13 @@ using MauiSherpa.Core.Services;
 
 namespace MauiSherpa.Pages.Forms;
 
-public record SecretCreateResult(string Key, string? Description, ManagedSecretType Type, byte[] Value, string? OriginalFileName);
+public record SecretCreateResult(
+    string Key,
+    string? Description,
+    ManagedSecretType Type,
+    byte[] Value,
+    string? OriginalFileName,
+    Dictionary<string, string> Metadata);
 
 public class CreateSecretPage : FormPage<SecretCreateResult>
 {
@@ -19,6 +25,10 @@ public class CreateSecretPage : FormPage<SecretCreateResult>
     private Button _fileButton = null!;
     private View _stringGroup = null!;
     private View _fileGroup = null!;
+    private VerticalStackLayout _metadataRows = null!;
+    private Label _metadataHint = null!;
+    private Label _metadataError = null!;
+    private readonly List<MetadataRow> _metadataEntries = new();
 
     private byte[]? _fileBytes;
     private string? _fileName;
@@ -43,6 +53,7 @@ public class CreateSecretPage : FormPage<SecretCreateResult>
             if (_folderPicker?.SelectedIndex < 0) return false;
             if (!IsKeyValid()) return false;
             if (_typePicker?.SelectedIndex < 0) return false;
+            if (!IsMetadataValid()) return false;
             if (_typePicker?.SelectedIndex == 0) // String
                 return !string.IsNullOrWhiteSpace(_valueEditor?.Text);
             else // File
@@ -106,6 +117,52 @@ public class CreateSecretPage : FormPage<SecretCreateResult>
         });
         _fileGroup.IsVisible = false;
 
+        _metadataRows = new VerticalStackLayout
+        {
+            Spacing = 8
+        };
+
+        _metadataHint = new Label
+        {
+            Text = "Add optional key/value metadata for this secret.",
+            FontSize = 11,
+        };
+        _metadataHint.SetDynamicResource(Label.TextColorProperty, FormTheme.TextMuted);
+
+        _metadataError = new Label
+        {
+            Text = "Metadata keys must be unique. A row with a value also needs a key.",
+            FontSize = 11,
+            IsVisible = false,
+        };
+        _metadataError.SetDynamicResource(Label.TextColorProperty, FormTheme.AccentDanger);
+
+        var addMetadataButton = new Button
+        {
+            Text = "Add Metadata",
+            BorderWidth = 0,
+            CornerRadius = 6,
+            FontSize = 13,
+            HeightRequest = 34,
+            Padding = new Thickness(12, 0),
+            HorizontalOptions = LayoutOptions.Start,
+        };
+        addMetadataButton.SetDynamicResource(Button.BackgroundColorProperty, FormTheme.InputBg);
+        addMetadataButton.SetDynamicResource(Button.TextColorProperty, FormTheme.TextPrimary);
+        addMetadataButton.Clicked += (_, _) => AddMetadataRow();
+
+        var metadataGroup = CreateFormGroup("Metadata", new VerticalStackLayout
+        {
+            Spacing = 8,
+            Children =
+            {
+                _metadataHint,
+                _metadataRows,
+                _metadataError,
+                addMetadataButton,
+            }
+        });
+
         return new VerticalStackLayout
         {
             Spacing = 16,
@@ -117,6 +174,7 @@ public class CreateSecretPage : FormPage<SecretCreateResult>
                 CreateFormGroup("Type", _typePicker),
                 _stringGroup,
                 _fileGroup,
+                metadataGroup,
             }
         };
     }
@@ -171,7 +229,13 @@ public class CreateSecretPage : FormPage<SecretCreateResult>
             originalFileName = _fileName;
         }
 
-        return Task.FromResult(new SecretCreateResult(key, description, type, value, originalFileName));
+        return Task.FromResult(new SecretCreateResult(
+            key,
+            description,
+            type,
+            value,
+            originalFileName,
+            GetMetadata()));
     }
 
     private bool IsKeyValid()
@@ -188,4 +252,119 @@ public class CreateSecretPage : FormPage<SecretCreateResult>
     }
 
     private static string FormatFolderPath(string folderPath) => folderPath == "/" ? "Root (/)" : folderPath;
+
+    private void AddMetadataRow(string key = "", string value = "")
+    {
+        var keyEntry = CreateEntry("metadata-key");
+        keyEntry.Text = key;
+        var valueEntry = CreateEntry("metadata value");
+        valueEntry.Text = value;
+
+        var removeButton = new Button
+        {
+            Text = "Remove",
+            BorderWidth = 0,
+            CornerRadius = 6,
+            FontSize = 13,
+            HeightRequest = 36,
+            Padding = new Thickness(10, 0),
+            VerticalOptions = LayoutOptions.Center,
+        };
+        removeButton.SetDynamicResource(Button.BackgroundColorProperty, FormTheme.InputBg);
+        removeButton.SetDynamicResource(Button.TextColorProperty, FormTheme.AccentDanger);
+
+        var rowLayout = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition(GridLength.Star),
+                new ColumnDefinition(GridLength.Star),
+                new ColumnDefinition(GridLength.Auto),
+            },
+            ColumnSpacing = 8,
+        };
+        Grid.SetColumn(keyEntry, 0);
+        Grid.SetColumn(valueEntry, 1);
+        Grid.SetColumn(removeButton, 2);
+        rowLayout.Children.Add(keyEntry);
+        rowLayout.Children.Add(valueEntry);
+        rowLayout.Children.Add(removeButton);
+
+        var row = new MetadataRow(keyEntry, valueEntry, rowLayout);
+        removeButton.Clicked += (_, _) =>
+        {
+            _metadataEntries.Remove(row);
+            _metadataRows.Children.Remove(rowLayout);
+            UpdateMetadataHint();
+            UpdateMetadataError();
+            UpdateSubmitEnabled();
+        };
+
+        keyEntry.TextChanged += (_, _) =>
+        {
+            UpdateMetadataError();
+            UpdateSubmitEnabled();
+        };
+        valueEntry.TextChanged += (_, _) =>
+        {
+            UpdateMetadataError();
+            UpdateSubmitEnabled();
+        };
+
+        _metadataEntries.Add(row);
+        _metadataRows.Children.Add(rowLayout);
+        UpdateMetadataHint();
+        UpdateMetadataError();
+        UpdateSubmitEnabled();
+    }
+
+    private void UpdateMetadataHint()
+    {
+        _metadataHint.Text = _metadataEntries.Count == 0
+            ? "Add optional key/value metadata for this secret."
+            : "Leave a value empty to store an empty value. Remove a row to delete it.";
+    }
+
+    private void UpdateMetadataError()
+    {
+        _metadataError.IsVisible = !IsMetadataValid();
+    }
+
+    private bool IsMetadataValid()
+    {
+        var keys = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var row in _metadataEntries)
+        {
+            var key = row.KeyEntry.Text?.Trim() ?? "";
+            var value = row.ValueEntry.Text ?? "";
+            if (string.IsNullOrEmpty(key))
+            {
+                if (!string.IsNullOrEmpty(value))
+                    return false;
+                continue;
+            }
+
+            if (!keys.Add(key))
+                return false;
+        }
+
+        return true;
+    }
+
+    private Dictionary<string, string> GetMetadata()
+    {
+        var metadata = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var row in _metadataEntries)
+        {
+            var key = row.KeyEntry.Text?.Trim() ?? "";
+            if (string.IsNullOrEmpty(key))
+                continue;
+
+            metadata[key] = row.ValueEntry.Text ?? "";
+        }
+
+        return metadata;
+    }
+
+    private sealed record MetadataRow(Entry KeyEntry, Entry ValueEntry, View Layout);
 }

--- a/src/MauiSherpa/Pages/Forms/CreateSecretPage.cs
+++ b/src/MauiSherpa/Pages/Forms/CreateSecretPage.cs
@@ -62,6 +62,7 @@ public class CreateSecretPage : FormPage<SecretCreateResult>
         _descriptionEntry = CreateEntry("Optional description");
 
         _typePicker = CreatePicker(null, new[] { "String", "File" });
+        _typePicker.SelectedIndex = 0;
         _typePicker.SelectedIndexChanged += (_, _) => OnTypeChanged();
 
         _valueEditor = new Editor

--- a/src/MauiSherpa/Pages/Forms/CreateSecretPage.cs
+++ b/src/MauiSherpa/Pages/Forms/CreateSecretPage.cs
@@ -1,5 +1,6 @@
 using Microsoft.Maui.Controls;
 using MauiSherpa.Core.Interfaces;
+using MauiSherpa.Core.Services;
 
 namespace MauiSherpa.Pages.Forms;
 
@@ -7,6 +8,9 @@ public record SecretCreateResult(string Key, string? Description, ManagedSecretT
 
 public class CreateSecretPage : FormPage<SecretCreateResult>
 {
+    private readonly string _initialFolderPath;
+    private readonly IReadOnlyList<string> _folderPaths;
+    private Picker _folderPicker = null!;
     private Entry _keyEntry = null!;
     private Entry _descriptionEntry = null!;
     private Picker _typePicker = null!;
@@ -21,11 +25,23 @@ public class CreateSecretPage : FormPage<SecretCreateResult>
 
     protected override string FormTitle => "Create Secret";
 
+    public CreateSecretPage(string initialFolderPath = "/", IReadOnlyList<string>? folderPaths = null)
+    {
+        _initialFolderPath = SecretPath.NormalizeFolderPath(initialFolderPath);
+        _folderPaths = new[] { "/" }
+            .Concat(folderPaths ?? Array.Empty<string>())
+            .Select(SecretPath.NormalizeFolderPath)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(path => path == "/" ? "" : path, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
     protected override bool CanSubmit
     {
         get
         {
-            if (string.IsNullOrWhiteSpace(_keyEntry?.Text)) return false;
+            if (_folderPicker?.SelectedIndex < 0) return false;
+            if (!IsKeyValid()) return false;
             if (_typePicker?.SelectedIndex < 0) return false;
             if (_typePicker?.SelectedIndex == 0) // String
                 return !string.IsNullOrWhiteSpace(_valueEditor?.Text);
@@ -36,7 +52,11 @@ public class CreateSecretPage : FormPage<SecretCreateResult>
 
     protected override View BuildFormContent()
     {
-        _keyEntry = CreateEntry("my-secret-key");
+        _folderPicker = CreatePicker(null, _folderPaths.Select(FormatFolderPath).ToList());
+        var selectedFolderIndex = _folderPaths.ToList().FindIndex(path => path == _initialFolderPath);
+        _folderPicker.SelectedIndex = selectedFolderIndex >= 0 ? selectedFolderIndex : 0;
+
+        _keyEntry = CreateEntry("api-key");
         _keyEntry.TextChanged += (_, _) => UpdateSubmitEnabled();
 
         _descriptionEntry = CreateEntry("Optional description");
@@ -90,7 +110,8 @@ public class CreateSecretPage : FormPage<SecretCreateResult>
             Spacing = 16,
             Children =
             {
-                CreateFormGroup("Key", _keyEntry, "Unique identifier for this secret"),
+                CreateFormGroup("Folder", _folderPicker, "Create folders from the Secrets page, then choose one here"),
+                CreateFormGroup("Key", _keyEntry, "Secret name within the selected folder"),
                 CreateFormGroup("Description", _descriptionEntry),
                 CreateFormGroup("Type", _typePicker),
                 _stringGroup,
@@ -131,7 +152,8 @@ public class CreateSecretPage : FormPage<SecretCreateResult>
 
     protected override Task<SecretCreateResult> OnSubmitAsync()
     {
-        var key = _keyEntry.Text.Trim();
+        var path = new SecretPath(_folderPaths[_folderPicker.SelectedIndex], _keyEntry.Text);
+        var key = path.ToFlatKey();
         var description = string.IsNullOrWhiteSpace(_descriptionEntry.Text) ? null : _descriptionEntry.Text.Trim();
         var type = _typePicker.SelectedIndex == 0 ? ManagedSecretType.String : ManagedSecretType.File;
 
@@ -150,4 +172,19 @@ public class CreateSecretPage : FormPage<SecretCreateResult>
 
         return Task.FromResult(new SecretCreateResult(key, description, type, value, originalFileName));
     }
+
+    private bool IsKeyValid()
+    {
+        try
+        {
+            _ = SecretPath.NormalizeKey(_keyEntry?.Text ?? "");
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+    }
+
+    private static string FormatFolderPath(string folderPath) => folderPath == "/" ? "Root (/)" : folderPath;
 }

--- a/src/MauiSherpa/Pages/Forms/CreateSecretPage.cs
+++ b/src/MauiSherpa/Pages/Forms/CreateSecretPage.cs
@@ -264,13 +264,13 @@ public class CreateSecretPage : FormPage<SecretCreateResult>
         {
             Text = "Remove",
             BorderWidth = 0,
-            CornerRadius = 6,
-            FontSize = 13,
+            CornerRadius = 5,
+            FontSize = 12,
             HeightRequest = 36,
             Padding = new Thickness(10, 0),
             VerticalOptions = LayoutOptions.Center,
         };
-        removeButton.SetDynamicResource(Button.BackgroundColorProperty, FormTheme.InputBg);
+        removeButton.SetDynamicResource(Button.BackgroundColorProperty, FormTheme.InputBorder);
         removeButton.SetDynamicResource(Button.TextColorProperty, FormTheme.AccentDanger);
 
         var rowLayout = new Grid
@@ -315,6 +315,8 @@ public class CreateSecretPage : FormPage<SecretCreateResult>
         _metadataRows.Children.Add(rowLayout);
         UpdateMetadataHint();
         UpdateMetadataError();
+        _metadataRows.InvalidateMeasure();
+        InvalidateMeasure();
         UpdateSubmitEnabled();
     }
 

--- a/src/MauiSherpa/Pages/Keystores.razor
+++ b/src/MauiSherpa/Pages/Keystores.razor
@@ -59,7 +59,7 @@
             <i class="fas fa-cloud info-icon"></i>
             <div>
                 <strong>Sync keystores across machines</strong>
-                <p>Configure a cloud secrets provider in <a href="/settings">Settings</a> to securely sync your signing keystores and passwords across all your development machines.</p>
+                <p>Configure a secrets provider in <a href="/settings">Settings</a> to securely store signing keystores and passwords. Use a cloud provider to sync across machines.</p>
             </div>
         </div>
         <button type="button" class="btn-close" @onclick="DismissSyncHint" title="Dismiss">×</button>

--- a/src/MauiSherpa/Pages/Modals/CloudProviderModal.razor
+++ b/src/MauiSherpa/Pages/Modals/CloudProviderModal.razor
@@ -5,7 +5,7 @@
 
 <div class="dialog-content">
     <div class="dialog-header">
-        <h2><i class="fas fa-cloud"></i> @(isEditing ? "Edit" : "Add") Cloud Provider</h2>
+        <h2><i class="fas fa-vault"></i> @(isEditing ? "Edit" : "Add") Secrets Provider</h2>
     </div>
     <div class="dialog-body">
         <div class="form-group">
@@ -22,7 +22,7 @@
             else
             {
                 <div class="provider-type-selector">
-                    @foreach (var type in CloudSecretsProviderFactory.SupportedProviders)
+                    @foreach (var type in AddableProviderTypes)
                     {
                         <div class="provider-type-card @(providerType == type ? "selected" : "")"
                              @onclick="@(() => OnProviderTypeChanged(type))">
@@ -95,8 +95,10 @@
     private bool isEditing;
     private string editingId = "";
     private string providerName = "";
-    private CloudSecretsProviderType providerType = CloudSecretsProviderType.Infisical;
+    private CloudSecretsProviderType providerType = CloudSecretsProviderType.Local;
     private Dictionary<string, string> providerSettings = new();
+    private IEnumerable<CloudSecretsProviderType> AddableProviderTypes =>
+        CloudSecretsProviderFactory.SupportedProviders.Where(type => type != CloudSecretsProviderType.Local);
 
     private bool CanSave
     {
@@ -123,7 +125,7 @@
         }
         else
         {
-            providerType = CloudSecretsProviderFactory.SupportedProviders.FirstOrDefault();
+            providerType = AddableProviderTypes.FirstOrDefault();
             InitializeDefaultSettings();
         }
     }
@@ -158,6 +160,7 @@
 
     private static string GetProviderIcon(CloudSecretsProviderType type) => type switch
     {
+        CloudSecretsProviderType.Local => "fas fa-database",
         CloudSecretsProviderType.Infisical => "fas fa-shield-alt",
         CloudSecretsProviderType.AzureKeyVault => "fas fa-key",
         CloudSecretsProviderType.AwsSecretsManager => "fab fa-aws",

--- a/src/MauiSherpa/Pages/Modals/CloudProviderPage.cs
+++ b/src/MauiSherpa/Pages/Modals/CloudProviderPage.cs
@@ -13,7 +13,7 @@ public class CloudProviderPage : HybridFormPage<CloudSecretsProviderConfig>
 {
     private readonly bool _isEditing;
 
-    protected override string FormTitle => _isEditing ? "Edit Cloud Provider" : "Add Cloud Provider";
+    protected override string FormTitle => _isEditing ? "Edit Secrets Provider" : "Add Secrets Provider";
     protected override string SubmitButtonText => "Save";
     protected override string BlazorRoute => "/modal/cloud-provider";
 

--- a/src/MauiSherpa/Pages/Modals/CreateSecretModalPage.cs
+++ b/src/MauiSherpa/Pages/Modals/CreateSecretModalPage.cs
@@ -1,0 +1,43 @@
+using MauiSherpa.Core.Interfaces;
+using MauiSherpa.Core.Services;
+using MauiSherpa.Pages.Forms;
+
+namespace MauiSherpa.Pages.Modals;
+
+public class CreateSecretModalPage : HybridFormPage<SecretCreateResult>
+{
+    protected override string FormTitle => "Create Secret";
+    protected override string SubmitButtonText => "Create";
+    protected override string BlazorRoute => "/modal/edit-secret";
+
+    public CreateSecretModalPage(
+        HybridFormBridgeHolder bridgeHolder,
+        string initialFolderPath = "/",
+        IReadOnlyList<string>? folderPaths = null)
+        : base(bridgeHolder)
+    {
+        ConfigureParameters(initialFolderPath, folderPaths);
+    }
+
+    private void ConfigureParameters(string initialFolderPath, IReadOnlyList<string>? folderPaths)
+    {
+        var normalizedInitialFolder = SecretPath.NormalizeFolderPath(initialFolderPath);
+        var normalizedFolders = new[] { "/" }
+            .Concat(folderPaths ?? Array.Empty<string>())
+            .Append(normalizedInitialFolder)
+            .Select(SecretPath.NormalizeFolderPath)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(path => path == "/" ? "" : path, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        Bridge.Parameters["Mode"] = "Create";
+        Bridge.Parameters["FolderPath"] = normalizedInitialFolder;
+        Bridge.Parameters["FolderPaths"] = normalizedFolders;
+        Bridge.Parameters["Key"] = "";
+        Bridge.Parameters["FullKey"] = "";
+        Bridge.Parameters["Description"] = "";
+        Bridge.Parameters["Type"] = ManagedSecretType.String;
+        Bridge.Parameters["FileName"] = "";
+        Bridge.Parameters["Metadata"] = new Dictionary<string, string>(StringComparer.Ordinal);
+    }
+}

--- a/src/MauiSherpa/Pages/Modals/EditSecretModal.razor
+++ b/src/MauiSherpa/Pages/Modals/EditSecretModal.razor
@@ -25,8 +25,18 @@
         </div>
         <div class="form-group">
             <label>Key</label>
-            <input type="text" class="form-control" value="@key" disabled />
-            <div class="form-hint">The key name stays the same; change the folder above to move it.</div>
+            @if (isCreateMode)
+            {
+                <input type="text" class="form-control" @bind="key" @bind:event="oninput"
+                       @bind:after="OnFieldChanged"
+                       placeholder="api-key" />
+                <div class="form-hint">Secret name within the selected folder.</div>
+            }
+            else
+            {
+                <input type="text" class="form-control" value="@key" disabled />
+                <div class="form-hint">The key name stays the same; change the folder above to move it.</div>
+            }
         </div>
         <div class="form-group">
             <label>Description</label>
@@ -34,13 +44,29 @@
                    @bind:after="OnFieldChanged"
                    placeholder="Optional description" />
         </div>
+        @if (isCreateMode)
+        {
+            <div class="form-group">
+                <label>Type</label>
+                <select class="form-control" @bind="secretType" @bind:after="OnTypeChanged">
+                    <option value="@ManagedSecretType.String">String</option>
+                    <option value="@ManagedSecretType.File">File</option>
+                </select>
+            </div>
+        }
         <div class="form-group">
-            <label>Value <span class="hint">(leave empty to keep current)</span></label>
+            <label>
+                Value
+                @if (!isCreateMode)
+                {
+                    <span class="hint">(leave empty to keep current)</span>
+                }
+            </label>
             @if (secretType == ManagedSecretType.String)
             {
                 <textarea class="form-control textarea" @bind="value" @bind:event="oninput"
                           @bind:after="OnFieldChanged"
-                          placeholder="Enter new value..." rows="4"></textarea>
+                          placeholder="@(isCreateMode ? "Enter secret value" : "Enter new value...")" rows="4"></textarea>
             }
             else
             {
@@ -116,13 +142,14 @@
     private byte[]? fileBytes;
     private readonly List<MetadataRow> metadataRows = new();
     private bool isMetadataValid = true;
+    private bool isCreateMode;
 
     protected override void OnInitialized()
     {
         var bridge = BridgeHolder.Current;
         if (bridge == null) return;
 
-        // Read parameters set by the MAUI page
+        isCreateMode = string.Equals(bridge.Parameters.GetValueOrDefault("Mode") as string, "Create", StringComparison.Ordinal);
         key = bridge.Parameters.GetValueOrDefault("Key") as string ?? "";
         folderPath = bridge.Parameters.GetValueOrDefault("FolderPath") as string ?? "/";
         selectedFolderPath = folderPath;
@@ -140,7 +167,7 @@
         }
 
         bridge.SubmitRequested += OnSubmitRequested;
-        bridge.SetValid(true); // Edit mode: always valid (value can be empty to keep current)
+        OnFieldChanged();
     }
 
     private Task OnSubmitRequested()
@@ -148,14 +175,32 @@
         var bridge = BridgeHolder.Current;
         if (bridge == null) return Task.CompletedTask;
 
-        bridge.Result = new EditSecretResult(
-            OriginalKey: fullKey,
-            Key: new SecretPath(selectedFolderPath, key).ToFlatKey(),
-            Description: description,
-            Value: !string.IsNullOrEmpty(value) ? System.Text.Encoding.UTF8.GetBytes(value) : null,
-            FileBytes: fileBytes,
-            Type: secretType,
-            Metadata: GetMetadata());
+        var normalizedKey = new SecretPath(selectedFolderPath, key).ToFlatKey();
+        if (isCreateMode)
+        {
+            var secretValue = secretType == ManagedSecretType.String
+                ? System.Text.Encoding.UTF8.GetBytes(value)
+                : fileBytes!;
+
+            bridge.Result = new SecretCreateResult(
+                Key: normalizedKey,
+                Description: string.IsNullOrWhiteSpace(description) ? null : description.Trim(),
+                Type: secretType,
+                Value: secretValue,
+                OriginalFileName: secretType == ManagedSecretType.File ? fileName : null,
+                Metadata: GetMetadata());
+        }
+        else
+        {
+            bridge.Result = new EditSecretResult(
+                OriginalKey: fullKey,
+                Key: normalizedKey,
+                Description: description,
+                Value: !string.IsNullOrEmpty(value) ? System.Text.Encoding.UTF8.GetBytes(value) : null,
+                FileBytes: fileBytes,
+                Type: secretType,
+                Metadata: GetMetadata());
+        }
 
         return Task.CompletedTask;
     }
@@ -163,7 +208,15 @@
     private void OnFieldChanged()
     {
         isMetadataValid = IsMetadataValid();
-        BridgeHolder.Current?.SetValid(isMetadataValid);
+        BridgeHolder.Current?.SetValid(isMetadataValid && IsFormValid());
+    }
+
+    private void OnTypeChanged()
+    {
+        value = "";
+        fileName = "";
+        fileBytes = null;
+        OnFieldChanged();
     }
 
     private static string FormatFolderPath(string folder) => folder == "/" ? "Root (/)" : folder;
@@ -177,6 +230,7 @@
 
             fileName = System.IO.Path.GetFileName(result);
             fileBytes = await System.IO.File.ReadAllBytesAsync(result);
+            OnFieldChanged();
             StateHasChanged();
         }
         catch { }
@@ -186,6 +240,7 @@
     {
         fileName = "";
         fileBytes = null;
+        OnFieldChanged();
     }
 
     private void AddMetadataRow()
@@ -218,6 +273,25 @@
         }
 
         return true;
+    }
+
+    private bool IsFormValid()
+    {
+        if (!isCreateMode)
+            return true;
+
+        try
+        {
+            _ = new SecretPath(selectedFolderPath, key).ToFlatKey();
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+
+        return secretType == ManagedSecretType.String
+            ? !string.IsNullOrWhiteSpace(value)
+            : fileBytes is not null;
     }
 
     private Dictionary<string, string> GetMetadata()

--- a/src/MauiSherpa/Pages/Modals/EditSecretModal.razor
+++ b/src/MauiSherpa/Pages/Modals/EditSecretModal.razor
@@ -62,6 +62,44 @@
                 </div>
             }
         </div>
+        <div class="form-group">
+            <div class="metadata-header">
+                <label>Metadata</label>
+                <button class="btn btn-secondary btn-small" @onclick="AddMetadataRow">
+                    <i class="fas fa-plus"></i> Add
+                </button>
+            </div>
+            <div class="form-hint">
+                Add optional key/value metadata. Empty rows are ignored; duplicate keys are not allowed.
+            </div>
+            @if (metadataRows.Count == 0)
+            {
+                <div class="metadata-empty">No metadata yet.</div>
+            }
+            else
+            {
+                <div class="metadata-list">
+                    @foreach (var row in metadataRows)
+                    {
+                        <div class="metadata-row" @key="row.Id">
+                            <input type="text" class="form-control" @bind="row.Key" @bind:event="oninput"
+                                   @bind:after="OnFieldChanged"
+                                   placeholder="metadata-key" />
+                            <input type="text" class="form-control" @bind="row.Value" @bind:event="oninput"
+                                   @bind:after="OnFieldChanged"
+                                   placeholder="metadata value" />
+                            <button class="btn-icon danger" title="Remove metadata" @onclick="() => RemoveMetadataRow(row)">
+                                <i class="fas fa-trash"></i>
+                            </button>
+                        </div>
+                    }
+                </div>
+                @if (!isMetadataValid)
+                {
+                    <div class="form-error">Metadata keys must be unique. A row with a value also needs a key.</div>
+                }
+            }
+        </div>
     </div>
 }
 
@@ -76,6 +114,8 @@
     private ManagedSecretType secretType = ManagedSecretType.String;
     private string fileName = "";
     private byte[]? fileBytes;
+    private readonly List<MetadataRow> metadataRows = new();
+    private bool isMetadataValid = true;
 
     protected override void OnInitialized()
     {
@@ -93,6 +133,11 @@
         description = bridge.Parameters.GetValueOrDefault("Description") as string ?? "";
         secretType = bridge.Parameters.GetValueOrDefault("Type") is ManagedSecretType t ? t : ManagedSecretType.String;
         fileName = bridge.Parameters.GetValueOrDefault("FileName") as string ?? "";
+        if (bridge.Parameters.GetValueOrDefault("Metadata") is Dictionary<string, string> metadata)
+        {
+            foreach (var kvp in metadata.OrderBy(kvp => kvp.Key, StringComparer.OrdinalIgnoreCase))
+                metadataRows.Add(new MetadataRow(kvp.Key, kvp.Value));
+        }
 
         bridge.SubmitRequested += OnSubmitRequested;
         bridge.SetValid(true); // Edit mode: always valid (value can be empty to keep current)
@@ -109,14 +154,16 @@
             Description: description,
             Value: !string.IsNullOrEmpty(value) ? System.Text.Encoding.UTF8.GetBytes(value) : null,
             FileBytes: fileBytes,
-            Type: secretType);
+            Type: secretType,
+            Metadata: GetMetadata());
 
         return Task.CompletedTask;
     }
 
     private void OnFieldChanged()
     {
-        BridgeHolder.Current?.SetValid(true);
+        isMetadataValid = IsMetadataValid();
+        BridgeHolder.Current?.SetValid(isMetadataValid);
     }
 
     private static string FormatFolderPath(string folder) => folder == "/" ? "Root (/)" : folder;
@@ -139,6 +186,68 @@
     {
         fileName = "";
         fileBytes = null;
+    }
+
+    private void AddMetadataRow()
+    {
+        metadataRows.Add(new MetadataRow());
+        OnFieldChanged();
+    }
+
+    private void RemoveMetadataRow(MetadataRow row)
+    {
+        metadataRows.Remove(row);
+        OnFieldChanged();
+    }
+
+    private bool IsMetadataValid()
+    {
+        var keys = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var row in metadataRows)
+        {
+            var keyText = row.Key.Trim();
+            if (string.IsNullOrEmpty(keyText))
+            {
+                if (!string.IsNullOrEmpty(row.Value))
+                    return false;
+                continue;
+            }
+
+            if (!keys.Add(keyText))
+                return false;
+        }
+
+        return true;
+    }
+
+    private Dictionary<string, string> GetMetadata()
+    {
+        var metadata = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var row in metadataRows)
+        {
+            var keyText = row.Key.Trim();
+            if (string.IsNullOrEmpty(keyText))
+                continue;
+
+            metadata[keyText] = row.Value;
+        }
+
+        return metadata;
+    }
+
+    private sealed class MetadataRow
+    {
+        public string Id { get; } = Guid.NewGuid().ToString("N");
+        public string Key { get; set; } = "";
+        public string Value { get; set; } = "";
+
+        public MetadataRow() { }
+
+        public MetadataRow(string key, string value)
+        {
+            Key = key;
+            Value = value;
+        }
     }
 
     public void Dispose()
@@ -193,6 +302,10 @@
         font-size: 11px;
         color: var(--text-muted);
     }
+    .form-error {
+        font-size: 11px;
+        color: var(--accent-danger);
+    }
     .file-picker { display: flex; align-items: center; gap: 8px; }
     .file-selected {
         display: flex;
@@ -211,6 +324,49 @@
     }
     .btn-clear:hover { color: var(--accent-danger); }
     .btn { padding: 6px 14px; border-radius: 6px; border: none; cursor: pointer; font-size: 13px; }
+    .btn-small { padding: 5px 10px; font-size: 12px; }
     .btn-secondary { background: var(--btn-secondary-bg); color: var(--text-primary); }
     .btn-secondary:hover { background: var(--border-color); }
+    .metadata-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+    }
+    .metadata-list {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+    }
+    .metadata-row {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) auto;
+        gap: 8px;
+        align-items: center;
+    }
+    .metadata-empty {
+        padding: 10px 12px;
+        border-radius: 6px;
+        background: var(--bg-tertiary);
+        color: var(--text-muted);
+        font-size: 13px;
+    }
+    .btn-icon {
+        width: 34px;
+        height: 34px;
+        border: none;
+        border-radius: 6px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        background: var(--btn-secondary-bg);
+        color: var(--text-muted);
+        cursor: pointer;
+    }
+    .btn-icon:hover {
+        background: var(--bg-tertiary);
+    }
+    .btn-icon.danger:hover {
+        color: var(--accent-danger);
+    }
 </style>

--- a/src/MauiSherpa/Pages/Modals/EditSecretModal.razor
+++ b/src/MauiSherpa/Pages/Modals/EditSecretModal.razor
@@ -1,5 +1,6 @@
 @page "/modal/edit-secret"
 @using MauiSherpa.Core.Interfaces
+@using MauiSherpa.Core.Services
 @using MauiSherpa.Pages.Forms
 @inject HybridFormBridgeHolder BridgeHolder
 @inject IDialogService DialogService
@@ -13,9 +14,19 @@
 {
     <div class="form-content">
         <div class="form-group">
+            <label>Folder</label>
+            <select class="form-control mono" @bind="selectedFolderPath" @bind:after="OnFieldChanged">
+                @foreach (var folder in folderPaths)
+                {
+                    <option value="@folder">@FormatFolderPath(folder)</option>
+                }
+            </select>
+            <div class="form-hint">Choose where this secret should live.</div>
+        </div>
+        <div class="form-group">
             <label>Key</label>
             <input type="text" class="form-control" value="@key" disabled />
-            <div class="form-hint">Key cannot be changed after creation</div>
+            <div class="form-hint">The key name stays the same; change the folder above to move it.</div>
         </div>
         <div class="form-group">
             <label>Description</label>
@@ -56,6 +67,10 @@
 
 @code {
     private string key = "";
+    private string folderPath = "/";
+    private string selectedFolderPath = "/";
+    private IReadOnlyList<string> folderPaths = Array.Empty<string>();
+    private string fullKey = "";
     private string description = "";
     private string value = "";
     private ManagedSecretType secretType = ManagedSecretType.String;
@@ -69,6 +84,12 @@
 
         // Read parameters set by the MAUI page
         key = bridge.Parameters.GetValueOrDefault("Key") as string ?? "";
+        folderPath = bridge.Parameters.GetValueOrDefault("FolderPath") as string ?? "/";
+        selectedFolderPath = folderPath;
+        folderPaths = bridge.Parameters.GetValueOrDefault("FolderPaths") as string[] ?? new[] { "/" };
+        if (!folderPaths.Contains(selectedFolderPath, StringComparer.Ordinal))
+            folderPaths = folderPaths.Concat(new[] { selectedFolderPath }).OrderBy(path => path == "/" ? "" : path, StringComparer.OrdinalIgnoreCase).ToArray();
+        fullKey = bridge.Parameters.GetValueOrDefault("FullKey") as string ?? key;
         description = bridge.Parameters.GetValueOrDefault("Description") as string ?? "";
         secretType = bridge.Parameters.GetValueOrDefault("Type") is ManagedSecretType t ? t : ManagedSecretType.String;
         fileName = bridge.Parameters.GetValueOrDefault("FileName") as string ?? "";
@@ -83,7 +104,8 @@
         if (bridge == null) return Task.CompletedTask;
 
         bridge.Result = new EditSecretResult(
-            Key: key,
+            OriginalKey: fullKey,
+            Key: new SecretPath(selectedFolderPath, key).ToFlatKey(),
             Description: description,
             Value: !string.IsNullOrEmpty(value) ? System.Text.Encoding.UTF8.GetBytes(value) : null,
             FileBytes: fileBytes,
@@ -96,6 +118,8 @@
     {
         BridgeHolder.Current?.SetValid(true);
     }
+
+    private static string FormatFolderPath(string folder) => folder == "/" ? "Root (/)" : folder;
 
     private async Task PickFile()
     {
@@ -156,6 +180,9 @@
     }
     .form-control:disabled {
         opacity: 0.6;
+    }
+    .mono {
+        font-family: monospace;
     }
     .textarea {
         resize: vertical;

--- a/src/MauiSherpa/Pages/Modals/EditSecretPage.cs
+++ b/src/MauiSherpa/Pages/Modals/EditSecretPage.cs
@@ -1,9 +1,11 @@
 using MauiSherpa.Core.Interfaces;
+using MauiSherpa.Core.Services;
 using MauiSherpa.Pages.Forms;
 
 namespace MauiSherpa.Pages.Modals;
 
 public record EditSecretResult(
+    string OriginalKey,
     string Key,
     string? Description,
     byte[]? Value,
@@ -18,17 +20,40 @@ public class EditSecretPage : HybridFormPage<EditSecretResult>
 
     public EditSecretPage(
         HybridFormBridgeHolder bridgeHolder,
-        ManagedSecret secret)
+        ManagedSecret secret,
+        IReadOnlyList<string>? folderPaths = null)
         : base(bridgeHolder)
     {
-        ConfigureParameters(secret);
+        ConfigureParameters(secret, folderPaths);
     }
 
-    private void ConfigureParameters(ManagedSecret secret)
+    private void ConfigureParameters(ManagedSecret secret, IReadOnlyList<string>? folderPaths)
     {
-        Bridge.Parameters["Key"] = secret.Key;
+        var normalizedFolders = new[] { "/" }
+            .Concat(folderPaths ?? Array.Empty<string>())
+            .Select(SecretPath.NormalizeFolderPath)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(path => path == "/" ? "" : path, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        Bridge.Parameters["FolderPath"] = GetSecretFolder(secret.Key);
+        Bridge.Parameters["FolderPaths"] = normalizedFolders;
+        Bridge.Parameters["Key"] = GetSecretName(secret.Key);
+        Bridge.Parameters["FullKey"] = secret.Key;
         Bridge.Parameters["Description"] = secret.Description ?? "";
         Bridge.Parameters["Type"] = secret.Type;
         Bridge.Parameters["FileName"] = secret.OriginalFileName ?? "";
+    }
+
+    private static string GetSecretFolder(string key)
+    {
+        var lastSeparator = key.LastIndexOf('/');
+        return lastSeparator < 0 ? "/" : SecretPath.NormalizeFolderPath(key[..lastSeparator]);
+    }
+
+    private static string GetSecretName(string key)
+    {
+        var lastSeparator = key.LastIndexOf('/');
+        return lastSeparator < 0 ? key : key[(lastSeparator + 1)..];
     }
 }

--- a/src/MauiSherpa/Pages/Modals/EditSecretPage.cs
+++ b/src/MauiSherpa/Pages/Modals/EditSecretPage.cs
@@ -10,7 +10,8 @@ public record EditSecretResult(
     string? Description,
     byte[]? Value,
     byte[]? FileBytes,
-    ManagedSecretType Type);
+    ManagedSecretType Type,
+    Dictionary<string, string> Metadata);
 
 public class EditSecretPage : HybridFormPage<EditSecretResult>
 {
@@ -43,6 +44,7 @@ public class EditSecretPage : HybridFormPage<EditSecretResult>
         Bridge.Parameters["Description"] = secret.Description ?? "";
         Bridge.Parameters["Type"] = secret.Type;
         Bridge.Parameters["FileName"] = secret.OriginalFileName ?? "";
+        Bridge.Parameters["Metadata"] = secret.Metadata;
     }
 
     private static string GetSecretFolder(string key)

--- a/src/MauiSherpa/Pages/Modals/LocalVaultIntroModal.razor
+++ b/src/MauiSherpa/Pages/Modals/LocalVaultIntroModal.razor
@@ -1,0 +1,394 @@
+@page "/modal/local-vault-intro"
+@using MauiSherpa.Core.Interfaces
+@inject MauiSherpa.Pages.Forms.ModalParameterService ModalParams
+@inject ICloudSecretsService CloudSecrets
+@inject ILocalVaultAccessService LocalVaultAccess
+@inject ILocalVaultIntroductionService LocalVaultIntro
+@inject ILoggingService Logger
+
+<div class="vault-intro">
+    <div class="dialog-header">
+        <div class="icon-wrap" aria-hidden="true">
+            <i class="fas fa-vault"></i>
+        </div>
+        <div>
+            <p class="eyebrow">New secure storage option</p>
+            <h2>Use Sherpa's Local Vault</h2>
+        </div>
+    </div>
+
+    <div class="dialog-body">
+        @if (previewOnly)
+        {
+            <div class="preview-note">
+                <i class="fas fa-flask" aria-hidden="true"></i>
+                <span>Debug preview: choosing an action here will not change your saved Local Vault preference.</span>
+            </div>
+        }
+
+        <p class="lead">
+            Sherpa can now store secrets locally in an encrypted vault on this machine. The vault database is encrypted,
+            and your operating system's secure storage is used only to protect the vault key.
+        </p>
+
+        <div class="trust-card">
+            <div class="trust-item">
+                <i class="fas fa-lock" aria-hidden="true"></i>
+                <div>
+                    <strong>Encrypted at rest</strong>
+                    <span>Secrets, provider settings, and metadata stay inside the Local Vault when you enable it.</span>
+                </div>
+            </div>
+            <div class="trust-item">
+                <i class="fas fa-shield-halved" aria-hidden="true"></i>
+                <div>
+                    <strong>Uses OS protection</strong>
+                    <span>@SecureStoragePromptCopy</span>
+                </div>
+            </div>
+            <div class="trust-item">
+                <i class="fas fa-folder-tree" aria-hidden="true"></i>
+                <div>
+                    <strong>Works with folders and metadata</strong>
+                    <span>Local secrets use the same folder and key/value metadata model as cloud providers.</span>
+                </div>
+            </div>
+        </div>
+
+        @if (isLoadingProviders)
+        {
+            <div class="status-row">
+                <i class="fas fa-spinner fa-spin" aria-hidden="true"></i>
+                <span>Checking your current secrets providers...</span>
+            </div>
+        }
+        else if (hasExistingProvider)
+        {
+            <div class="context-message">
+                <i class="fas fa-circle-info" aria-hidden="true"></i>
+                <span>You already have a secrets provider configured. You can keep using it, or enable Local Vault and make it the default provider for new secrets.</span>
+            </div>
+        }
+        else
+        {
+            <div class="context-message warning">
+                <i class="fas fa-triangle-exclamation" aria-hidden="true"></i>
+                <span>If you skip Local Vault, you will need to configure a secrets provider later in Settings before Sherpa can store secrets.</span>
+            </div>
+        }
+
+        @if (!string.IsNullOrWhiteSpace(errorMessage))
+        {
+            <div class="error-message" role="alert">
+                <i class="fas fa-circle-exclamation" aria-hidden="true"></i>
+                <span>@errorMessage</span>
+            </div>
+        }
+    </div>
+
+    <div class="dialog-footer">
+        <button class="btn btn-secondary" @onclick="DeclineAsync" disabled="@isBusy">
+            @SecondaryActionText
+        </button>
+        <button class="btn btn-primary" @onclick="EnableAsync" disabled="@isBusy">
+            @if (isBusy)
+            {
+                <i class="fas fa-spinner fa-spin" aria-hidden="true"></i>
+                <span>Enabling...</span>
+            }
+            else
+            {
+                <i class="fas fa-lock" aria-hidden="true"></i>
+                <span>@PrimaryActionText</span>
+            }
+        </button>
+    </div>
+</div>
+
+@code {
+    private bool previewOnly;
+    private bool isLoadingProviders = true;
+    private bool hasExistingProvider;
+    private bool isBusy;
+    private string? errorMessage;
+
+    private string PrimaryActionText => hasExistingProvider ? "Enable & Make Default" : "Enable Local Vault";
+    private string SecondaryActionText => hasExistingProvider ? "Keep Current Provider" : "Configure Later";
+
+    private static string SecureStoragePromptCopy =>
+        OperatingSystem.IsMacOS() || OperatingSystem.IsMacCatalyst()
+            ? "macOS may ask you to allow Sherpa access to Keychain before the vault is created."
+            : "Your platform may show a secure-storage prompt before the vault is created.";
+
+    protected override async Task OnInitializedAsync()
+    {
+        previewOnly = ModalParams.Get<bool>("PreviewOnly");
+
+        try
+        {
+            var providers = await CloudSecrets.GetProvidersAsync();
+            hasExistingProvider = providers.Any(p => p.ProviderType != CloudSecretsProviderType.Local);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning($"Failed to inspect existing secrets providers for Local Vault intro: {ex.Message}");
+        }
+        finally
+        {
+            isLoadingProviders = false;
+        }
+    }
+
+    private async Task EnableAsync()
+    {
+        if (isBusy)
+            return;
+
+        errorMessage = null;
+
+        if (previewOnly)
+        {
+            ModalParams.Complete(LocalVaultIntroductionResult.EnableLocal);
+            return;
+        }
+
+        isBusy = true;
+        try
+        {
+            var accessState = await LocalVaultAccess.RequestAccessAsync();
+            if (accessState.Problem != LocalVaultAccessProblem.None)
+            {
+                errorMessage = accessState.Message
+                    ?? "Sherpa couldn't access the operating system secure storage needed for the Local Vault key. You can try again, or configure a different provider later in Settings.";
+                return;
+            }
+
+            await LocalVaultIntro.MarkEnabledAsync();
+            await CloudSecrets.EnableDefaultLocalProviderAsync(setActiveProvider: true);
+            ModalParams.Complete(LocalVaultIntroductionResult.EnableLocal);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError("Failed to enable Local Vault", ex);
+            errorMessage = "Sherpa couldn't enable Local Vault. You can try again, or configure a different provider later in Settings.";
+        }
+        finally
+        {
+            isBusy = false;
+        }
+    }
+
+    private async Task DeclineAsync()
+    {
+        if (isBusy)
+            return;
+
+        if (!previewOnly)
+            await LocalVaultIntro.MarkDeclinedAsync();
+
+        ModalParams.Complete(LocalVaultIntroductionResult.DeclineLocal);
+    }
+}
+
+<style>
+    .vault-intro {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        color: var(--text-primary);
+        background: var(--card-bg);
+    }
+
+    .dialog-header {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+        padding: 1.5rem 1.5rem 1.25rem;
+        border-bottom: 1px solid var(--border-color);
+    }
+
+    .icon-wrap {
+        width: 3.25rem;
+        height: 3.25rem;
+        border-radius: 1rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: color-mix(in srgb, var(--primary) 14%, transparent);
+        color: var(--primary);
+        font-size: 1.35rem;
+        flex-shrink: 0;
+    }
+
+    .eyebrow {
+        margin: 0 0 0.25rem;
+        font-size: 0.75rem;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--primary);
+    }
+
+    h2 {
+        margin: 0;
+        font-size: 1.35rem;
+        line-height: 1.2;
+        font-weight: 700;
+        color: var(--text-primary);
+    }
+
+    .dialog-body {
+        flex: 1;
+        overflow-y: auto;
+        padding: 1.5rem;
+    }
+
+    .lead {
+        margin: 0 0 1.25rem;
+        color: var(--text-secondary);
+        font-size: 0.95rem;
+        line-height: 1.6;
+    }
+
+    .preview-note,
+    .context-message,
+    .error-message,
+    .status-row {
+        display: flex;
+        gap: 0.75rem;
+        align-items: flex-start;
+        padding: 0.875rem 1rem;
+        border-radius: 0.75rem;
+        font-size: 0.875rem;
+        line-height: 1.45;
+        margin-bottom: 1rem;
+    }
+
+    .preview-note {
+        background: color-mix(in srgb, var(--accent-purple, var(--primary)) 12%, transparent);
+        color: var(--text-secondary);
+        border: 1px solid color-mix(in srgb, var(--accent-purple, var(--primary)) 24%, transparent);
+    }
+
+    .context-message,
+    .status-row {
+        background: var(--bg-secondary);
+        color: var(--text-secondary);
+        border: 1px solid var(--border-color);
+    }
+
+    .context-message i,
+    .status-row i {
+        color: var(--primary);
+        margin-top: 0.1rem;
+    }
+
+    .context-message.warning {
+        background: color-mix(in srgb, var(--accent-warning, #f59e0b) 12%, transparent);
+        border-color: color-mix(in srgb, var(--accent-warning, #f59e0b) 26%, transparent);
+    }
+
+    .context-message.warning i {
+        color: var(--accent-warning, #f59e0b);
+    }
+
+    .error-message {
+        margin-top: 1rem;
+        margin-bottom: 0;
+        background: color-mix(in srgb, var(--accent-danger, #ef4444) 12%, transparent);
+        border: 1px solid color-mix(in srgb, var(--accent-danger, #ef4444) 28%, transparent);
+        color: var(--text-primary);
+    }
+
+    .error-message i {
+        color: var(--accent-danger, #ef4444);
+        margin-top: 0.1rem;
+    }
+
+    .trust-card {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        padding: 1rem;
+        border-radius: 1rem;
+        background: var(--bg-secondary);
+        border: 1px solid var(--border-color);
+        margin-bottom: 1rem;
+    }
+
+    .trust-item {
+        display: flex;
+        gap: 0.875rem;
+        align-items: flex-start;
+    }
+
+    .trust-item i {
+        width: 2rem;
+        height: 2rem;
+        border-radius: 0.65rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: var(--primary);
+        background: color-mix(in srgb, var(--primary) 12%, transparent);
+        flex-shrink: 0;
+    }
+
+    .trust-item strong {
+        display: block;
+        font-size: 0.9rem;
+        color: var(--text-primary);
+        margin-bottom: 0.15rem;
+    }
+
+    .trust-item span {
+        display: block;
+        font-size: 0.82rem;
+        line-height: 1.45;
+        color: var(--text-secondary);
+    }
+
+    .dialog-footer {
+        display: flex;
+        justify-content: flex-end;
+        gap: 0.75rem;
+        padding: 1rem 1.5rem 1.25rem;
+        border-top: 1px solid var(--border-color);
+        background: var(--card-bg);
+    }
+
+    .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.5rem;
+        min-height: 2.75rem;
+        padding: 0.65rem 1rem;
+        border-radius: 0.65rem;
+        font-weight: 600;
+        border: 1px solid transparent;
+        cursor: pointer;
+        transition: opacity 0.15s ease, transform 0.15s ease;
+    }
+
+    .btn:disabled {
+        opacity: 0.55;
+        cursor: not-allowed;
+    }
+
+    .btn:not(:disabled):active {
+        transform: scale(0.98);
+    }
+
+    .btn-primary {
+        color: var(--button-primary-text, white);
+        background: var(--primary);
+        border-color: var(--primary);
+    }
+
+    .btn-secondary {
+        color: var(--text-primary);
+        background: var(--bg-secondary);
+        border-color: var(--border-color);
+    }
+</style>

--- a/src/MauiSherpa/Pages/Modals/LocalVaultIntroModal.razor
+++ b/src/MauiSherpa/Pages/Modals/LocalVaultIntroModal.razor
@@ -27,8 +27,7 @@
         }
 
         <p class="lead">
-            Sherpa can now store secrets locally in an encrypted vault on this machine. The vault database is encrypted,
-            and your operating system's secure storage is used only to protect the vault key.
+            Sherpa can now store secrets locally in an encrypted vault. The operating system protects only the vault key.
         </p>
 
         <div class="trust-card">
@@ -36,7 +35,7 @@
                 <i class="fas fa-lock" aria-hidden="true"></i>
                 <div>
                     <strong>Encrypted at rest</strong>
-                    <span>Secrets, provider settings, and metadata stay inside the Local Vault when you enable it.</span>
+                    <span>Secrets, provider settings, and metadata stay in the vault.</span>
                 </div>
             </div>
             <div class="trust-item">
@@ -50,7 +49,7 @@
                 <i class="fas fa-folder-tree" aria-hidden="true"></i>
                 <div>
                     <strong>Works with folders and metadata</strong>
-                    <span>Local secrets use the same folder and key/value metadata model as cloud providers.</span>
+                    <span>Local secrets support the same folders and key/value metadata as cloud providers.</span>
                 </div>
             </div>
         </div>
@@ -191,202 +190,215 @@
 }
 
 <style>
+    html,
+    body,
+    #app {
+        background: var(--bg-primary) !important;
+    }
+
     .vault-intro {
         display: flex;
         flex-direction: column;
-        height: 100%;
+        height: calc(100% + 2rem);
+        width: calc(100% + 2.5rem);
+        margin: -1rem -1.25rem;
         color: var(--text-primary);
-        background: var(--card-bg);
+        background: var(--bg-primary);
+        font-size: 13px;
     }
 
-    .dialog-header {
+    .vault-intro .dialog-header {
         display: flex;
         align-items: center;
-        gap: 1rem;
-        padding: 1.5rem 1.5rem 1.25rem;
+        gap: 0.75rem;
+        padding: 1rem 1.25rem 0.875rem;
         border-bottom: 1px solid var(--border-color);
+        background: var(--bg-primary);
     }
 
-    .icon-wrap {
-        width: 3.25rem;
-        height: 3.25rem;
-        border-radius: 1rem;
+    .vault-intro .icon-wrap {
+        width: 2.5rem;
+        height: 2.5rem;
+        border-radius: 0.75rem;
         display: flex;
         align-items: center;
         justify-content: center;
-        background: color-mix(in srgb, var(--primary) 14%, transparent);
-        color: var(--primary);
-        font-size: 1.35rem;
+        background: color-mix(in srgb, var(--accent-primary) 14%, transparent);
+        color: var(--accent-primary);
+        font-size: 1.05rem;
         flex-shrink: 0;
     }
 
-    .eyebrow {
-        margin: 0 0 0.25rem;
-        font-size: 0.75rem;
+    .vault-intro .eyebrow {
+        margin: 0 0 0.15rem;
+        font-size: 0.68rem;
         font-weight: 700;
         letter-spacing: 0.08em;
         text-transform: uppercase;
-        color: var(--primary);
+        color: var(--accent-primary);
     }
 
-    h2 {
+    .vault-intro h2 {
         margin: 0;
-        font-size: 1.35rem;
+        font-size: 1.12rem;
         line-height: 1.2;
         font-weight: 700;
         color: var(--text-primary);
     }
 
-    .dialog-body {
+    .vault-intro .dialog-body {
         flex: 1;
         overflow-y: auto;
-        padding: 1.5rem;
+        padding: 1rem 1.25rem;
     }
 
-    .lead {
-        margin: 0 0 1.25rem;
+    .vault-intro .lead {
+        margin: 0 0 0.75rem;
         color: var(--text-secondary);
-        font-size: 0.95rem;
-        line-height: 1.6;
-    }
-
-    .preview-note,
-    .context-message,
-    .error-message,
-    .status-row {
-        display: flex;
-        gap: 0.75rem;
-        align-items: flex-start;
-        padding: 0.875rem 1rem;
-        border-radius: 0.75rem;
-        font-size: 0.875rem;
+        font-size: 0.84rem;
         line-height: 1.45;
-        margin-bottom: 1rem;
     }
 
-    .preview-note {
-        background: color-mix(in srgb, var(--accent-purple, var(--primary)) 12%, transparent);
+    .vault-intro .preview-note,
+    .vault-intro .context-message,
+    .vault-intro .error-message,
+    .vault-intro .status-row {
+        display: flex;
+        gap: 0.55rem;
+        align-items: flex-start;
+        padding: 0.65rem 0.75rem;
+        border-radius: 0.65rem;
+        font-size: 0.8rem;
+        line-height: 1.35;
+        margin-bottom: 0.75rem;
+    }
+
+    .vault-intro .preview-note {
+        background: color-mix(in srgb, var(--accent-purple) 12%, transparent);
         color: var(--text-secondary);
-        border: 1px solid color-mix(in srgb, var(--accent-purple, var(--primary)) 24%, transparent);
+        border: 1px solid color-mix(in srgb, var(--accent-purple) 24%, transparent);
     }
 
-    .context-message,
-    .status-row {
+    .vault-intro .context-message,
+    .vault-intro .status-row {
         background: var(--bg-secondary);
         color: var(--text-secondary);
         border: 1px solid var(--border-color);
     }
 
-    .context-message i,
-    .status-row i {
-        color: var(--primary);
+    .vault-intro .context-message i,
+    .vault-intro .status-row i {
+        color: var(--accent-primary);
         margin-top: 0.1rem;
     }
 
-    .context-message.warning {
+    .vault-intro .context-message.warning {
         background: color-mix(in srgb, var(--accent-warning, #f59e0b) 12%, transparent);
         border-color: color-mix(in srgb, var(--accent-warning, #f59e0b) 26%, transparent);
     }
 
-    .context-message.warning i {
+    .vault-intro .context-message.warning i {
         color: var(--accent-warning, #f59e0b);
     }
 
-    .error-message {
-        margin-top: 1rem;
+    .vault-intro .error-message {
+        margin-top: 0.75rem;
         margin-bottom: 0;
         background: color-mix(in srgb, var(--accent-danger, #ef4444) 12%, transparent);
         border: 1px solid color-mix(in srgb, var(--accent-danger, #ef4444) 28%, transparent);
         color: var(--text-primary);
     }
 
-    .error-message i {
+    .vault-intro .error-message i {
         color: var(--accent-danger, #ef4444);
         margin-top: 0.1rem;
     }
 
-    .trust-card {
-        display: flex;
-        flex-direction: column;
-        gap: 0.75rem;
-        padding: 1rem;
-        border-radius: 1rem;
+    .vault-intro .trust-card {
+        display: grid;
+        gap: 0.55rem;
+        padding: 0.75rem;
+        border-radius: 0.75rem;
         background: var(--bg-secondary);
         border: 1px solid var(--border-color);
-        margin-bottom: 1rem;
+        margin-bottom: 0.75rem;
     }
 
-    .trust-item {
+    .vault-intro .trust-item {
         display: flex;
-        gap: 0.875rem;
+        gap: 0.65rem;
         align-items: flex-start;
     }
 
-    .trust-item i {
-        width: 2rem;
-        height: 2rem;
-        border-radius: 0.65rem;
+    .vault-intro .trust-item i {
+        width: 1.5rem;
+        height: 1.5rem;
+        border-radius: 0.5rem;
         display: flex;
         align-items: center;
         justify-content: center;
-        color: var(--primary);
-        background: color-mix(in srgb, var(--primary) 12%, transparent);
+        color: var(--accent-primary);
+        background: color-mix(in srgb, var(--accent-primary) 12%, transparent);
         flex-shrink: 0;
+        font-size: 0.78rem;
+        margin-top: 0.05rem;
     }
 
-    .trust-item strong {
+    .vault-intro .trust-item strong {
         display: block;
-        font-size: 0.9rem;
+        font-size: 0.83rem;
         color: var(--text-primary);
-        margin-bottom: 0.15rem;
+        margin-bottom: 0.05rem;
     }
 
-    .trust-item span {
+    .vault-intro .trust-item span {
         display: block;
-        font-size: 0.82rem;
-        line-height: 1.45;
+        font-size: 0.76rem;
+        line-height: 1.32;
         color: var(--text-secondary);
     }
 
-    .dialog-footer {
+    .vault-intro .dialog-footer {
         display: flex;
         justify-content: flex-end;
-        gap: 0.75rem;
-        padding: 1rem 1.5rem 1.25rem;
+        gap: 0.6rem;
+        padding: 0.75rem 1.25rem 1rem;
         border-top: 1px solid var(--border-color);
-        background: var(--card-bg);
+        background: var(--bg-primary);
     }
 
-    .btn {
+    .vault-intro .btn {
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        gap: 0.5rem;
-        min-height: 2.75rem;
-        padding: 0.65rem 1rem;
-        border-radius: 0.65rem;
+        gap: 0.4rem;
+        min-height: 2.25rem;
+        padding: 0.45rem 0.85rem;
+        border-radius: 0.55rem;
         font-weight: 600;
+        font-size: 0.82rem;
         border: 1px solid transparent;
         cursor: pointer;
         transition: opacity 0.15s ease, transform 0.15s ease;
     }
 
-    .btn:disabled {
+    .vault-intro .btn:disabled {
         opacity: 0.55;
         cursor: not-allowed;
     }
 
-    .btn:not(:disabled):active {
+    .vault-intro .btn:not(:disabled):active {
         transform: scale(0.98);
     }
 
-    .btn-primary {
-        color: var(--button-primary-text, white);
-        background: var(--primary);
-        border-color: var(--primary);
+    .vault-intro .btn-primary {
+        color: var(--text-inverse);
+        background: var(--accent-primary);
+        border-color: var(--accent-primary);
+        box-shadow: 0 2px 8px color-mix(in srgb, var(--accent-primary) 28%, transparent);
     }
 
-    .btn-secondary {
+    .vault-intro .btn-secondary {
         color: var(--text-primary);
         background: var(--bg-secondary);
         border-color: var(--border-color);

--- a/src/MauiSherpa/Pages/Secrets.razor
+++ b/src/MauiSherpa/Pages/Secrets.razor
@@ -16,6 +16,7 @@
 @inject IPlatformService PlatformInfo
 @inject IFormModalService FormModalService
 @inject HybridFormBridgeHolder BridgeHolder
+@inject ILocalVaultAccessService LocalVaultAccess
 @implements IDisposable
 
 <div class="page-header">
@@ -29,6 +30,22 @@
         </div>
     }
 </div>
+
+@if (ShouldShowLocalVaultNotice)
+{
+    <div class="vault-access-card">
+        <div class="vault-access-content">
+            <i class="fas fa-key"></i>
+            <div>
+                <strong>Local Vault access is disabled</strong>
+                <p>MAUI Sherpa cannot access the Local Vault key in OS secure storage. Grant access to use the Local provider on this Mac.</p>
+            </div>
+        </div>
+        <button class="btn btn-primary" @onclick="GrantLocalVaultAccessAsync" disabled="@isGrantingLocalVaultAccess">
+            <i class="fas @(isGrantingLocalVaultAccess ? "fa-spinner fa-spin" : "fa-unlock")"></i> Grant Access
+        </button>
+    </div>
+}
 
 @if (CloudSecretsService.ActiveProvider is null)
 {
@@ -258,6 +275,7 @@ else
     string searchText = "";
     string filterType = "";
     string currentFolder = "/";
+    bool isGrantingLocalVaultAccess;
 
 
 
@@ -334,6 +352,7 @@ else
         ToolbarService.ToolbarItemClicked += OnToolbarItemClicked;
         ToolbarService.SearchTextChanged += OnSearchTextChanged;
         ToolbarService.FilterChanged += OnToolbarFilterChanged;
+        LocalVaultAccess.StateChanged += OnLocalVaultStateChanged;
 
         await CloudSecretsService.InitializeAsync();
         await LoadProvidersAsync();
@@ -393,6 +412,43 @@ else
         ToolbarService.ToolbarItemClicked -= OnToolbarItemClicked;
         ToolbarService.SearchTextChanged -= OnSearchTextChanged;
         ToolbarService.FilterChanged -= OnToolbarFilterChanged;
+        LocalVaultAccess.StateChanged -= OnLocalVaultStateChanged;
+    }
+
+    bool ShouldShowLocalVaultNotice =>
+        LocalVaultAccess.GetState().RequiresUserAction &&
+        (CloudSecretsService.ActiveProvider?.ProviderType == CloudSecretsProviderType.Local ||
+            providers.All(p => p.ProviderType == CloudSecretsProviderType.Local));
+
+    void OnLocalVaultStateChanged()
+    {
+        InvokeAsync(StateHasChanged);
+    }
+
+    async Task GrantLocalVaultAccessAsync()
+    {
+        isGrantingLocalVaultAccess = true;
+        StateHasChanged();
+        try
+        {
+            var state = await LocalVaultAccess.RequestAccessAsync();
+            if (state.RequiresUserAction)
+            {
+                ToastService.ShowError("Local Vault access was not granted.");
+                return;
+            }
+
+            ToastService.ShowSuccess("Local Vault access granted.");
+            await CloudSecretsService.InitializeAsync();
+            await LoadProvidersAsync();
+            ConfigureNativeToolbar(resetSearch: true);
+            await RefreshAsync();
+        }
+        finally
+        {
+            isGrantingLocalVaultAccess = false;
+            StateHasChanged();
+        }
     }
 
     async Task LoadProvidersAsync()
@@ -546,7 +602,7 @@ else
 
     async Task ShowCreateModal()
     {
-        var page = new CreateSecretPage(currentFolder, AllKnownFolderPaths.ToList());
+        var page = new CreateSecretModalPage(BridgeHolder, currentFolder, AllKnownFolderPaths.ToList());
         var result = await FormModalService.ShowAsync<SecretCreateResult>(page);
         if (result == null) return;
 
@@ -932,6 +988,36 @@ else
 
     .toolbar { margin-bottom: 1rem; display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center; }
     .error-bar { background: var(--status-error-bg); color: var(--status-error-text); padding: 0.75rem 1rem; border-radius: 0.75rem; margin-bottom: 1rem; }
+    .vault-access-card {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 1rem;
+        padding: 1rem;
+        margin-bottom: 1rem;
+        background: var(--card-bg);
+        border-radius: var(--card-radius);
+    }
+    .vault-access-content {
+        display: flex;
+        align-items: flex-start;
+        gap: 0.875rem;
+        color: var(--text-secondary);
+    }
+    .vault-access-content i {
+        color: var(--accent-primary);
+        margin-top: 0.125rem;
+    }
+    .vault-access-content strong {
+        display: block;
+        color: var(--text-primary);
+        margin-bottom: 0.25rem;
+    }
+    .vault-access-content p {
+        margin: 0;
+        color: var(--text-muted);
+        font-size: 0.875rem;
+    }
 
     .provider-picker {
         display: inline-flex;

--- a/src/MauiSherpa/Pages/Secrets.razor
+++ b/src/MauiSherpa/Pages/Secrets.razor
@@ -556,7 +556,7 @@ else
             async ctx =>
             {
                 return await SecretsService.CreateAsync(result.Key, result.Value, result.Type, result.Description,
-                    result.OriginalFileName);
+                    result.OriginalFileName, result.Metadata);
             });
 
         await RefreshAsync();
@@ -710,8 +710,8 @@ else
             async ctx =>
             {
                 return isMove
-                    ? await SecretsService.MoveAsync(result.OriginalKey, result.Key, result.Value ?? result.FileBytes, result.Description)
-                    : await SecretsService.UpdateAsync(result.Key, result.Value ?? result.FileBytes, result.Description);
+                    ? await SecretsService.MoveAsync(result.OriginalKey, result.Key, result.Value ?? result.FileBytes, result.Description, metadata: result.Metadata)
+                    : await SecretsService.UpdateAsync(result.Key, result.Value ?? result.FileBytes, result.Description, metadata: result.Metadata);
             });
 
         await RefreshAsync();

--- a/src/MauiSherpa/Pages/Secrets.razor
+++ b/src/MauiSherpa/Pages/Secrets.razor
@@ -1,5 +1,6 @@
 @page "/secrets"
 @using MauiSherpa.Core.Interfaces
+@using MauiSherpa.Core.Services
 @using MauiSherpa.Services
 @using MauiSherpa.Pages.Forms
 @using MauiSherpa.Pages.Modals
@@ -17,32 +18,48 @@
 @inject HybridFormBridgeHolder BridgeHolder
 @implements IDisposable
 
-<h1><i class="fas fa-vault"></i> Secrets</h1>
+<div class="page-header">
+    <h1><i class="fas fa-vault"></i> Secrets</h1>
+    @if (CloudSecretsService.ActiveProvider is not null)
+    {
+        <div class="provider-info" title="Selected secrets provider">
+            <i class="fas fa-shield-alt"></i>
+            <span>@CloudSecretsService.ActiveProvider.Name</span>
+            <span class="provider-type">(@FormatProviderType(CloudSecretsService.ActiveProvider.ProviderType))</span>
+        </div>
+    }
+</div>
 
 @if (CloudSecretsService.ActiveProvider is null)
 {
     <div class="empty-state">
         <div class="empty-icon"><i class="fas fa-cloud-slash"></i></div>
-        <div class="empty-title">No Cloud Provider Configured</div>
-        <div class="empty-description">Configure a cloud secrets provider in <a href="settings">Settings</a> to manage secrets.</div>
+        <div class="empty-title">No Secrets Provider Configured</div>
+        <div class="empty-description">Configure a secrets provider in <a href="settings">Settings</a> to manage secrets.</div>
     </div>
 }
 else
 {
-    <div class="provider-info">
-        <i class="fas fa-cloud"></i>
-        <span>@CloudSecretsService.ActiveProvider.Name</span>
-        <span class="provider-type">(@FormatProviderType(CloudSecretsService.ActiveProvider.ProviderType))</span>
-    </div>
-
     @if (!PlatformInfo.HasNativeToolbar)
     {
     <div class="toolbar">
+        <label class="provider-picker">
+            <span>Provider</span>
+            <select class="filter-select" value="@CloudSecretsService.ActiveProvider.Id" @onchange="OnProviderChanged" disabled="@isLoading">
+                @foreach (var provider in providers)
+                {
+                    <option value="@provider.Id">@GetProviderDisplayName(provider)</option>
+                }
+            </select>
+        </label>
         <button class="btn btn-primary" @onclick="RefreshAsync" disabled="@isLoading">
             <i class="fas @(isLoading ? "fa-spinner fa-spin" : "fa-sync-alt")"></i> Refresh
         </button>
         <button class="btn btn-success" @onclick="ShowCreateModal" disabled="@isLoading">
             <i class="fas fa-plus"></i> Create Secret
+        </button>
+        <button class="btn btn-secondary" @onclick="@(() => ShowCreateFolderDialog(currentFolder))" disabled="@isLoading">
+            <i class="fas fa-folder-plus"></i> New Folder
         </button>
     </div>
     }
@@ -71,8 +88,45 @@ else
     </div>
     }
 
+    <div class="folder-section">
+        <div class="breadcrumbs">
+            <button class="breadcrumb-item" @onclick="NavigateRoot">
+                <i class="fas fa-home"></i> Secrets
+            </button>
+            @foreach (var crumb in FolderBreadcrumbs)
+            {
+                <span class="breadcrumb-separator">/</span>
+                <button class="breadcrumb-item" @onclick="@(() => NavigateToFolder(crumb.Path))">@crumb.Name</button>
+            }
+        </div>
+        @if (!PlatformInfo.HasNativeToolbar)
+        {
+            <div class="folder-actions">
+                <button class="btn btn-success btn-sm" @onclick="@(() => ShowCreateFolderDialog(currentFolder))" disabled="@isLoading" title="Create a folder inside the current folder">
+                    <i class="fas fa-folder-plus"></i> New Folder
+                </button>
+                @if (currentFolder != "/")
+                {
+                    <button class="btn btn-secondary btn-sm" @onclick="@(() => ShowRenameFolderDialog(currentFolder))" disabled="@isLoading">
+                        <i class="fas fa-pen"></i> Rename
+                    </button>
+                    <button class="btn btn-danger btn-sm" @onclick="@(() => DeleteFolder(currentFolder))" disabled="@isLoading">
+                        <i class="fas fa-trash-alt"></i> Delete
+                    </button>
+                    <button class="btn btn-secondary btn-sm" @onclick="NavigateUp">
+                        <i class="fas fa-arrow-up"></i> Up
+                    </button>
+                }
+            </div>
+        }
+    </div>
+
     <div class="results-info">
-        Showing @FilteredSecrets.Count() of @secrets.Count secrets
+        Showing @VisibleSecrets.Count() of @CurrentFolderSecrets.Count() secrets in @currentFolder
+        @if (VisibleFolders.Any() && string.IsNullOrEmpty(searchText))
+        {
+            <span> · @VisibleFolders.Count() folders</span>
+        }
     </div>
 
     <div class="secret-list">
@@ -81,27 +135,70 @@ else
             <div class="loading-state">
                 <div class="loading-spinner"><i class="fas fa-key"></i></div>
                 <div class="loading-title">Loading Secrets</div>
-                <div class="loading-description">Fetching managed secrets from cloud provider...</div>
+                <div class="loading-description">Fetching managed secrets from secrets provider...</div>
             </div>
         }
-        else if (!FilteredSecrets.Any())
+        else if (!VisibleFolders.Any() && !VisibleSecrets.Any())
         {
             <div class="empty-state">
                 <div class="empty-icon"><i class="fas @(secrets.Count == 0 ? "fa-key" : "fa-search")"></i></div>
-                <div class="empty-title">@(secrets.Count == 0 ? "No secrets found" : "No matching secrets")</div>
-                <div class="empty-description">@(secrets.Count == 0 ? "Click \"Create Secret\" to store a new secret" : "No secrets match your search or filters. Try adjusting your criteria.")</div>
+                <div class="empty-title">@(secrets.Count == 0 ? "No secrets found" : string.IsNullOrEmpty(searchText) ? "No secrets in this folder" : "No matching secrets")</div>
+                <div class="empty-description">@(secrets.Count == 0 ? "Create a folder or click \"Create Secret\" to store a new secret." : string.IsNullOrEmpty(searchText) ? "Create a subfolder, create a secret in this folder, or navigate to another folder." : "No secrets match your search or filters. Try adjusting your criteria.")</div>
+                @if (string.IsNullOrEmpty(searchText))
+                {
+                    <div class="empty-actions">
+                        <button class="btn btn-success empty-action" @onclick="@(() => ShowCreateFolderDialog(currentFolder))" disabled="@isLoading">
+                            <i class="fas fa-folder-plus"></i> New Folder
+                        </button>
+                        <button class="btn btn-primary empty-action" @onclick="ShowCreateModal" disabled="@isLoading">
+                            <i class="fas fa-plus"></i> New Secret
+                        </button>
+                    </div>
+                }
             </div>
         }
         else
         {
-            @foreach (var secret in FilteredSecrets)
+            @if (string.IsNullOrEmpty(searchText))
+            {
+                @foreach (var folder in VisibleFolders)
+                {
+                    <div class="folder-card">
+                        <button class="folder-open-action" @onclick="@(() => NavigateToFolder(folder.Path))">
+                            <span class="folder-icon"><i class="fas fa-folder"></i></span>
+                            <span class="folder-name">@folder.Name</span>
+                            <span class="folder-count">@folder.Count secrets</span>
+                            <span class="folder-chevron"><i class="fas fa-chevron-right"></i></span>
+                        </button>
+                        @if (!PlatformInfo.HasNativeToolbar)
+                        {
+                            <div class="folder-card-actions">
+                                <button class="btn btn-success btn-icon" @onclick="@(() => ShowCreateFolderDialog(folder.Path))" disabled="@isLoading" title="Create subfolder">
+                                    <i class="fas fa-folder-plus"></i>
+                                </button>
+                                <button class="btn btn-secondary btn-icon" @onclick="@(() => ShowRenameFolderDialog(folder.Path))" disabled="@isLoading" title="Rename folder">
+                                    <i class="fas fa-pen"></i>
+                                </button>
+                                <button class="btn btn-danger btn-icon" @onclick="@(() => DeleteFolder(folder.Path))" disabled="@isLoading" title="Delete folder">
+                                    <i class="fas fa-trash-alt"></i>
+                                </button>
+                            </div>
+                        }
+                    </div>
+                }
+            }
+            @foreach (var secret in VisibleSecrets)
             {
                 <div class="secret-card">
                     <div class="secret-icon">
                         <i class="fas @(secret.Type == ManagedSecretType.File ? "fa-file-shield" : "fa-key")"></i>
                     </div>
                     <div class="secret-details">
-                        <div class="secret-name">@secret.Key</div>
+                        <div class="secret-name">@GetSecretDisplayName(secret)</div>
+                        @if (GetSecretFolder(secret.Key) != "/")
+                        {
+                            <div class="secret-path">@GetSecretFolder(secret.Key)</div>
+                        }
                         @if (!string.IsNullOrEmpty(secret.Description))
                         {
                             <div class="secret-description">@secret.Description</div>
@@ -153,14 +250,24 @@ else
 
 @code {
     List<ManagedSecret> secrets = new();
+    List<ManagedSecretFolder> folders = new();
+    List<CloudSecretsProviderConfig> providers = new();
+    List<string> providerFilterIds = new();
     bool isLoading = false;
     string errorMessage = "";
     string searchText = "";
     string filterType = "";
+    string currentFolder = "/";
 
 
 
-    IEnumerable<ManagedSecret> FilteredSecrets => secrets.Where(s =>
+    IEnumerable<ManagedSecret> CurrentFolderSecrets => secrets.Where(s => GetSecretFolder(s.Key) == currentFolder);
+
+    IEnumerable<ManagedSecret> VisibleSecrets => CurrentFolderSecrets.Where(PassesFilters);
+
+    IEnumerable<ManagedSecret> SecretsMatchingType => secrets.Where(PassesTypeFilter);
+
+    bool PassesFilters(ManagedSecret s)
     {
         if (!string.IsNullOrEmpty(searchText))
         {
@@ -175,19 +282,62 @@ else
                 return false;
         }
         return true;
-    });
+    }
+
+    bool PassesTypeFilter(ManagedSecret s)
+    {
+        if (!string.IsNullOrEmpty(filterType) && Enum.TryParse<ManagedSecretType>(filterType, out var ft))
+            return s.Type == ft;
+
+        return true;
+    }
+
+    IEnumerable<FolderListItem> VisibleFolders => string.IsNullOrEmpty(searchText)
+        ? AllKnownFolderPaths
+            .Select(path => GetImmediateChildFolder(path, currentFolder))
+            .Where(f => f is not null)
+            .GroupBy(f => f!.Path, StringComparer.Ordinal)
+            .Select(g => new FolderListItem(
+                g.First()!.Name,
+                g.Key,
+                SecretsMatchingType.Count(secret => IsInFolderTree(GetSecretFolder(secret.Key), g.Key))))
+            .OrderBy(f => f.Name, StringComparer.OrdinalIgnoreCase)
+        : Enumerable.Empty<FolderListItem>();
+
+    IEnumerable<string> AllKnownFolderPaths => new[] { "/" }
+        .Concat(folders.Select(f => f.Path))
+        .Concat(secrets.SelectMany(s => GetAncestorFolders(GetSecretFolder(s.Key))))
+        .Select(SecretPath.NormalizeFolderPath)
+        .Distinct(StringComparer.Ordinal)
+        .OrderBy(path => path == "/" ? "" : path, StringComparer.OrdinalIgnoreCase);
+
+    IEnumerable<FolderCrumb> FolderBreadcrumbs
+    {
+        get
+        {
+            if (currentFolder == "/")
+                return Enumerable.Empty<FolderCrumb>();
+
+            var crumbs = new List<FolderCrumb>();
+            var path = "";
+            foreach (var segment in currentFolder.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries))
+            {
+                path += "/" + segment;
+                crumbs.Add(new FolderCrumb(segment, path));
+            }
+            return crumbs;
+        }
+    }
 
     protected override async Task OnInitializedAsync()
     {
-        ToolbarService.SetItems(
-            new ToolbarAction("refresh", "Refresh", "arrow.clockwise"),
-            new ToolbarAction("create", "Create Secret", "plus")
-        );
-        ToolbarService.SetSearch("Search secrets...");
         ToolbarService.ToolbarItemClicked += OnToolbarItemClicked;
         ToolbarService.SearchTextChanged += OnSearchTextChanged;
+        ToolbarService.FilterChanged += OnToolbarFilterChanged;
 
         await CloudSecretsService.InitializeAsync();
+        await LoadProvidersAsync();
+        ConfigureNativeToolbar(resetSearch: true);
         await RefreshAsync();
     }
 
@@ -201,7 +351,21 @@ else
                     ToolbarService.SetItemEnabled("refresh", false);
                     try { await RefreshAsync(); } finally { ToolbarService.SetItemEnabled("refresh", true); }
                     break;
-                case "create": ShowCreateModal(); break;
+                case "create-folder":
+                    await ShowCreateFolderDialog();
+                    break;
+                case "create":
+                    await ShowCreateModal();
+                    break;
+                case "rename-folder":
+                    await ShowRenameFolderDialog(currentFolder);
+                    break;
+                case "delete-folder":
+                    await DeleteFolder(currentFolder);
+                    break;
+                case "up-folder":
+                    NavigateUp();
+                    break;
             }
             StateHasChanged();
         });
@@ -212,10 +376,97 @@ else
         InvokeAsync(() => { searchText = text; StateHasChanged(); });
     }
 
+    private void OnToolbarFilterChanged(string filterId, int selectedIndex)
+    {
+        if (filterId != "provider")
+            return;
+
+        InvokeAsync(async () =>
+        {
+            await SelectProviderByIndexAsync(selectedIndex);
+            StateHasChanged();
+        });
+    }
+
     public void Dispose()
     {
         ToolbarService.ToolbarItemClicked -= OnToolbarItemClicked;
         ToolbarService.SearchTextChanged -= OnSearchTextChanged;
+        ToolbarService.FilterChanged -= OnToolbarFilterChanged;
+    }
+
+    async Task LoadProvidersAsync()
+    {
+        var loaded = await CloudSecretsService.GetProvidersAsync();
+        providers = loaded
+            .OrderBy(p => p.ProviderType == CloudSecretsProviderType.Local ? 0 : 1)
+            .ThenBy(p => p.Name, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    void ConfigureNativeToolbar(bool resetSearch = false)
+    {
+        if (!PlatformInfo.HasNativeToolbar)
+            return;
+
+        var actions = new List<ToolbarAction>
+        {
+            new("create", "New Secret", "plus"),
+            new("create-folder", "New Folder", "folder.badge.plus")
+        };
+
+        if (currentFolder != "/")
+        {
+            actions.Add(new ToolbarAction("rename-folder", "Rename Folder", "pencil"));
+            actions.Add(new ToolbarAction("delete-folder", "Delete Folder", "trash", IsPrimary: false));
+            actions.Add(new ToolbarAction("up-folder", "Up Folder", "arrow.up"));
+        }
+
+        actions.Add(new ToolbarAction("refresh", "Refresh", "arrow.clockwise"));
+
+        ToolbarService.SetItems(actions.ToArray());
+        if (resetSearch || ToolbarService.SearchPlaceholder is null)
+            ToolbarService.SetSearch("Search secrets...");
+        ConfigureProviderFilter();
+        UpdateNativeToolbarItemStates();
+    }
+
+    void ConfigureProviderFilter()
+    {
+        if (!PlatformInfo.HasNativeToolbar)
+            return;
+
+        if (providers.Count == 0 || CloudSecretsService.ActiveProvider is null)
+        {
+            providerFilterIds.Clear();
+            ToolbarService.SetFilters();
+            return;
+        }
+
+        var toolbarProviders = providers.ToList();
+        if (!toolbarProviders.Any(p => p.Id == CloudSecretsService.ActiveProvider.Id))
+            toolbarProviders.Insert(0, CloudSecretsService.ActiveProvider);
+
+        providerFilterIds = toolbarProviders.Select(p => p.Id).ToList();
+        var options = toolbarProviders.Select(GetProviderDisplayName).ToArray();
+        var selectedIndex = toolbarProviders.FindIndex(p => p.Id == CloudSecretsService.ActiveProvider.Id);
+        if (selectedIndex < 0)
+            selectedIndex = 0;
+
+        ToolbarService.SetFilters(new ToolbarFilter("provider", "Providers", options, selectedIndex));
+    }
+
+    void UpdateNativeToolbarItemStates()
+    {
+        if (!PlatformInfo.HasNativeToolbar)
+            return;
+
+        ToolbarService.SetItemEnabled("create", !isLoading);
+        ToolbarService.SetItemEnabled("create-folder", !isLoading);
+        ToolbarService.SetItemEnabled("refresh", !isLoading);
+        ToolbarService.SetItemEnabled("rename-folder", !isLoading && currentFolder != "/");
+        ToolbarService.SetItemEnabled("delete-folder", !isLoading && currentFolder != "/");
+        ToolbarService.SetItemEnabled("up-folder", !isLoading && currentFolder != "/");
     }
 
     async Task RefreshAsync()
@@ -224,12 +475,15 @@ else
 
         isLoading = true;
         errorMessage = "";
+        UpdateNativeToolbarItemStates();
         StateHasChanged();
 
         try
         {
             var result = await SecretsService.ListAsync();
             secrets = result.ToList();
+            var folderResult = await SecretsService.ListFoldersAsync();
+            folders = folderResult.ToList();
         }
         catch (Exception ex)
         {
@@ -239,19 +493,66 @@ else
         finally
         {
             isLoading = false;
+            UpdateNativeToolbarItemStates();
+            StateHasChanged();
+        }
+    }
+
+    async Task OnProviderChanged(ChangeEventArgs e)
+    {
+        var providerId = e.Value?.ToString();
+        if (string.IsNullOrWhiteSpace(providerId))
+            return;
+
+        await SelectProviderAsync(providerId);
+    }
+
+    async Task SelectProviderByIndexAsync(int selectedIndex)
+    {
+        if (selectedIndex < 0 || selectedIndex >= providerFilterIds.Count)
+            return;
+
+        await SelectProviderAsync(providerFilterIds[selectedIndex]);
+    }
+
+    async Task SelectProviderAsync(string providerId)
+    {
+        if (CloudSecretsService.ActiveProvider?.Id == providerId)
+            return;
+
+        isLoading = true;
+        UpdateNativeToolbarItemStates();
+        StateHasChanged();
+
+        try
+        {
+            await CloudSecretsService.SetActiveProviderAsync(providerId);
+            await LoadProvidersAsync();
+            searchText = "";
+            filterType = "";
+            currentFolder = "/";
+            secrets.Clear();
+            folders.Clear();
+            ConfigureNativeToolbar(resetSearch: true);
+            await RefreshAsync();
+        }
+        finally
+        {
+            isLoading = false;
+            UpdateNativeToolbarItemStates();
             StateHasChanged();
         }
     }
 
     async Task ShowCreateModal()
     {
-        var page = new CreateSecretPage();
+        var page = new CreateSecretPage(currentFolder, AllKnownFolderPaths.ToList());
         var result = await FormModalService.ShowAsync<SecretCreateResult>(page);
         if (result == null) return;
 
         await OperationModal.RunAsync(
             "Creating Secret",
-            $"Storing secret '{result.Key}' in cloud provider...",
+            $"Storing secret '{result.Key}' in secrets provider...",
             async ctx =>
             {
                 return await SecretsService.CreateAsync(result.Key, result.Value, result.Type, result.Description,
@@ -259,23 +560,163 @@ else
             });
 
         await RefreshAsync();
+        NavigateToFolder(GetSecretFolder(result.Key));
+    }
+
+    async Task ShowCreateFolderDialog(string? parentFolder = null)
+    {
+        var normalizedParent = SecretPath.NormalizeFolderPath(parentFolder ?? currentFolder);
+        var folderName = await DialogService.ShowInputDialogAsync(
+            normalizedParent == "/" ? "Create Folder" : "Create Subfolder",
+            $"Create a folder inside {normalizedParent}",
+            "folder-name");
+        if (string.IsNullOrWhiteSpace(folderName))
+            return;
+
+        string newFolderPath;
+        try
+        {
+            var folderKey = SecretPath.NormalizeKey(folderName);
+            newFolderPath = normalizedParent == "/" ? "/" + folderKey : normalizedParent + "/" + folderKey;
+            newFolderPath = SecretPath.NormalizeFolderPath(newFolderPath);
+        }
+        catch (ArgumentException ex)
+        {
+            ToastService.ShowError(ex.Message);
+            return;
+        }
+
+        if (AllKnownFolderPaths.Contains(newFolderPath, StringComparer.Ordinal))
+        {
+            ToastService.ShowInfo("Folder already exists");
+            NavigateToFolder(newFolderPath);
+            return;
+        }
+
+        await OperationModal.RunAsync(
+            "Creating Folder",
+            $"Creating folder '{newFolderPath}' in secrets provider...",
+            async ctx => await SecretsService.CreateFolderAsync(newFolderPath));
+
+        await RefreshAsync();
+        NavigateToFolder(newFolderPath);
+    }
+
+    async Task ShowRenameFolderDialog(string folderPath)
+    {
+        var normalizedPath = SecretPath.NormalizeFolderPath(folderPath);
+        if (normalizedPath == "/")
+            return;
+
+        var existingName = GetFolderName(normalizedPath);
+        var newName = await DialogService.ShowInputDialogAsync(
+            "Rename Folder",
+            $"Rename {normalizedPath}",
+            existingName);
+        if (string.IsNullOrWhiteSpace(newName))
+            return;
+
+        string newFolderPath;
+        try
+        {
+            var folderKey = SecretPath.NormalizeKey(newName);
+            var parentFolder = GetParentFolder(normalizedPath);
+            newFolderPath = parentFolder == "/" ? "/" + folderKey : parentFolder + "/" + folderKey;
+            newFolderPath = SecretPath.NormalizeFolderPath(newFolderPath);
+        }
+        catch (ArgumentException ex)
+        {
+            ToastService.ShowError(ex.Message);
+            return;
+        }
+
+        if (newFolderPath == normalizedPath)
+            return;
+
+        if (AllKnownFolderPaths.Contains(newFolderPath, StringComparer.Ordinal))
+        {
+            ToastService.ShowError("A folder with that name already exists");
+            return;
+        }
+
+        var renamed = await OperationModal.RunAsync(
+            "Renaming Folder",
+            $"Renaming folder '{normalizedPath}' to '{newFolderPath}'...",
+            async ctx => await SecretsService.RenameFolderAsync(normalizedPath, newFolderPath));
+
+        await RefreshAsync();
+        if (renamed.Success)
+        {
+            if (currentFolder == normalizedPath || currentFolder.StartsWith(normalizedPath + "/", StringComparison.Ordinal))
+                NavigateToFolder(newFolderPath + currentFolder[normalizedPath.Length..]);
+            else
+                NavigateToFolder(newFolderPath);
+        }
+        else
+        {
+            ToastService.ShowError("Folder could not be renamed");
+        }
+    }
+
+    async Task DeleteFolder(string folderPath)
+    {
+        var normalizedPath = SecretPath.NormalizeFolderPath(folderPath);
+        if (normalizedPath == "/")
+            return;
+
+        var hasSecrets = secrets.Any(secret => IsInFolderTree(GetSecretFolder(secret.Key), normalizedPath));
+        var hasChildFolders = AllKnownFolderPaths.Any(path => path != normalizedPath && path.StartsWith(normalizedPath + "/", StringComparison.Ordinal));
+        if (hasSecrets || hasChildFolders)
+        {
+            ToastService.ShowError("Only empty folders can be deleted");
+            return;
+        }
+
+        var confirmed = await AlertService.ShowConfirmAsync(
+            "Delete Folder",
+            $"Delete empty folder '{normalizedPath}'?");
+        if (!confirmed)
+            return;
+
+        var deleted = await OperationModal.RunAsync(
+            "Deleting Folder",
+            $"Deleting folder '{normalizedPath}'...",
+            async ctx => await SecretsService.DeleteFolderAsync(normalizedPath));
+
+        await RefreshAsync();
+        if (deleted.Success)
+        {
+            if (currentFolder == normalizedPath || currentFolder.StartsWith(normalizedPath + "/", StringComparison.Ordinal))
+                NavigateToFolder(GetParentFolder(normalizedPath));
+        }
+        else
+        {
+            ToastService.ShowError("Folder could not be deleted");
+        }
     }
 
     async Task ShowEditModal(ManagedSecret secret)
     {
-        var page = new EditSecretPage(BridgeHolder, secret);
+        var page = new EditSecretPage(BridgeHolder, secret, AllKnownFolderPaths.ToList());
         var result = await FormModalService.ShowAsync<EditSecretResult>(page);
         if (result == null) return;
 
+        var isMove = !string.Equals(result.OriginalKey, result.Key, StringComparison.Ordinal);
         await OperationModal.RunAsync(
-            "Updating Secret",
-            $"Updating secret '{result.Key}' in cloud provider...",
+            isMove ? "Moving Secret" : "Updating Secret",
+            isMove
+                ? $"Moving secret '{result.OriginalKey}' to '{result.Key}' in secrets provider..."
+                : $"Updating secret '{result.Key}' in secrets provider...",
             async ctx =>
             {
-                return await SecretsService.UpdateAsync(result.Key, result.Value ?? result.FileBytes, result.Description);
+                return isMove
+                    ? await SecretsService.MoveAsync(result.OriginalKey, result.Key, result.Value ?? result.FileBytes, result.Description)
+                    : await SecretsService.UpdateAsync(result.Key, result.Value ?? result.FileBytes, result.Description);
             });
 
         await RefreshAsync();
+        if (isMove)
+            NavigateToFolder(GetSecretFolder(result.Key));
     }
 
     async Task DeleteSecret(ManagedSecret secret)
@@ -288,7 +729,7 @@ else
 
         await OperationModal.RunAsync(
             "Deleting Secret",
-            $"Removing secret '{secret.Key}' from cloud provider...",
+            $"Removing secret '{secret.Key}' from secrets provider...",
             async ctx =>
             {
                 return await SecretsService.DeleteAsync(secret.Key);
@@ -351,6 +792,7 @@ else
 
     string FormatProviderType(CloudSecretsProviderType type) => type switch
     {
+        CloudSecretsProviderType.Local => "Local",
         CloudSecretsProviderType.AzureKeyVault => "Azure Key Vault",
         CloudSecretsProviderType.AwsSecretsManager => "AWS Secrets Manager",
         CloudSecretsProviderType.GoogleSecretManager => "Google Secret Manager",
@@ -358,27 +800,147 @@ else
         CloudSecretsProviderType.AzureDevOps => "Azure DevOps",
         _ => type.ToString()
     };
+
+    string GetProviderDisplayName(CloudSecretsProviderConfig provider)
+    {
+        if (provider.ProviderType == CloudSecretsProviderType.Local)
+            return "Local";
+
+        return $"{provider.Name} ({FormatProviderType(provider.ProviderType)})";
+    }
+
+    void NavigateToFolder(string folder)
+    {
+        currentFolder = SecretPath.NormalizeFolderPath(folder);
+        ConfigureNativeToolbar();
+    }
+
+    void NavigateRoot() => NavigateToFolder("/");
+
+    void NavigateUp()
+    {
+        if (currentFolder == "/")
+            return;
+
+        var trimmed = currentFolder.TrimEnd('/');
+        var lastSeparator = trimmed.LastIndexOf('/');
+        currentFolder = lastSeparator <= 0 ? "/" : trimmed[..lastSeparator];
+    }
+
+    string GetSecretDisplayName(ManagedSecret secret) => GetSecretName(secret.Key);
+
+    static string GetSecretFolder(string key)
+    {
+        var lastSeparator = key.LastIndexOf('/');
+        return lastSeparator < 0 ? "/" : SecretPath.NormalizeFolderPath(key[..lastSeparator]);
+    }
+
+    static string GetSecretName(string key)
+    {
+        var lastSeparator = key.LastIndexOf('/');
+        return lastSeparator < 0 ? key : key[(lastSeparator + 1)..];
+    }
+
+    static FolderListItem? GetImmediateChildFolder(string folder, string parentFolder)
+    {
+        if (folder == parentFolder)
+            return null;
+
+        var parentPrefix = parentFolder == "/" ? "/" : parentFolder + "/";
+        if (!folder.StartsWith(parentPrefix, StringComparison.Ordinal))
+            return null;
+
+        var remainder = parentFolder == "/"
+            ? folder.TrimStart('/')
+            : folder[parentPrefix.Length..];
+        var firstSegment = remainder.Split('/', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+        if (string.IsNullOrEmpty(firstSegment))
+            return null;
+
+        var childPath = parentFolder == "/" ? "/" + firstSegment : parentFolder + "/" + firstSegment;
+        return new FolderListItem(firstSegment, childPath, 0);
+    }
+
+    static bool IsInFolderTree(string secretFolder, string folder)
+    {
+        return secretFolder == folder ||
+            (folder != "/" && secretFolder.StartsWith(folder + "/", StringComparison.Ordinal)) ||
+            (folder == "/" && secretFolder == "/");
+    }
+
+    static IEnumerable<string> GetAncestorFolders(string folder)
+    {
+        var normalized = SecretPath.NormalizeFolderPath(folder);
+        if (normalized == "/")
+            yield break;
+
+        var current = "";
+        foreach (var segment in normalized.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries))
+        {
+            current += "/" + segment;
+            yield return current;
+        }
+    }
+
+    static string GetFolderName(string folderPath)
+    {
+        var normalized = SecretPath.NormalizeFolderPath(folderPath);
+        var lastSeparator = normalized.LastIndexOf('/');
+        return lastSeparator < 0 ? normalized : normalized[(lastSeparator + 1)..];
+    }
+
+    static string GetParentFolder(string folderPath)
+    {
+        var normalized = SecretPath.NormalizeFolderPath(folderPath);
+        if (normalized == "/")
+            return "/";
+
+        var lastSeparator = normalized.LastIndexOf('/');
+        return lastSeparator <= 0 ? "/" : normalized[..lastSeparator];
+    }
+
+    record FolderListItem(string Name, string Path, int Count);
+    record FolderCrumb(string Name, string Path);
 }
 
 <style>
-    h1 { margin-bottom: 1.25rem; font-size: 1.75rem; color: var(--text-primary); }
+    .page-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+        margin-bottom: 1.25rem;
+        flex-wrap: wrap;
+    }
+
+    h1 { margin: 0; font-size: 1.75rem; color: var(--text-primary); }
 
     .provider-info {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        margin-bottom: 1rem;
         font-size: 0.875rem;
         color: var(--text-primary);
         background: var(--accent-bg, rgba(66, 153, 225, 0.15));
         padding: 0.5rem 1rem;
         border-radius: var(--card-radius, 1rem);
+        margin-left: auto;
+        white-space: nowrap;
     }
     .provider-info i { color: var(--accent-primary); }
     .provider-type { color: var(--text-muted); }
 
-    .toolbar { margin-bottom: 1rem; display: flex; gap: 0.75rem; flex-wrap: wrap; }
+    .toolbar { margin-bottom: 1rem; display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center; }
     .error-bar { background: var(--status-error-bg); color: var(--status-error-text); padding: 0.75rem 1rem; border-radius: 0.75rem; margin-bottom: 1rem; }
+
+    .provider-picker {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        color: var(--text-secondary);
+        font-size: 0.8125rem;
+        font-weight: 600;
+    }
 
     /* Filter Section */
     .filter-section {
@@ -405,10 +967,47 @@ else
     }
     .filter-select:focus { outline: none; border-color: var(--accent-primary); }
 
+    .folder-section {
+        background: var(--card-bg);
+        border-radius: var(--card-radius);
+        padding: 0.625rem 1rem;
+        margin-bottom: 1rem;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 1rem;
+        flex-wrap: wrap;
+    }
+
+    .breadcrumbs {
+        display: flex;
+        align-items: center;
+        gap: 0.375rem;
+        flex-wrap: wrap;
+        min-width: 0;
+    }
+
+    .breadcrumb-item {
+        border: 0;
+        background: transparent;
+        color: var(--accent-primary);
+        font-size: 0.875rem;
+        font-weight: 600;
+        padding: 0.25rem 0.375rem;
+        border-radius: 0.375rem;
+        cursor: pointer;
+    }
+
+    .breadcrumb-item:hover { background: var(--bg-tertiary); }
+    .breadcrumb-item i { margin-right: 0.35rem; }
+    .breadcrumb-separator { color: var(--text-muted); }
+    .folder-actions { display: flex; align-items: center; gap: 0.75rem; }
+
     .results-info { font-size: 0.8125rem; color: var(--text-muted); margin-bottom: 0.75rem; }
 
     /* Buttons */
     .btn i { font-size: 0.75rem; }
+    .btn-sm { padding: 0.375rem 0.625rem; font-size: 0.75rem; }
     .btn-icon {
         width: 2rem; height: 2rem; padding: 0;
         display: inline-flex; align-items: center; justify-content: center;
@@ -418,6 +1017,46 @@ else
 
     /* Secret List */
     .secret-list { display: flex; flex-direction: column; gap: 0.75rem; margin-bottom: 1.25rem; }
+
+    .folder-card {
+        background: var(--card-bg);
+        border-radius: var(--card-radius);
+        padding: 0.625rem;
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        width: 100%;
+        color: var(--text-primary);
+        text-align: left;
+    }
+
+    .folder-card:hover {
+        background: var(--bg-secondary);
+    }
+
+    .folder-open-action {
+        border: 0;
+        background: transparent;
+        color: inherit;
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        flex: 1;
+        min-width: 0;
+        padding: 0.25rem;
+        cursor: pointer;
+        text-align: left;
+    }
+    .folder-open-action:focus-visible {
+        outline: 2px solid var(--accent-primary);
+        outline-offset: 2px;
+        border-radius: 0.375rem;
+    }
+    .folder-icon { color: var(--accent-primary); font-size: 1.25rem; }
+    .folder-name { font-weight: 600; flex: 1; }
+    .folder-count { color: var(--text-muted); font-size: 0.8125rem; }
+    .folder-chevron { color: var(--text-muted); }
+    .folder-card-actions { display: flex; gap: 0.25rem; align-items: center; }
 
     .secret-card {
         background: var(--card-bg);
@@ -433,6 +1072,7 @@ else
     .secret-icon i { font-size: 1.25rem; }
     .secret-details { flex: 1; }
     .secret-name { font-weight: 600; font-size: 1rem; color: var(--text-primary); font-family: monospace; }
+    .secret-path { font-size: 0.75rem; color: var(--text-muted); font-family: monospace; margin-top: 0.125rem; }
     .secret-description { font-size: 0.875rem; color: var(--text-secondary); margin-top: 0.25rem; }
     .secret-badges { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-top: 0.5rem; }
     .secret-meta { font-size: 0.8125rem; color: var(--text-muted); margin-top: 0.5rem; }
@@ -451,6 +1091,13 @@ else
     .empty-description { color: var(--text-muted); font-size: 0.875rem; }
     .empty-description a { color: var(--accent-primary); text-decoration: none; }
     .empty-description a:hover { text-decoration: underline; }
+    .empty-actions {
+        display: inline-flex;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+        justify-content: center;
+        margin-top: 1.25rem;
+    }
 
     .loading-state { background: var(--card-bg); border-radius: var(--card-radius); padding: 3.75rem 2.5rem; text-align: center; }
     .loading-spinner { font-size: 48px; margin-bottom: 1rem; color: var(--accent-primary); animation: pulse 2s infinite; }

--- a/src/MauiSherpa/Pages/SecretsPublish.razor
+++ b/src/MauiSherpa/Pages/SecretsPublish.razor
@@ -17,7 +17,7 @@
 {
     <div class="info-message">
         <i class="fas fa-info-circle"></i>
-        Configure a cloud secrets provider in <a href="settings">Settings</a> to create and manage publish profiles.
+        Configure a secrets provider in <a href="settings">Settings</a> to create and manage publish profiles.
     </div>
 }
 else if (isLoading)

--- a/src/MauiSherpa/Pages/Settings.razor
+++ b/src/MauiSherpa/Pages/Settings.razor
@@ -413,17 +413,17 @@
 </div>
 
 <div class="settings-section">
-    <h2><i class="fas fa-cloud"></i> Cloud Secrets Storage</h2>
+    <h2><i class="fas fa-vault"></i> Secrets Storage</h2>
     <p class="section-description">
-        Store certificate private keys securely in the cloud to sync across machines.
-        This enables sharing signing certificates between development machines and CI/CD pipelines.
+        Store app secrets, signing certificates, and publish profiles securely.
+        The default Local provider keeps secrets on this machine; cloud providers can sync across machines and CI/CD pipelines.
     </p>
     
     @if (cloudProviders.Count == 0)
     {
         <div class="settings-container">
             <div class="empty-providers">
-                <p>No cloud providers configured</p>
+                <p>No secrets providers configured</p>
             </div>
         </div>
     }
@@ -460,12 +460,15 @@
                             <button class="btn btn-sm btn-secondary" @onclick="@(() => TestProvider(provider))" title="Test Connection">
                                 <i class="fas fa-plug"></i> Test
                             </button>
-                            <button class="btn btn-sm btn-secondary" @onclick="@(() => EditProvider(provider))" title="Edit">
-                                <i class="fas fa-edit"></i> Edit
-                            </button>
-                            <button class="btn btn-sm btn-danger" @onclick="@(() => DeleteProvider(provider))" title="Delete">
-                                <i class="fas fa-trash"></i> Delete
-                            </button>
+                            @if (!IsBuiltInLocalProvider(provider))
+                            {
+                                <button class="btn btn-sm btn-secondary" @onclick="@(() => EditProvider(provider))" title="Edit">
+                                    <i class="fas fa-edit"></i> Edit
+                                </button>
+                                <button class="btn btn-sm btn-danger" @onclick="@(() => DeleteProvider(provider))" title="Delete">
+                                    <i class="fas fa-trash"></i> Delete
+                                </button>
+                            }
                         </div>
                     </div>
                     <div class="provider-details">
@@ -473,6 +476,13 @@
                             <span class="detail-label">TYPE</span>
                             <span class="detail-value">@CloudSecretsProviderFactory.GetProviderDisplayName(provider.ProviderType)</span>
                         </div>
+                        @if (IsBuiltInLocalProvider(provider))
+                        {
+                            <div class="detail-item">
+                                <span class="detail-label">SCOPE</span>
+                                <span class="detail-value">Built-in encrypted local vault</span>
+                            </div>
+                        }
                         @if (provider.ProviderType == CloudSecretsProviderType.Infisical)
                         {
                             <div class="detail-item">
@@ -535,7 +545,7 @@
     
     <div class="section-add-action">
         <button class="btn btn-success" @onclick="ShowAddProviderDialog">
-            <i class="fas fa-plus"></i> Add Cloud Provider
+            <i class="fas fa-plus"></i> Add Secrets Provider
         </button>
     </div>
 </div>
@@ -1453,13 +1463,13 @@
     
     private async Task LoadCloudProviders()
     {
-        cloudProviders = (await CloudSecretsService.GetProvidersAsync()).ToList();
-        
         // Initialize service if needed
         if (CloudSecretsService is CloudSecretsService svc)
         {
             await svc.InitializeAsync();
         }
+
+        cloudProviders = (await CloudSecretsService.GetProvidersAsync()).ToList();
     }
 
     private async Task LoadSecretsPublishers()
@@ -1996,10 +2006,11 @@
         await LoadGoogleIdentities();
     }
     
-    // Cloud Provider Methods
+    // Secrets Provider Methods
     
     private string GetProviderIcon(CloudSecretsProviderType type) => type switch
     {
+        CloudSecretsProviderType.Local => "fas fa-database",
         CloudSecretsProviderType.Infisical => "fas fa-shield-alt",
         CloudSecretsProviderType.AzureKeyVault => "fas fa-key",
         CloudSecretsProviderType.AwsSecretsManager => "fab fa-aws",
@@ -2009,6 +2020,10 @@
         CloudSecretsProviderType.AzureDevOps => "fab fa-microsoft",
         _ => "fas fa-lock"
     };
+
+    private static bool IsBuiltInLocalProvider(CloudSecretsProviderConfig provider) =>
+        provider.Id == MauiSherpa.Core.Services.CloudSecretsService.DefaultLocalProviderId &&
+        provider.ProviderType == CloudSecretsProviderType.Local;
 
     private static string GetVaultwardenServerDisplay(CloudSecretsProviderConfig provider)
     {
@@ -2159,7 +2174,7 @@
         if (success)
             await AlertService.ShowToastAsync("Connection successful!");
         else
-            await AlertService.ShowAlertAsync("Connection Failed", "Could not connect to the cloud provider. Check your credentials and settings.");
+            await AlertService.ShowAlertAsync("Connection Failed", "Could not connect to the secrets provider. Check your credentials and settings.");
     }
     
     private async Task SetActiveProvider(CloudSecretsProviderConfig provider)

--- a/src/MauiSherpa/Pages/Settings.razor
+++ b/src/MauiSherpa/Pages/Settings.razor
@@ -31,6 +31,7 @@
 @inject MauiSherpa.Pages.Forms.ModalParameterService ModalParams
 @inject MauiSherpa.Pages.Forms.HybridFormBridgeHolder BridgeHolder
 @inject IXcodeService XcodeService
+@inject ILocalVaultAccessService LocalVaultAccess
 
 @if (!PlatformInfo.HasNativeToolbar)
 {
@@ -418,6 +419,22 @@
         Store app secrets, signing certificates, and publish profiles securely.
         The default Local provider keeps secrets on this machine; cloud providers can sync across machines and CI/CD pipelines.
     </p>
+
+    @if (ShouldShowLocalVaultNotice)
+    {
+        <div class="vault-access-card">
+            <div class="vault-access-content">
+                <i class="fas fa-key"></i>
+                <div>
+                    <strong>Local Vault access is disabled</strong>
+                    <p>MAUI Sherpa cannot access the Local Vault key in OS secure storage. Grant access to use Local secrets on this Mac.</p>
+                </div>
+            </div>
+            <button class="btn btn-primary" @onclick="GrantLocalVaultAccessAsync" disabled="@isGrantingLocalVaultAccess">
+                <i class="fas @(isGrantingLocalVaultAccess ? "fa-spinner fa-spin" : "fa-unlock")"></i> Grant Access
+            </button>
+        </div>
+    }
     
     @if (cloudProviders.Count == 0)
     {
@@ -1142,6 +1159,36 @@
     .empty-identities { padding: 1.25rem; text-align: center; color: var(--text-muted); }
 
     /* Cloud Provider Styles */
+    .vault-access-card {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 1rem;
+        padding: 1rem;
+        margin-bottom: 1rem;
+        background: var(--card-bg);
+        border-radius: var(--card-radius, 1rem);
+    }
+    .vault-access-content {
+        display: flex;
+        align-items: flex-start;
+        gap: 0.875rem;
+        color: var(--text-secondary);
+    }
+    .vault-access-content i {
+        color: var(--accent-primary);
+        margin-top: 0.125rem;
+    }
+    .vault-access-content strong {
+        display: block;
+        color: var(--text-primary);
+        margin-bottom: 0.25rem;
+    }
+    .vault-access-content p {
+        margin: 0;
+        color: var(--text-muted);
+        font-size: 0.875rem;
+    }
     .empty-providers { padding: 1.25rem; text-align: center; color: var(--text-muted); }
     
     .provider-list { display: flex; flex-direction: column; gap: 1rem; }
@@ -1306,6 +1353,7 @@
     
     // Cloud provider state
     private List<CloudSecretsProviderConfig> cloudProviders = new();
+    private bool isGrantingLocalVaultAccess;
 
     // CI/CD Publisher state
     private List<SecretsPublisherConfig> secretsPublishers = new();
@@ -1339,6 +1387,7 @@
         
         // Subscribe to cloud provider changes
         CloudSecretsService.OnActiveProviderChanged += OnCloudProviderChanged;
+        LocalVaultAccess.StateChanged += OnLocalVaultStateChanged;
         
         // Subscribe to secrets publisher changes
         SecretsPublisherService.OnPublishersChanged += OnPublishersChanged;
@@ -1448,7 +1497,43 @@
         SdkSettings.SdkPathChanged -= OnSdkPathChanged;
         JdkSettings.JdkPathChanged -= OnJdkPathChanged;
         CloudSecretsService.OnActiveProviderChanged -= OnCloudProviderChanged;
+        LocalVaultAccess.StateChanged -= OnLocalVaultStateChanged;
         SecretsPublisherService.OnPublishersChanged -= OnPublishersChanged;
+    }
+
+    private bool ShouldShowLocalVaultNotice =>
+        LocalVaultAccess.GetState().RequiresUserAction &&
+        (CloudSecretsService.ActiveProvider?.ProviderType == CloudSecretsProviderType.Local ||
+            cloudProviders.All(p => p.ProviderType == CloudSecretsProviderType.Local));
+
+    private void OnLocalVaultStateChanged()
+    {
+        InvokeAsync(StateHasChanged);
+    }
+
+    private async Task GrantLocalVaultAccessAsync()
+    {
+        isGrantingLocalVaultAccess = true;
+        StateHasChanged();
+        try
+        {
+            var state = await LocalVaultAccess.RequestAccessAsync();
+            if (state.RequiresUserAction)
+            {
+                await AlertService.ShowToastAsync("Local Vault access was not granted.");
+                return;
+            }
+
+            await AlertService.ShowToastAsync("Local Vault access granted.");
+            if (CloudSecretsService is CloudSecretsService svc)
+                await svc.InitializeAsync();
+            await LoadCloudProviders();
+        }
+        finally
+        {
+            isGrantingLocalVaultAccess = false;
+            StateHasChanged();
+        }
     }
 
     private async Task LoadAppleIdentities()

--- a/src/MauiSherpa/Services/LocalSecretsKeyStore.cs
+++ b/src/MauiSherpa/Services/LocalSecretsKeyStore.cs
@@ -3,29 +3,75 @@ using MauiSherpa.Core.Interfaces;
 
 namespace MauiSherpa.Services;
 
-public class LocalSecretsKeyStore : ILocalSecretsKeyStore
+public class LocalSecretsKeyStore : ILocalSecretsKeyStore, ILocalVaultAccessService
 {
     private const string KeyName = "MAUI Sherpa Local Vault";
     private const string LegacyKeyName = "local_secrets_sqlcipher_key";
+    private const string AccessDeniedKey = "LocalVault.AccessDenied";
+    private const string AccessDeniedMessageKey = "LocalVault.AccessDeniedMessage";
+    private const string AccessDeniedAtKey = "LocalVault.AccessDeniedAtUtc";
     private const int KeySize = 32;
 
     private readonly ISecureStorage _secureStorage;
+    private readonly IPreferences _preferences;
     private readonly ILoggingService _logger;
     private readonly SemaphoreSlim _keyLock = new(1, 1);
     private string? _cachedKey;
 
-    public LocalSecretsKeyStore(ISecureStorage secureStorage, ILoggingService logger)
+    public LocalSecretsKeyStore(ISecureStorage secureStorage, IPreferences preferences, ILoggingService logger)
     {
         _secureStorage = secureStorage;
+        _preferences = preferences;
         _logger = logger;
     }
 
+    public event Action? StateChanged;
+
     public async Task<string> GetOrCreateKeyAsync(CancellationToken cancellationToken = default)
+        => await GetOrCreateKeyAsync(forcePrompt: false, cancellationToken);
+
+    public LocalVaultAccessState GetState()
+    {
+        if (!string.IsNullOrWhiteSpace(_cachedKey) || !_preferences.Get(AccessDeniedKey, false))
+            return LocalVaultAccessState.Available;
+
+        var message = _preferences.Get<string?>(AccessDeniedMessageKey, null);
+        var lastFailureText = _preferences.Get<string?>(AccessDeniedAtKey, null);
+        DateTime? lastFailureUtc = DateTime.TryParse(lastFailureText, null, System.Globalization.DateTimeStyles.RoundtripKind, out var parsed)
+            ? parsed
+            : null;
+
+        return new LocalVaultAccessState(
+            LocalVaultAccessProblem.AccessDenied,
+            string.IsNullOrWhiteSpace(message)
+                ? "MAUI Sherpa cannot access the Local Vault key in OS secure storage."
+                : message,
+            lastFailureUtc);
+    }
+
+    public async Task<LocalVaultAccessState> RequestAccessAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await GetOrCreateKeyAsync(forcePrompt: true, cancellationToken);
+            ClearAccessFailure();
+        }
+        catch (LocalVaultUnavailableException)
+        {
+        }
+
+        return GetState();
+    }
+
+    private async Task<string> GetOrCreateKeyAsync(bool forcePrompt, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
         if (!string.IsNullOrWhiteSpace(_cachedKey))
             return _cachedKey;
+
+        if (!forcePrompt && GetState().RequiresUserAction)
+            throw new LocalVaultUnavailableException(GetState().Message ?? "Local vault access requires user approval.");
 
         await _keyLock.WaitAsync(cancellationToken);
         try
@@ -33,10 +79,14 @@ public class LocalSecretsKeyStore : ILocalSecretsKeyStore
             if (!string.IsNullOrWhiteSpace(_cachedKey))
                 return _cachedKey;
 
+            if (!forcePrompt && GetState().RequiresUserAction)
+                throw new LocalVaultUnavailableException(GetState().Message ?? "Local vault access requires user approval.");
+
             var existing = await _secureStorage.GetAsync(KeyName);
             if (!string.IsNullOrWhiteSpace(existing))
             {
                 _cachedKey = existing;
+                ClearAccessFailure();
                 return existing;
             }
 
@@ -46,24 +96,48 @@ public class LocalSecretsKeyStore : ILocalSecretsKeyStore
                 await _secureStorage.SetAsync(KeyName, legacy);
                 _secureStorage.Remove(LegacyKeyName);
                 _cachedKey = legacy;
+                ClearAccessFailure();
                 return legacy;
             }
 
             var key = Convert.ToBase64String(RandomNumberGenerator.GetBytes(KeySize));
             await _secureStorage.SetAsync(KeyName, key);
             _cachedKey = key;
+            ClearAccessFailure();
             return key;
+        }
+        catch (LocalVaultUnavailableException)
+        {
+            throw;
         }
         catch (Exception ex)
         {
+            var message = "MAUI Sherpa needs access to the Local Vault key in OS secure storage before local secrets can be used.";
+            RecordAccessFailure(message, ex);
             _logger.LogError("OS secure storage is required for the MAUI Sherpa local vault key.", ex);
-            throw new InvalidOperationException(
-                "Local secrets storage requires OS secure storage for the MAUI Sherpa local vault key. The local secrets database was not opened.",
-                ex);
+            throw new LocalVaultUnavailableException(message, ex);
         }
         finally
         {
             _keyLock.Release();
         }
+    }
+
+    private void RecordAccessFailure(string message, Exception exception)
+    {
+        _preferences.Set(AccessDeniedKey, true);
+        _preferences.Set(AccessDeniedMessageKey, $"{message} {exception.Message}");
+        _preferences.Set(AccessDeniedAtKey, DateTime.UtcNow.ToString("O"));
+        StateChanged?.Invoke();
+    }
+
+    private void ClearAccessFailure()
+    {
+        var hadFailure = _preferences.Get(AccessDeniedKey, false);
+        _preferences.Remove(AccessDeniedKey);
+        _preferences.Remove(AccessDeniedMessageKey);
+        _preferences.Remove(AccessDeniedAtKey);
+        if (hadFailure)
+            StateChanged?.Invoke();
     }
 }

--- a/src/MauiSherpa/Services/LocalSecretsKeyStore.cs
+++ b/src/MauiSherpa/Services/LocalSecretsKeyStore.cs
@@ -1,0 +1,69 @@
+using System.Security.Cryptography;
+using MauiSherpa.Core.Interfaces;
+
+namespace MauiSherpa.Services;
+
+public class LocalSecretsKeyStore : ILocalSecretsKeyStore
+{
+    private const string KeyName = "MAUI Sherpa Local Vault";
+    private const string LegacyKeyName = "local_secrets_sqlcipher_key";
+    private const int KeySize = 32;
+
+    private readonly ISecureStorage _secureStorage;
+    private readonly ILoggingService _logger;
+    private readonly SemaphoreSlim _keyLock = new(1, 1);
+    private string? _cachedKey;
+
+    public LocalSecretsKeyStore(ISecureStorage secureStorage, ILoggingService logger)
+    {
+        _secureStorage = secureStorage;
+        _logger = logger;
+    }
+
+    public async Task<string> GetOrCreateKeyAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!string.IsNullOrWhiteSpace(_cachedKey))
+            return _cachedKey;
+
+        await _keyLock.WaitAsync(cancellationToken);
+        try
+        {
+            if (!string.IsNullOrWhiteSpace(_cachedKey))
+                return _cachedKey;
+
+            var existing = await _secureStorage.GetAsync(KeyName);
+            if (!string.IsNullOrWhiteSpace(existing))
+            {
+                _cachedKey = existing;
+                return existing;
+            }
+
+            var legacy = await _secureStorage.GetAsync(LegacyKeyName);
+            if (!string.IsNullOrWhiteSpace(legacy))
+            {
+                await _secureStorage.SetAsync(KeyName, legacy);
+                _secureStorage.Remove(LegacyKeyName);
+                _cachedKey = legacy;
+                return legacy;
+            }
+
+            var key = Convert.ToBase64String(RandomNumberGenerator.GetBytes(KeySize));
+            await _secureStorage.SetAsync(KeyName, key);
+            _cachedKey = key;
+            return key;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError("OS secure storage is required for the MAUI Sherpa local vault key.", ex);
+            throw new InvalidOperationException(
+                "Local secrets storage requires OS secure storage for the MAUI Sherpa local vault key. The local secrets database was not opened.",
+                ex);
+        }
+        finally
+        {
+            _keyLock.Release();
+        }
+    }
+}

--- a/src/MauiSherpa/Services/LocalVaultIntroModalService.cs
+++ b/src/MauiSherpa/Services/LocalVaultIntroModalService.cs
@@ -1,0 +1,58 @@
+using MauiSherpa.Core.Interfaces;
+using MauiSherpa.Pages.Forms;
+
+namespace MauiSherpa.Services;
+
+public sealed class LocalVaultIntroModalService
+{
+    private const string PreviewOnlyParameter = "PreviewOnly";
+    private readonly ModalParameterService _modalParams;
+    private readonly ILocalVaultIntroductionService _introductionService;
+    private readonly SemaphoreSlim _modalLock = new(1, 1);
+
+    public LocalVaultIntroModalService(
+        ModalParameterService modalParams,
+        ILocalVaultIntroductionService introductionService)
+    {
+        _modalParams = modalParams;
+        _introductionService = introductionService;
+    }
+
+    public async Task<LocalVaultIntroductionResult?> ShowIfNeededAsync()
+    {
+        if (_introductionService.GetState().HasSeenCurrentVersion)
+            return null;
+
+        return await ShowAsync(previewOnly: false);
+    }
+
+    public Task<LocalVaultIntroductionResult?> ShowPreviewAsync() =>
+        ShowAsync(previewOnly: true);
+
+    private async Task<LocalVaultIntroductionResult?> ShowAsync(bool previewOnly)
+    {
+        await _modalLock.WaitAsync();
+        try
+        {
+            var nav = Application.Current?.Windows.FirstOrDefault()?.Page?.Navigation;
+            if (nav == null)
+                return null;
+
+            _modalParams.Clear();
+            _modalParams.Set(PreviewOnlyParameter, previewOnly);
+
+            var resultTask = _modalParams.WaitForResultAsync();
+            var page = new ProgressModalPage("/modal/local-vault-intro", 620, 520);
+            await nav.PushModalAsync(page, animated: true);
+            var result = await resultTask;
+            await nav.PopModalAsync(animated: true);
+
+            return result is LocalVaultIntroductionResult typedResult ? typedResult : null;
+        }
+        finally
+        {
+            _modalParams.Clear();
+            _modalLock.Release();
+        }
+    }
+}

--- a/src/MauiSherpa/Services/LocalVaultIntroductionService.cs
+++ b/src/MauiSherpa/Services/LocalVaultIntroductionService.cs
@@ -1,0 +1,58 @@
+using MauiSherpa.Core.Interfaces;
+
+namespace MauiSherpa.Services;
+
+public sealed class LocalVaultIntroductionService : ILocalVaultIntroductionService
+{
+    private const string VersionKey = "local_vault_intro_version";
+    private const string DecisionKey = "local_vault_intro_decision";
+    private const string DecidedAtKey = "local_vault_intro_decided_at_utc";
+
+    private readonly IPreferences _preferences;
+
+    public LocalVaultIntroductionService(IPreferences preferences)
+    {
+        _preferences = preferences;
+    }
+
+    public event Action? StateChanged;
+
+    public LocalVaultIntroductionState GetState()
+    {
+        var version = _preferences.Get(VersionKey, 0);
+        var decisionText = _preferences.Get(DecisionKey, string.Empty);
+        var decidedAtText = _preferences.Get(DecidedAtKey, string.Empty);
+
+        if (!Enum.TryParse<LocalVaultIntroductionDecision>(decisionText, out var decision))
+            decision = LocalVaultIntroductionDecision.NotSet;
+
+        DateTime? decidedAt = null;
+        if (DateTime.TryParse(decidedAtText, null, System.Globalization.DateTimeStyles.RoundtripKind, out var parsed))
+            decidedAt = parsed;
+
+        if (version != LocalVaultIntroductionState.CurrentVersion)
+            return LocalVaultIntroductionState.NotShown;
+
+        return new LocalVaultIntroductionState(version, decision, decidedAt);
+    }
+
+    public Task MarkEnabledAsync(CancellationToken cancellationToken = default)
+    {
+        SetDecision(LocalVaultIntroductionDecision.Enabled);
+        return Task.CompletedTask;
+    }
+
+    public Task MarkDeclinedAsync(CancellationToken cancellationToken = default)
+    {
+        SetDecision(LocalVaultIntroductionDecision.Declined);
+        return Task.CompletedTask;
+    }
+
+    private void SetDecision(LocalVaultIntroductionDecision decision)
+    {
+        _preferences.Set(VersionKey, LocalVaultIntroductionState.CurrentVersion);
+        _preferences.Set(DecisionKey, decision.ToString());
+        _preferences.Set(DecidedAtKey, DateTime.UtcNow.ToString("O"));
+        StateChanged?.Invoke();
+    }
+}

--- a/src/MauiSherpa/Services/SecureStorageService.cs
+++ b/src/MauiSherpa/Services/SecureStorageService.cs
@@ -7,7 +7,7 @@ namespace MauiSherpa.Services;
 /// Secure storage service that uses platform Keychain/DPAPI when available,
 /// with a fallback to local JSON file for debugging scenarios where entitlements aren't configured.
 /// </summary>
-public class SecureStorageService : ISecureStorageService
+public class SecureStorageService : ILegacySecureStorageService
 {
     private readonly string _fallbackPath;
     private readonly ISecureStorage _secureStorage;

--- a/tests/MauiSherpa.Core.Tests/Services/CloudSecretsProviderFactoryTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/CloudSecretsProviderFactoryTests.cs
@@ -1,0 +1,75 @@
+using FluentAssertions;
+using MauiSherpa.Core.Interfaces;
+using MauiSherpa.Core.Services;
+
+namespace MauiSherpa.Core.Tests.Services;
+
+public class CloudSecretsProviderFactoryTests
+{
+    [Fact]
+    public void SupportedProviders_IncludesLocalFirst()
+    {
+        var factory = new CloudSecretsProviderFactory(new TestLogger(), new TestLocalSecretsKeyStore());
+
+        factory.SupportedProviders[0].Should().Be(CloudSecretsProviderType.Local);
+        factory.SupportedProviders.Should().Contain(CloudSecretsProviderType.Local);
+    }
+
+    [Fact]
+    public void GetProviderDisplayName_Local_ReturnsLocal()
+    {
+        var factory = new CloudSecretsProviderFactory(new TestLogger(), new TestLocalSecretsKeyStore());
+
+        factory.GetProviderDisplayName(CloudSecretsProviderType.Local).Should().Be("Local");
+    }
+
+    [Fact]
+    public void GetProviderSettings_Local_HasNoRequiredSettings()
+    {
+        var factory = new CloudSecretsProviderFactory(new TestLogger(), new TestLocalSecretsKeyStore());
+
+        factory.GetProviderSettings(CloudSecretsProviderType.Local).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CreateProvider_Local_ReturnsLocalProvider()
+    {
+        var factory = new CloudSecretsProviderFactory(new TestLogger(), new TestLocalSecretsKeyStore());
+        var config = new CloudSecretsProviderConfig("local", "Local", CloudSecretsProviderType.Local, new());
+
+        var provider = factory.CreateProvider(config);
+
+        provider.Should().BeOfType<LocalSqlCipherSecretsProvider>();
+        provider.ProviderType.Should().Be(CloudSecretsProviderType.Local);
+        provider.DisplayName.Should().Be("Local");
+    }
+
+    [Fact]
+    public void CreateProvider_LocalWithoutKeyStore_Throws()
+    {
+        var factory = new CloudSecretsProviderFactory(new TestLogger());
+        var config = new CloudSecretsProviderConfig("local", "Local", CloudSecretsProviderType.Local, new());
+
+        var act = () => factory.CreateProvider(config);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Local secrets key storage*");
+    }
+
+    private sealed class TestLocalSecretsKeyStore : ILocalSecretsKeyStore
+    {
+        public Task<string> GetOrCreateKeyAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult("test-key");
+    }
+
+    private sealed class TestLogger : ILoggingService
+    {
+        public void LogInformation(string message) { }
+        public void LogWarning(string message) { }
+        public void LogError(string message, Exception? exception = null) { }
+        public void LogDebug(string message) { }
+        public IReadOnlyList<LogEntry> GetRecentLogs(int maxCount = 500) => Array.Empty<LogEntry>();
+        public void ClearLogs() { }
+        public event Action? OnLogAdded;
+    }
+}

--- a/tests/MauiSherpa.Core.Tests/Services/CloudSecretsServiceTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/CloudSecretsServiceTests.cs
@@ -25,6 +25,65 @@ public class CloudSecretsServiceTests
     }
 
     [Fact]
+    public async Task InitializeAsync_WithNoProvidersAndIntroNotSeen_DoesNotActivateLocalProvider()
+    {
+        var secureStorage = new InMemorySecureStorage();
+        var service = CreateService(
+            secureStorage: secureStorage,
+            localVaultIntroduction: new TestLocalVaultIntroductionService(LocalVaultIntroductionState.NotShown));
+
+        await service.InitializeAsync();
+
+        service.ActiveProvider.Should().BeNull();
+        secureStorage.Values.Should().NotContainKey("cloud_secrets_active_provider");
+
+        var providers = await service.GetProvidersAsync();
+        providers.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task InitializeAsync_WithRemoteProviderAndIntroNotSeen_ActivatesRemoteWithoutLocal()
+    {
+        var secureStorage = new InMemorySecureStorage();
+        var intro = new TestLocalVaultIntroductionService(LocalVaultIntroductionState.NotShown);
+        var service = CreateService(secureStorage: secureStorage, localVaultIntroduction: intro);
+        var provider = new CloudSecretsProviderConfig(
+            "remote",
+            "Remote",
+            CloudSecretsProviderType.AzureKeyVault,
+            new Dictionary<string, string>
+            {
+                ["VaultUrl"] = "https://test.vault.azure.net",
+                ["TenantId"] = "tenant",
+                ["ClientId"] = "client",
+                ["ClientSecret"] = "secret"
+            });
+
+        await service.SaveProviderAsync(provider);
+        await service.InitializeAsync();
+
+        service.ActiveProvider.Should().NotBeNull();
+        service.ActiveProvider!.Id.Should().Be("remote");
+        secureStorage.Values["cloud_secrets_active_provider"].Should().Be("remote");
+
+        var providers = await service.GetProvidersAsync();
+        providers.Should().ContainSingle(p => p.Id == "remote");
+        providers.Should().NotContain(p => p.Id == "local");
+    }
+
+    [Fact]
+    public async Task GetProvidersAsync_WithIntroNotSeen_DoesNotTouchVaultStore()
+    {
+        var service = CreateService(
+            vaultStore: new ThrowingLocalVaultStore(),
+            localVaultIntroduction: new TestLocalVaultIntroductionService(LocalVaultIntroductionState.NotShown));
+
+        var providers = await service.GetProvidersAsync();
+
+        providers.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task InitializeAsync_WithExistingActiveProvider_AddsLocalAndDoesNotOverride()
     {
         var service = CreateService();
@@ -163,6 +222,25 @@ public class CloudSecretsServiceTests
     }
 
     [Fact]
+    public async Task EnableDefaultLocalProviderAsync_WithIntroEnabled_CreatesAndActivatesLocalProvider()
+    {
+        var secureStorage = new InMemorySecureStorage();
+        var service = CreateService(
+            secureStorage: secureStorage,
+            localVaultIntroduction: new TestLocalVaultIntroductionService(
+                new LocalVaultIntroductionState(
+                    LocalVaultIntroductionState.CurrentVersion,
+                    LocalVaultIntroductionDecision.Enabled,
+                    DateTime.UtcNow)));
+
+        await service.EnableDefaultLocalProviderAsync();
+
+        service.ActiveProvider.Should().NotBeNull();
+        service.ActiveProvider!.Id.Should().Be("local");
+        secureStorage.Values["cloud_secrets_active_provider"].Should().Be("local");
+    }
+
+    [Fact]
     public async Task SaveProviderAsync_WithUnavailableVaultStore_PersistsMetadataAndSettingsToJson()
     {
         var fileSystem = new InMemoryFileSystem();
@@ -234,7 +312,8 @@ public class CloudSecretsServiceTests
         InMemorySecureStorage? secureStorage = null,
         InMemoryFileSystem? fileSystem = null,
         ILocalVaultStore? vaultStore = null,
-        ILocalVaultAccessService? localVaultAccess = null)
+        ILocalVaultAccessService? localVaultAccess = null,
+        ILocalVaultIntroductionService? localVaultIntroduction = null)
     {
         var logger = new TestLogger();
         return new CloudSecretsService(
@@ -243,7 +322,8 @@ public class CloudSecretsServiceTests
             logger,
             new CloudSecretsProviderFactory(logger, new TestLocalSecretsKeyStore(), vaultStore),
             vaultStore,
-            localVaultAccess);
+            localVaultAccess,
+            localVaultIntroduction);
     }
 
     private static SqlCipherLocalVaultStore CreateVaultStore()
@@ -268,6 +348,21 @@ public class CloudSecretsServiceTests
 
         public Task<LocalVaultAccessState> RequestAccessAsync(CancellationToken cancellationToken = default)
             => Task.FromResult(state);
+
+        public event Action? StateChanged
+        {
+            add { }
+            remove { }
+        }
+    }
+
+    private sealed class TestLocalVaultIntroductionService(LocalVaultIntroductionState state) : ILocalVaultIntroductionService
+    {
+        public LocalVaultIntroductionState GetState() => state;
+
+        public Task MarkEnabledAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task MarkDeclinedAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
 
         public event Action? StateChanged
         {

--- a/tests/MauiSherpa.Core.Tests/Services/CloudSecretsServiceTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/CloudSecretsServiceTests.cs
@@ -85,6 +85,40 @@ public class CloudSecretsServiceTests
     }
 
     [Fact]
+    public async Task InitializeAsync_WithRemoteProviderAndLocalVaultUnavailable_ActivatesRemoteProvider()
+    {
+        var secureStorage = new InMemorySecureStorage();
+        var service = CreateService(
+            secureStorage: secureStorage,
+            localVaultAccess: new TestLocalVaultAccessService(
+                new LocalVaultAccessState(LocalVaultAccessProblem.AccessDenied, "Denied")));
+        var provider = new CloudSecretsProviderConfig(
+            "remote",
+            "Remote",
+            CloudSecretsProviderType.AzureKeyVault,
+            new Dictionary<string, string>
+            {
+                ["VaultUrl"] = "https://test.vault.azure.net",
+                ["TenantId"] = "tenant",
+                ["ClientId"] = "client",
+                ["ClientSecret"] = "secret"
+            });
+
+        await service.SaveProviderAsync(provider);
+
+        await service.InitializeAsync();
+
+        service.ActiveProvider.Should().NotBeNull();
+        service.ActiveProvider!.Id.Should().Be("remote");
+        service.ActiveProvider.ProviderType.Should().Be(CloudSecretsProviderType.AzureKeyVault);
+        secureStorage.Values["cloud_secrets_active_provider"].Should().Be("remote");
+
+        var providers = await service.GetProvidersAsync();
+        providers.Should().Contain(p => p.Id == "remote");
+        providers.Should().ContainSingle(p => p.Id == "local" && p.ProviderType == CloudSecretsProviderType.Local);
+    }
+
+    [Fact]
     public async Task DeleteProviderAsync_LocalProvider_DoesNotDeleteLocal()
     {
         var service = CreateService();
@@ -126,6 +160,31 @@ public class CloudSecretsServiceTests
         metadataItem.Should().NotBeNull();
         settingsItem.Should().NotBeNull();
         fileSystem.Files.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SaveProviderAsync_WithUnavailableVaultStore_PersistsMetadataAndSettingsToJson()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        var service = CreateService(fileSystem: fileSystem, vaultStore: new ThrowingLocalVaultStore());
+        var provider = new CloudSecretsProviderConfig(
+            "remote",
+            "Remote",
+            CloudSecretsProviderType.AzureKeyVault,
+            new Dictionary<string, string>
+            {
+                ["VaultUrl"] = "https://test.vault.azure.net",
+                ["TenantId"] = "tenant",
+                ["ClientId"] = "client",
+                ["ClientSecret"] = "secret"
+            });
+
+        await service.SaveProviderAsync(provider);
+        var providers = await service.GetProvidersAsync();
+
+        providers.Should().ContainSingle(p => p.Id == "remote");
+        fileSystem.Files.Should().ContainKey(Path.Combine(AppDataPath.GetAppDataDirectory(), "cloud-secrets-providers.json"));
+        fileSystem.Files.Should().ContainKey(Path.Combine(AppDataPath.GetAppDataDirectory(), "cloud-secrets-remote.json"));
     }
 
     [Fact]
@@ -174,7 +233,8 @@ public class CloudSecretsServiceTests
     private static CloudSecretsService CreateService(
         InMemorySecureStorage? secureStorage = null,
         InMemoryFileSystem? fileSystem = null,
-        ILocalVaultStore? vaultStore = null)
+        ILocalVaultStore? vaultStore = null,
+        ILocalVaultAccessService? localVaultAccess = null)
     {
         var logger = new TestLogger();
         return new CloudSecretsService(
@@ -182,7 +242,8 @@ public class CloudSecretsServiceTests
             fileSystem ?? new InMemoryFileSystem(),
             logger,
             new CloudSecretsProviderFactory(logger, new TestLocalSecretsKeyStore(), vaultStore),
-            vaultStore);
+            vaultStore,
+            localVaultAccess);
     }
 
     private static SqlCipherLocalVaultStore CreateVaultStore()
@@ -199,6 +260,63 @@ public class CloudSecretsServiceTests
     {
         public Task<string> GetOrCreateKeyAsync(CancellationToken cancellationToken = default)
             => Task.FromResult("test-key");
+    }
+
+    private sealed class TestLocalVaultAccessService(LocalVaultAccessState state) : ILocalVaultAccessService
+    {
+        public LocalVaultAccessState GetState() => state;
+
+        public Task<LocalVaultAccessState> RequestAccessAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(state);
+
+        public event Action? StateChanged
+        {
+            add { }
+            remove { }
+        }
+    }
+
+    private sealed class ThrowingLocalVaultStore : ILocalVaultStore
+    {
+        public string DatabasePath => "throwing";
+
+        public Task<LocalVaultItem> PutAsync(
+            string scope,
+            string path,
+            string key,
+            byte[] value,
+            string contentType,
+            Dictionary<string, string>? metadata = null,
+            CancellationToken cancellationToken = default)
+            => throw new LocalVaultUnavailableException("Vault unavailable");
+
+        public Task<LocalVaultItem?> GetAsync(
+            string scope,
+            string path,
+            string key,
+            CancellationToken cancellationToken = default)
+            => throw new LocalVaultUnavailableException("Vault unavailable");
+
+        public Task<bool> RemoveAsync(
+            string scope,
+            string path,
+            string key,
+            CancellationToken cancellationToken = default)
+            => throw new LocalVaultUnavailableException("Vault unavailable");
+
+        public Task<bool> ExistsAsync(
+            string scope,
+            string path,
+            string key,
+            CancellationToken cancellationToken = default)
+            => throw new LocalVaultUnavailableException("Vault unavailable");
+
+        public Task<IReadOnlyList<LocalVaultItem>> ListAsync(
+            string scope,
+            string? path = null,
+            string? keyPrefix = null,
+            CancellationToken cancellationToken = default)
+            => throw new LocalVaultUnavailableException("Vault unavailable");
     }
 
     private sealed class InMemorySecureStorage : ISecureStorageService

--- a/tests/MauiSherpa.Core.Tests/Services/CloudSecretsServiceTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/CloudSecretsServiceTests.cs
@@ -1,0 +1,278 @@
+using FluentAssertions;
+using MauiSherpa.Core.Interfaces;
+using MauiSherpa.Core.Services;
+
+namespace MauiSherpa.Core.Tests.Services;
+
+public class CloudSecretsServiceTests
+{
+    [Fact]
+    public async Task InitializeAsync_WithNoProviders_CreatesAndActivatesLocalProvider()
+    {
+        var secureStorage = new InMemorySecureStorage();
+        var service = CreateService(secureStorage: secureStorage);
+
+        await service.InitializeAsync();
+
+        service.ActiveProvider.Should().NotBeNull();
+        service.ActiveProvider!.Id.Should().Be("local");
+        service.ActiveProvider.Name.Should().Be("Local");
+        service.ActiveProvider.ProviderType.Should().Be(CloudSecretsProviderType.Local);
+        secureStorage.Values["cloud_secrets_active_provider"].Should().Be("local");
+
+        var providers = await service.GetProvidersAsync();
+        providers.Should().ContainSingle(p => p.ProviderType == CloudSecretsProviderType.Local);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_WithExistingActiveProvider_AddsLocalAndDoesNotOverride()
+    {
+        var service = CreateService();
+        var provider = new CloudSecretsProviderConfig(
+            "remote",
+            "Remote",
+            CloudSecretsProviderType.AzureKeyVault,
+            new Dictionary<string, string>
+            {
+                ["VaultUrl"] = "https://test.vault.azure.net",
+                ["TenantId"] = "tenant",
+                ["ClientId"] = "client",
+                ["ClientSecret"] = "secret"
+            });
+
+        await service.SaveProviderAsync(provider);
+        await service.SetActiveProviderAsync(provider.Id);
+
+        await service.InitializeAsync();
+
+        service.ActiveProvider.Should().NotBeNull();
+        service.ActiveProvider!.Id.Should().Be("remote");
+        service.ActiveProvider.ProviderType.Should().Be(CloudSecretsProviderType.AzureKeyVault);
+
+        var providers = await service.GetProvidersAsync();
+        providers.Should().Contain(p => p.Id == "remote");
+        providers.Should().ContainSingle(p => p.Id == "local" && p.ProviderType == CloudSecretsProviderType.Local);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_WithExistingProvidersButNoActiveProvider_ActivatesLocal()
+    {
+        var secureStorage = new InMemorySecureStorage();
+        var service = CreateService(secureStorage: secureStorage);
+        var provider = new CloudSecretsProviderConfig(
+            "remote",
+            "Remote",
+            CloudSecretsProviderType.AzureKeyVault,
+            new Dictionary<string, string>
+            {
+                ["VaultUrl"] = "https://test.vault.azure.net",
+                ["TenantId"] = "tenant",
+                ["ClientId"] = "client",
+                ["ClientSecret"] = "secret"
+            });
+
+        await service.SaveProviderAsync(provider);
+
+        await service.InitializeAsync();
+
+        service.ActiveProvider.Should().NotBeNull();
+        service.ActiveProvider!.Id.Should().Be("local");
+        secureStorage.Values["cloud_secrets_active_provider"].Should().Be("local");
+
+        var providers = await service.GetProvidersAsync();
+        providers.Should().Contain(p => p.Id == "remote");
+        providers.Should().ContainSingle(p => p.Id == "local" && p.ProviderType == CloudSecretsProviderType.Local);
+    }
+
+    [Fact]
+    public async Task DeleteProviderAsync_LocalProvider_DoesNotDeleteLocal()
+    {
+        var service = CreateService();
+
+        await service.InitializeAsync();
+        await service.DeleteProviderAsync("local");
+
+        var providers = await service.GetProvidersAsync();
+        providers.Should().ContainSingle(p => p.Id == "local" && p.ProviderType == CloudSecretsProviderType.Local);
+    }
+
+    [Fact]
+    public async Task SaveProviderAsync_WithVaultStore_PersistsMetadataAndSettingsInVault()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        var vaultStore = CreateVaultStore();
+        var service = CreateService(fileSystem: fileSystem, vaultStore: vaultStore);
+        var provider = new CloudSecretsProviderConfig(
+            "remote",
+            "Remote",
+            CloudSecretsProviderType.AzureKeyVault,
+            new Dictionary<string, string>
+            {
+                ["VaultUrl"] = "https://test.vault.azure.net",
+                ["TenantId"] = "tenant",
+                ["ClientId"] = "client",
+                ["ClientSecret"] = "secret"
+            });
+
+        await service.SaveProviderAsync(provider);
+        var providers = await service.GetProvidersAsync();
+        var metadataItem = await vaultStore.GetAsync(LocalVaultScopes.CloudProvider, "/", "providers");
+        var settingsItem = await vaultStore.GetAsync(LocalVaultScopes.CloudProvider, "/providers", "settings-remote");
+
+        providers.Should().ContainSingle(p => p.Id == "local" && p.ProviderType == CloudSecretsProviderType.Local);
+        var remote = providers.Should().ContainSingle(p => p.Id == "remote").Subject;
+        remote.Settings["VaultUrl"].Should().Be("https://test.vault.azure.net");
+        remote.Settings["ClientSecret"].Should().Be("secret");
+        metadataItem.Should().NotBeNull();
+        settingsItem.Should().NotBeNull();
+        fileSystem.Files.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetProvidersAsync_WithVaultStore_MigratesLegacyJsonAndDeletesFiles()
+    {
+        var fileSystem = new InMemoryFileSystem();
+        var vaultStore = CreateVaultStore();
+        var settingsPath = Path.Combine(AppDataPath.GetAppDataDirectory(), "cloud-secrets-providers.json");
+        var providerSettingsPath = Path.Combine(AppDataPath.GetAppDataDirectory(), "cloud-secrets-remote.json");
+        await fileSystem.WriteFileAsync(settingsPath, """
+            [
+              {
+                "Id": "remote",
+                "Name": "Remote",
+                "ProviderType": 1,
+                "NonSecretSettingKeys": [ "VaultUrl", "TenantId", "ClientId" ]
+              }
+            ]
+            """);
+        await fileSystem.WriteFileAsync(providerSettingsPath, """
+            {
+              "VaultUrl": "https://test.vault.azure.net",
+              "TenantId": "tenant",
+              "ClientId": "client"
+            }
+            """);
+        var secureStorage = new InMemorySecureStorage();
+        await secureStorage.SetAsync("cloud_secrets_provider_remote", """
+            {
+              "ClientSecret": "secret"
+            }
+            """);
+        var service = CreateService(secureStorage: secureStorage, fileSystem: fileSystem, vaultStore: vaultStore);
+
+        var providers = await service.GetProvidersAsync();
+
+        providers.Should().ContainSingle(p => p.Id == "local" && p.ProviderType == CloudSecretsProviderType.Local);
+        var remote = providers.Should().ContainSingle(p => p.Id == "remote").Subject;
+        remote.Settings["ClientSecret"].Should().Be("secret");
+        (await fileSystem.FileExistsAsync(settingsPath)).Should().BeFalse();
+        (await fileSystem.FileExistsAsync(providerSettingsPath)).Should().BeFalse();
+        (await vaultStore.GetAsync(LocalVaultScopes.CloudProvider, "/", "providers")).Should().NotBeNull();
+        (await vaultStore.GetAsync(LocalVaultScopes.CloudProvider, "/providers", "settings-remote")).Should().NotBeNull();
+    }
+
+    private static CloudSecretsService CreateService(
+        InMemorySecureStorage? secureStorage = null,
+        InMemoryFileSystem? fileSystem = null,
+        ILocalVaultStore? vaultStore = null)
+    {
+        var logger = new TestLogger();
+        return new CloudSecretsService(
+            secureStorage ?? new InMemorySecureStorage(),
+            fileSystem ?? new InMemoryFileSystem(),
+            logger,
+            new CloudSecretsProviderFactory(logger, new TestLocalSecretsKeyStore(), vaultStore),
+            vaultStore);
+    }
+
+    private static SqlCipherLocalVaultStore CreateVaultStore()
+    {
+        var testDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(testDir);
+        return new SqlCipherLocalVaultStore(
+            new TestLocalSecretsKeyStore(),
+            new TestLogger(),
+            new LocalVaultOptions(Path.Combine(testDir, "vault.db")));
+    }
+
+    private sealed class TestLocalSecretsKeyStore : ILocalSecretsKeyStore
+    {
+        public Task<string> GetOrCreateKeyAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult("test-key");
+    }
+
+    private sealed class InMemorySecureStorage : ISecureStorageService
+    {
+        public Dictionary<string, string> Values { get; } = new();
+
+        public Task<string?> GetAsync(string key)
+            => Task.FromResult(Values.TryGetValue(key, out var value) ? value : null);
+
+        public Task SetAsync(string key, string value)
+        {
+            Values[key] = value;
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveAsync(string key)
+        {
+            Values.Remove(key);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class InMemoryFileSystem : IFileSystemService
+    {
+        private readonly Dictionary<string, string> _files = new();
+        private readonly HashSet<string> _directories = new(StringComparer.Ordinal);
+
+        public IReadOnlyDictionary<string, string> Files => _files;
+
+        public Task<string?> ReadFileAsync(string path)
+            => Task.FromResult(_files.TryGetValue(path, out var content) ? content : null);
+
+        public Task WriteFileAsync(string path, string content)
+        {
+            _files[path] = content;
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> FileExistsAsync(string path) => Task.FromResult(_files.ContainsKey(path));
+
+        public Task<bool> DirectoryExistsAsync(string path) => Task.FromResult(_directories.Contains(path));
+
+        public Task<IReadOnlyList<string>> GetFilesAsync(string path, string searchPattern = "*")
+            => Task.FromResult<IReadOnlyList<string>>(_files.Keys.Where(x => x.StartsWith(path, StringComparison.Ordinal)).ToList());
+
+        public Task CreateDirectoryAsync(string path)
+        {
+            _directories.Add(path);
+            return Task.CompletedTask;
+        }
+
+        public Task DeleteFileAsync(string path)
+        {
+            _files.Remove(path);
+            return Task.CompletedTask;
+        }
+
+        public Task DeleteDirectoryAsync(string path)
+        {
+            _directories.Remove(path);
+            return Task.CompletedTask;
+        }
+
+        public void RevealInFileManager(string path) { }
+    }
+
+    private sealed class TestLogger : ILoggingService
+    {
+        public void LogInformation(string message) { }
+        public void LogWarning(string message) { }
+        public void LogError(string message, Exception? exception = null) { }
+        public void LogDebug(string message) { }
+        public IReadOnlyList<LogEntry> GetRecentLogs(int maxCount = 500) => Array.Empty<LogEntry>();
+        public void ClearLogs() { }
+        public event Action? OnLogAdded;
+    }
+}

--- a/tests/MauiSherpa.Core.Tests/Services/EncryptedSettingsServiceTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/EncryptedSettingsServiceTests.cs
@@ -232,6 +232,132 @@ public class EncryptedSettingsServiceTests
         loaded.AppleIdentities[0].Name.Should().Be("Test 日本語 émojis 🎉");
         loaded.AppleIdentities[0].P8Content.Should().Contain("BEGIN PRIVATE KEY");
     }
+
+    [Fact]
+    public async Task GetSettingsAsync_WithVault_MigratesLegacyEncryptedFileAndCleansUp()
+    {
+        var legacySecureStorage = new InMemorySecureStorage();
+        var settingsPath = Path.Combine(_testDir, "vault-migration-settings.enc");
+        var legacyService = new EncryptedSettingsService(
+            new InMemoryFileSystem(),
+            legacySecureStorage,
+            vaultStore: null,
+            settingsPath);
+        await legacyService.SaveSettingsAsync(new MauiSherpaSettings
+        {
+            Preferences = new AppPreferences { Theme = "Dark" }
+        });
+        File.Exists(settingsPath).Should().BeTrue();
+        legacySecureStorage.Values.Should().ContainKey("MauiSherpa_MasterKey");
+
+        var vaultStore = CreateVaultStore();
+        var vaultService = new EncryptedSettingsService(
+            new InMemoryFileSystem(),
+            legacySecureStorage,
+            vaultStore,
+            settingsPath);
+
+        var settings = await vaultService.GetSettingsAsync();
+        var savedItem = await vaultStore.GetAsync(LocalVaultScopes.Settings, "/", "maui-sherpa-settings");
+
+        settings.Preferences.Theme.Should().Be("Dark");
+        savedItem.Should().NotBeNull();
+        File.Exists(settingsPath).Should().BeFalse();
+        legacySecureStorage.Values.Should().NotContainKey("MauiSherpa_MasterKey");
+    }
+
+    [Fact]
+    public async Task SaveSettingsAsync_WithVault_DoesNotCreateLegacyEncryptedFile()
+    {
+        var settingsPath = Path.Combine(_testDir, "vault-only-settings.enc");
+        var vaultStore = CreateVaultStore();
+        var service = new EncryptedSettingsService(
+            new InMemoryFileSystem(),
+            new InMemorySecureStorage(),
+            vaultStore,
+            settingsPath);
+
+        await service.SaveSettingsAsync(new MauiSherpaSettings
+        {
+            Preferences = new AppPreferences { Theme = "Light" }
+        });
+        var loaded = await service.GetSettingsAsync();
+
+        loaded.Preferences.Theme.Should().Be("Light");
+        File.Exists(settingsPath).Should().BeFalse();
+    }
+
+    private SqlCipherLocalVaultStore CreateVaultStore()
+    {
+        return new SqlCipherLocalVaultStore(
+            new TestLocalVaultKeyStore(),
+            new TestLogger(),
+            new LocalVaultOptions(Path.Combine(_testDir, $"{Guid.NewGuid():N}.db")));
+    }
+
+    private sealed class TestLocalVaultKeyStore : ILocalVaultKeyStore
+    {
+        public Task<string> GetOrCreateKeyAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult("test-key");
+    }
+
+    private sealed class InMemorySecureStorage : ISecureStorageService
+    {
+        public Dictionary<string, string> Values { get; } = new();
+
+        public Task<string?> GetAsync(string key)
+            => Task.FromResult(Values.TryGetValue(key, out var value) ? value : null);
+
+        public Task SetAsync(string key, string value)
+        {
+            Values[key] = value;
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveAsync(string key)
+        {
+            Values.Remove(key);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class InMemoryFileSystem : IFileSystemService
+    {
+        public Task<string?> ReadFileAsync(string path) => Task.FromResult<string?>(null);
+        public Task WriteFileAsync(string path, string content) => Task.CompletedTask;
+        public Task<bool> FileExistsAsync(string path) => Task.FromResult(File.Exists(path));
+        public Task<bool> DirectoryExistsAsync(string path) => Task.FromResult(Directory.Exists(path));
+        public Task<IReadOnlyList<string>> GetFilesAsync(string path, string searchPattern = "*") => Task.FromResult<IReadOnlyList<string>>(Array.Empty<string>());
+        public Task CreateDirectoryAsync(string path)
+        {
+            Directory.CreateDirectory(path);
+            return Task.CompletedTask;
+        }
+        public Task DeleteFileAsync(string path)
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+            return Task.CompletedTask;
+        }
+        public Task DeleteDirectoryAsync(string path)
+        {
+            if (Directory.Exists(path))
+                Directory.Delete(path, recursive: true);
+            return Task.CompletedTask;
+        }
+        public void RevealInFileManager(string path) { }
+    }
+
+    private sealed class TestLogger : ILoggingService
+    {
+        public void LogInformation(string message) { }
+        public void LogWarning(string message) { }
+        public void LogError(string message, Exception? exception = null) { }
+        public void LogDebug(string message) { }
+        public IReadOnlyList<LogEntry> GetRecentLogs(int maxCount = 500) => Array.Empty<LogEntry>();
+        public void ClearLogs() { }
+        public event Action? OnLogAdded;
+    }
 }
 
 /// <summary>

--- a/tests/MauiSherpa.Core.Tests/Services/EncryptedSettingsServiceTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/EncryptedSettingsServiceTests.cs
@@ -287,6 +287,27 @@ public class EncryptedSettingsServiceTests
         File.Exists(settingsPath).Should().BeFalse();
     }
 
+    [Fact]
+    public async Task BeforeIntroEnabled_UsesLegacyEncryptedSettingsOnly()
+    {
+        var settingsPath = Path.Combine(_testDir, "intro-pending-settings.enc");
+        var service = new EncryptedSettingsService(
+            new InMemoryFileSystem(),
+            new InMemorySecureStorage(),
+            new ThrowingLocalVaultStore(),
+            new TestLocalVaultIntroductionService(LocalVaultIntroductionState.NotShown),
+            settingsPath);
+
+        await service.SaveSettingsAsync(new MauiSherpaSettings
+        {
+            Preferences = new AppPreferences { Theme = "Dark" }
+        });
+        var settings = await service.GetSettingsAsync();
+
+        settings.Preferences.Theme.Should().Be("Dark");
+        File.Exists(settingsPath).Should().BeTrue();
+    }
+
     private SqlCipherLocalVaultStore CreateVaultStore()
     {
         return new SqlCipherLocalVaultStore(
@@ -299,6 +320,61 @@ public class EncryptedSettingsServiceTests
     {
         public Task<string> GetOrCreateKeyAsync(CancellationToken cancellationToken = default)
             => Task.FromResult("test-key");
+    }
+
+    private sealed class TestLocalVaultIntroductionService(LocalVaultIntroductionState state) : ILocalVaultIntroductionService
+    {
+        public LocalVaultIntroductionState GetState() => state;
+        public Task MarkEnabledAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task MarkDeclinedAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public event Action? StateChanged
+        {
+            add { }
+            remove { }
+        }
+    }
+
+    private sealed class ThrowingLocalVaultStore : ILocalVaultStore
+    {
+        public string DatabasePath => "throwing";
+
+        public Task<LocalVaultItem> PutAsync(
+            string scope,
+            string path,
+            string key,
+            byte[] value,
+            string contentType,
+            Dictionary<string, string>? metadata = null,
+            CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("Vault should not be used before intro is enabled.");
+
+        public Task<LocalVaultItem?> GetAsync(
+            string scope,
+            string path,
+            string key,
+            CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("Vault should not be used before intro is enabled.");
+
+        public Task<bool> RemoveAsync(
+            string scope,
+            string path,
+            string key,
+            CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("Vault should not be used before intro is enabled.");
+
+        public Task<bool> ExistsAsync(
+            string scope,
+            string path,
+            string key,
+            CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("Vault should not be used before intro is enabled.");
+
+        public Task<IReadOnlyList<LocalVaultItem>> ListAsync(
+            string scope,
+            string? path = null,
+            string? keyPrefix = null,
+            CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("Vault should not be used before intro is enabled.");
     }
 
     private sealed class InMemorySecureStorage : ISecureStorageService

--- a/tests/MauiSherpa.Core.Tests/Services/LocalSqlCipherSecretsProviderTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/LocalSqlCipherSecretsProviderTests.cs
@@ -1,0 +1,171 @@
+using FluentAssertions;
+using System.Text;
+using MauiSherpa.Core.Interfaces;
+using MauiSherpa.Core.Services;
+using Shiny.DocumentDb;
+using Shiny.DocumentDb.Sqlite.SqlCipher;
+
+namespace MauiSherpa.Core.Tests.Services;
+
+public class LocalSqlCipherSecretsProviderTests : IDisposable
+{
+    private readonly string _tempDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+
+    public LocalSqlCipherSecretsProviderTests()
+    {
+        Directory.CreateDirectory(_tempDirectory);
+    }
+
+    [Fact]
+    public async Task StoreGetListAndDelete_RoundTripsSecret()
+    {
+        var provider = CreateProvider();
+        var value = Encoding.UTF8.GetBytes("secret-value");
+
+        var stored = await provider.StoreSecretAsync("sherpa-secrets/api-key", value, new Dictionary<string, string>
+        {
+            ["kind"] = "test"
+        });
+        var exists = await provider.SecretExistsAsync("sherpa-secrets/api-key");
+        var retrieved = await provider.GetSecretAsync("sherpa-secrets/api-key");
+        var listed = await provider.ListSecretsAsync("sherpa-secrets/");
+        var deleted = await provider.DeleteSecretAsync("sherpa-secrets/api-key");
+        var afterDelete = await provider.GetSecretAsync("sherpa-secrets/api-key");
+
+        stored.Should().BeTrue();
+        exists.Should().BeTrue();
+        retrieved.Should().BeEquivalentTo(value);
+        listed.Should().ContainSingle().Which.Should().Be("sherpa-secrets/api-key");
+        deleted.Should().BeTrue();
+        afterDelete.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SameKey_ReopensExistingDatabase()
+    {
+        var keyStore = new TestLocalSecretsKeyStore("same-key");
+        var databasePath = GetDatabasePath();
+        var first = CreateProvider(keyStore, databasePath);
+
+        await first.StoreSecretAsync("key", Encoding.UTF8.GetBytes("value"));
+
+        var second = CreateProvider(keyStore, databasePath);
+        var value = await second.GetSecretAsync("key");
+
+        Encoding.UTF8.GetString(value!).Should().Be("value");
+    }
+
+    [Fact]
+    public async Task KeyStoreFailure_FailsClearly()
+    {
+        var provider = CreateProvider(new FailingLocalSecretsKeyStore(), GetDatabasePath());
+
+        var tested = await provider.TestConnectionAsync();
+        var stored = await provider.StoreSecretAsync("key", Encoding.UTF8.GetBytes("value"));
+
+        tested.Should().BeFalse();
+        stored.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task LegacyLocalSecretsDatabase_IsMigratedIntoSharedVault()
+    {
+        var keyStore = new TestLocalSecretsKeyStore("legacy-key");
+        var legacyDatabasePath = GetDatabasePath();
+        var vaultDatabasePath = GetDatabasePath();
+        var legacyStore = new DocumentStore(new DocumentStoreOptions
+        {
+            DatabaseProvider = new SqlCipherDatabaseProvider(legacyDatabasePath, "legacy-key")
+        });
+        await legacyStore.Insert(new LocalSqlCipherSecretsProvider.LocalSecretDocument
+        {
+            Id = "legacy-id",
+            Key = "sherpa-secrets/api-key",
+            Value = Encoding.UTF8.GetBytes("legacy-value"),
+            Metadata = new Dictionary<string, string> { ["source"] = "legacy" },
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+
+        var vaultStore = new SqlCipherLocalVaultStore(
+            keyStore,
+            new TestLogger(),
+            new LocalVaultOptions(vaultDatabasePath));
+        var config = new CloudSecretsProviderConfig(
+            "local",
+            "Local",
+            CloudSecretsProviderType.Local,
+            new Dictionary<string, string>
+            {
+                [LocalSqlCipherSecretsProvider.DatabasePathSettingKey] = legacyDatabasePath
+            });
+        var provider = new LocalSqlCipherSecretsProvider(config, new TestLogger(), vaultStore, keyStore);
+
+        var retrieved = await provider.GetSecretAsync("sherpa-secrets/api-key");
+        var listed = await provider.ListSecretsAsync("sherpa-secrets/");
+        var migratedItem = await vaultStore.GetAsync(LocalVaultScopes.LocalProviderSecret, "/sherpa-secrets", "api-key");
+
+        Encoding.UTF8.GetString(retrieved!).Should().Be("legacy-value");
+        listed.Should().ContainSingle().Which.Should().Be("sherpa-secrets/api-key");
+        migratedItem.Should().NotBeNull();
+        migratedItem!.Metadata["source"].Should().Be("legacy");
+        File.Exists(legacyDatabasePath).Should().BeFalse();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDirectory))
+            Directory.Delete(_tempDirectory, recursive: true);
+    }
+
+    private LocalSqlCipherSecretsProvider CreateProvider(
+        ILocalSecretsKeyStore? keyStore = null,
+        string? databasePath = null)
+    {
+        var config = new CloudSecretsProviderConfig(
+            "local",
+            "Local",
+            CloudSecretsProviderType.Local,
+            new Dictionary<string, string>
+            {
+                [LocalSqlCipherSecretsProvider.DatabasePathSettingKey] = databasePath ?? GetDatabasePath()
+            });
+
+        return new LocalSqlCipherSecretsProvider(
+            config,
+            new TestLogger(),
+            keyStore ?? new TestLocalSecretsKeyStore("test-key"));
+    }
+
+    private string GetDatabasePath() => Path.Combine(_tempDirectory, $"{Guid.NewGuid():N}.db");
+
+    private sealed class TestLocalSecretsKeyStore : ILocalSecretsKeyStore
+    {
+        private readonly string _key;
+
+        public TestLocalSecretsKeyStore(string key)
+        {
+            _key = key;
+        }
+
+        public Task<string> GetOrCreateKeyAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(_key);
+    }
+
+    private sealed class FailingLocalSecretsKeyStore : ILocalSecretsKeyStore
+    {
+        public Task<string> GetOrCreateKeyAsync(CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("Secure storage unavailable");
+    }
+
+    private sealed class TestLogger : ILoggingService
+    {
+        public void LogInformation(string message) { }
+        public void LogWarning(string message) { }
+        public void LogError(string message, Exception? exception = null) { }
+        public void LogDebug(string message) { }
+        public IReadOnlyList<LogEntry> GetRecentLogs(int maxCount = 500) => Array.Empty<LogEntry>();
+        public void ClearLogs() { }
+        public event Action? OnLogAdded;
+    }
+}

--- a/tests/MauiSherpa.Core.Tests/Services/LocalSqlCipherSecretsProviderTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/LocalSqlCipherSecretsProviderTests.cs
@@ -41,6 +41,36 @@ public class LocalSqlCipherSecretsProviderTests : IDisposable
     }
 
     [Fact]
+    public async Task Metadata_RoundTripsAndUpdatesIndependently()
+    {
+        var provider = CreateProvider();
+        var value = Encoding.UTF8.GetBytes("secret-value");
+
+        await provider.StoreSecretAsync("sherpa-secrets/api-key", value, new Dictionary<string, string>
+        {
+            ["environment/name"] = "prod",
+            ["owner=email"] = "team@example.com"
+        });
+
+        var createdMetadata = await provider.GetSecretMetadataAsync("sherpa-secrets/api-key");
+        var updated = await provider.SetSecretMetadataAsync("sherpa-secrets/api-key", new Dictionary<string, string>
+        {
+            ["environment/name"] = "stage"
+        });
+        var updatedMetadata = await provider.GetSecretMetadataAsync("sherpa-secrets/api-key");
+        var retrieved = await provider.GetSecretAsync("sherpa-secrets/api-key");
+        await provider.StoreSecretAsync("sherpa-secrets/api-key", Encoding.UTF8.GetBytes("new-value"));
+        var preservedMetadata = await provider.GetSecretMetadataAsync("sherpa-secrets/api-key");
+
+        createdMetadata.Should().ContainKey("environment/name").WhoseValue.Should().Be("prod");
+        createdMetadata.Should().ContainKey("owner=email").WhoseValue.Should().Be("team@example.com");
+        updated.Should().BeTrue();
+        updatedMetadata.Should().ContainSingle().Which.Should().Be(new KeyValuePair<string, string>("environment/name", "stage"));
+        retrieved.Should().BeEquivalentTo(value);
+        preservedMetadata.Should().ContainSingle().Which.Should().Be(new KeyValuePair<string, string>("environment/name", "stage"));
+    }
+
+    [Fact]
     public async Task SameKey_ReopensExistingDatabase()
     {
         var keyStore = new TestLocalSecretsKeyStore("same-key");

--- a/tests/MauiSherpa.Core.Tests/Services/ManagedSecretsServiceTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/ManagedSecretsServiceTests.cs
@@ -213,7 +213,14 @@ public class ManagedSecretsServiceTests
     public async Task GetAsync_ReturnsMetadata()
     {
         SetupActiveProvider();
-        var expected = new ManagedSecret("my-key", ManagedSecretType.File, "A file", "data.bin", DateTime.UtcNow, DateTime.UtcNow);
+        var expected = new ManagedSecret(
+            "my-key",
+            ManagedSecretType.File,
+            "A file",
+            "data.bin",
+            DateTime.UtcNow,
+            DateTime.UtcNow,
+            new Dictionary<string, string> { ["environment/name"] = "prod" });
         SetupMetadata("my-key", expected);
 
         var result = await _sut.GetAsync("my-key");
@@ -222,6 +229,7 @@ public class ManagedSecretsServiceTests
         result!.Key.Should().Be("my-key");
         result.Type.Should().Be(ManagedSecretType.File);
         result.OriginalFileName.Should().Be("data.bin");
+        result.Metadata.Should().ContainKey("environment/name").WhoseValue.Should().Be("prod");
     }
 
     [Fact]
@@ -242,6 +250,11 @@ public class ManagedSecretsServiceTests
     {
         SetupActiveProvider();
         var value = Encoding.UTF8.GetBytes("test-value");
+        var metadata = new Dictionary<string, string>
+        {
+            ["environment/name"] = "prod",
+            ["owner=email"] = "team@example.com"
+        };
 
         _cloudService.Setup(x => x.StoreSecretAsync("sherpa-secrets/new-key", value, null, It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
@@ -250,13 +263,17 @@ public class ManagedSecretsServiceTests
                 It.IsAny<byte[]>(), null, It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
-        var result = await _sut.CreateAsync("new-key", value, ManagedSecretType.String, "A test secret");
+        var result = await _sut.CreateAsync("new-key", value, ManagedSecretType.String, "A test secret", metadata: metadata);
 
         result.Should().BeTrue();
         _cloudService.Verify(x => x.StoreSecretAsync("sherpa-secrets/new-key", value, null, It.IsAny<CancellationToken>()), Times.Once);
         _cloudService.Verify(x => x.StoreSecretAsync(
             "sherpa-secrets-meta/new-key",
-            It.IsAny<byte[]>(), null, It.IsAny<CancellationToken>()), Times.Once);
+            It.Is<byte[]>(b =>
+                Encoding.UTF8.GetString(b).Contains("\"environment/name\":\"prod\"") &&
+                Encoding.UTF8.GetString(b).Contains("\"owner=email\":\"team@example.com\"")),
+            null,
+            It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]

--- a/tests/MauiSherpa.Core.Tests/Services/ManagedSecretsServiceTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/ManagedSecretsServiceTests.cs
@@ -67,6 +67,149 @@ public class ManagedSecretsServiceTests
     }
 
     [Fact]
+    public async Task ListFoldersAsync_WithFolders_ReturnsManagedSecretFolders()
+    {
+        SetupActiveProvider();
+        var folderKeys = new List<string> { "sherpa-secret-folders/team", "sherpa-secret-folders/team/mobile" };
+        _cloudService.Setup(x => x.ListSecretsAsync("sherpa-secret-folders/", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(folderKeys);
+
+        SetupFolderByFullKey("sherpa-secret-folders/team", new ManagedSecretFolder("/team", "team", DateTime.UtcNow));
+        SetupFolderByFullKey("sherpa-secret-folders/team/mobile", new ManagedSecretFolder("/team/mobile", "mobile", DateTime.UtcNow));
+
+        var result = await _sut.ListFoldersAsync();
+
+        result.Should().HaveCount(2);
+        result.Select(f => f.Path).Should().Equal("/team", "/team/mobile");
+    }
+
+    [Fact]
+    public async Task CreateFolderAsync_StoresFolderMetadata()
+    {
+        SetupActiveProvider();
+        _cloudService.Setup(x => x.StoreSecretAsync(
+                "sherpa-secrets/team/mobile/sherpa-folder-marker",
+                It.IsAny<byte[]>(),
+                It.IsAny<Dictionary<string, string>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _cloudService.Setup(x => x.StoreSecretAsync(
+                "sherpa-secret-folders/team/mobile",
+                It.IsAny<byte[]>(),
+                null,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var result = await _sut.CreateFolderAsync("/team/mobile");
+
+        result.Should().BeTrue();
+        _cloudService.Verify(x => x.StoreSecretAsync(
+            "sherpa-secrets/team/mobile/sherpa-folder-marker",
+            It.IsAny<byte[]>(),
+            It.Is<Dictionary<string, string>>(m => m["SherpaKind"] == "FolderPlaceholder" && m["FolderPath"] == "/team/mobile"),
+            It.IsAny<CancellationToken>()), Times.Once);
+        _cloudService.Verify(x => x.StoreSecretAsync(
+            "sherpa-secret-folders/team/mobile",
+            It.Is<byte[]>(b => Encoding.UTF8.GetString(b).Contains("\"path\":\"/team/mobile\"")),
+            null,
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateFolderAsync_Root_Throws()
+    {
+        SetupActiveProvider();
+
+        var act = () => _sut.CreateFolderAsync("/");
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task RenameFolderAsync_MovesSecretsAndChildFolders()
+    {
+        SetupActiveProvider();
+        var created = DateTime.UtcNow.AddDays(-1);
+        var api = new ManagedSecret("team/api-key", ManagedSecretType.String, "API Key", null, created, created);
+        var token = new ManagedSecret("team/mobile/token", ManagedSecretType.String, "Token", null, created, created);
+
+        SetupSecretMetadataList(api, token);
+        SetupSecretValue("team/api-key", "api-value");
+        SetupSecretValue("team/mobile/token", "token-value");
+        SetupFolderList(
+            new ManagedSecretFolder("/team", "team", created),
+            new ManagedSecretFolder("/team/mobile", "mobile", created));
+        _cloudService.Setup(x => x.StoreSecretAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<Dictionary<string, string>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _cloudService.Setup(x => x.DeleteSecretAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var result = await _sut.RenameFolderAsync("/team", "/project");
+
+        result.Should().BeTrue();
+        _cloudService.Verify(x => x.StoreSecretAsync("sherpa-secrets/project/api-key", It.IsAny<byte[]>(), null, It.IsAny<CancellationToken>()), Times.Once);
+        _cloudService.Verify(x => x.StoreSecretAsync("sherpa-secrets/project/mobile/token", It.IsAny<byte[]>(), null, It.IsAny<CancellationToken>()), Times.Once);
+        _cloudService.Verify(x => x.StoreSecretAsync("sherpa-secrets-meta/project/api-key", It.IsAny<byte[]>(), null, It.IsAny<CancellationToken>()), Times.Once);
+        _cloudService.Verify(x => x.StoreSecretAsync("sherpa-secrets-meta/project/mobile/token", It.IsAny<byte[]>(), null, It.IsAny<CancellationToken>()), Times.Once);
+        _cloudService.Verify(x => x.StoreSecretAsync("sherpa-secret-folders/project", It.IsAny<byte[]>(), null, It.IsAny<CancellationToken>()), Times.Once);
+        _cloudService.Verify(x => x.StoreSecretAsync("sherpa-secret-folders/project/mobile", It.IsAny<byte[]>(), null, It.IsAny<CancellationToken>()), Times.Once);
+        _cloudService.Verify(x => x.StoreSecretAsync("sherpa-secrets/project/sherpa-folder-marker", It.IsAny<byte[]>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()), Times.Once);
+        _cloudService.Verify(x => x.StoreSecretAsync("sherpa-secrets/project/mobile/sherpa-folder-marker", It.IsAny<byte[]>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()), Times.Once);
+        _cloudService.Verify(x => x.DeleteSecretAsync("sherpa-secrets/team/api-key", It.IsAny<CancellationToken>()), Times.Once);
+        _cloudService.Verify(x => x.DeleteSecretAsync("sherpa-secrets-meta/team/api-key", It.IsAny<CancellationToken>()), Times.Once);
+        _cloudService.Verify(x => x.DeleteSecretAsync("sherpa-secret-folders/team", It.IsAny<CancellationToken>()), Times.Once);
+        _cloudService.Verify(x => x.DeleteSecretAsync("sherpa-secret-folders/team/mobile", It.IsAny<CancellationToken>()), Times.Once);
+        _cloudService.Verify(x => x.DeleteSecretAsync("sherpa-secrets/team/sherpa-folder-marker", It.IsAny<CancellationToken>()), Times.Once);
+        _cloudService.Verify(x => x.DeleteSecretAsync("sherpa-secrets/team/mobile/sherpa-folder-marker", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task RenameFolderAsync_ExistingTargetSecret_ReturnsFalse()
+    {
+        SetupActiveProvider();
+        var created = DateTime.UtcNow;
+        SetupSecretMetadataList(
+            new ManagedSecret("team/api-key", ManagedSecretType.String, "API Key", null, created, created),
+            new ManagedSecret("project/api-key", ManagedSecretType.String, "Existing", null, created, created));
+
+        var result = await _sut.RenameFolderAsync("/team", "/project");
+
+        result.Should().BeFalse();
+        _cloudService.Verify(x => x.StoreSecretAsync(It.IsAny<string>(), It.IsAny<byte[]>(), null, It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task DeleteFolderAsync_EmptyFolder_DeletesFolderMetadata()
+    {
+        SetupActiveProvider();
+        SetupSecretMetadataList();
+        SetupFolderList(new ManagedSecretFolder("/team", "team", DateTime.UtcNow));
+        _cloudService.Setup(x => x.DeleteSecretAsync("sherpa-secret-folders/team", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _cloudService.Setup(x => x.DeleteSecretAsync("sherpa-secrets/team/sherpa-folder-marker", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var result = await _sut.DeleteFolderAsync("/team");
+
+        result.Should().BeTrue();
+        _cloudService.Verify(x => x.DeleteSecretAsync("sherpa-secret-folders/team", It.IsAny<CancellationToken>()), Times.Once);
+        _cloudService.Verify(x => x.DeleteSecretAsync("sherpa-secrets/team/sherpa-folder-marker", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteFolderAsync_WithSecrets_ReturnsFalse()
+    {
+        SetupActiveProvider();
+        var created = DateTime.UtcNow;
+        SetupSecretMetadataList(new ManagedSecret("team/api-key", ManagedSecretType.String, "API Key", null, created, created));
+
+        var result = await _sut.DeleteFolderAsync("/team");
+
+        result.Should().BeFalse();
+        _cloudService.Verify(x => x.DeleteSecretAsync("sherpa-secret-folders/team", It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
     public async Task GetAsync_ReturnsMetadata()
     {
         SetupActiveProvider();
@@ -169,6 +312,75 @@ public class ManagedSecretsServiceTests
     }
 
     [Fact]
+    public async Task MoveAsync_CopiesSecretAndMetadataThenDeletesOriginal()
+    {
+        SetupActiveProvider();
+        var created = DateTime.UtcNow.AddDays(-1);
+        var existing = new ManagedSecret("team/api-key", ManagedSecretType.String, "Old desc", null, created, created);
+        SetupMetadata("team/api-key", existing);
+        SetupMetadata("project/api-key", null);
+        SetupSecretValue("team/api-key", "secret-value");
+        _cloudService.Setup(x => x.SecretExistsAsync("sherpa-secrets/project/api-key", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _cloudService.Setup(x => x.StoreSecretAsync("sherpa-secrets/project/api-key", It.IsAny<byte[]>(), null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _cloudService.Setup(x => x.StoreSecretAsync("sherpa-secrets-meta/project/api-key", It.IsAny<byte[]>(), null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _cloudService.Setup(x => x.DeleteSecretAsync("sherpa-secrets/team/api-key", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _cloudService.Setup(x => x.DeleteSecretAsync("sherpa-secrets-meta/team/api-key", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var result = await _sut.MoveAsync("team/api-key", "project/api-key", description: "New desc");
+
+        result.Should().BeTrue();
+        _cloudService.Verify(x => x.StoreSecretAsync(
+            "sherpa-secrets/project/api-key",
+            It.Is<byte[]>(b => b.SequenceEqual(Encoding.UTF8.GetBytes("secret-value"))),
+            null,
+            It.IsAny<CancellationToken>()), Times.Once);
+        _cloudService.Verify(x => x.StoreSecretAsync(
+            "sherpa-secrets-meta/project/api-key",
+            It.Is<byte[]>(b => Encoding.UTF8.GetString(b).Contains("\"key\":\"project/api-key\"") && Encoding.UTF8.GetString(b).Contains("\"description\":\"New desc\"")),
+            null,
+            It.IsAny<CancellationToken>()), Times.Once);
+        _cloudService.Verify(x => x.DeleteSecretAsync("sherpa-secrets/team/api-key", It.IsAny<CancellationToken>()), Times.Once);
+        _cloudService.Verify(x => x.DeleteSecretAsync("sherpa-secrets-meta/team/api-key", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task MoveAsync_TargetExists_ReturnsFalse()
+    {
+        SetupActiveProvider();
+        var created = DateTime.UtcNow;
+        SetupMetadata("team/api-key", new ManagedSecret("team/api-key", ManagedSecretType.String, "API Key", null, created, created));
+        SetupMetadata("project/api-key", new ManagedSecret("project/api-key", ManagedSecretType.String, "Existing", null, created, created));
+
+        var result = await _sut.MoveAsync("team/api-key", "project/api-key");
+
+        result.Should().BeFalse();
+        _cloudService.Verify(x => x.StoreSecretAsync("sherpa-secrets/project/api-key", It.IsAny<byte[]>(), null, It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task MoveAsync_SameKey_UpdatesSecret()
+    {
+        SetupActiveProvider();
+        var created = DateTime.UtcNow;
+        SetupMetadata("team/api-key", new ManagedSecret("team/api-key", ManagedSecretType.String, "Old desc", null, created, created));
+        var newValue = Encoding.UTF8.GetBytes("new-value");
+        _cloudService.Setup(x => x.StoreSecretAsync("sherpa-secrets/team/api-key", newValue, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _cloudService.Setup(x => x.StoreSecretAsync("sherpa-secrets-meta/team/api-key", It.IsAny<byte[]>(), null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var result = await _sut.MoveAsync("team/api-key", "team/api-key", newValue, "New desc");
+
+        result.Should().BeTrue();
+        _cloudService.Verify(x => x.DeleteSecretAsync("sherpa-secrets/team/api-key", It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
     public async Task DeleteAsync_DeletesValueAndMetadata()
     {
         SetupActiveProvider();
@@ -211,17 +423,57 @@ public class ManagedSecretsServiceTests
         _cloudService.Setup(x => x.ActiveProvider).Returns(provider);
     }
 
-    void SetupMetadata(string key, ManagedSecret meta)
+    void SetupMetadata(string key, ManagedSecret? meta)
     {
-        var json = JsonSerializer.Serialize(meta, JsonOptions);
-        var bytes = Encoding.UTF8.GetBytes(json);
-        _cloudService.Setup(x => x.GetSecretAsync($"sherpa-secrets-meta/{key}", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(bytes);
+        if (meta is null)
+        {
+            _cloudService.Setup(x => x.GetSecretAsync($"sherpa-secrets-meta/{key}", It.IsAny<CancellationToken>()))
+                .ReturnsAsync((byte[]?)null);
+        }
+        else
+        {
+            var json = JsonSerializer.Serialize(meta, JsonOptions);
+            var bytes = Encoding.UTF8.GetBytes(json);
+            _cloudService.Setup(x => x.GetSecretAsync($"sherpa-secrets-meta/{key}", It.IsAny<CancellationToken>()))
+                .ReturnsAsync(bytes);
+        }
     }
 
     void SetupMetadataByFullKey(string fullKey, ManagedSecret meta)
     {
         var json = JsonSerializer.Serialize(meta, JsonOptions);
+        var bytes = Encoding.UTF8.GetBytes(json);
+        _cloudService.Setup(x => x.GetSecretAsync(fullKey, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(bytes);
+    }
+
+    void SetupSecretMetadataList(params ManagedSecret[] secrets)
+    {
+        var keys = secrets.Select(secret => $"sherpa-secrets-meta/{secret.Key}").ToList();
+        _cloudService.Setup(x => x.ListSecretsAsync("sherpa-secrets-meta/", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(keys);
+        foreach (var secret in secrets)
+            SetupMetadataByFullKey($"sherpa-secrets-meta/{secret.Key}", secret);
+    }
+
+    void SetupSecretValue(string key, string value)
+    {
+        _cloudService.Setup(x => x.GetSecretAsync($"sherpa-secrets/{key}", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Encoding.UTF8.GetBytes(value));
+    }
+
+    void SetupFolderList(params ManagedSecretFolder[] folders)
+    {
+        var keys = folders.Select(folder => $"sherpa-secret-folders/{folder.Path.TrimStart('/')}").ToList();
+        _cloudService.Setup(x => x.ListSecretsAsync("sherpa-secret-folders/", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(keys);
+        foreach (var folder in folders)
+            SetupFolderByFullKey($"sherpa-secret-folders/{folder.Path.TrimStart('/')}", folder);
+    }
+
+    void SetupFolderByFullKey(string fullKey, ManagedSecretFolder folder)
+    {
+        var json = JsonSerializer.Serialize(folder, JsonOptions);
         var bytes = Encoding.UTF8.GetBytes(json);
         _cloudService.Setup(x => x.GetSecretAsync(fullKey, It.IsAny<CancellationToken>()))
             .ReturnsAsync(bytes);

--- a/tests/MauiSherpa.Core.Tests/Services/SecretPathTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/SecretPathTests.cs
@@ -1,0 +1,48 @@
+using FluentAssertions;
+using MauiSherpa.Core.Services;
+
+namespace MauiSherpa.Core.Tests.Services;
+
+public class SecretPathTests
+{
+    [Theory]
+    [InlineData(null, "/")]
+    [InlineData("", "/")]
+    [InlineData("managed", "/managed")]
+    [InlineData("/managed/", "/managed")]
+    [InlineData("\\managed\\certificates", "/managed/certificates")]
+    public void NormalizeFolderPath_NormalizesSupportedFolders(string? input, string expected)
+    {
+        SecretPath.NormalizeFolderPath(input).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("/managed//certificates")]
+    [InlineData("/managed/../certificates")]
+    [InlineData("/managed/./certificates")]
+    public void NormalizeFolderPath_RejectsAmbiguousFolders(string input)
+    {
+        var act = () => SecretPath.NormalizeFolderPath(input);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void FromFlatKey_SplitsOnLastSeparator()
+    {
+        var path = SecretPath.FromFlatKey("sherpa-secrets/api-key");
+
+        path.FolderPath.Should().Be("/sherpa-secrets");
+        path.Key.Should().Be("api-key");
+        path.ToFlatKey().Should().Be("sherpa-secrets/api-key");
+    }
+
+    [Fact]
+    public void CreateId_UsesNormalizedPath()
+    {
+        var left = LocalVaultItem.CreateId("LOCAL-PROVIDER-SECRET", "managed", "api-key");
+        var right = LocalVaultItem.CreateId("local-provider-secret", "/managed/", "api-key");
+
+        left.Should().Be(right);
+    }
+}

--- a/tests/MauiSherpa.Core.Tests/Services/SqlCipherLocalVaultStoreTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/SqlCipherLocalVaultStoreTests.cs
@@ -1,0 +1,100 @@
+using System.Text;
+using FluentAssertions;
+using MauiSherpa.Core.Interfaces;
+using MauiSherpa.Core.Services;
+
+namespace MauiSherpa.Core.Tests.Services;
+
+public class SqlCipherLocalVaultStoreTests : IDisposable
+{
+    private readonly string _tempDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+
+    public SqlCipherLocalVaultStoreTests()
+    {
+        Directory.CreateDirectory(_tempDirectory);
+    }
+
+    [Fact]
+    public async Task PutGetListRemove_RoundTripsVaultItem()
+    {
+        var store = CreateStore();
+        var value = Encoding.UTF8.GetBytes("secret-value");
+
+        var saved = await store.PutAsync(
+            LocalVaultScopes.LocalProviderSecret,
+            "/managed",
+            "api-key",
+            value,
+            LocalVaultContentTypes.Binary,
+            new Dictionary<string, string> { ["kind"] = "test" });
+
+        var loaded = await store.GetAsync(LocalVaultScopes.LocalProviderSecret, "managed", "api-key");
+        var listed = await store.ListAsync(LocalVaultScopes.LocalProviderSecret, "/managed");
+        var exists = await store.ExistsAsync(LocalVaultScopes.LocalProviderSecret, "/managed", "api-key");
+        var removed = await store.RemoveAsync(LocalVaultScopes.LocalProviderSecret, "/managed", "api-key");
+        var afterRemove = await store.GetAsync(LocalVaultScopes.LocalProviderSecret, "/managed", "api-key");
+
+        saved.Id.Should().Be(LocalVaultItem.CreateId(LocalVaultScopes.LocalProviderSecret, "/managed", "api-key"));
+        loaded.Should().NotBeNull();
+        loaded!.Value.Should().BeEquivalentTo(value);
+        loaded.Metadata["kind"].Should().Be("test");
+        listed.Should().ContainSingle(x => x.Key == "api-key");
+        exists.Should().BeTrue();
+        removed.Should().BeTrue();
+        afterRemove.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task PutAsync_SamePathAndKeyDifferentScopes_DoNotCollide()
+    {
+        var store = CreateStore();
+
+        await store.PutAsync(LocalVaultScopes.Settings, "/", "shared", Encoding.UTF8.GetBytes("settings"), LocalVaultContentTypes.Text);
+        await store.PutAsync(LocalVaultScopes.SecureStorage, "/", "shared", Encoding.UTF8.GetBytes("secure"), LocalVaultContentTypes.Text);
+
+        var settings = await store.GetAsync(LocalVaultScopes.Settings, "/", "shared");
+        var secure = await store.GetAsync(LocalVaultScopes.SecureStorage, "/", "shared");
+
+        Encoding.UTF8.GetString(settings!.Value).Should().Be("settings");
+        Encoding.UTF8.GetString(secure!.Value).Should().Be("secure");
+        settings.Id.Should().NotBe(secure.Id);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDirectory))
+            Directory.Delete(_tempDirectory, recursive: true);
+    }
+
+    private SqlCipherLocalVaultStore CreateStore(string key = "test-key")
+    {
+        return new SqlCipherLocalVaultStore(
+            new TestLocalVaultKeyStore(key),
+            new TestLogger(),
+            new LocalVaultOptions(Path.Combine(_tempDirectory, $"{Guid.NewGuid():N}.db")));
+    }
+
+    private sealed class TestLocalVaultKeyStore : ILocalVaultKeyStore
+    {
+        private readonly string _key;
+
+        public TestLocalVaultKeyStore(string key)
+        {
+            _key = key;
+        }
+
+        public Task<string> GetOrCreateKeyAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(_key);
+    }
+
+    private sealed class TestLogger : ILoggingService
+    {
+        public void LogInformation(string message) { }
+        public void LogWarning(string message) { }
+        public void LogError(string message, Exception? exception = null) { }
+        public void LogDebug(string message) { }
+        public IReadOnlyList<LogEntry> GetRecentLogs(int maxCount = 500) => Array.Empty<LogEntry>();
+        public void ClearLogs() { }
+        public event Action? OnLogAdded;
+    }
+}

--- a/tests/MauiSherpa.Core.Tests/Services/VaultSecureStorageServiceTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/VaultSecureStorageServiceTests.cs
@@ -56,6 +56,26 @@ public class VaultSecureStorageServiceTests : IDisposable
         legacy.Values.Should().NotContainKey("api-key");
     }
 
+    [Fact]
+    public async Task BeforeIntroEnabled_UsesLegacySecureStorageOnly()
+    {
+        var legacy = new InMemoryLegacySecureStorage();
+        await legacy.SetAsync("api-key", "legacy-value");
+        var service = new VaultSecureStorageService(
+            new ThrowingLocalVaultStore(),
+            legacy,
+            new TestLogger(),
+            new TestLocalVaultIntroductionService(LocalVaultIntroductionState.NotShown));
+
+        var value = await service.GetAsync("api-key");
+        await service.SetAsync("new-key", "new-value");
+        await service.RemoveAsync("api-key");
+
+        value.Should().Be("legacy-value");
+        legacy.Values.Should().NotContainKey("api-key");
+        legacy.Values["new-key"].Should().Be("new-value");
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(_tempDirectory))
@@ -96,6 +116,61 @@ public class VaultSecureStorageServiceTests : IDisposable
     {
         public Task<string> GetOrCreateKeyAsync(CancellationToken cancellationToken = default)
             => Task.FromResult("test-key");
+    }
+
+    private sealed class TestLocalVaultIntroductionService(LocalVaultIntroductionState state) : ILocalVaultIntroductionService
+    {
+        public LocalVaultIntroductionState GetState() => state;
+        public Task MarkEnabledAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task MarkDeclinedAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public event Action? StateChanged
+        {
+            add { }
+            remove { }
+        }
+    }
+
+    private sealed class ThrowingLocalVaultStore : ILocalVaultStore
+    {
+        public string DatabasePath => "throwing";
+
+        public Task<LocalVaultItem> PutAsync(
+            string scope,
+            string path,
+            string key,
+            byte[] value,
+            string contentType,
+            Dictionary<string, string>? metadata = null,
+            CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("Vault should not be used before intro is enabled.");
+
+        public Task<LocalVaultItem?> GetAsync(
+            string scope,
+            string path,
+            string key,
+            CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("Vault should not be used before intro is enabled.");
+
+        public Task<bool> RemoveAsync(
+            string scope,
+            string path,
+            string key,
+            CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("Vault should not be used before intro is enabled.");
+
+        public Task<bool> ExistsAsync(
+            string scope,
+            string path,
+            string key,
+            CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("Vault should not be used before intro is enabled.");
+
+        public Task<IReadOnlyList<LocalVaultItem>> ListAsync(
+            string scope,
+            string? path = null,
+            string? keyPrefix = null,
+            CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("Vault should not be used before intro is enabled.");
     }
 
     private sealed class TestLogger : ILoggingService

--- a/tests/MauiSherpa.Core.Tests/Services/VaultSecureStorageServiceTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/VaultSecureStorageServiceTests.cs
@@ -1,0 +1,111 @@
+using FluentAssertions;
+using MauiSherpa.Core.Interfaces;
+using MauiSherpa.Core.Services;
+
+namespace MauiSherpa.Core.Tests.Services;
+
+public class VaultSecureStorageServiceTests : IDisposable
+{
+    private readonly string _tempDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+
+    public VaultSecureStorageServiceTests()
+    {
+        Directory.CreateDirectory(_tempDirectory);
+    }
+
+    [Fact]
+    public async Task GetAsync_MigratesLegacyValueIntoVaultAndRemovesLegacyCopy()
+    {
+        var legacy = new InMemoryLegacySecureStorage();
+        await legacy.SetAsync("cloud/provider:secret", "secret-value");
+        var service = CreateService(legacy);
+
+        var value = await service.GetAsync("cloud/provider:secret");
+        var secondRead = await service.GetAsync("cloud/provider:secret");
+
+        value.Should().Be("secret-value");
+        secondRead.Should().Be("secret-value");
+        legacy.Values.Should().NotContainKey("cloud/provider:secret");
+    }
+
+    [Fact]
+    public async Task SetAsync_WritesVaultAndRemovesLegacyCopy()
+    {
+        var legacy = new InMemoryLegacySecureStorage();
+        await legacy.SetAsync("api-key", "old-value");
+        var service = CreateService(legacy);
+
+        await service.SetAsync("api-key", "new-value");
+        var value = await service.GetAsync("api-key");
+
+        value.Should().Be("new-value");
+        legacy.Values.Should().NotContainKey("api-key");
+    }
+
+    [Fact]
+    public async Task RemoveAsync_RemovesVaultAndLegacyValues()
+    {
+        var legacy = new InMemoryLegacySecureStorage();
+        await legacy.SetAsync("api-key", "old-value");
+        var service = CreateService(legacy);
+        await service.SetAsync("api-key", "new-value");
+
+        await service.RemoveAsync("api-key");
+
+        (await service.GetAsync("api-key")).Should().BeNull();
+        legacy.Values.Should().NotContainKey("api-key");
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDirectory))
+            Directory.Delete(_tempDirectory, recursive: true);
+    }
+
+    private VaultSecureStorageService CreateService(InMemoryLegacySecureStorage legacy)
+    {
+        var vaultStore = new SqlCipherLocalVaultStore(
+            new TestLocalVaultKeyStore(),
+            new TestLogger(),
+            new LocalVaultOptions(Path.Combine(_tempDirectory, $"{Guid.NewGuid():N}.db")));
+
+        return new VaultSecureStorageService(vaultStore, legacy, new TestLogger());
+    }
+
+    private sealed class InMemoryLegacySecureStorage : ILegacySecureStorageService
+    {
+        public Dictionary<string, string> Values { get; } = new();
+
+        public Task<string?> GetAsync(string key)
+            => Task.FromResult(Values.TryGetValue(key, out var value) ? value : null);
+
+        public Task SetAsync(string key, string value)
+        {
+            Values[key] = value;
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveAsync(string key)
+        {
+            Values.Remove(key);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class TestLocalVaultKeyStore : ILocalVaultKeyStore
+    {
+        public Task<string> GetOrCreateKeyAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult("test-key");
+    }
+
+    private sealed class TestLogger : ILoggingService
+    {
+        public void LogInformation(string message) { }
+        public void LogWarning(string message) { }
+        public void LogError(string message, Exception? exception = null) { }
+        public void LogDebug(string message) { }
+        public IReadOnlyList<LogEntry> GetRecentLogs(int maxCount = 500) => Array.Empty<LogEntry>();
+        public void ClearLogs() { }
+        public event Action? OnLogAdded;
+    }
+}


### PR DESCRIPTION
## Summary
- Add a SQLCipher-backed local vault and always-available Local secrets provider
- Centralize secure storage/settings/provider metadata through vault-backed adapters with migration cleanup
- Add hierarchical managed-secret folders, folder-aware create/edit flows, and macOS native toolbar provider/actions UX
- Document the secrets storage architecture and root-key strategy

## Validation
- `/usr/local/bin/dotnet test tests/MauiSherpa.Core.Tests/MauiSherpa.Core.Tests.csproj --verbosity minimal`
- `/usr/local/bin/dotnet build src/MauiSherpa.MacOS/MauiSherpa.MacOS.csproj -f net10.0-macos --verbosity minimal`
- `git diff --check`