### PR TITLE
Fix Copilot SDK integration

### DIFF
--- a/src/MauiSherpa.Core/MauiSherpa.Core.csproj
+++ b/src/MauiSherpa.Core/MauiSherpa.Core.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2" />
     <PackageReference Include="FluentValidation" Version="11.11.0" />
-    <PackageReference Include="GitHub.Copilot.SDK" Version="0.2.0" />
+    <PackageReference Include="GitHub.Copilot.SDK" Version="1.0.2" />
     <PackageReference Include="Microsoft.TeamFoundation.DistributedTask.WebApi" Version="19.225.2" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="19.225.2" />
     <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="19.225.2" />

--- a/src/MauiSherpa.Core/Services/CopilotService.cs
+++ b/src/MauiSherpa.Core/Services/CopilotService.cs
@@ -1,5 +1,6 @@
-using GitHub.Copilot.SDK;
+using GitHub.Copilot;
 using MauiSherpa.Core.Interfaces;
+using Microsoft.Extensions.AI;
 using System.Text.Json;
 
 namespace MauiSherpa.Core.Services;
@@ -30,7 +31,7 @@ public class CopilotService : ICopilotService, IAsyncDisposable
     private IDisposable? _eventSubscription;
     private CopilotAvailability? _cachedAvailability;
 
-    public bool IsConnected => _client?.State == ConnectionState.Connected;
+    public bool IsConnected => _client != null;
     public string? CurrentSessionId => _session?.SessionId;
     public IReadOnlyList<CopilotChatMessage> Messages => _messages.AsReadOnly();
     public CopilotAvailability? CachedAvailability => _cachedAvailability;
@@ -348,9 +349,9 @@ public class CopilotService : ICopilotService, IAsyncDisposable
 
                 var options = new CopilotClientOptions
                 {
-                    AutoStart = true,
-                    CliPath = cliPath,
-                    Cwd = _copilotWorkingDirectory,
+                    Connection = RuntimeConnection.ForStdio(cliPath),
+                    WorkingDirectory = _copilotWorkingDirectory,
+                    BaseDirectory = _copilotWorkingDirectory,
                     Environment = cliEnvironment
                 };
 
@@ -457,7 +458,7 @@ public class CopilotService : ICopilotService, IAsyncDisposable
         await _clientGate.WaitAsync();
         try
         {
-            if (_client?.State == ConnectionState.Connected)
+            if (_client != null)
             {
                 _logger.LogInformation("Already connected to Copilot");
                 return;
@@ -495,11 +496,10 @@ public class CopilotService : ICopilotService, IAsyncDisposable
 
             var options = new CopilotClientOptions
             {
-                AutoStart = true,
-                UseStdio = true,
-                Cwd = _copilotWorkingDirectory,
-                LogLevel = "info",
-                CliPath = cliPath,
+                Connection = RuntimeConnection.ForStdio(cliPath),
+                WorkingDirectory = _copilotWorkingDirectory,
+                BaseDirectory = _copilotWorkingDirectory,
+                LogLevel = CopilotLogLevel.Info,
                 Environment = cliEnvironment
             };
 
@@ -588,7 +588,7 @@ public class CopilotService : ICopilotService, IAsyncDisposable
             {
                 Model = model ?? "claude-opus-4.5", // Use Claude Opus 4.5 as default
                 Streaming = true,
-                Tools = tools.ToList(),
+                Tools = tools.Cast<AIFunctionDeclaration>().ToList(),
                 OnPermissionRequest = HandleSdkPermissionRequest,
                 SystemMessage = new SystemMessageConfig
                 {
@@ -624,7 +624,7 @@ public class CopilotService : ICopilotService, IAsyncDisposable
             _session = await _client.CreateSessionAsync(config);
             
             // Subscribe to session events
-            _eventSubscription = _session.On(HandleSessionEvent);
+            _eventSubscription = _session.On<SessionEvent>(HandleSessionEvent);
             
             _logger.LogInformation($"Session started: {_session.SessionId}");
         }
@@ -635,7 +635,8 @@ public class CopilotService : ICopilotService, IAsyncDisposable
         }
     }
     
-    private async Task<PermissionRequestResult> HandleSdkPermissionRequest(PermissionRequest request, PermissionInvocation invocation)
+#pragma warning disable GHCP001
+    private async Task<GitHub.Copilot.Rpc.PermissionDecision> HandleSdkPermissionRequest(PermissionRequest request, PermissionInvocation invocation)
     {
         var resolved = ResolvePermissionRequest(request);
 
@@ -666,22 +667,23 @@ public class CopilotService : ICopilotService, IAsyncDisposable
             if (result.IsAllowed)
             {
                 _logger.LogDebug($"Returning approved for tool: {resolved.ToolName}");
-                return new PermissionRequestResult { Kind = PermissionRequestResultKind.Approved };
+                return GitHub.Copilot.Rpc.PermissionDecision.ApproveOnce();
             }
 
             _logger.LogDebug($"Returning interactive denial for tool: {resolved.ToolName}");
-            return new PermissionRequestResult { Kind = PermissionRequestResultKind.DeniedInteractivelyByUser };
+            return GitHub.Copilot.Rpc.PermissionDecision.Reject(result.DenialReason);
         }
         
         // Default: allow read-only tools, deny destructive tools
         if (resolved.IsReadOnly)
         {
-            return new PermissionRequestResult { Kind = PermissionRequestResultKind.Approved };
+            return GitHub.Copilot.Rpc.PermissionDecision.ApproveOnce();
         }
         
         // Default deny for destructive tools if no handler
-        return new PermissionRequestResult { Kind = PermissionRequestResultKind.DeniedCouldNotRequestFromUser };
+        return GitHub.Copilot.Rpc.PermissionDecision.UserNotAvailable();
     }
