### PR TITLE
Add winget manifest publishing workflow

### DIFF
--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -1,6 +1,10 @@
 name: Publish Winget Manifest
 
 on:
+  pull_request:
+    paths:
+      - '.github/workflows/publish-winget.yml'
+      - 'winget/**'
   release:
     types: [published]
   workflow_dispatch:

--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -110,28 +110,38 @@ PY
           x64_sha = os.environ['X64_SHA256']
           arm64_sha = os.environ['ARM64_SHA256']
 
-          template = Path('winget/maui-sherpa.template.yaml').read_text(encoding='utf-8')
-          template = template.replace('__VERSION__', version)
-          template = template.replace('__RELEASE_TAG__', release_tag)
-          template = template.replace('__X64_SHA256__', x64_sha)
-          template = template.replace('__ARM64_SHA256__', arm64_sha)
+          output_dir = Path('./artifacts/manifests')
+          output_dir.mkdir(parents=True, exist_ok=True)
 
-          output = Path('./artifacts/maui-sherpa.yaml')
-          output.write_text(template, encoding='utf-8')
-          print(output)
-          print(template)
+          templates = {
+              'winget/Maui.Sherpa.version.template.yaml': 'Maui.Sherpa.yaml',
+              'winget/Maui.Sherpa.installer.template.yaml': 'Maui.Sherpa.installer.yaml',
+              'winget/Maui.Sherpa.locale.en-US.template.yaml': 'Maui.Sherpa.locale.en-US.yaml',
+          }
+
+          for template_path, output_name in templates.items():
+              content = Path(template_path).read_text(encoding='utf-8')
+              content = content.replace('__VERSION__', version)
+              content = content.replace('__RELEASE_TAG__', release_tag)
+              content = content.replace('__X64_SHA256__', x64_sha)
+              content = content.replace('__ARM64_SHA256__', arm64_sha)
+
+              output = output_dir / output_name
+              output.write_text(content, encoding='utf-8')
+              print(output)
+              print(content)
           PY
 
       - name: Validate Winget manifest
         shell: pwsh
         run: |
-          winget validate --manifest ./artifacts/maui-sherpa.yaml
+          winget validate --manifest ./artifacts/manifests
 
       - name: Upload generated manifest
         uses: actions/upload-artifact@v4
         with:
           name: maui-sherpa-winget-manifest
-          path: ./artifacts/maui-sherpa.yaml
+          path: ./artifacts/manifests
           retention-days: 30
 
       - name: Notify about manual submission

--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -37,6 +37,9 @@ jobs:
             TAG="$RELEASE_TAG_INPUT"
           elif [[ -n "$RELEASE_EVENT_TAG" ]]; then
             TAG="$RELEASE_EVENT_TAG"
+          elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            VERSION=$(grep '<AppVersion>' Directory.Build.props | sed 's/.*<AppVersion>\(.*\)<\/AppVersion>.*/\1/')
+            TAG="v$VERSION"
           else
             echo "No release tag was provided"
             exit 1
@@ -46,20 +49,33 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Download Windows release assets
+      - name: Prepare Windows release assets
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           mkdir -p ./artifacts
-          gh release download "${{ steps.release.outputs.tag }}" \
-            --repo "${{ github.repository }}" \
-            --pattern "MAUI-Sherpa.win-x64.zip" \
-            --dir ./artifacts
-          gh release download "${{ steps.release.outputs.tag }}" \
-            --repo "${{ github.repository }}" \
-            --pattern "MAUI-Sherpa.win-arm64.zip" \
-            --dir ./artifacts
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            python3 - <<'PY'
+import zipfile
+from pathlib import Path
+artifacts = Path('./artifacts')
+artifacts.mkdir(parents=True, exist_ok=True)
+(artifacts / 'placeholder.txt').write_text('placeholder', encoding='utf-8')
+for archive_name in ['MAUI-Sherpa.win-x64.zip', 'MAUI-Sherpa.win-arm64.zip']:
+    with zipfile.ZipFile(artifacts / archive_name, 'w') as zf:
+        zf.write(artifacts / 'placeholder.txt', 'placeholder.txt')
+PY
+          else
+            gh release download "${{ steps.release.outputs.tag }}" \
+              --repo "${{ github.repository }}" \
+              --pattern "MAUI-Sherpa.win-x64.zip" \
+              --dir ./artifacts
+            gh release download "${{ steps.release.outputs.tag }}" \
+              --repo "${{ github.repository }}" \
+              --pattern "MAUI-Sherpa.win-arm64.zip" \
+              --dir ./artifacts
+          fi
 
       - name: Compute SHA256 hashes
         id: hashes

--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -1,6 +1,13 @@
 name: Publish Winget Manifest
 
 on:
+  push:
+    branches:
+      - main
+      - redth-winget-publishing
+    paths:
+      - '.github/workflows/publish-winget.yml'
+      - 'winget/**'
   pull_request:
     paths:
       - '.github/workflows/publish-winget.yml'

