### PR TITLE
Add publish profile identity mappings

### DIFF
--- a/src/MauiSherpa.Core/Interfaces.cs
+++ b/src/MauiSherpa.Core/Interfaces.cs
@@ -3389,6 +3389,12 @@ public record PublishProfile(
 {
     /// <summary>Multiple publisher targets for this profile</summary>
     public List<PublishProfilePublisher> Publishers { get; init; } = new();
+
+    /// <summary>Apple developer identities whose credentials should be published as secrets</summary>
+    public List<PublishProfileAppleIdentity> AppleIdentities { get; init; } = new();
+
+    /// <summary>Google developer identities whose credentials should be published as secrets</summary>
+    public List<PublishProfileGoogleIdentity> GoogleIdentities { get; init; } = new();
 }
 
 /// <summary>
@@ -3422,6 +3428,24 @@ public record PublishProfileAppleConfig(
     string? NotarizationAppleIdManualValue,
     string? NotarizationPasswordManualValue,
     string? NotarizationTeamIdManualValue,
+    Dictionary<string, List<string>> KeyMappings
+);
+
+/// <summary>
+/// Apple developer identity within a publish profile.
+/// </summary>
+public record PublishProfileAppleIdentity(
+    string Label,
+    string IdentityId,
+    Dictionary<string, List<string>> KeyMappings
+);
+
+/// <summary>
+/// Google developer identity within a publish profile.
+/// </summary>
+public record PublishProfileGoogleIdentity(
+    string Label,
+    string IdentityId,
     Dictionary<string, List<string>> KeyMappings
 );
 
@@ -3606,6 +3630,8 @@ public record PublishProfileData(
 )
 {
     public List<PublishProfilePublisher> Publishers { get; init; } = new();
+    public List<PublishProfileAppleIdentity> AppleIdentities { get; init; } = new();
+    public List<PublishProfileGoogleIdentity> GoogleIdentities { get; init; } = new();
 }
 
 public record AppPreferences

--- a/src/MauiSherpa.Core/Services/BackupService.cs
+++ b/src/MauiSherpa.Core/Services/BackupService.cs
@@ -235,7 +235,11 @@ public class BackupService : IBackupService
                     AppleConfigs: p.AppleConfigs,
                     AndroidConfigs: p.AndroidConfigs,
                     SecretMappings: p.SecretMappings)
-                { Publishers = p.Publishers })
+                {
+                    Publishers = p.Publishers,
+                    AppleIdentities = p.AppleIdentities,
+                    GoogleIdentities = p.GoogleIdentities
+                })
                 .ToList()
         };
     }

--- a/src/MauiSherpa.Core/Services/PublishProfileService.cs
+++ b/src/MauiSherpa.Core/Services/PublishProfileService.cs
@@ -16,6 +16,7 @@ public class PublishProfileService : IPublishProfileService
     readonly IAppleConnectService _appleConnect;
     readonly IAppleIdentityService _appleIdentity;
     readonly IAppleIdentityStateService _identityState;
+    readonly IGoogleIdentityService _googleIdentity;
     readonly ILoggingService _logger;
 
     static readonly JsonSerializerOptions JsonOptions = new()
@@ -37,6 +38,7 @@ public class PublishProfileService : IPublishProfileService
         IAppleConnectService appleConnect,
         IAppleIdentityService appleIdentity,
         IAppleIdentityStateService identityState,
+        IGoogleIdentityService googleIdentity,
         ILoggingService logger)
     {
         _cloudService = cloudService;
@@ -47,6 +49,7 @@ public class PublishProfileService : IPublishProfileService
         _appleConnect = appleConnect;
         _appleIdentity = appleIdentity;
         _identityState = identityState;
+        _googleIdentity = googleIdentity;
         _logger = logger;
     }
 
@@ -269,6 +272,40 @@ public class PublishProfileService : IPublishProfileService
             }
         }
 
+        // Resolve Apple developer identities
+        foreach (var appleIdentity in profile.AppleIdentities ?? Enumerable.Empty<PublishProfileAppleIdentity>())
+        {
+            ct.ThrowIfCancellationRequested();
+
+            if (string.IsNullOrWhiteSpace(appleIdentity.IdentityId))
+                continue;
+
+            progress?.Report($"Fetching Apple identity {appleIdentity.Label}...");
+            try
+            {
+                var identity = await _appleIdentity.GetIdentityAsync(appleIdentity.IdentityId);
+                if (identity is null)
+                {
+                    _logger.LogWarning($"Apple identity '{appleIdentity.IdentityId}' was not found for publish profile item '{appleIdentity.Label}'");
+                    continue;
+                }
+
+                var defaultKeys = GetAppleIdentityDefaultKeys(appleIdentity);
+                if (!string.IsNullOrEmpty(identity.KeyId))
+                    AddMappedSecrets(secrets, appleIdentity.KeyMappings, defaultKeys.KeyId, identity.KeyId);
+                if (!string.IsNullOrEmpty(identity.IssuerId))
+                    AddMappedSecrets(secrets, appleIdentity.KeyMappings, defaultKeys.IssuerId, identity.IssuerId);
+                if (!string.IsNullOrEmpty(identity.P8KeyContent))
+                    AddMappedSecrets(secrets, appleIdentity.KeyMappings, defaultKeys.P8Key, identity.P8KeyContent);
+                else
+                    _logger.LogWarning($"Apple identity '{identity.Name}' has no private key content to publish");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning($"Failed to resolve Apple identity for {appleIdentity.Label}: {ex.Message}");
+            }
+        }
+
         // Resolve Android configs
         foreach (var android in profile.AndroidConfigs)
         {
@@ -312,6 +349,40 @@ public class PublishProfileService : IPublishProfileService
                 {
                     _logger.LogWarning($"Failed to resolve keystore for {android.Label}: {ex.Message}");
                 }
+            }
+        }
+
+        // Resolve Google developer identities
+        foreach (var googleIdentity in profile.GoogleIdentities ?? Enumerable.Empty<PublishProfileGoogleIdentity>())
+        {
+            ct.ThrowIfCancellationRequested();
+
+            if (string.IsNullOrWhiteSpace(googleIdentity.IdentityId))
+                continue;
+
+            progress?.Report($"Fetching Google identity {googleIdentity.Label}...");
+            try
+            {
+                var identity = await _googleIdentity.GetIdentityAsync(googleIdentity.IdentityId);
+                if (identity is null)
+                {
+                    _logger.LogWarning($"Google identity '{googleIdentity.IdentityId}' was not found for publish profile item '{googleIdentity.Label}'");
+                    continue;
+                }
+
+                var defaultKeys = GetGoogleIdentityDefaultKeys(googleIdentity);
+                if (!string.IsNullOrEmpty(identity.ProjectId))
+                    AddMappedSecrets(secrets, googleIdentity.KeyMappings, defaultKeys.ProjectId, identity.ProjectId);
+                if (!string.IsNullOrEmpty(identity.ClientEmail))
+                    AddMappedSecrets(secrets, googleIdentity.KeyMappings, defaultKeys.ClientEmail, identity.ClientEmail);
+                if (!string.IsNullOrEmpty(identity.ServiceAccountJson))
+                    AddMappedSecrets(secrets, googleIdentity.KeyMappings, defaultKeys.ServiceAccountJson, identity.ServiceAccountJson);
+                else
+                    _logger.LogWarning($"Google identity '{identity.Name}' has no service account JSON to publish");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning($"Failed to resolve Google identity for {googleIdentity.Label}: {ex.Message}");
             }
         }
 