+#pragma warning restore GHCP001
 
     private ResolvedPermissionRequest ResolvePermissionRequest(PermissionRequest request)
     {
@@ -880,7 +882,7 @@ public class CopilotService : ICopilotService, IAsyncDisposable
     {
         if (_session == null)
         {
-            throw new InvalidOperationException("No active session. Call StartSessionAsync first.");
+            await StartSessionAsync();
         }
 
         try

--- a/src/MauiSherpa.MacOS/MauiSherpa.MacOS.csproj
+++ b/src/MauiSherpa.MacOS/MauiSherpa.MacOS.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="Blazorise.Icons.FontAwesome" Version="1.7.2" />
     <!-- Reference the SDK directly so its build targets run with the AppKit publish RID
          instead of inheriting the build-host architecture from MauiSherpa.Core. -->
-    <PackageReference Include="GitHub.Copilot.SDK" Version="0.2.0" PrivateAssets="all" />
+    <PackageReference Include="GitHub.Copilot.SDK" Version="1.0.2" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Components.QuickGrid" Version="10.0.1" />
     <PackageReference Include="Markdig" Version="0.44.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="10.0.1" />

--- a/src/MauiSherpa/Pages/Copilot.razor
+++ b/src/MauiSherpa/Pages/Copilot.razor
@@ -2534,6 +2534,10 @@ else
             if (!CopilotService.IsConnected)
             {
                 await CopilotService.ConnectAsync();
+            }
+
+            if (CopilotService.CurrentSessionId == null)
+            {
                 await CopilotService.StartSessionAsync(systemPrompt: _systemPrompt);
             }
 


### PR DESCRIPTION
The Copilot integration was broken because the app was still using an older SDK that cannot deserialize responses from the current Copilot CLI. This updates the SDK usage and fixes the connected-but-sessionless path exposed during native macOS validation.

## Changes
- Update `GitHub.Copilot.SDK` references to `1.0.2` for Core and native macOS.
- Migrate `CopilotService` to the v1 SDK APIs for stdio connections, session events, tool declarations, and permission decisions.
- Ensure a Copilot session is started before sending when availability checks have already created/reused a connected client.

## Validation
- Built native macOS target: `dotnet build src/MauiSherpa.MacOS/MauiSherpa.MacOS.csproj -f net10.0-macos -v minimal`
- Ran Core tests: `dotnet test tests/MauiSherpa.Core.Tests/MauiSherpa.Core.Tests.csproj -v minimal`
- Validated native macOS Copilot flow: toolbar Copilot opens, authenticates as `Redth`, starts a session, sends a prompt, and receives an assistant response.

## Notes
- This intentionally does not change Mac Catalyst. Native macOS/AppKit was used for final validation.