### PR TITLE
Fix Copilot CLI CSPRNG crash on Windows release builds

### DIFF
--- a/src/MauiSherpa.Core/Services/CopilotService.cs
+++ b/src/MauiSherpa.Core/Services/CopilotService.cs
@@ -223,6 +223,29 @@ public class CopilotService : ICopilotService, IAsyncDisposable
                 environment[variable] = value;
         }
 
+        if (OperatingSystem.IsWindows())
+        {
+            // The Copilot CLI is a Node.js binary. On Windows, Node initializes its CSPRNG
+            // (via bcryptprimitives.dll) during startup and aborts with
+            // "Assertion failed: ncrypto::CSPRNG(nullptr, 0)" when SystemRoot/windir are not
+            // present in its environment. Because we pass a replacement environment to the
+            // child process, these (and other essential Windows variables) must be forwarded
+            // explicitly or the CLI crashes before it can connect.
+            foreach (var variable in new[]
+            {
+                "SystemRoot", "windir", "SystemDrive", "ComSpec", "PATHEXT",
+                "ProgramData", "ProgramFiles", "ProgramFiles(x86)", "ProgramW6432",
+                "LOCALAPPDATA", "APPDATA", "ALLUSERSPROFILE", "PUBLIC",
+                "USERNAME", "USERDOMAIN", "COMPUTERNAME",
+                "NUMBER_OF_PROCESSORS", "PROCESSOR_ARCHITECTURE"
+            })
+            {
+                var value = Environment.GetEnvironmentVariable(variable);
+                if (!string.IsNullOrWhiteSpace(value) && !environment.ContainsKey(variable))
+                    environment[variable] = value;
+            }
+        }
+
         return environment;
     }
 


### PR DESCRIPTION
## Problem

On packaged Windows release builds, connecting to GitHub Copilot failed with:

```
CLI process exited unexpectedly.
stderr: # ...copilot.exe: ... node::InitializeOncePerProcessInternal(...)
  # Assertion failed: ncrypto::CSPRNG(nullptr, 0)
```

## Root cause

`copilot.exe` is a Node.js binary. On Windows, Node initializes its CSPRNG at startup via `bcryptprimitives.dll`, which requires `SystemRoot`/`windir` to be present in the process environment.

`CopilotService.BuildCliEnvironment` builds a **replacement** environment for the spawned CLI process and only forwarded a Unix-oriented set of variables (HOME, PATH, TMP, LANG, etc.). On Windows `SystemRoot`/`windir` were never included, so Node aborted before it could connect. Debug `dotnet run` happens to inherit a different env and doesn't hit this, but the packaged WinGet/release build does.

## Fix

Add a Windows-only block in `BuildCliEnvironment` that forwards the essential system environment variables Node and its child processes need (`SystemRoot`, `windir`, `SystemDrive`, `ComSpec`, `PATHEXT`, `ProgramData`, `ProgramFiles`, etc.).

## Verification

Reproduced the exact CI release publish locally (`win-x64`, `WindowsPackageType=None`, `WindowsAppSDKSelfContained=true`, self-contained), launched the published app, and confirmed Copilot now connects successfully where it previously failed.