### PR TITLE
Fix default local secrets provider

### DIFF
--- a/docs/secrets-storage.md
+++ b/docs/secrets-storage.md
@@ -8,7 +8,7 @@ MAUI Sherpa stores credentials, signing material, provider configuration, and ap
 | --- | --- | --- | --- |
 | SQLCipher root key | `ILocalVaultKeyStore`, `LocalSecretsKeyStore` | Local vault encryption key | OS secure storage entry `MAUI Sherpa Local Vault`. This is the only long-term OS secure-storage dependency for migrated app-owned data. |
 | Central local vault | `ILocalVaultStore`, `SqlCipherLocalVaultStore` | Generic app-owned secrets, metadata, settings, and provider data | Shiny DocumentDB over SQLCipher in `local-vault.db`. Records use a generic scope/path/key envelope. |
-| Local secrets provider | `LocalSqlCipherSecretsProvider` | Managed secrets, local copies of synced certs/keystores, publish profile payloads | Built-in provider and logical provider view over the central local vault under `local-provider-secret`. It is offered as the default provider unless the user declines the Local Vault introduction. Existing flat keys are preserved in metadata for compatibility. |
+| Local secrets provider | `LocalSqlCipherSecretsProvider` | Managed secrets, local copies of synced certs/keystores, publish profile payloads | Built-in provider and logical provider view over the central local vault under `local-provider-secret`. It is always offered as the local default provider. Existing flat keys are preserved in metadata for compatibility. |
 | Legacy Local provider DB | first-pass `local-secrets.db` | Local-provider secret values | Lazily migrated into the central vault on Local provider use, then deleted after successful verification/write. |
 | Secure-storage compatibility | `VaultSecureStorageService` | Existing app-owned key/value secrets | Reads/writes the central vault under `secure`. On first read, legacy OS/fallback secure-storage values are copied into the vault and removed from the old store. |
 | Encrypted settings | `EncryptedSettingsService` | Settings snapshots that may include sensitive config | Vault-backed settings document under `settings`. Existing `settings.enc`, `.bak`, `.unreadable`, and `MauiSherpa_MasterKey` are removed after successful migration. |
@@ -62,13 +62,13 @@ The app offers and can select the built-in Local provider before the user answer
 
 - `NotSet`: the current introduction has not been answered. The app shows the introduction on startup, offers Local as the default secrets provider, and keeps non-provider compatibility adapters on legacy storage.
 - `Enabled`: the user approved Local Vault. Sherpa may request OS secure-storage access for the root key, create the built-in Local provider, migrate legacy local values into the vault, and make Local the default provider when requested.
-- `Declined`: the user chose not to use Local Vault for now. Sherpa does not show the introduction repeatedly, hides Local from provider lists, and chooses a remote provider as the implicit default if one exists.
+- `Declined`: the user chose not to use Local Vault for now. Sherpa does not show the introduction repeatedly, keeps Local visible, and chooses a remote provider as the implicit default if one exists.
 
 While the decision is `NotSet` or `Declined`, compatibility adapters intentionally stay on legacy storage:
 
 - `VaultSecureStorageService` reads and writes the legacy `ILegacySecureStorageService` instead of touching `ILocalVaultStore`.
 - `EncryptedSettingsService` reads and writes `settings.enc` instead of opening the vault.
-- `CloudSecretsService` stores provider metadata/settings in the legacy JSON files until Local Vault is enabled. It still surfaces Local while the decision is `NotSet`, but hides Local after a decline.
+- `CloudSecretsService` stores provider metadata/settings in the legacy JSON files until Local Vault is enabled. It still surfaces Local while the decision is `NotSet` or `Declined`; declined only prevents Local from being preferred over an available remote provider.
 
 The startup flow shows the Local Vault introduction before update prompts, and the modal's enable action calls `ILocalVaultAccessService.RequestAccessAsync()` before marking Local Vault as enabled. If the OS secure-storage prompt is denied or unavailable, Sherpa leaves the decision unset so the user can retry or decline without leaving a half-enabled Local provider.
 

--- a/docs/secrets-storage.md
+++ b/docs/secrets-storage.md
@@ -8,7 +8,7 @@ MAUI Sherpa stores credentials, signing material, provider configuration, and ap
 | --- | --- | --- | --- |
 | SQLCipher root key | `ILocalVaultKeyStore`, `LocalSecretsKeyStore` | Local vault encryption key | OS secure storage entry `MAUI Sherpa Local Vault`. This is the only long-term OS secure-storage dependency for migrated app-owned data. |
 | Central local vault | `ILocalVaultStore`, `SqlCipherLocalVaultStore` | Generic app-owned secrets, metadata, settings, and provider data | Shiny DocumentDB over SQLCipher in `local-vault.db`. Records use a generic scope/path/key envelope. |