@@ -383,6 +454,24 @@ public class PublishProfileService : IPublishProfileService
             _ => ""
         };
         return string.IsNullOrEmpty(distLabel) ? $"APPLE_{platLabel}" : $"APPLE_{platLabel}_{distLabel}";
+    }
+
+    static (string KeyId, string IssuerId, string P8Key) GetAppleIdentityDefaultKeys(PublishProfileAppleIdentity identity)
+    {
+        var label = SanitizeLabel(identity.Label);
+        return (
+            $"APPLE_{label}_KEY_ID",
+            $"APPLE_{label}_ISSUER_ID",
+            $"APPLE_{label}_P8_KEY");
+    }
+
+    static (string ProjectId, string ClientEmail, string ServiceAccountJson) GetGoogleIdentityDefaultKeys(PublishProfileGoogleIdentity identity)
+    {
+        var label = SanitizeLabel(identity.Label);
+        return (
+            $"GOOGLE_{label}_PROJECT_ID",
+            $"GOOGLE_{label}_CLIENT_EMAIL",
+            $"GOOGLE_{label}_SERVICE_ACCOUNT_JSON");
     }
 
     static string SanitizeLabel(string label)

--- a/src/MauiSherpa.MacOS/Resources/PrivacyInfo.plist
+++ b/src/MauiSherpa.MacOS/Resources/PrivacyInfo.plist
@@ -4,5 +4,7 @@
 <dict>
     <key>NSLocalNetworkUsageDescription</key>
     <string>MAUI Sherpa connects to MAUI DevFlow and Ailoha agents running on your local network to inspect MAUI apps.</string>
+    <key>NSBluetoothAlwaysUsageDescription</key>
+    <string>MAUI Sherpa uses Bluetooth through Apple development tooling to discover and communicate with nearby development devices.</string>
 </dict>
 </plist>

