### PR TITLE
chore: configure Dependabot for NuGet and SDK updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "dotnet-sdk"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary
- add a repository-level Dependabot config for weekly NuGet package updates
- enable weekly updates for the pinned .NET SDK version declared in `global.json`
- keep the update volume bounded with a modest open PR limit

## Notes
- the repository does not currently include a committed workload-set manifest, so there was nothing separate to configure for workload-set updates in this change