-| Local secrets provider | `LocalSqlCipherSecretsProvider` | Managed secrets, local copies of synced certs/keystores, publish profile payloads | Built-in provider and logical provider view over the central local vault under `local-provider-secret`. It is created and offered as a default only after the user opts in to the Local Vault introduction. Existing flat keys are preserved in metadata for compatibility. |
+| Local secrets provider | `LocalSqlCipherSecretsProvider` | Managed secrets, local copies of synced certs/keystores, publish profile payloads | Built-in provider and logical provider view over the central local vault under `local-provider-secret`. It is offered as the default provider unless the user declines the Local Vault introduction. Existing flat keys are preserved in metadata for compatibility. |
 | Legacy Local provider DB | first-pass `local-secrets.db` | Local-provider secret values | Lazily migrated into the central vault on Local provider use, then deleted after successful verification/write. |
 | Secure-storage compatibility | `VaultSecureStorageService` | Existing app-owned key/value secrets | Reads/writes the central vault under `secure`. On first read, legacy OS/fallback secure-storage values are copied into the vault and removed from the old store. |
 | Encrypted settings | `EncryptedSettingsService` | Settings snapshots that may include sensitive config | Vault-backed settings document under `settings`. Existing `settings.enc`, `.bak`, `.unreadable`, and `MauiSherpa_MasterKey` are removed after successful migration. |
@@ -58,17 +58,17 @@ flowchart LR
 
 ## First-run Local Vault introduction
 
-The app does not create or activate the Local provider until the user has seen the Local Vault introduction and explicitly enables it. `ILocalVaultIntroductionService` persists the current introduction version and decision in preferences:
+The app offers and can select the built-in Local provider before the user answers the Local Vault introduction, but compatibility migrations and vault-backed app settings wait until the user explicitly enables Local Vault. `ILocalVaultIntroductionService` persists the current introduction version and decision in preferences:
 
-- `NotSet`: the current introduction has not been answered. The app shows the introduction on startup and treats Local Vault as disabled.
+- `NotSet`: the current introduction has not been answered. The app shows the introduction on startup, offers Local as the default secrets provider, and keeps non-provider compatibility adapters on legacy storage.
 - `Enabled`: the user approved Local Vault. Sherpa may request OS secure-storage access for the root key, create the built-in Local provider, migrate legacy local values into the vault, and make Local the default provider when requested.
-- `Declined`: the user chose not to use Local Vault for now. Sherpa does not show the introduction repeatedly and does not auto-create or auto-select Local.
+- `Declined`: the user chose not to use Local Vault for now. Sherpa does not show the introduction repeatedly, hides Local from provider lists, and chooses a remote provider as the implicit default if one exists.
 
 While the decision is `NotSet` or `Declined`, compatibility adapters intentionally stay on legacy storage:
 
 - `VaultSecureStorageService` reads and writes the legacy `ILegacySecureStorageService` instead of touching `ILocalVaultStore`.
 - `EncryptedSettingsService` reads and writes `settings.enc` instead of opening the vault.
-- `CloudSecretsService` stores provider metadata/settings in the legacy JSON files, hides Local from provider lists, and chooses a remote provider as the implicit default if one exists.
+- `CloudSecretsService` stores provider metadata/settings in the legacy JSON files until Local Vault is enabled. It still surfaces Local while the decision is `NotSet`, but hides Local after a decline.
 
 The startup flow shows the Local Vault introduction before update prompts, and the modal's enable action calls `ILocalVaultAccessService.RequestAccessAsync()` before marking Local Vault as enabled. If the OS secure-storage prompt is denied or unavailable, Sherpa leaves the decision unset so the user can retry or decline without leaving a half-enabled Local provider.
 

--- a/src/MauiSherpa.Core/Interfaces.cs
+++ b/src/MauiSherpa.Core/Interfaces.cs
@@ -3090,7 +3090,7 @@ public interface ICloudSecretsService
     Task SaveProviderAsync(CloudSecretsProviderConfig provider);
 
     /// <summary>
-    /// Enables the built-in Local provider after the user opts in to the local vault.
+    /// Ensures the built-in Local provider exists and optionally makes it active.
     /// </summary>
     Task EnableDefaultLocalProviderAsync(bool setActiveProvider = true);
     

