### PR TITLE
Add v0.11.3 release notes and bump winget manifest to schema 1.12.0

### DIFF
--- a/docs/release-notes/v0.11.3.md
+++ b/docs/release-notes/v0.11.3.md
@@ -1,0 +1,12 @@
+## 🏔️ v0.11.3 — "Opening a Supply Line"
+
+Still camped at the same altitude, but we're laying down a fresh resupply route. This patch is all about how Sherpa gets into your pack in the first place — opening a new delivery channel for Windows climbers and keeping our own gear inventory current.
+
+### 🔧 Infrastructure
+
+- **Winget manifest publishing** — A new workflow generates and validates a Windows Package Manager manifest on every release, paving the way to `winget install` Sherpa straight onto your Windows rig. (#187)
+- **Dependabot for NuGet & the .NET SDK** — Automated checks now keep our dependencies and toolchain fresh, so the kit never goes stale between climbs. (#176)
+
+---
+
+*The trail hasn't changed, but there's a new way to get supplies up the mountain.* 📦

--- a/winget/Maui.Sherpa.installer.template.yaml
+++ b/winget/Maui.Sherpa.installer.template.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 PackageIdentifier: Maui.Sherpa
 PackageVersion: __VERSION__
 InstallerType: zip
@@ -14,4 +14,4 @@ Installers:
     InstallerUrl: https://github.com/Redth/MAUI.Sherpa/releases/download/__RELEASE_TAG__/MAUI-Sherpa.win-arm64.zip
     InstallerSha256: __ARM64_SHA256__
 ManifestType: installer
-ManifestVersion: 1.10.0
+ManifestVersion: 1.12.0

--- a/winget/Maui.Sherpa.locale.en-US.template.yaml
+++ b/winget/Maui.Sherpa.locale.en-US.template.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 PackageIdentifier: Maui.Sherpa
 PackageVersion: __VERSION__
 PackageLocale: en-US
@@ -23,4 +23,4 @@ Tags:
   - github-copilot
 ReleaseNotesUrl: https://github.com/Redth/MAUI.Sherpa/releases/tag/__RELEASE_TAG__
 ManifestType: defaultLocale
-ManifestVersion: 1.10.0
+ManifestVersion: 1.12.0

--- a/winget/Maui.Sherpa.version.template.yaml
+++ b/winget/Maui.Sherpa.version.template.yaml
@@ -1,6 +1,6 @@
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 PackageIdentifier: Maui.Sherpa
 PackageVersion: __VERSION__
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.10.0
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Two related release-tidy changes:

1. **v0.11.3 release notes** — mountaineering-themed notes ("Opening a Supply Line"), generated via the `release-notes` skill. Patch release, infrastructure only: winget publishing (#187) + Dependabot (#176).

2. **Winget manifest schema 1.12.0** — bumped the three `winget/*.template.yaml` files from `1.10.0` to the current winget-pkgs schema `1.12.0` (`ManifestVersion` + `yaml-language-server` schema URLs). No required-field changes between 1.10→1.12. Regenerated manifests validate clean (`winget validate` → succeeded).

The v0.11.3 tag/release is published and the winget-pkgs submission PR is microsoft/winget-pkgs#391648.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>