--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -1,0 +1,113 @@
+name: Publish Winget Manifest
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to build the Winget manifest for (for example v0.8.1)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  generate-manifest:
+    name: Generate Winget manifest
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Determine release tag
+        id: release
+        shell: bash
+        env:
+          RELEASE_TAG_INPUT: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || '' }}
+          RELEASE_EVENT_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [[ -n "$RELEASE_TAG_INPUT" ]]; then
+            TAG="$RELEASE_TAG_INPUT"
+          elif [[ -n "$RELEASE_EVENT_TAG" ]]; then
+            TAG="$RELEASE_EVENT_TAG"
+          else
+            echo "No release tag was provided"
+            exit 1
+          fi
+
+          VERSION="${TAG#v}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Download Windows release assets
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p ./artifacts
+          gh release download "${{ steps.release.outputs.tag }}" \
+            --repo "${{ github.repository }}" \
+            --pattern "MAUI-Sherpa.win-x64.zip" \
+            --dir ./artifacts
+          gh release download "${{ steps.release.outputs.tag }}" \
+            --repo "${{ github.repository }}" \
+            --pattern "MAUI-Sherpa.win-arm64.zip" \
+            --dir ./artifacts
+
+      - name: Compute SHA256 hashes
+        id: hashes
+        shell: pwsh
+        run: |
+          $x64Hash = (Get-FileHash ./artifacts/MAUI-Sherpa.win-x64.zip -Algorithm SHA256).Hash.ToLowerInvariant()
+          $arm64Hash = (Get-FileHash ./artifacts/MAUI-Sherpa.win-arm64.zip -Algorithm SHA256).Hash.ToLowerInvariant()
+          Write-Output "x64_sha256=$x64Hash" >> $env:GITHUB_OUTPUT
+          Write-Output "arm64_sha256=$arm64Hash" >> $env:GITHUB_OUTPUT
+
+      - name: Render Winget manifest
+        shell: bash
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          X64_SHA256: ${{ steps.hashes.outputs.x64_sha256 }}
+          ARM64_SHA256: ${{ steps.hashes.outputs.arm64_sha256 }}
+        run: |
+          python3 - <<'PY'
+          import os
+          from pathlib import Path
+
+          version = os.environ['VERSION']
+          release_tag = os.environ['RELEASE_TAG']
+          x64_sha = os.environ['X64_SHA256']
+          arm64_sha = os.environ['ARM64_SHA256']
+
+          template = Path('winget/maui-sherpa.template.yaml').read_text(encoding='utf-8')
+          template = template.replace('__VERSION__', version)
+          template = template.replace('__RELEASE_TAG__', release_tag)
+          template = template.replace('__X64_SHA256__', x64_sha)
+          template = template.replace('__ARM64_SHA256__', arm64_sha)
+
+          output = Path('./artifacts/maui-sherpa.yaml')
+          output.write_text(template, encoding='utf-8')
+          print(output)
+          print(template)
+          PY
+
+      - name: Validate Winget manifest
+        shell: pwsh
+        run: |
+          winget validate --manifest ./artifacts/maui-sherpa.yaml
+
+      - name: Upload generated manifest
+        uses: actions/upload-artifact@v4
+        with:
+          name: maui-sherpa-winget-manifest
+          path: ./artifacts/maui-sherpa.yaml
+          retention-days: 30
+
+      - name: Notify about manual submission
+        if: ${{ github.event_name == 'release' }}
+        run: |
+          Write-Host "The manifest is ready. To publish it in winget, submit the generated file to the microsoft/winget-pkgs repository."

--- a/README.md
+++ b/README.md
@@ -234,8 +234,15 @@ brew install --cask redth/tap/maui-sherpa
 2. Extract and move `MAUI Sherpa.app` to Applications
 3. Right-click and select "Open" on first launch (to bypass Gatekeeper)
 
-#### Windows
-1. Download `MAUI-Sherpa.windows-x64.zip` or `MAUI-Sherpa.windows-arm64.zip`
+#### Windows (Winget)
+```powershell
+winget install Maui.Sherpa
+```
+
+This becomes available once the generated manifest is accepted into the upstream `microsoft/winget-pkgs` repository.
+
+#### Windows (Manual)
+1. Download `MAUI-Sherpa.win-x64.zip` or `MAUI-Sherpa.win-arm64.zip`
 2. Extract to your preferred location
 3. Run `MauiSherpa.exe`
 