--- a/src/MauiSherpa.Core/Services/CloudSecretsService.cs
+++ b/src/MauiSherpa.Core/Services/CloudSecretsService.cs
@@ -70,7 +70,7 @@ public class CloudSecretsService : ICloudSecretsService
         await LoadMetadataAsync();
 
         var metadata = _providerMetadata;
-        if (ShouldOfferDefaultLocalProvider() && _providerMetadata.All(p => p.Id != DefaultLocalProviderId))
+        if (_providerMetadata.All(p => p.Id != DefaultLocalProviderId))
         {
             if (CanUseLocalVault())
             {
@@ -97,9 +97,6 @@ public class CloudSecretsService : ICloudSecretsService
 
         foreach (var meta in metadata)
         {
-            if (meta.Id == DefaultLocalProviderId && !ShouldOfferDefaultLocalProvider())
-                continue;
-
             var config = await LoadProviderConfigAsync(meta);
             if (config != null)
                 result.Add(config);
@@ -644,16 +641,18 @@ public class CloudSecretsService : ICloudSecretsService
                 return nonLocal.Id;
         }
 
-        if (ShouldOfferDefaultLocalProvider())
+        if (ShouldPreferDefaultLocalProvider())
         {
             return providers.FirstOrDefault(p => p.Id == DefaultLocalProviderId)?.Id
                 ?? providers.FirstOrDefault()?.Id;
         }
 
-        return providers.FirstOrDefault(p => p.ProviderType != CloudSecretsProviderType.Local)?.Id;
+        return providers.FirstOrDefault(p => p.ProviderType != CloudSecretsProviderType.Local)?.Id
+            ?? providers.FirstOrDefault(p => p.Id == DefaultLocalProviderId)?.Id
+            ?? providers.FirstOrDefault()?.Id;
     }
 
-    private bool ShouldOfferDefaultLocalProvider() =>
+    private bool ShouldPreferDefaultLocalProvider() =>
         _localVaultIntroduction?.GetState().HasDeclined != true;
 
     private bool IsLocalVaultStorageEnabled() =>

--- a/src/MauiSherpa.Core/Services/CloudSecretsService.cs
+++ b/src/MauiSherpa.Core/Services/CloudSecretsService.cs
@@ -68,14 +68,36 @@ public class CloudSecretsService : ICloudSecretsService
     public async Task<IReadOnlyList<CloudSecretsProviderConfig>> GetProvidersAsync()
     {
         await LoadMetadataAsync();
-        if (IsLocalProviderEnabled())
+
+        var metadata = _providerMetadata;
+        if (ShouldOfferDefaultLocalProvider() && _providerMetadata.All(p => p.Id != DefaultLocalProviderId))
+        {
+            if (CanUseLocalVault())
+            {
+                await EnsureDefaultLocalProviderMetadataAsync();
+                metadata = _providerMetadata;
+            }
+            else
+            {
+                var withDefaultLocal = new List<CloudSecretsProviderMetadata>
+                {
+                    CreateDefaultLocalProviderMetadata()
+                };
+                withDefaultLocal.AddRange(_providerMetadata);
+                metadata = withDefaultLocal;
+            }
+        }
+        else if (CanUseLocalVault())
+        {
             await EnsureDefaultLocalProviderMetadataAsync();
+            metadata = _providerMetadata;
+        }
 
         var result = new List<CloudSecretsProviderConfig>();
 
-        foreach (var meta in _providerMetadata)
+        foreach (var meta in metadata)
         {
-            if (meta.Id == DefaultLocalProviderId && !IsLocalProviderEnabled())
+            if (meta.Id == DefaultLocalProviderId && !ShouldOfferDefaultLocalProvider())
                 continue;
 
             var config = await LoadProviderConfigAsync(meta);
@@ -152,7 +174,7 @@ public class CloudSecretsService : ICloudSecretsService
     {
         if (providerId == DefaultLocalProviderId)
         {
-            if (IsLocalProviderEnabled())
+            if (CanUseLocalVault())
                 await EnsureDefaultLocalProviderAsync();
             _logger.LogInformation("The default Local secrets provider cannot be deleted.");
             return;
@@ -466,15 +488,16 @@ public class CloudSecretsService : ICloudSecretsService
         if (_providerMetadata.Any(p => p.Id == DefaultLocalProviderId))
             return;
 
-        var localProvider = new CloudSecretsProviderMetadata(
+        _providerMetadata.Insert(0, CreateDefaultLocalProviderMetadata());
+        await PersistMetadataAsync();
+    }
+
+    private static CloudSecretsProviderMetadata CreateDefaultLocalProviderMetadata() =>
+        new(
             DefaultLocalProviderId,
             "Local",
             CloudSecretsProviderType.Local,
             new List<string>());
-
-        _providerMetadata.Insert(0, localProvider);
-        await PersistMetadataAsync();
-    }
 
     private async Task PersistMetadataAsync()
     {
@@ -621,7 +644,7 @@ public class CloudSecretsService : ICloudSecretsService
                 return nonLocal.Id;
         }
 
-        if (IsLocalProviderEnabled())
+        if (ShouldOfferDefaultLocalProvider())
         {
             return providers.FirstOrDefault(p => p.Id == DefaultLocalProviderId)?.Id
                 ?? providers.FirstOrDefault()?.Id;
@@ -630,11 +653,14 @@ public class CloudSecretsService : ICloudSecretsService
         return providers.FirstOrDefault(p => p.ProviderType != CloudSecretsProviderType.Local)?.Id;
     }
 
-    private bool IsLocalProviderEnabled() =>
+    private bool ShouldOfferDefaultLocalProvider() =>
+        _localVaultIntroduction?.GetState().HasDeclined != true;
+
+    private bool IsLocalVaultStorageEnabled() =>
         _localVaultIntroduction?.GetState().IsLocalVaultEnabled != false;
 
     private bool CanUseLocalVault() =>
-        _vaultStore is not null && IsLocalProviderEnabled();
+        _vaultStore is not null && IsLocalVaultStorageEnabled();
 
     private async Task<string?> TryGetSecureStorageAsync(string key)
     {

--- a/src/MauiSherpa/Pages/Modals/LocalVaultIntroModal.razor
+++ b/src/MauiSherpa/Pages/Modals/LocalVaultIntroModal.razor
@@ -183,7 +183,12 @@
             return;
 
         if (!previewOnly)
+        {
             await LocalVaultIntro.MarkDeclinedAsync();
+            if (CloudSecrets.ActiveProvider?.ProviderType == CloudSecretsProviderType.Local)
+                await CloudSecrets.SetActiveProviderAsync(null);
+            await CloudSecrets.InitializeAsync();
+        }
 
         ModalParams.Complete(LocalVaultIntroductionResult.DeclineLocal);
     }

--- a/src/MauiSherpa/Pages/Secrets.razor
+++ b/src/MauiSherpa/Pages/Secrets.razor
@@ -52,7 +52,7 @@
     <div class="empty-state">
         <div class="empty-icon"><i class="fas fa-cloud-slash"></i></div>
         <div class="empty-title">No Secrets Provider Configured</div>
-        <div class="empty-description">Configure a secrets provider in <a href="settings">Settings</a> to manage secrets.</div>
+        <div class="empty-description">Configure a secrets provider in <button type="button" class="inline-link" @onclick="OpenSettingsDialogAsync">Settings</button> to manage secrets.</div>
     </div>
 }
 else
@@ -449,6 +449,14 @@ else
             isGrantingLocalVaultAccess = false;
             StateHasChanged();
         }
+    }
+
+    async Task OpenSettingsDialogAsync()
+    {
+        var page = new SettingsPage(BridgeHolder);
+        await FormModalService.ShowViewAsync(page, async () => await page.ShowAsync());
+        await LoadProvidersAsync();
+        await RefreshAsync();
     }
 
     async Task LoadProvidersAsync()
@@ -970,6 +978,29 @@ else
     }
 
     h1 { margin: 0; font-size: 1.75rem; color: var(--text-primary); }
