### PR TITLE
Configure Dependabot update grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,18 @@ updates:
       day: "monday"
       time: "06:00"
       timezone: "UTC"
+    groups:
+      nuget-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      nuget-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "dotnet-sdk"
@@ -16,4 +28,8 @@ updates:
       day: "monday"
       time: "06:00"
       timezone: "UTC"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     open-pull-requests-limit: 10


### PR DESCRIPTION
Dependabot currently opens separate PRs for each NuGet package update and can propose .NET SDK major-version jumps. This makes dependency maintenance noisier than needed and can move the repo to a new SDK major before we are ready.

This updates the Dependabot configuration to batch NuGet updates into grouped PRs by SemVer level, while ignoring major updates for the .NET SDK ecosystem so SDK updates stay within the current major version.

Validation: parsed `.github/dependabot.yml` successfully.