--- a/src/MauiSherpa/Pages/Modals/AppleIdentityPickerModal.razor
+++ b/src/MauiSherpa/Pages/Modals/AppleIdentityPickerModal.razor
@@ -1,0 +1,162 @@
+@page "/modal/apple-identity-picker"
+@using MauiSherpa.Core.Interfaces
+@using MauiSherpa.Pages.Forms
+@inject HybridFormBridgeHolder BridgeHolder
+@implements IDisposable
+
+@{
+    var bridge = BridgeHolder.Current;
+}
+
+@if (bridge != null)
+{
+    <div class="form-content">
+        <div class="search-box">
+            <i class="fas fa-search"></i>
+            <input type="text" @bind="searchQuery" @bind:event="oninput" placeholder="Search Apple identities..." />
+            @if (!string.IsNullOrEmpty(searchQuery))
+            {
+                <button class="clear-search" @onclick="@(() => searchQuery = "")">×</button>
+            }
+        </div>
+
+        <div class="selection-list">
+            @foreach (var identity in FilteredIdentities)
+            {
+                var isExisting = existingIdentityIds.Contains(identity.Id);
+                <label class="selection-item @(selectedIdentity?.Id == identity.Id ? "selected" : "") @(isExisting ? "disabled" : "")"
+                       @onclick="@(() => { if (!isExisting) SelectIdentity(identity); })">
+                    <div class="item-content">
+                        <div class="item-name">@identity.Name</div>
+                        <div class="item-detail">
+                            @if (isExisting)
+                            {
+                                <span class="already-added">Already added</span>
+                            }
+                            else
+                            {
+                                <span class="mono">@identity.KeyId</span>
+                                <span> · </span>
+                                <span class="mono">@identity.IssuerId</span>
+                            }
+                        </div>
+                    </div>
+                    @if (selectedIdentity?.Id == identity.Id)
+                    {
+                        <i class="fas fa-check" style="color: var(--accent-color, #8b5cf6);"></i>
+                    }
+                </label>
+            }
+            @if (!FilteredIdentities.Any())
+            {
+                <div class="empty-hint">No matching Apple identities</div>
+            }
+        </div>
+    </div>
+}
+
+<style>
+    .form-content { display: flex; flex-direction: column; gap: 0.75rem; }
+    .search-box {
+        display: flex; align-items: center; gap: 0.5rem;
+        background: var(--input-bg, #edf2f7); border-radius: 6px; padding: 0.5rem 0.75rem;
+        border: 1px solid var(--border-color, #e2e8f0);
+    }
+    .search-box i { color: var(--text-muted, #a0aec0); font-size: 0.8rem; flex-shrink: 0; }
+    .search-box input {
+        flex: 1; border: none; background: transparent; outline: none; font-size: 0.85rem;
+        color: var(--text-primary, #1a202c);
+    }
+    .clear-search {
+        background: none; border: none; color: var(--text-muted); cursor: pointer; font-size: 1rem;
+        padding: 0 4px; line-height: 1;
+    }
+    .selection-list {
+        display: flex; flex-direction: column; gap: 2px;
+        max-height: 320px; overflow-y: auto;
+    }
+    .selection-item {
+        display: flex; align-items: center; gap: 0.75rem;
+        padding: 0.5rem 0.75rem; border-radius: 6px; cursor: pointer;
+        transition: background 0.15s;
+    }
+    .selection-item:hover:not(.disabled) { background: var(--hover-bg, rgba(0,0,0,0.04)); }
+    .selection-item.selected { background: var(--accent-bg, rgba(139,92,246,0.08)); }
+    .selection-item.disabled { opacity: 0.5; cursor: not-allowed; }
+    .item-content { flex: 1; min-width: 0; }
+    .item-name { font-size: 0.85rem; font-weight: 500; color: var(--text-primary); }
+    .item-detail { font-size: 0.75rem; color: var(--text-secondary, #718096); margin-top: 2px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .mono { font-family: "SF Mono", Menlo, Monaco, monospace; }
+    .already-added { color: var(--text-muted, #a0aec0); font-style: italic; }
+    .empty-hint {
+        text-align: center; color: var(--text-muted); padding: 2rem; font-size: 0.85rem;
+    }
+</style>
+
+@code {
+    private string searchQuery = "";
+    private AppleIdentity? selectedIdentity;
+    private IReadOnlyList<AppleIdentity> appleIdentities = Array.Empty<AppleIdentity>();
+    private HashSet<string> existingIdentityIds = new();
+
+    private IEnumerable<AppleIdentity> FilteredIdentities =>
+        string.IsNullOrEmpty(searchQuery)
+            ? appleIdentities
+            : appleIdentities.Where(i =>
+                i.Name.Contains(searchQuery, StringComparison.OrdinalIgnoreCase) ||
+                i.KeyId.Contains(searchQuery, StringComparison.OrdinalIgnoreCase) ||
+                i.IssuerId.Contains(searchQuery, StringComparison.OrdinalIgnoreCase));
+
+    protected override void OnInitialized()
+    {
+        var bridge = BridgeHolder.Current;
+        if (bridge == null) return;
+
+        if (bridge.Parameters.TryGetValue("AppleIdentities", out var identities) && identities is IReadOnlyList<AppleIdentity> list)
+            appleIdentities = list;
+
+        if (bridge.Parameters.TryGetValue("ExistingIdentityIds", out var ids) && ids is IReadOnlyList<string> existing)
+            existingIdentityIds = new HashSet<string>(existing);
+
+        bridge.SubmitRequested += OnSubmit;
+        bridge.CancelRequested += OnCancel;
+        bridge.SetValid(false);
+    }
+
+    private void SelectIdentity(AppleIdentity identity)
+    {
+        selectedIdentity = identity;
+        var bridge = BridgeHolder.Current;
+        if (bridge != null)
+        {
+            bridge.Result = selectedIdentity;
+            bridge.SetValid(true);
+        }
+        StateHasChanged();
+    }
+
+    private Task OnSubmit()
+    {
+        var bridge = BridgeHolder.Current;
+        if (bridge != null)
+            bridge.Result = selectedIdentity;
+        return Task.CompletedTask;
+    }
+
+    private void OnCancel()
+    {
+        var bridge = BridgeHolder.Current;
+        if (bridge != null)
+            bridge.Result = null;
+    }
+
+    public void Dispose()
+    {
+        var bridge = BridgeHolder.Current;
+        if (bridge != null)
+        {
+            bridge.SubmitRequested -= OnSubmit;
+            bridge.CancelRequested -= OnCancel;
+        }
+    }
+}

--- a/src/MauiSherpa/Pages/Modals/AppleIdentityPickerPage.cs
+++ b/src/MauiSherpa/Pages/Modals/AppleIdentityPickerPage.cs
@@ -1,0 +1,35 @@
+using MauiSherpa.Core.Interfaces;
+using MauiSherpa.Pages.Forms;
+#if MACOSAPP
+using Microsoft.Maui.Platforms.MacOS.Platform;
+#endif
+#if LINUXGTK
+using Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
+#endif
+
+namespace MauiSherpa.Pages.Modals;
+
+public class AppleIdentityPickerPage : HybridFormPage<AppleIdentity?>
+{
+    protected override string FormTitle => "Add Apple Identity";
+    protected override string SubmitButtonText => "Add";
+    protected override string BlazorRoute => "/modal/apple-identity-picker";
+
+    public AppleIdentityPickerPage(
+        HybridFormBridgeHolder bridgeHolder,
+        IReadOnlyList<AppleIdentity> appleIdentities,
+        IReadOnlyList<string> existingIdentityIds)
+        : base(bridgeHolder)
+    {
+        Bridge.Parameters["AppleIdentities"] = appleIdentities;
+        Bridge.Parameters["ExistingIdentityIds"] = existingIdentityIds;
+
+#if MACOSAPP
+        MacOSPage.SetModalSheetSizesToContent(this, true);
+        MacOSPage.SetModalSheetMinWidth(this, 450);
+#elif LINUXGTK
+        GtkPage.SetModalSizesToContent(this, true);
+        GtkPage.SetModalMinWidth(this, 450);
+#endif
+    }
+}

--- a/src/MauiSherpa/Pages/Modals/GoogleIdentityPickerModal.razor
+++ b/src/MauiSherpa/Pages/Modals/GoogleIdentityPickerModal.razor
@@ -1,0 +1,162 @@
+@page "/modal/google-identity-picker"
+@using MauiSherpa.Core.Interfaces
+@using MauiSherpa.Pages.Forms
+@inject HybridFormBridgeHolder BridgeHolder
+@implements IDisposable
+
+@{
+    var bridge = BridgeHolder.Current;
+}
+
+@if (bridge != null)
+{
+    <div class="form-content">
+        <div class="search-box">
+            <i class="fas fa-search"></i>
+            <input type="text" @bind="searchQuery" @bind:event="oninput" placeholder="Search Google identities..." />
+            @if (!string.IsNullOrEmpty(searchQuery))
+            {
+                <button class="clear-search" @onclick="@(() => searchQuery = "")">×</button>
+            }
+        </div>
+
+        <div class="selection-list">
+            @foreach (var identity in FilteredIdentities)
+            {
+                var isExisting = existingIdentityIds.Contains(identity.Id);
+                <label class="selection-item @(selectedIdentity?.Id == identity.Id ? "selected" : "") @(isExisting ? "disabled" : "")"
+                       @onclick="@(() => { if (!isExisting) SelectIdentity(identity); })">
+                    <div class="item-content">
+                        <div class="item-name">@identity.Name</div>
+                        <div class="item-detail">
+                            @if (isExisting)
+                            {
+                                <span class="already-added">Already added</span>
+                            }
+                            else
+                            {
+                                <span class="mono">@identity.ProjectId</span>
+                                <span> · </span>
+                                <span class="mono">@identity.ClientEmail</span>
+                            }
+                        </div>
+                    </div>
+                    @if (selectedIdentity?.Id == identity.Id)
+                    {
+                        <i class="fas fa-check" style="color: var(--accent-color, #8b5cf6);"></i>
+                    }
+                </label>
+            }
+            @if (!FilteredIdentities.Any())
+            {
+                <div class="empty-hint">No matching Google identities</div>
+            }
+        </div>
+    </div>
+}
+
+<style>
+    .form-content { display: flex; flex-direction: column; gap: 0.75rem; }
+    .search-box {
+        display: flex; align-items: center; gap: 0.5rem;
+        background: var(--input-bg, #edf2f7); border-radius: 6px; padding: 0.5rem 0.75rem;
+        border: 1px solid var(--border-color, #e2e8f0);
+    }
+    .search-box i { color: var(--text-muted, #a0aec0); font-size: 0.8rem; flex-shrink: 0; }
+    .search-box input {
+        flex: 1; border: none; background: transparent; outline: none; font-size: 0.85rem;
+        color: var(--text-primary, #1a202c);
+    }
+    .clear-search {
+        background: none; border: none; color: var(--text-muted); cursor: pointer; font-size: 1rem;
+        padding: 0 4px; line-height: 1;
+    }
+    .selection-list {
+        display: flex; flex-direction: column; gap: 2px;
+        max-height: 320px; overflow-y: auto;
+    }
+    .selection-item {
+        display: flex; align-items: center; gap: 0.75rem;
+        padding: 0.5rem 0.75rem; border-radius: 6px; cursor: pointer;
+        transition: background 0.15s;
+    }
+    .selection-item:hover:not(.disabled) { background: var(--hover-bg, rgba(0,0,0,0.04)); }
+    .selection-item.selected { background: var(--accent-bg, rgba(139,92,246,0.08)); }
+    .selection-item.disabled { opacity: 0.5; cursor: not-allowed; }
+    .item-content { flex: 1; min-width: 0; }
+    .item-name { font-size: 0.85rem; font-weight: 500; color: var(--text-primary); }
+    .item-detail { font-size: 0.75rem; color: var(--text-secondary, #718096); margin-top: 2px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .mono { font-family: "SF Mono", Menlo, Monaco, monospace; }
+    .already-added { color: var(--text-muted, #a0aec0); font-style: italic; }
+    .empty-hint {
+        text-align: center; color: var(--text-muted); padding: 2rem; font-size: 0.85rem;
+    }
+</style>
+
+@code {
+    private string searchQuery = "";
+    private GoogleIdentity? selectedIdentity;
+    private IReadOnlyList<GoogleIdentity> googleIdentities = Array.Empty<GoogleIdentity>();
+    private HashSet<string> existingIdentityIds = new();
+
+    private IEnumerable<GoogleIdentity> FilteredIdentities =>
+        string.IsNullOrEmpty(searchQuery)
+            ? googleIdentities
+            : googleIdentities.Where(i =>
+                i.Name.Contains(searchQuery, StringComparison.OrdinalIgnoreCase) ||
+                i.ProjectId.Contains(searchQuery, StringComparison.OrdinalIgnoreCase) ||
+                i.ClientEmail.Contains(searchQuery, StringComparison.OrdinalIgnoreCase));
+
+    protected override void OnInitialized()
+    {
+        var bridge = BridgeHolder.Current;
+        if (bridge == null) return;
+
+        if (bridge.Parameters.TryGetValue("GoogleIdentities", out var identities) && identities is IReadOnlyList<GoogleIdentity> list)
+            googleIdentities = list;
+
+        if (bridge.Parameters.TryGetValue("ExistingIdentityIds", out var ids) && ids is IReadOnlyList<string> existing)
+            existingIdentityIds = new HashSet<string>(existing);
+
+        bridge.SubmitRequested += OnSubmit;
+        bridge.CancelRequested += OnCancel;
+        bridge.SetValid(false);
+    }
+
+    private void SelectIdentity(GoogleIdentity identity)
+    {
+        selectedIdentity = identity;
+        var bridge = BridgeHolder.Current;
+        if (bridge != null)
+        {
+            bridge.Result = selectedIdentity;
+            bridge.SetValid(true);
+        }
+        StateHasChanged();
+    }
+
+    private Task OnSubmit()
+    {
+        var bridge = BridgeHolder.Current;
+        if (bridge != null)
+            bridge.Result = selectedIdentity;
+        return Task.CompletedTask;
+    }
+
+    private void OnCancel()
+    {
+        var bridge = BridgeHolder.Current;
+        if (bridge != null)
+            bridge.Result = null;
+    }
+
+    public void Dispose()
+    {
+        var bridge = BridgeHolder.Current;
+        if (bridge != null)
+        {
+            bridge.SubmitRequested -= OnSubmit;
+            bridge.CancelRequested -= OnCancel;
+        }
+    }
+}

--- a/src/MauiSherpa/Pages/Modals/GoogleIdentityPickerPage.cs
+++ b/src/MauiSherpa/Pages/Modals/GoogleIdentityPickerPage.cs
@@ -1,0 +1,35 @@
+using MauiSherpa.Core.Interfaces;
+using MauiSherpa.Pages.Forms;
+#if MACOSAPP
+using Microsoft.Maui.Platforms.MacOS.Platform;
+#endif
+#if LINUXGTK
+using Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
+#endif
+
+namespace MauiSherpa.Pages.Modals;
+
+public class GoogleIdentityPickerPage : HybridFormPage<GoogleIdentity?>
+{
+    protected override string FormTitle => "Add Google Identity";
+    protected override string SubmitButtonText => "Add";
+    protected override string BlazorRoute => "/modal/google-identity-picker";
+
+    public GoogleIdentityPickerPage(
+        HybridFormBridgeHolder bridgeHolder,
+        IReadOnlyList<GoogleIdentity> googleIdentities,
+        IReadOnlyList<string> existingIdentityIds)
+        : base(bridgeHolder)
+    {
+        Bridge.Parameters["GoogleIdentities"] = googleIdentities;
+        Bridge.Parameters["ExistingIdentityIds"] = existingIdentityIds;
+
+#if MACOSAPP
+        MacOSPage.SetModalSheetSizesToContent(this, true);
+        MacOSPage.SetModalSheetMinWidth(this, 450);
+#elif LINUXGTK
+        GtkPage.SetModalSizesToContent(this, true);
+        GtkPage.SetModalMinWidth(this, 450);
+#endif
+    }
+}

--- a/src/MauiSherpa/Pages/Modals/PublishProfileEditorModal.razor
+++ b/src/MauiSherpa/Pages/Modals/PublishProfileEditorModal.razor
@@ -4,6 +4,7 @@
 @using Shiny.Mediator
 @inject HybridFormBridgeHolder BridgeHolder
 @inject IAppleIdentityService AppleIdentityService
+@inject IGoogleIdentityService GoogleIdentityService
 @inject IKeystoreService KeystoreService
 @inject IManagedSecretsService ManagedSecrets
 @inject ISecretsPublisherService PublisherService
@@ -11,6 +12,7 @@
 @inject IMediator Mediator
 @inject IFormModalService FormModal
 @inject IEncryptedSettingsService SettingsService
+@inject ILoggingService Logger
 @implements IDisposable
 
 <div class="profile-editor">
@@ -217,6 +219,102 @@
                             </div>
                         }
                     }
+
+                <div class="section-header section-spaced">
+                    <span>Apple Identities</span>
+                    <button class="btn-action small" @onclick="OpenAppleIdentityPicker">
+                        <i class="fa-solid fa-plus"></i> Add Identity
+                    </button>
+                </div>
+                <div class="form-hint">App Store Connect identities to publish as CI/CD secrets</div>
+
+                @if (!appleIdentityConfigs.Any())
+                {
+                    <div class="empty-state">
+                        <i class="fa-solid fa-id-badge"></i>
+                        <p>No Apple identities added</p>
+                        @if (!appleIdentities.Any())
+                        {
+                            <div class="form-hint text-muted">No Apple identities configured. Configure in Settings first.</div>
+                        }
+                    </div>
+                }
+                else
+                {
+                    @foreach (var config in appleIdentityConfigs)
+                    {
+                        var identity = appleIdentities.FirstOrDefault(i => i.Id == config.IdentityId);
+                        <div class="config-card">
+                            <div class="config-header">
+                                <div class="config-badges">
+                                    <i class="fa-solid fa-id-badge"></i>
+                                    <span class="config-label-text">@config.Label</span>
+                                    @if (identity is null)
+                                    {
+                                        <span class="badge warning">Missing</span>
+                                    }
+                                </div>
+                                <div class="config-actions">
+                                    <button class="btn-icon-action danger" @onclick="@(() => appleIdentityConfigs.Remove(config))" title="Remove">
+                                        <i class="fa-solid fa-trash-can"></i>
+                                    </button>
+                                </div>
+                            </div>
+                            <div class="config-summary">
+                                @if (identity is not null)
+                                {
+                                    <div class="summary-item"><i class="fa-solid fa-key"></i> <span class="@(demoMode ? "demo-blur" : "")">@identity.KeyId</span></div>
+                                    <div class="summary-item"><i class="fa-solid fa-fingerprint"></i> <span class="@(demoMode ? "demo-blur" : "")">@identity.IssuerId</span></div>
+                                    <div class="summary-item"><i class="fa-solid fa-file-code"></i> Private key (.p8)</div>
+                                }
+                                else
+                                {
+                                    <div class="summary-item"><i class="fa-solid fa-triangle-exclamation"></i> Identity no longer exists in Settings</div>
+                                }
+                            </div>
+                            @{
+                                var keys = config.GetDefaultKeys();
+                                if (keys.Any())
+                                {
+                                    <div class="key-mappings-section">
+                                        <div class="key-mappings-label"><i class="fa-solid fa-key"></i> Key Mappings</div>
+                                        <div class="key-mappings">
+                                            @foreach (var defaultKey in keys)
+                                            {
+                                                <div class="key-mapping-row">
+                                                    <div class="key-label">@defaultKey</div>
+                                                    <div class="key-destinations">
+                                                        @{
+                                                            var destinations = config.KeyMappings.GetValueOrDefault(defaultKey) ?? new List<string>();
+                                                        }
+                                                        @foreach (var dest in destinations)
+                                                        {
+                                                            <div class="destination-row">
+                                                                <input type="text" class="dest-input" value="@dest"
+                                                                       @onchange="@(e => UpdateDestination(config.KeyMappings, defaultKey, dest, e.Value?.ToString() ?? ""))" />
+                                                                @if (destinations.Count > 1)
+                                                                {
+                                                                    <button class="chip-remove" @onclick="@(() => RemoveDestination(config.KeyMappings, defaultKey, dest))">×</button>
+                                                                }
+                                                                else
+                                                                {
+                                                                    <div class="btn-placeholder"></div>
+                                                                }
+                                                            </div>
+                                                        }
+                                                        <button class="btn-add-dest" @onclick="@(() => AddDestination(config.KeyMappings, defaultKey))" title="Add another destination">
+                                                            <i class="fa-solid fa-plus"></i>
+                                                        </button>
+                                                    </div>
+                                                </div>
+                                            }
+                                        </div>
+                                    </div>
+                                }
+                            }
+                        </div>
+                    }
+                }
             </div>
         }
 
@@ -310,6 +408,102 @@
                                     </div>
                                 }
                             </div>
+                        </div>
+                    }
+                }
+
+                <div class="section-header section-spaced">
+                    <span>Google Identities</span>
+                    <button class="btn-action small" @onclick="OpenGoogleIdentityPicker">
+                        <i class="fa-solid fa-plus"></i> Add Identity
+                    </button>
+                </div>
+                <div class="form-hint">Google service account identities to publish as CI/CD secrets</div>
+
+                @if (!googleIdentityConfigs.Any())
+                {
+                    <div class="empty-state">
+                        <i class="fa-brands fa-google"></i>
+                        <p>No Google identities added</p>
+                        @if (!googleIdentities.Any())
+                        {
+                            <div class="form-hint text-muted">No Google identities configured. Configure in Settings first.</div>
+                        }
+                    </div>
+                }
+                else
+                {
+                    @foreach (var config in googleIdentityConfigs)
+                    {
+                        var identity = googleIdentities.FirstOrDefault(i => i.Id == config.IdentityId);
+                        <div class="config-card">
+                            <div class="config-header">
+                                <div class="config-badges">
+                                    <i class="fa-brands fa-google"></i>
+                                    <span class="config-label-text">@config.Label</span>
+                                    @if (identity is null)
+                                    {
+                                        <span class="badge warning">Missing</span>
+                                    }
+                                </div>
+                                <div class="config-actions">
+                                    <button class="btn-icon-action danger" @onclick="@(() => googleIdentityConfigs.Remove(config))" title="Remove">
+                                        <i class="fa-solid fa-trash-can"></i>
+                                    </button>
+                                </div>
+                            </div>
+                            <div class="config-summary">
+                                @if (identity is not null)
+                                {
+                                    <div class="summary-item"><i class="fa-solid fa-diagram-project"></i> <span class="@(demoMode ? "demo-blur" : "")">@identity.ProjectId</span></div>
+                                    <div class="summary-item"><i class="fa-solid fa-envelope"></i> <span class="@(demoMode ? "demo-blur" : "")">@identity.ClientEmail</span></div>
+                                    <div class="summary-item"><i class="fa-solid fa-file-code"></i> Service account JSON</div>
+                                }
+                                else
+                                {
+                                    <div class="summary-item"><i class="fa-solid fa-triangle-exclamation"></i> Identity no longer exists in Settings</div>
+                                }
+                            </div>
+                            @{
+                                var keys = config.GetDefaultKeys();
+                                if (keys.Any())
+                                {
+                                    <div class="key-mappings-section">
+                                        <div class="key-mappings-label"><i class="fa-solid fa-key"></i> Key Mappings</div>
+                                        <div class="key-mappings">
+                                            @foreach (var defaultKey in keys)
+                                            {
+                                                <div class="key-mapping-row">
+                                                    <div class="key-label">@defaultKey</div>
+                                                    <div class="key-destinations">
+                                                        @{
+                                                            var destinations = config.KeyMappings.GetValueOrDefault(defaultKey) ?? new List<string>();
+                                                        }
+                                                        @foreach (var dest in destinations)
+                                                        {
+                                                            <div class="destination-row">
+                                                                <input type="text" class="dest-input" value="@dest"
+                                                                       @onchange="@(e => UpdateDestination(config.KeyMappings, defaultKey, dest, e.Value?.ToString() ?? ""))" />
+                                                                @if (destinations.Count > 1)
+                                                                {
+                                                                    <button class="chip-remove" @onclick="@(() => RemoveDestination(config.KeyMappings, defaultKey, dest))">×</button>
+                                                                }
+                                                                else
+                                                                {
+                                                                    <div class="btn-placeholder"></div>
+                                                                }
+                                                            </div>
+                                                        }
+                                                        <button class="btn-add-dest" @onclick="@(() => AddDestination(config.KeyMappings, defaultKey))" title="Add another destination">
+                                                            <i class="fa-solid fa-plus"></i>
+                                                        </button>
+                                                    </div>
+                                                </div>
+                                            }
+                                        </div>
+                                    </div>
+                                }
+                            }
                         </div>
                     }
                 }
@@ -533,6 +727,10 @@
         color: var(--text-primary);
     }
 
+    .section-spaced {
+        margin-top: 8px;
+    }
+
     .btn-action {
         display: inline-flex;
         align-items: center;
@@ -550,6 +748,11 @@
 
     .btn-action:hover {
         opacity: 0.9;
+    }
+
+    .btn-action:disabled {
+        opacity: 0.55;
+        cursor: not-allowed;
     }
 
     .btn-action.small {
@@ -1000,6 +1203,11 @@
         color: var(--success-color, #22c55e);
     }
 
+    .badge.warning {
+        background: rgba(245, 158, 11, 0.12);
+        color: var(--warning-color, #f59e0b);
+    }
+
     .config-summary {
         padding: 8px 14px 10px 18px;
         display: flex;
@@ -1036,11 +1244,14 @@
 
     // Apple
     private List<AppleConfigVM> appleConfigs = new();
+    private List<AppleIdentityConfigVM> appleIdentityConfigs = new();
     private List<AppleIdentity> appleIdentities = new();
 
     // Android
     private List<AndroidConfigVM> androidConfigs = new();
+    private List<GoogleIdentityConfigVM> googleIdentityConfigs = new();
     private List<AndroidKeystore> keystores = new();
+    private List<GoogleIdentity> googleIdentities = new();
 
     // Secrets
     private List<SecretMappingVM> secretMappings = new();
@@ -1104,11 +1315,25 @@
                 IsComplete = true
             }).ToList();
 
+            appleIdentityConfigs = (existing.AppleIdentities ?? new()).Select(a => new AppleIdentityConfigVM
+            {
+                Label = a.Label,
+                IdentityId = a.IdentityId,
+                KeyMappings = a.KeyMappings.ToDictionary(k => k.Key, k => k.Value.ToList())
+            }).ToList();
+
             androidConfigs = existing.AndroidConfigs.Select(a => new AndroidConfigVM
             {
                 Label = a.Label,
                 KeystoreId = a.KeystoreId,
                 KeyMappings = a.KeyMappings.ToDictionary(k => k.Key, k => k.Value.ToList())
+            }).ToList();
+
+            googleIdentityConfigs = (existing.GoogleIdentities ?? new()).Select(g => new GoogleIdentityConfigVM
+            {
+                Label = g.Label,
+                IdentityId = g.IdentityId,
+                KeyMappings = g.KeyMappings.ToDictionary(k => k.Key, k => k.Value.ToList())
             }).ToList();
 
             secretMappings = existing.SecretMappings.Select(s => new SecretMappingVM
@@ -1133,10 +1358,16 @@
 
             // Load Apple identities (cert/profile loading deferred to wizard identity selection)
             try { appleIdentities = (await AppleIdentityService.GetIdentitiesAsync()).ToList(); }
-            catch { }
+            catch (Exception ex) { Logger.LogWarning($"Failed to load Apple identities for publish profile editor: {ex.Message}"); }
+
+            try { googleIdentities = (await GoogleIdentityService.GetIdentitiesAsync()).ToList(); }
+            catch (Exception ex) { Logger.LogWarning($"Failed to load Google identities for publish profile editor: {ex.Message}"); }
 
         }
-        catch { }
+        catch (Exception ex)
+        {
+            Logger.LogWarning($"Failed to load publish profile editor data: {ex.Message}");
+        }
 
         StateHasChanged();
     }
@@ -1215,7 +1446,20 @@
                 ? (BridgeHolder.Current?.Parameters.TryGetValue("Profile", out var p) == true && p is PublishProfile ep ? ep.CreatedAt : DateTime.UtcNow)
                 : DateTime.UtcNow,
             UpdatedAt: DateTime.UtcNow
-        ) { Publishers = profilePublishers.ToList() };
+        )
+        {
+            Publishers = profilePublishers.ToList(),
+            AppleIdentities = appleIdentityConfigs.Select(a => new PublishProfileAppleIdentity(
+                a.Label,
+                a.IdentityId,
+                a.KeyMappings.ToDictionary(k => k.Key, k => k.Value.ToList())
+            )).ToList(),
+            GoogleIdentities = googleIdentityConfigs.Select(g => new PublishProfileGoogleIdentity(
+                g.Label,
+                g.IdentityId,
+                g.KeyMappings.ToDictionary(k => k.Key, k => k.Value.ToList())
+            )).ToList()
+        };
 
         try
         {
@@ -1256,10 +1500,46 @@
         ValidateForm();
     }
 
+    private async Task OpenAppleIdentityPicker()
+    {
+        var existingIdentityIds = appleIdentityConfigs.Select(a => a.IdentityId).ToList();
+        var page = new AppleIdentityPickerPage(BridgeHolder, appleIdentities, existingIdentityIds);
+        var result = await FormModal.ShowAsync(page);
+        if (result is null || appleIdentityConfigs.Any(a => a.IdentityId == result.Id))
+            return;
+
+        var config = new AppleIdentityConfigVM
+        {
+            Label = result.Name,
+            IdentityId = result.Id
+        };
+        config.GetDefaultKeys();
+        appleIdentityConfigs.Add(config);
+        ValidateForm();
+    }
+
     // Android helpers
     private void AddAndroidConfig()
     {
         androidConfigs.Add(new AndroidConfigVM { Label = "PlayStore" });
+    }
+
+    private async Task OpenGoogleIdentityPicker()
+    {
+        var existingIdentityIds = googleIdentityConfigs.Select(g => g.IdentityId).ToList();
+        var page = new GoogleIdentityPickerPage(BridgeHolder, googleIdentities, existingIdentityIds);
+        var result = await FormModal.ShowAsync(page);
+        if (result is null || googleIdentityConfigs.Any(g => g.IdentityId == result.Id))
+            return;
+
+        var config = new GoogleIdentityConfigVM
+        {
+            Label = result.Name,
+            IdentityId = result.Id
+        };
+        config.GetDefaultKeys();
+        googleIdentityConfigs.Add(config);
+        ValidateForm();
     }
 
     // Secrets helpers
@@ -1338,6 +1618,74 @@
                 keys.Add($"ANDROID_{label}_KEY_ALIAS");
                 keys.Add($"ANDROID_{label}_KEY_PASSWORD");
             }
+
+            foreach (var key in keys)
+            {
+                if (!KeyMappings.ContainsKey(key))
+                    KeyMappings[key] = new List<string> { key };
+            }
+
+            foreach (var k in KeyMappings.Keys.ToList())
+            {
+                if (!keys.Contains(k))
+                    KeyMappings.Remove(k);
+            }
+
+            return keys;
+        }
+    }
+
+    private class AppleIdentityConfigVM
+    {
+        public string Label { get; set; } = "";
+        public string IdentityId { get; set; } = "";
+        public Dictionary<string, List<string>> KeyMappings { get; set; } = new();
+
+        public List<string> GetDefaultKeys()
+        {
+            var label = string.IsNullOrWhiteSpace(Label)
+                ? "IDENTITY"
+                : Label.ToUpperInvariant().Replace(' ', '_').Replace('-', '_');
+            var keys = new List<string>
+            {
+                $"APPLE_{label}_KEY_ID",
+                $"APPLE_{label}_ISSUER_ID",
+                $"APPLE_{label}_P8_KEY"
+            };
+
+            foreach (var key in keys)
+            {
+                if (!KeyMappings.ContainsKey(key))
+                    KeyMappings[key] = new List<string> { key };
+            }
+
+            foreach (var k in KeyMappings.Keys.ToList())
+            {
+                if (!keys.Contains(k))
+                    KeyMappings.Remove(k);
+            }
+
+            return keys;
+        }
+    }
+
+    private class GoogleIdentityConfigVM
+    {
+        public string Label { get; set; } = "";
+        public string IdentityId { get; set; } = "";
+        public Dictionary<string, List<string>> KeyMappings { get; set; } = new();
+
+        public List<string> GetDefaultKeys()
+        {
+            var label = string.IsNullOrWhiteSpace(Label)
+                ? "IDENTITY"
+                : Label.ToUpperInvariant().Replace(' ', '_').Replace('-', '_');
+            var keys = new List<string>
+            {
+                $"GOOGLE_{label}_PROJECT_ID",
+                $"GOOGLE_{label}_CLIENT_EMAIL",
+                $"GOOGLE_{label}_SERVICE_ACCOUNT_JSON"
+            };
 
             foreach (var key in keys)
             {

--- a/src/MauiSherpa/Pages/SecretsPublish.razor
+++ b/src/MauiSherpa/Pages/SecretsPublish.razor
@@ -65,10 +65,22 @@ else
                             <i class="fa-brands fa-apple"></i> @profile.AppleConfigs.Count Apple
                         </span>
                     }
+                    @if (profile.AppleIdentities.Any())
+                    {
+                        <span class="summary-badge apple">
+                            <i class="fa-solid fa-id-badge"></i> @profile.AppleIdentities.Count Apple @(profile.AppleIdentities.Count == 1 ? "Identity" : "Identities")
+                        </span>
+                    }
                     @if (profile.AndroidConfigs.Any())
                     {
                         <span class="summary-badge android">
                             <i class="fa-brands fa-android"></i> @profile.AndroidConfigs.Count Android
+                        </span>
+                    }
+                    @if (profile.GoogleIdentities.Any())
+                    {
+                        <span class="summary-badge android">
+                            <i class="fa-brands fa-google"></i> @profile.GoogleIdentities.Count Google @(profile.GoogleIdentities.Count == 1 ? "Identity" : "Identities")
                         </span>
                     }
                     @if (profile.SecretMappings.Any())

--- a/tests/MauiSherpa.Core.Tests/Services/PublishProfileServiceTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/PublishProfileServiceTests.cs
@@ -1,0 +1,150 @@
+using System.Text.Json;
+using FluentAssertions;
+using MauiSherpa.Core.Interfaces;
+using MauiSherpa.Core.Services;
+using Moq;
+
+namespace MauiSherpa.Core.Tests.Services;
+
+public class PublishProfileServiceTests
+{
+    readonly Mock<ICloudSecretsService> _cloudService = new();
+    readonly Mock<ICertificateSyncService> _certSync = new();
+    readonly Mock<IKeystoreService> _keystoreService = new();
+    readonly Mock<ISecureStorageService> _secureStorage = new();
+    readonly Mock<IManagedSecretsService> _managedSecrets = new();
+    readonly Mock<IAppleConnectService> _appleConnect = new();
+    readonly Mock<IAppleIdentityService> _appleIdentity = new();
+    readonly Mock<IAppleIdentityStateService> _identityState = new();
+    readonly Mock<IGoogleIdentityService> _googleIdentity = new();
+    readonly Mock<ILoggingService> _logger = new();
+    readonly PublishProfileService _sut;
+
+    static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    public PublishProfileServiceTests()
+    {
+        _sut = new PublishProfileService(
+            _cloudService.Object,
+            _certSync.Object,
+            _keystoreService.Object,
+            _secureStorage.Object,
+            _managedSecrets.Object,
+            _appleConnect.Object,
+            _appleIdentity.Object,
+            _identityState.Object,
+            _googleIdentity.Object,
+            _logger.Object);
+    }
+
+    [Fact]
+    public async Task ResolveSecretsAsync_WithAppleIdentity_MapsIdentityCredentials()
+    {
+        _appleIdentity.Setup(x => x.GetIdentityAsync("identity-1"))
+            .ReturnsAsync(new AppleIdentity(
+                Id: "identity-1",
+                Name: "Production Team",
+                KeyId: "ABC123XYZ0",
+                IssuerId: "11111111-2222-3333-4444-555555555555",
+                P8KeyPath: null,
+                P8KeyContent: "-----BEGIN PRIVATE KEY-----\nsecret\n-----END PRIVATE KEY-----"));
+
+        var profile = CreateProfile() with
+        {
+            AppleIdentities = new List<PublishProfileAppleIdentity>
+            {
+                new(
+                    Label: "Production Team",
+                    IdentityId: "identity-1",
+                    KeyMappings: new Dictionary<string, List<string>>
+                    {
+                        ["APPLE_PRODUCTION_TEAM_KEY_ID"] = new() { "ASC_KEY_ID" },
+                        ["APPLE_PRODUCTION_TEAM_ISSUER_ID"] = new() { "ASC_ISSUER_ID" },
+                        ["APPLE_PRODUCTION_TEAM_P8_KEY"] = new() { "ASC_PRIVATE_KEY", "ASC_PRIVATE_KEY_COPY" }
+                    })
+            }
+        };
+
+        var secrets = await _sut.ResolveSecretsAsync(profile);
+
+        secrets.Should().Contain("ASC_KEY_ID", "ABC123XYZ0");
+        secrets.Should().Contain("ASC_ISSUER_ID", "11111111-2222-3333-4444-555555555555");
+        secrets.Should().Contain("ASC_PRIVATE_KEY", "-----BEGIN PRIVATE KEY-----\nsecret\n-----END PRIVATE KEY-----");
+        secrets.Should().Contain("ASC_PRIVATE_KEY_COPY", "-----BEGIN PRIVATE KEY-----\nsecret\n-----END PRIVATE KEY-----");
+        _appleIdentity.Verify(x => x.GetIdentityAsync("identity-1"), Times.Once);
+    }
+
+    [Fact]
+    public async Task ResolveSecretsAsync_WithGoogleIdentity_MapsIdentityCredentials()
+    {
+        const string serviceAccountJson = """
+            {"type":"service_account","project_id":"firebase-prod","private_key":"secret","client_email":"firebase-adminsdk@example.iam.gserviceaccount.com"}
+            """;
+        _googleIdentity.Setup(x => x.GetIdentityAsync("google-1"))
+            .ReturnsAsync(new GoogleIdentity(
+                Id: "google-1",
+                Name: "Firebase Prod",
+                ProjectId: "firebase-prod",
+                ClientEmail: "firebase-adminsdk@example.iam.gserviceaccount.com",
+                ServiceAccountJsonPath: null,
+                ServiceAccountJson: serviceAccountJson));
+
+        var profile = CreateProfile() with
+        {
+            GoogleIdentities = new List<PublishProfileGoogleIdentity>
+            {
+                new(
+                    Label: "Firebase Prod",
+                    IdentityId: "google-1",
+                    KeyMappings: new Dictionary<string, List<string>>
+                    {
+                        ["GOOGLE_FIREBASE_PROD_PROJECT_ID"] = new() { "FIREBASE_PROJECT_ID" },
+                        ["GOOGLE_FIREBASE_PROD_CLIENT_EMAIL"] = new() { "FIREBASE_CLIENT_EMAIL" },
+                        ["GOOGLE_FIREBASE_PROD_SERVICE_ACCOUNT_JSON"] = new() { "FIREBASE_SERVICE_ACCOUNT_JSON" }
+                    })
+            }
+        };
+
+        var secrets = await _sut.ResolveSecretsAsync(profile);
+
+        secrets.Should().Contain("FIREBASE_PROJECT_ID", "firebase-prod");
+        secrets.Should().Contain("FIREBASE_CLIENT_EMAIL", "firebase-adminsdk@example.iam.gserviceaccount.com");
+        secrets.Should().Contain("FIREBASE_SERVICE_ACCOUNT_JSON", serviceAccountJson);
+        _googleIdentity.Verify(x => x.GetIdentityAsync("google-1"), Times.Once);
+    }
+
+    [Fact]
+    public void DeserializeProfile_WhenIdentityPropertiesAreMissing_UsesEmptyLists()
+    {
+        var original = CreateProfile();
+        var json = JsonSerializer.Serialize(original, JsonOptions);
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+        var legacyProperties = root.EnumerateObject()
+            .Where(property => property.Name is not "appleIdentities" and not "googleIdentities")
+            .Select(property => $"\"{property.Name}\":{property.Value.GetRawText()}");
+        var legacyJson = "{" + string.Join(",", legacyProperties) + "}";
+
+        var profile = JsonSerializer.Deserialize<PublishProfile>(legacyJson, JsonOptions);
+
+        profile.Should().NotBeNull();
+        profile!.AppleIdentities.Should().BeEmpty();
+        profile.GoogleIdentities.Should().BeEmpty();
+    }
+
+    static PublishProfile CreateProfile() => new(
+        Id: "profile-1",
+        Name: "Profile",
+        Description: null,
+        PublisherId: null,
+        RepositoryId: null,
+        RepositoryFullName: null,
+        AppleConfigs: new List<PublishProfileAppleConfig>(),
+        AndroidConfigs: new List<PublishProfileAndroidConfig>(),
+        SecretMappings: new List<PublishProfileSecretMapping>(),
+        CreatedAt: DateTime.UtcNow,
+        UpdatedAt: DateTime.UtcNow);
+}


### PR DESCRIPTION
Publish profiles can now reuse the Apple and Google developer identities already configured in Settings, instead of requiring those credential values to be re-entered as generic secrets.

## Summary
- Adds Apple and Google identity mapping sections to the publish profile editor, with picker modals that load configured identities from Settings.
- Extends publish profile data, backup data, and secret resolution so mapped identity fields are emitted alongside existing platform configuration mappings.
- Shows Apple/Google identity counts in the publish profile list for quick review.
- Adds the native macOS Bluetooth usage description needed by Apple development tooling to avoid a TCC launch kill while observing devices.

## Validation
- `dotnet test tests/MauiSherpa.Core.Tests/MauiSherpa.Core.Tests.csproj --nologo --verbosity minimal`
- `dotnet build src/MauiSherpa.MacOS --nologo --verbosity minimal`