+
+    .inline-link {
+        display: inline;
+        margin: 0;
+        padding: 0;
+        border: 0;
+        background: transparent;
+        color: var(--accent-primary);
+        font: inherit;
+        text-decoration: underline;
+        cursor: pointer;
+    }
+
+    .inline-link:hover,
+    .inline-link:focus-visible {
+        color: var(--accent-primary-hover);
+    }
+
+    .inline-link:focus-visible {
+        outline: 2px solid var(--accent-primary);
+        outline-offset: 2px;
+        border-radius: 0.1875rem;
+    }
 
     .provider-info {
         display: inline-flex;

--- a/src/MauiSherpa/Pages/Settings.razor
+++ b/src/MauiSherpa/Pages/Settings.razor
@@ -728,7 +728,7 @@
         gap: 0.75rem;
     }
 
-    h2 i {
+    .settings-section h2 > i {
         width: 2rem;
         height: 2rem;
         border-radius: 0.75rem;
@@ -738,6 +738,8 @@
         color: var(--accent-primary);
         background: var(--accent-bg);
         font-size: 0.95rem;
+        line-height: 1;
+        text-align: center;
         flex: 0 0 auto;
     }
 
@@ -766,7 +768,7 @@
 
     .section-description {
         color: var(--text-muted);
-        margin: 0 0 0.875rem 2.75rem;
+        margin: 0 0 0.875rem 0;
         max-width: 58rem;
         font-size: 0.875rem;
         line-height: 1.45;

--- a/src/MauiSherpa/Pages/Settings.razor
+++ b/src/MauiSherpa/Pages/Settings.razor
@@ -706,17 +706,76 @@
 
 
 <style>
+    body:has(.modal-layout),
+    body:has(.modal-layout) #app {
+        background: transparent !important;
+    }
+
+    .modal-layout {
+        background: transparent;
+        padding: 0;
+    }
+
     h1 { margin-bottom: 1.25rem; font-size: 1.75rem; color: var(--text-primary); font-weight: 600; }
-    h2 { margin: 0 0 0.25rem 0; font-size: 1.125rem; color: var(--text-primary); font-weight: 600; display: flex; align-items: center; gap: 0.625rem; }
-    h2 i { color: var(--text-secondary); }
+    h2 {
+        margin: 0 0 0.35rem 0;
+        font-size: 1.075rem;
+        line-height: 1.25;
+        color: var(--text-primary);
+        font-weight: 700;
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+    }
+
+    h2 i {
+        width: 2rem;
+        height: 2rem;
+        border-radius: 0.75rem;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        color: var(--accent-primary);
+        background: var(--accent-bg);
+        font-size: 0.95rem;
+        flex: 0 0 auto;
+    }
 
     /* Extra padding when rendered inside hybrid modal dialog */
-    .modal-layout .settings-section { padding-left: 24px; padding-right: 24px; }
-    .modal-layout .settings-section:first-child { padding-top: 16px; }
+    .modal-layout .settings-section {
+        margin-left: 16px;
+        margin-right: 16px;
+    }
 
-    .settings-section { margin-bottom: 1.25rem; }
-    .section-description { color: var(--text-muted); margin-bottom: 0.5rem; font-size: 0.875rem; }
-    .section-description a { color: var(--accent-primary); }
+    .modal-layout .settings-section:first-child {
+        margin-top: 16px;
+    }
+
+    .modal-layout .settings-section:last-of-type {
+        margin-bottom: 24px;
+    }
+
+    .settings-section {
+        margin-bottom: 1.5rem;
+        padding: 0;
+        background: transparent;
+        border: 0;
+        border-radius: 0;
+        box-shadow: none;
+    }
+
+    .section-description {
+        color: var(--text-muted);
+        margin: 0 0 0.875rem 2.75rem;
+        max-width: 58rem;
+        font-size: 0.875rem;
+        line-height: 1.45;
+    }
+
+    .section-description a {
+        color: var(--accent-primary);
+        font-weight: 500;
+    }
 
     .btn-update-available {
         display: inline-flex;
@@ -739,6 +798,7 @@
 
     .settings-container {
         background: var(--card-bg);
+        border: 1px solid var(--border-color-light);
         padding: 1rem 1.25rem;
         border-radius: var(--card-radius);
     }
@@ -753,7 +813,7 @@
         column-gap: 1.5rem;
         row-gap: 0.5rem;
         padding: 1rem 0;
-        border-bottom: 1px solid var(--border-color);
+        border-bottom: 1px solid var(--border-color-light);
     }
 
     .setting-item:first-child { padding-top: 0; }
@@ -929,27 +989,34 @@
     /* Connected list pattern - items share one card with separators */
     .connected-list {
         background: var(--card-bg);
+        border: 1px solid var(--border-color-light);
         border-radius: var(--card-radius);
         overflow: hidden;
     }
 
     .connected-list-item {
-        padding: 0.75rem 0.75rem;
+        padding: 1rem 1.25rem;
         position: relative;
+        transition: background 0.15s ease;
+    }
+
+    .connected-list-item:hover {
+        background: var(--bg-hover);
     }
 
     .connected-list-item:not(:last-child)::after {
         content: '';
         position: absolute;
         bottom: 0;
-        left: 0.75rem;
-        right: 0.75rem;
+        left: 1.25rem;
+        right: 1.25rem;
         height: 1px;
-        background: var(--border-color);
+        background: var(--border-color-light);
     }
 
     .connected-list-item.active {
-        border-left: 3px solid var(--accent-primary);
+        box-shadow: inset 4px 0 0 var(--accent-primary);
+        background: var(--bg-secondary);
     }
 
     .section-add-action {
@@ -968,7 +1035,8 @@
         display: flex;
         justify-content: space-between;
         align-items: center;
-        margin-bottom: 0.75rem;
+        margin-bottom: 0.875rem;
+        gap: 1rem;
     }
 
     .identity-info {
@@ -978,17 +1046,24 @@
     }
 
     .identity-icon {
-        font-size: 1.25rem;
+        width: 2rem;
+        height: 2rem;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 1.15rem;
+        border-radius: 0.625rem;
+        background: var(--bg-tertiary);
         color: var(--text-secondary);
     }
 
-    .identity-name { font-weight: 600; color: var(--text-primary); font-size: 0.9375rem; }
-    .identity-actions { display: flex; gap: 0.5rem; }
+    .identity-name { font-weight: 700; color: var(--text-primary); font-size: 0.975rem; }
+    .identity-actions { display: flex; gap: 0.5rem; flex-wrap: wrap; justify-content: flex-end; }
 
     .identity-details {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-        gap: 1rem;
+        gap: 1rem 1.25rem;
     }
 
     .detail-item {
@@ -1001,13 +1076,15 @@
         font-size: 0.6875rem;
         color: var(--text-muted);
         text-transform: uppercase;
-        letter-spacing: 0.05em;
-        font-weight: 500;
+        letter-spacing: 0.08em;
+        font-weight: 700;
     }
 
     .detail-value {
-        font-size: 0.875rem;
+        font-size: 0.9rem;
         color: var(--text-primary);
+        line-height: 1.35;
+        overflow-wrap: anywhere;
     }
 
     .detail-value.mono {
@@ -1089,8 +1166,8 @@
         gap: 0.375rem;
         margin-top: 0.5rem;
         padding: 0.25rem 0.625rem;
-        background: #bee3f8;
-        color: #2c5282;
+        background: var(--status-info-bg);
+        color: var(--status-info-text);
         border-radius: 0.75rem;
         font-size: 0.75rem;
         font-weight: 500;
@@ -1156,7 +1233,15 @@
         cursor: not-allowed;
     }
 
-    .empty-identities { padding: 1.25rem; text-align: center; color: var(--text-muted); }
+    .empty-identities {
+        padding: 1.5rem;
+        text-align: center;
+        color: var(--text-muted);
+    }
+
+    .empty-identities p {
+        margin: 0;
+    }
 
     /* Cloud Provider Styles */
     .vault-access-card {
@@ -1167,6 +1252,7 @@
         padding: 1rem;
         margin-bottom: 1rem;
         background: var(--card-bg);
+        border: 1px solid var(--border-color-light);
         border-radius: var(--card-radius, 1rem);
     }
     .vault-access-content {
@@ -1189,7 +1275,15 @@
         color: var(--text-muted);
         font-size: 0.875rem;
     }
-    .empty-providers { padding: 1.25rem; text-align: center; color: var(--text-muted); }
+    .empty-providers {
+        padding: 1.5rem;
+        text-align: center;
+        color: var(--text-muted);
+    }
+
+    .empty-providers p {
+        margin: 0;
+    }
     
     .provider-list { display: flex; flex-direction: column; gap: 1rem; }
     
@@ -1208,7 +1302,8 @@
         display: flex;
         justify-content: space-between;
         align-items: center;
-        margin-bottom: 0.75rem;
+        margin-bottom: 0.875rem;
+        gap: 1rem;
     }
     
     .provider-info {
@@ -1218,14 +1313,21 @@
     }
     
     .provider-icon {
-        font-size: 1.25rem;
+        width: 2rem;
+        height: 2rem;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 1.15rem;
+        border-radius: 0.625rem;
+        background: var(--bg-tertiary);
         color: var(--text-secondary);
     }
     
     .provider-name {
-        font-weight: 600;
+        font-weight: 700;
         color: var(--text-primary);
-        font-size: 0.9375rem;
+        font-size: 0.975rem;
     }
 
     .provider-link {
@@ -1254,12 +1356,14 @@
     .provider-actions {
         display: flex;
         gap: 0.5rem;
+        flex-wrap: wrap;
+        justify-content: flex-end;
     }
     
     .provider-details {
         display: flex;
         flex-wrap: wrap;
-        gap: 1rem;
+        gap: 1rem 1.25rem;
     }
 
     /* Backup & Restore Styles */
@@ -1275,6 +1379,7 @@
         gap: 1.25rem;
         padding: 1.25rem;
         background: var(--card-bg);
+        border: 1px solid var(--border-color-light);
         border-radius: var(--card-radius, 1rem);
     }
 