--- a/winget/Maui.Sherpa.installer.template.yaml
+++ b/winget/Maui.Sherpa.installer.template.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+PackageIdentifier: Maui.Sherpa
+PackageVersion: __VERSION__
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: MauiSherpa.exe
+    PortableCommandAlias: mauisherpa
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Redth/MAUI.Sherpa/releases/download/__RELEASE_TAG__/MAUI-Sherpa.win-x64.zip
+    InstallerSha256: __X64_SHA256__
+  - Architecture: arm64
+    InstallerUrl: https://github.com/Redth/MAUI.Sherpa/releases/download/__RELEASE_TAG__/MAUI-Sherpa.win-arm64.zip
+    InstallerSha256: __ARM64_SHA256__
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/winget/Maui.Sherpa.locale.en-US.template.yaml
+++ b/winget/Maui.Sherpa.locale.en-US.template.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
 PackageIdentifier: Maui.Sherpa
 PackageVersion: __VERSION__
 PackageLocale: en-US
@@ -9,7 +10,7 @@ PackageUrl: https://github.com/Redth/MAUI.Sherpa
 License: MIT
 LicenseUrl: https://github.com/Redth/MAUI.Sherpa/blob/main/LICENSE
 ShortDescription: Desktop app for managing .NET MAUI developer tools
-Description: |
+Description: |-
   MAUI Sherpa is a desktop application for macOS, Windows, and Linux that helps manage your .NET MAUI development environment. It provides a unified interface for Android SDK management, Apple Developer tools, environment diagnostics, DevFlow app inspection, and GitHub Copilot integration.
 Moniker: mauisherpa
 Tags:
@@ -21,24 +22,5 @@ Tags:
   - apple
   - github-copilot
 ReleaseNotesUrl: https://github.com/Redth/MAUI.Sherpa/releases/tag/__RELEASE_TAG__
-Installers:
-  - Architecture: x64
-    InstallerType: zip
-    InstallerUrl: https://github.com/Redth/MAUI.Sherpa/releases/download/__RELEASE_TAG__/MAUI-Sherpa.win-x64.zip
-    InstallerSha256: __X64_SHA256__
-    NestedInstallerType: portable
-    NestedInstallerFiles:
-      - RelativeFilePath: MauiSherpa.exe
-        PortableCommandAlias: mauisherpa
-    Scope: user
-  - Architecture: arm64
-    InstallerType: zip
-    InstallerUrl: https://github.com/Redth/MAUI.Sherpa/releases/download/__RELEASE_TAG__/MAUI-Sherpa.win-arm64.zip
-    InstallerSha256: __ARM64_SHA256__
-    NestedInstallerType: portable
-    NestedInstallerFiles:
-      - RelativeFilePath: MauiSherpa.exe
-        PortableCommandAlias: mauisherpa
-    Scope: user
-ManifestType: singleton
+ManifestType: defaultLocale
 ManifestVersion: 1.10.0

--- a/winget/Maui.Sherpa.version.template.yaml
+++ b/winget/Maui.Sherpa.version.template.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+PackageIdentifier: Maui.Sherpa
+PackageVersion: __VERSION__
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0

--- a/winget/maui-sherpa.template.yaml
+++ b/winget/maui-sherpa.template.yaml
@@ -1,0 +1,44 @@
+PackageIdentifier: Maui.Sherpa
+PackageVersion: __VERSION__
+PackageLocale: en-US
+Publisher: Redth
+PublisherUrl: https://github.com/Redth/MAUI.Sherpa
+PublisherSupportUrl: https://github.com/Redth/MAUI.Sherpa/issues
+PackageName: Maui.Sherpa
+PackageUrl: https://github.com/Redth/MAUI.Sherpa
+License: MIT
+LicenseUrl: https://github.com/Redth/MAUI.Sherpa/blob/main/LICENSE
+ShortDescription: Desktop app for managing .NET MAUI developer tools
+Description: |
+  MAUI Sherpa is a desktop application for macOS, Windows, and Linux that helps manage your .NET MAUI development environment. It provides a unified interface for Android SDK management, Apple Developer tools, environment diagnostics, DevFlow app inspection, and GitHub Copilot integration.
+Moniker: mauisherpa
+Tags:
+  - maui
+  - dotnet
+  - dotnet-maui
+  - developer-tools
+  - android
+  - apple
+  - github-copilot
+ReleaseNotesUrl: https://github.com/Redth/MAUI.Sherpa/releases/tag/__RELEASE_TAG__
+Installers:
+  - Architecture: x64
+    InstallerType: zip
+    InstallerUrl: https://github.com/Redth/MAUI.Sherpa/releases/download/__RELEASE_TAG__/MAUI-Sherpa.win-x64.zip
+    InstallerSha256: __X64_SHA256__
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: MauiSherpa.exe
+        PortableCommandAlias: mauisherpa
+    Scope: user
+  - Architecture: arm64
+    InstallerType: zip
+    InstallerUrl: https://github.com/Redth/MAUI.Sherpa/releases/download/__RELEASE_TAG__/MAUI-Sherpa.win-arm64.zip
+    InstallerSha256: __ARM64_SHA256__
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: MauiSherpa.exe
+        PortableCommandAlias: mauisherpa
+    Scope: user
+ManifestType: singleton
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Adds a workflow to generate and validate a Winget manifest from the Windows release artifacts, plus the initial manifest template.