--- a/tests/MauiSherpa.Core.Tests/Services/CloudSecretsServiceTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/CloudSecretsServiceTests.cs
@@ -25,12 +25,74 @@ public class CloudSecretsServiceTests
     }
 
     [Fact]
-    public async Task InitializeAsync_WithNoProvidersAndIntroNotSeen_DoesNotActivateLocalProvider()
+    public async Task InitializeAsync_WithNoProvidersAndIntroNotSeen_CreatesAndActivatesLocalProvider()
     {
         var secureStorage = new InMemorySecureStorage();
         var service = CreateService(
             secureStorage: secureStorage,
             localVaultIntroduction: new TestLocalVaultIntroductionService(LocalVaultIntroductionState.NotShown));
+
+        await service.InitializeAsync();
+
+        service.ActiveProvider.Should().NotBeNull();
+        service.ActiveProvider!.Id.Should().Be("local");
+        service.ActiveProvider.Name.Should().Be("Local");
+        service.ActiveProvider.ProviderType.Should().Be(CloudSecretsProviderType.Local);
+        secureStorage.Values["cloud_secrets_active_provider"].Should().Be("local");
+
+        var providers = await service.GetProvidersAsync();
+        providers.Should().ContainSingle(p => p.ProviderType == CloudSecretsProviderType.Local);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_WithRemoteProviderAndIntroNotSeen_ActivatesLocalAndKeepsRemoteVisible()
+    {
+        var secureStorage = new InMemorySecureStorage();
+        var intro = new TestLocalVaultIntroductionService(LocalVaultIntroductionState.NotShown);
+        var service = CreateService(secureStorage: secureStorage, localVaultIntroduction: intro);
+        var provider = new CloudSecretsProviderConfig(
+            "remote",
+            "Remote",
+            CloudSecretsProviderType.AzureKeyVault,
+            new Dictionary<string, string>
+            {
+                ["VaultUrl"] = "https://test.vault.azure.net",
+                ["TenantId"] = "tenant",
+                ["ClientId"] = "client",
+                ["ClientSecret"] = "secret"
+            });
+
+        await service.SaveProviderAsync(provider);
+        await service.InitializeAsync();
+
+        service.ActiveProvider.Should().NotBeNull();
+        service.ActiveProvider!.Id.Should().Be("local");
+        secureStorage.Values["cloud_secrets_active_provider"].Should().Be("local");
+
+        var providers = await service.GetProvidersAsync();
+        providers.Should().ContainSingle(p => p.Id == "remote");
+        providers.Should().ContainSingle(p => p.Id == "local" && p.ProviderType == CloudSecretsProviderType.Local);
+    }
+
+    [Fact]
+    public async Task GetProvidersAsync_WithIntroNotSeen_OffersLocalWithoutTouchingVaultStore()
+    {
+        var service = CreateService(
+            vaultStore: new ThrowingLocalVaultStore(),
+            localVaultIntroduction: new TestLocalVaultIntroductionService(LocalVaultIntroductionState.NotShown));
+
+        var providers = await service.GetProvidersAsync();
+
+        providers.Should().ContainSingle(p => p.Id == "local" && p.ProviderType == CloudSecretsProviderType.Local);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_WithNoProvidersAndIntroDeclined_DoesNotActivateLocalProvider()
+    {
+        var secureStorage = new InMemorySecureStorage();
+        var service = CreateService(
+            secureStorage: secureStorage,
+            localVaultIntroduction: new TestLocalVaultIntroductionService(CreateDeclinedIntroState()));
 
         await service.InitializeAsync();
 
@@ -42,11 +104,12 @@ public class CloudSecretsServiceTests
     }
 
     [Fact]
-    public async Task InitializeAsync_WithRemoteProviderAndIntroNotSeen_ActivatesRemoteWithoutLocal()
+    public async Task InitializeAsync_WithRemoteProviderAndIntroDeclined_ActivatesRemoteWithoutLocal()
     {
         var secureStorage = new InMemorySecureStorage();
-        var intro = new TestLocalVaultIntroductionService(LocalVaultIntroductionState.NotShown);
-        var service = CreateService(secureStorage: secureStorage, localVaultIntroduction: intro);
+        var service = CreateService(
+            secureStorage: secureStorage,
+            localVaultIntroduction: new TestLocalVaultIntroductionService(CreateDeclinedIntroState()));
         var provider = new CloudSecretsProviderConfig(
             "remote",
             "Remote",
@@ -69,18 +132,6 @@ public class CloudSecretsServiceTests
         var providers = await service.GetProvidersAsync();
         providers.Should().ContainSingle(p => p.Id == "remote");
         providers.Should().NotContain(p => p.Id == "local");
-    }
-
-    [Fact]
-    public async Task GetProvidersAsync_WithIntroNotSeen_DoesNotTouchVaultStore()
-    {
-        var service = CreateService(
-            vaultStore: new ThrowingLocalVaultStore(),
-            localVaultIntroduction: new TestLocalVaultIntroductionService(LocalVaultIntroductionState.NotShown));
-
-        var providers = await service.GetProvidersAsync();
-
-        providers.Should().BeEmpty();
     }
 
     [Fact]
@@ -335,6 +386,12 @@ public class CloudSecretsServiceTests
             new TestLogger(),
             new LocalVaultOptions(Path.Combine(testDir, "vault.db")));
     }
+
+    private static LocalVaultIntroductionState CreateDeclinedIntroState() =>
+        new(
+            LocalVaultIntroductionState.CurrentVersion,
+            LocalVaultIntroductionDecision.Declined,
+            DateTime.UtcNow);
 
     private sealed class TestLocalSecretsKeyStore : ILocalSecretsKeyStore
     {

--- a/tests/MauiSherpa.Core.Tests/Services/CloudSecretsServiceTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/CloudSecretsServiceTests.cs
@@ -87,7 +87,7 @@ public class CloudSecretsServiceTests
     }
 
     [Fact]
-    public async Task InitializeAsync_WithNoProvidersAndIntroDeclined_DoesNotActivateLocalProvider()
+    public async Task InitializeAsync_WithNoProvidersAndIntroDeclined_StillCreatesAndActivatesLocalProvider()
     {
         var secureStorage = new InMemorySecureStorage();
         var service = CreateService(
@@ -96,15 +96,17 @@ public class CloudSecretsServiceTests
 
         await service.InitializeAsync();
 
-        service.ActiveProvider.Should().BeNull();
-        secureStorage.Values.Should().NotContainKey("cloud_secrets_active_provider");
+        service.ActiveProvider.Should().NotBeNull();
+        service.ActiveProvider!.Id.Should().Be("local");
+        service.ActiveProvider.ProviderType.Should().Be(CloudSecretsProviderType.Local);
+        secureStorage.Values["cloud_secrets_active_provider"].Should().Be("local");
 
         var providers = await service.GetProvidersAsync();
-        providers.Should().BeEmpty();
+        providers.Should().ContainSingle(p => p.Id == "local" && p.ProviderType == CloudSecretsProviderType.Local);
     }
 
     [Fact]
-    public async Task InitializeAsync_WithRemoteProviderAndIntroDeclined_ActivatesRemoteWithoutLocal()
+    public async Task InitializeAsync_WithRemoteProviderAndIntroDeclined_ActivatesRemoteAndKeepsLocalVisible()
     {
         var secureStorage = new InMemorySecureStorage();
         var service = CreateService(
@@ -131,7 +133,7 @@ public class CloudSecretsServiceTests
 
         var providers = await service.GetProvidersAsync();
         providers.Should().ContainSingle(p => p.Id == "remote");
-        providers.Should().NotContain(p => p.Id == "local");
+        providers.Should().ContainSingle(p => p.Id == "local" && p.ProviderType == CloudSecretsProviderType.Local);
     }
 
     [Fact]


### PR DESCRIPTION
v0.11.0 should show a default Local secrets provider so users have an immediate storage option. The Local Vault intro should control vault-backed migration and onboarding prompts, not whether Local exists in Settings. This also fixes the Secrets empty-state Settings action so it opens the same dialog as the toolbar button, and polishes the Settings dialog layout.

## Summary
- Surface Local as a built-in provider while the intro decision is `NotSet` or `Declined`, without touching vault-backed provider metadata before opt-in.
- Keep a configured remote provider preferred after decline, but fall back to Local when no remote provider exists so Settings never shows an empty provider list for the built-in default.
- Open Settings from the Secrets page in the native dialog flow instead of navigating the main content area.
- Refresh the Settings dialog visuals with transparent dialog content, tighter gutters, clearer section hierarchy, and consistent inner cards for settings/providers/identities.
- Clear active Local during the decline flow only long enough to re-evaluate the best active provider.
- Update tests and storage docs to distinguish provider visibility from vault-backed migration enablement.

## Testing
- `dotnet test tests/MauiSherpa.Core.Tests/MauiSherpa.Core.Tests.csproj --filter CloudSecretsServiceTests --no-restore --verbosity minimal`
- `dotnet build src/MauiSherpa.MacOS/MauiSherpa.MacOS.csproj -f net10.0-macos --no-restore --verbosity minimal`