### PR TITLE
Add Android SDK packages page with update detection and cleanup

### DIFF
--- a/src/MauiSherpa.Core/Interfaces.cs
+++ b/src/MauiSherpa.Core/Interfaces.cs
@@ -2159,10 +2159,16 @@ public interface IOperationContext
     bool IsCancellationRequested { get; }
 
     /// <summary>
-    /// Whether the operation's optional secondary choice (if any) was selected
-    /// by the user. False when the operation defines no secondary option.
+    /// Ids of the operation's optional secondary choices that the user selected
+    /// (e.g. specific older package versions to remove). Empty when the
+    /// operation defines no secondary options or none were selected.
     /// </summary>
-    bool SecondaryOptionEnabled { get; }
+    IReadOnlyCollection<string> EnabledSecondaryOptionIds { get; }
+
+    /// <summary>
+    /// Convenience check for whether a specific secondary option was selected.
+    /// </summary>
+    bool IsSecondaryOptionEnabled(string optionId) => EnabledSecondaryOptionIds.Contains(optionId);
 }
 
 /// <summary>
@@ -2226,8 +2232,17 @@ public record OperationItem(
     Func<IOperationContext, Task<bool>> Execute,
     bool IsEnabled = true,
     bool CanDisable = true,
-    string? SecondaryOptionLabel = null,
-    bool SecondaryOptionDefault = false
+    IReadOnlyList<OperationSecondaryOption>? SecondaryOptions = null
+);
+
+/// <summary>
+/// An optional per-item secondary choice (e.g. "Remove older version 35.0.0").
+/// Each option is independently selectable in the confirmation UI.
+/// </summary>
+public record OperationSecondaryOption(
+    string Id,
+    string Label,
+    bool DefaultEnabled = false
 );
 
 /// <summary>
@@ -2246,16 +2261,21 @@ public class OperationItemStatus
     public TimeSpan? Duration { get; set; }
 
     /// <summary>
-    /// Optional secondary per-item choice (e.g. "Remove older versions"). When
-    /// non-null, the modal renders a secondary checkbox during confirmation.
+    /// Optional per-item secondary choices (e.g. older versions to remove).
+    /// When non-empty, the modal renders a sub-checkbox for each during
+    /// confirmation.
     /// </summary>
-    public string? SecondaryOptionLabel { get; init; }
+    public List<OperationSecondaryOptionStatus> SecondaryOptions { get; init; } = new();
+}
 
-    /// <summary>
-    /// Whether the secondary option is currently selected. Exposed to the
-    /// operation via <see cref="IOperationContext.SecondaryOptionEnabled"/>.
-    /// </summary>
-    public bool SecondaryOptionEnabled { get; set; }
+/// <summary>
+/// Runtime state of a single secondary option (selected or not).
+/// </summary>
+public class OperationSecondaryOptionStatus
+{
+    public string Id { get; init; } = "";
+    public string Label { get; init; } = "";
+    public bool Enabled { get; set; }
 }
 
 /// <summary>

--- a/src/MauiSherpa.Core/Interfaces.cs
+++ b/src/MauiSherpa.Core/Interfaces.cs
@@ -2157,6 +2157,12 @@ public interface IOperationContext
     /// Whether cancellation has been requested
     /// </summary>
     bool IsCancellationRequested { get; }
+
+    /// <summary>
+    /// Whether the operation's optional secondary choice (if any) was selected
+    /// by the user. False when the operation defines no secondary option.
+    /// </summary>
+    bool SecondaryOptionEnabled { get; }
 }
 
 /// <summary>
@@ -2219,7 +2225,9 @@ public record OperationItem(
     string Description,
     Func<IOperationContext, Task<bool>> Execute,
     bool IsEnabled = true,
-    bool CanDisable = true
+    bool CanDisable = true,
+    string? SecondaryOptionLabel = null,
+    bool SecondaryOptionDefault = false
 );
 
 /// <summary>
@@ -2236,6 +2244,18 @@ public class OperationItemStatus
     public List<OperationLogEntry> Log { get; } = new();
     public string? ErrorMessage { get; set; }
     public TimeSpan? Duration { get; set; }
+
+    /// <summary>
+    /// Optional secondary per-item choice (e.g. "Remove older versions"). When
+    /// non-null, the modal renders a secondary checkbox during confirmation.
+    /// </summary>
+    public string? SecondaryOptionLabel { get; init; }
+
+    /// <summary>
+    /// Whether the secondary option is currently selected. Exposed to the
+    /// operation via <see cref="IOperationContext.SecondaryOptionEnabled"/>.
+    /// </summary>
+    public bool SecondaryOptionEnabled { get; set; }
 }
 
 /// <summary>

--- a/src/MauiSherpa.Core/Services/AndroidSdkPackageVersioning.cs
+++ b/src/MauiSherpa.Core/Services/AndroidSdkPackageVersioning.cs
@@ -1,0 +1,280 @@
+using MauiSherpa.Core.Interfaces;
+
+namespace MauiSherpa.Core.Services;
+
+/// <summary>
+/// Describes how an Android SDK package group encodes its "version", which
+/// determines whether a newer release is a genuine in-place update or just a
+/// distinct, coexisting package.
+/// </summary>
+public enum SdkPackageVersioningStrategy
+{
+    /// <summary>
+    /// The package Path is constant and the release version lives only in the
+    /// Version field (e.g. <c>emulator</c>, <c>platform-tools</c>). A newer
+    /// Version on the same Path is a real in-place update.
+    /// </summary>
+    FixedPath,
+
+    /// <summary>
+    /// The Path identifies a fixed target/variant (API level, ABI, etc.) and the
+    /// Version field is an integer revision that bumps in place
+    /// (e.g. <c>platforms;android-33</c>, <c>system-images;...</c>). A newer
+    /// revision on the same Path is a real in-place update.
+    /// </summary>
+    Revision,
+
+    /// <summary>
+    /// The release version is embedded in the Path and multiple versions coexist
+    /// side-by-side (e.g. <c>build-tools;36.1.0</c>, <c>ndk;27.x</c>,
+    /// <c>cmake;3.22.1</c>). A newer release is a separate package, NOT an update.
+    /// </summary>
+    SideBySide
+}
+
+/// <summary>
+/// Central, testable logic for classifying Android SDK package groups and
+/// detecting genuine in-place updates.
+///
+/// An "update" is the same exact package Path with a newer stable Version. This
+/// matches the Android SDK manager's own "Available Updates" computation:
+/// FixedPath and Revision groups share a Path across versions (so a newer Version
+/// is an update), while SideBySide groups encode the version in the Path (so a
+/// newer release has a different Path and is intentionally never an update).
+/// </summary>
+public static class AndroidSdkPackageVersioning
+{
+    // Groups whose version lives only in the Version field (constant Path).
+    private static readonly HashSet<string> FixedPathGroups = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "emulator",
+        "platform-tools",
+        "tools",
+        "docs",
+        "ndk-bundle",
+        "extras",
+        "build",      // e.g. build;templates
+        "patcher",
+    };
+
+    // Groups whose version is embedded in the Path (coexisting, side-by-side).
+    private static readonly HashSet<string> SideBySideGroups = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "build-tools",
+        "ndk",
+        "cmake",
+    };
+
+    // Groups where the Path is a fixed target/variant and the Version is an
+    // updatable revision number.
+    private static readonly HashSet<string> RevisionGroups = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "platforms",
+        "sources",
+        "system-images",
+        "skiaparser",
+        "add-ons",
+    };
+
+    /// <summary>
+    /// Returns the leading group segment of a package path (text before the
+    /// first <c>;</c>), e.g. <c>system-images;android-33;...</c> → <c>system-images</c>.
+    /// </summary>
+    public static string GetGroup(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return string.Empty;
+
+        var separatorIndex = path.IndexOf(';');
+        return separatorIndex < 0 ? path : path[..separatorIndex];
+    }
+
+    /// <summary>
+    /// Classifies a package path into its versioning strategy.
+    /// </summary>
+    public static SdkPackageVersioningStrategy Classify(string? path)
+    {
+        var group = GetGroup(path);
+
+        if (SideBySideGroups.Contains(group))
+            return SdkPackageVersioningStrategy.SideBySide;
+
+        if (FixedPathGroups.Contains(group))
+            return SdkPackageVersioningStrategy.FixedPath;
+
+        if (RevisionGroups.Contains(group))
+            return SdkPackageVersioningStrategy.Revision;
+
+        // cmdline-tools is special: "cmdline-tools;latest" is a fixed-path,
+        // in-place package, while numbered ("cmdline-tools;13.0") entries are
+        // side-by-side. Default the group to FixedPath but override numbered ones.
+        if (string.Equals(group, "cmdline-tools", StringComparison.OrdinalIgnoreCase))
+        {
+            return IsCmdlineToolsLatest(path)
+                ? SdkPackageVersioningStrategy.FixedPath
+                : SdkPackageVersioningStrategy.SideBySide;
+        }
+
+        // Unknown groups: treat conservatively as Revision so exact-path updates
+        // are still detected (same Path + newer Version), without ever surfacing
+        // distinct paths as updates.
+        return SdkPackageVersioningStrategy.Revision;
+    }
+
+    private static bool IsCmdlineToolsLatest(string? path)
+    {
+        var remainder = GetSubPath(path);
+        return string.Equals(remainder, "latest", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string GetSubPath(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return string.Empty;
+
+        var separatorIndex = path.IndexOf(';');
+        return separatorIndex < 0 ? string.Empty : path[(separatorIndex + 1)..];
+    }
+
+    /// <summary>
+    /// True when a package group can ever produce in-place updates
+    /// (FixedPath or Revision). SideBySide groups never can.
+    /// </summary>
+    public static bool SupportsInPlaceUpdate(string? path)
+        => Classify(path) != SdkPackageVersioningStrategy.SideBySide;
+
+    /// <summary>
+    /// Finds the best available in-place update for an installed package, or null
+    /// if none. An update is the same exact Path with a newer (stable, by default)
+    /// Version. SideBySide packages never return an update.
+    /// </summary>
+    public static SdkPackageInfo? GetInPlaceUpdate(
+        SdkPackageInfo installed,
+        IEnumerable<SdkPackageInfo> availablePackages,
+        bool requireStable = true)
+    {
+        if (installed is null || availablePackages is null)
+            return null;
+
+        if (string.IsNullOrWhiteSpace(installed.Version))
+            return null;
+
+        if (!SupportsInPlaceUpdate(installed.Path))
+            return null;
+
+        return availablePackages
+            .Where(a => a is not null)
+            .Where(a => string.Equals(a.Path, installed.Path, StringComparison.OrdinalIgnoreCase))
+            .Where(a => !string.IsNullOrWhiteSpace(a.Version))
+            .Where(a => CompareVersions(a.Version, installed.Version) > 0)
+            .Where(a => !requireStable || IsStableVersion(a.Version))
+            .OrderByDescending(a => a.Version, VersionComparer.Instance)
+            .FirstOrDefault();
+    }
+
+    /// <summary>
+    /// True when an installed package has a genuine in-place update available.
+    /// </summary>
+    public static bool HasInPlaceUpdate(
+        SdkPackageInfo installed,
+        IEnumerable<SdkPackageInfo> availablePackages,
+        bool requireStable = true)
+        => GetInPlaceUpdate(installed, availablePackages, requireStable) is not null;
+
+    /// <summary>
+    /// Returns all installed packages that have a genuine in-place update available.
+    /// </summary>
+    public static IEnumerable<SdkPackageInfo> GetUpdates(
+        IEnumerable<SdkPackageInfo> installedPackages,
+        IEnumerable<SdkPackageInfo> availablePackages,
+        bool requireStable = true)
+    {
+        if (installedPackages is null || availablePackages is null)
+            return [];
+
+        var available = availablePackages.ToList();
+        return installedPackages.Where(p => HasInPlaceUpdate(p, available, requireStable)).ToList();
+    }
+
+    /// <summary>
+    /// Compares two Android SDK version strings. Handles pure integer revisions
+    /// (e.g. <c>3</c> vs <c>10</c>) and dotted semver (e.g. <c>36.4.10</c> vs
+    /// <c>36.6.11</c>). Returns &gt;0 when <paramref name="version1"/> is newer.
+    /// </summary>
+    public static int CompareVersions(string? version1, string? version2)
+    {
+        var v1Empty = string.IsNullOrWhiteSpace(version1);
+        var v2Empty = string.IsNullOrWhiteSpace(version2);
+        if (v1Empty && v2Empty) return 0;
+        if (v1Empty) return -1;
+        if (v2Empty) return 1;
+
+        var parts1 = version1!.Split(['.', '-', '_'], StringSplitOptions.RemoveEmptyEntries);
+        var parts2 = version2!.Split(['.', '-', '_'], StringSplitOptions.RemoveEmptyEntries);
+        var maxParts = Math.Max(parts1.Length, parts2.Length);
+
+        for (var i = 0; i < maxParts; i++)
+        {
+            var p1 = i < parts1.Length ? parts1[i] : "0";
+            var p2 = i < parts2.Length ? parts2[i] : "0";
+
+            if (int.TryParse(p1, out var n1) && int.TryParse(p2, out var n2))
+            {
+                if (n1 != n2)
+                    return n1 > n2 ? 1 : -1;
+                continue;
+            }
+
+            var comparison = string.Compare(p1, p2, StringComparison.OrdinalIgnoreCase);
+            if (comparison != 0)
+                return comparison;
+        }
+
+        return 0;
+    }
+
+    private static readonly string[] PrereleaseMarkers =
+    [
+        "preview", "alpha", "beta", "rc", "dev", "canary", "nightly"
+    ];
+
+    /// <summary>
+    /// True when a version string looks like a stable release. Prerelease markers
+    /// are matched as whole, token-delimited segments (split on <c>. - _ space</c>)
+    /// so they don't false-match substrings inside ordinary version numbers.
+    /// </summary>
+    public static bool IsStableVersion(string? version)
+    {
+        if (string.IsNullOrWhiteSpace(version))
+            return false;
+
+        var tokens = version.Split(['.', '-', '_', ' '], StringSplitOptions.RemoveEmptyEntries);
+        foreach (var token in tokens)
+        {
+            foreach (var marker in PrereleaseMarkers)
+            {
+                // Match a whole token ("rc") or a token that starts with the
+                // marker followed by a digit ("rc1", "beta2", "alpha03").
+                if (token.Equals(marker, StringComparison.OrdinalIgnoreCase))
+                    return false;
+
+                if (token.Length > marker.Length
+                    && token.StartsWith(marker, StringComparison.OrdinalIgnoreCase)
+                    && char.IsDigit(token[marker.Length]))
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// <see cref="IComparer{T}"/> over version strings using <see cref="CompareVersions"/>.
+    /// </summary>
+    public sealed class VersionComparer : IComparer<string?>
+    {
+        public static VersionComparer Instance { get; } = new();
+
+        public int Compare(string? x, string? y) => CompareVersions(x, y);
+    }
+}

--- a/src/MauiSherpa.Core/Services/AndroidSdkPackageVersioning.cs
+++ b/src/MauiSherpa.Core/Services/AndroidSdkPackageVersioning.cs
@@ -182,7 +182,100 @@ public static class AndroidSdkPackageVersioning
         => GetInPlaceUpdate(installed, availablePackages, requireStable) is not null;
 
     /// <summary>
-    /// Returns all installed packages that have a genuine in-place update available.
+    /// Finds a newer side-by-side release for an installed package, or null.
+    ///
+    /// Side-by-side groups (build-tools, ndk, cmake, numbered cmdline-tools) embed
+    /// the version in the Path, so a newer release is a distinct, coexisting
+    /// package rather than an in-place update. Detection is therefore anchored on
+    /// the <em>newest installed</em> package in the group: this method returns the
+    /// newest available (stable, by default) release in the same group, but only
+    /// when <paramref name="installed"/> is that newest-installed anchor and the
+    /// newest available is strictly newer. For every other (older, coexisting)
+    /// installed package in the group it returns null, so only the anchor surfaces
+    /// the hint and acts as the update target.
+    /// </summary>
+    public static SdkPackageInfo? GetSideBySideUpdate(
+        SdkPackageInfo installed,
+        IEnumerable<SdkPackageInfo> installedPackages,
+        IEnumerable<SdkPackageInfo> availablePackages,
+        bool requireStable = true)
+    {
+        if (installed is null || installedPackages is null || availablePackages is null)
+            return null;
+
+        if (string.IsNullOrWhiteSpace(installed.Version))
+            return null;
+
+        if (Classify(installed.Path) != SdkPackageVersioningStrategy.SideBySide)
+            return null;
+
+        var group = GetGroup(installed.Path);
+
+        var newestInstalled = installedPackages
+            .Where(p => p is not null)
+            .Where(p => !string.IsNullOrWhiteSpace(p.Version))
+            .Where(p => string.Equals(GetGroup(p.Path), group, StringComparison.OrdinalIgnoreCase))
+            .OrderByDescending(p => p.Version, VersionComparer.Instance)
+            .FirstOrDefault();
+
+        if (newestInstalled is null)
+            return null;
+
+        // Only the newest installed package in the group is the anchor.
+        if (!string.Equals(installed.Path, newestInstalled.Path, StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        var newestAvailable = availablePackages
+            .Where(a => a is not null)
+            .Where(a => !string.IsNullOrWhiteSpace(a.Version))
+            .Where(a => string.Equals(GetGroup(a.Path), group, StringComparison.OrdinalIgnoreCase))
+            .Where(a => !requireStable || IsStableVersion(a.Version))
+            .OrderByDescending(a => a.Version, VersionComparer.Instance)
+            .FirstOrDefault();
+
+        if (newestAvailable is not null
+            && CompareVersions(newestAvailable.Version, newestInstalled.Version) > 0)
+            return newestAvailable;
+
+        return null;
+    }
+
+    /// <summary>
+    /// Returns the available package to install in order to update
+    /// <paramref name="installed"/>, honoring its versioning strategy: an in-place
+    /// update for FixedPath/Revision groups, or the newest side-by-side release for
+    /// SideBySide groups. Null when no update is available.
+    /// </summary>
+    public static SdkPackageInfo? GetUpdate(
+        SdkPackageInfo installed,
+        IEnumerable<SdkPackageInfo> installedPackages,
+        IEnumerable<SdkPackageInfo> availablePackages,
+        bool requireStable = true)
+    {
+        if (installed is null)
+            return null;
+
+        return Classify(installed.Path) == SdkPackageVersioningStrategy.SideBySide
+            ? GetSideBySideUpdate(installed, installedPackages, availablePackages, requireStable)
+            : GetInPlaceUpdate(installed, availablePackages, requireStable);
+    }
+
+    /// <summary>
+    /// True when an installed package has any update available (in-place or a newer
+    /// side-by-side release).
+    /// </summary>
+    public static bool HasUpdate(
+        SdkPackageInfo installed,
+        IEnumerable<SdkPackageInfo> installedPackages,
+        IEnumerable<SdkPackageInfo> availablePackages,
+        bool requireStable = true)
+        => GetUpdate(installed, installedPackages, availablePackages, requireStable) is not null;
+
+    /// <summary>
+    /// Returns all installed packages that have an update available, honoring each
+    /// package group's versioning strategy. In-place groups yield the installed
+    /// package whose Path has a newer Version; side-by-side groups yield the newest
+    /// installed package in the group when a newer release is available.
     /// </summary>
     public static IEnumerable<SdkPackageInfo> GetUpdates(
         IEnumerable<SdkPackageInfo> installedPackages,
@@ -192,8 +285,9 @@ public static class AndroidSdkPackageVersioning
         if (installedPackages is null || availablePackages is null)
             return [];
 
+        var installed = installedPackages.ToList();
         var available = availablePackages.ToList();
-        return installedPackages.Where(p => HasInPlaceUpdate(p, available, requireStable)).ToList();
+        return installed.Where(p => GetUpdate(p, installed, available, requireStable) is not null).ToList();
     }
 
     /// <summary>

--- a/src/MauiSherpa.MacOS/BlazorContentPage.cs
+++ b/src/MauiSherpa.MacOS/BlazorContentPage.cs
@@ -988,10 +988,12 @@ public class BlazorContentPage : ContentPage
                 ("install-missing", "Install Missing", "arrow.down.circle"),
                 ("save", "Save", "checkmark"),
                 ("reset", "Reset to Defaults", "trash"),
+                ("update-all", "Update Packages", "arrow.up.circle"),
                 ("refresh", "Refresh", "arrow.clockwise"),
             };
 
             ToolbarItem? refreshItem = null;
+            ToolbarItem? updateItem = null;
             var leadingItems = new List<ToolbarItem>();
             var allToolbarItems = new List<ToolbarItem> { copilotItem, doctorItem, settingsItem };
             foreach (var (id, label, icon) in supersetActions)
@@ -1014,6 +1016,8 @@ public class BlazorContentPage : ContentPage
 
                 if (actionId == "refresh")
                     refreshItem = item;
+                else if (actionId == "update-all")
+                    updateItem = item;
                 else
                     leadingItems.Add(item);
             }
@@ -1133,6 +1137,8 @@ public class BlazorContentPage : ContentPage
                 layout.Add(MacOSToolbarLayoutItem.Item(item));
             layout.Add(MacOSToolbarLayoutItem.FlexibleSpace);
             layout.Add(MacOSToolbarLayoutItem.Search(_searchItem));
+            if (updateItem != null)
+                layout.Add(MacOSToolbarLayoutItem.Item(updateItem));
             if (refreshItem != null)
                 layout.Add(MacOSToolbarLayoutItem.Item(refreshItem));
 

--- a/src/MauiSherpa.MacOS/MauiSherpa.MacOS.csproj
+++ b/src/MauiSherpa.MacOS/MauiSherpa.MacOS.csproj
@@ -9,6 +9,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <EnableDefaultCssItems>false</EnableDefaultCssItems>
+    <EnableDefaultRazorItems>false</EnableDefaultRazorItems>
     <SupportedOSPlatformVersion>14.0</SupportedOSPlatformVersion>
     <DefineConstants>$(DefineConstants);MACOSAPP</DefineConstants>
 
@@ -26,6 +27,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <RazorComponent Include="Components/**/*.razor" />
+    <RazorComponent Include="Pages/**/*.razor" />
     <PackageReference Include="Microsoft.Maui.Platforms.MacOS" Version="0.1.0-preview.8.26256.5" />
     <PackageReference Include="Microsoft.Maui.Platforms.MacOS.BlazorWebView" Version="0.1.0-preview.8.26256.5" />
     <PackageReference Include="Microsoft.Maui.Platforms.MacOS.Essentials" Version="0.1.0-preview.8.26256.5" />

--- a/src/MauiSherpa/Components/MultiOperationModal.razor
+++ b/src/MauiSherpa/Components/MultiOperationModal.razor
@@ -63,29 +63,6 @@
                             <div class="operation-info">
                                 <span class="operation-name">@op.Name</span>
                                 <span class="operation-desc">@op.Description</span>
-                                @if (showSecondary)
-                                {
-                                    <div class="operation-secondary-list" @onclick:stopPropagation="true">
-                                        @if (op.SecondaryOptions.Count > 1)
-                                        {
-                                            <div class="secondary-bulk">
-                                                <button type="button" class="link-btn" @onclick="@(() => SetAllSecondary(op.Id, true))">Select all</button>
-                                                <span class="secondary-bulk-sep">·</span>
-                                                <button type="button" class="link-btn" @onclick="@(() => SetAllSecondary(op.Id, false))">Deselect all</button>
-                                            </div>
-                                        }
-                                        @foreach (var opt in op.SecondaryOptions)
-                                        {
-                                            <label class="operation-secondary">
-                                                <input type="checkbox"
-                                                       checked="@opt.Enabled"
-                                                       disabled="@(!op.IsEnabled)"
-                                                       @onchange="@(e => HandleSecondaryToggle(op.Id, opt.Id, (bool)(e.Value ?? false)))" />
-                                                <span>@opt.Label</span>
-                                            </label>
-                                        }
-                                    </div>
-                                }
                             </div>
                         </div>
                         <div class="operation-right">
@@ -99,7 +76,31 @@
                             }
                         </div>
                     </div>
-                    
+
+                    @if (showSecondary)
+                    {
+                        <div class="operation-secondary-list" @onclick:stopPropagation="true">
+                            @if (op.SecondaryOptions.Count > 1)
+                            {
+                                <div class="secondary-bulk">
+                                    <button type="button" class="link-btn" @onclick="@(() => SetAllSecondary(op.Id, true))">Select all</button>
+                                    <span class="secondary-bulk-sep">·</span>
+                                    <button type="button" class="link-btn" @onclick="@(() => SetAllSecondary(op.Id, false))">Deselect all</button>
+                                </div>
+                            }
+                            @foreach (var opt in op.SecondaryOptions)
+                            {
+                                <label class="operation-secondary">
+                                    <input type="checkbox"
+                                           checked="@opt.Enabled"
+                                           disabled="@(!op.IsEnabled)"
+                                           @onchange="@(e => HandleSecondaryToggle(op.Id, opt.Id, (bool)(e.Value ?? false)))" />
+                                    <span>@opt.Label</span>
+                                </label>
+                            }
+                        </div>
+                    }
+
                     @if (isExpanded && op.Log.Any())
                     {
                         <div class="operation-log">
@@ -308,7 +309,7 @@
         display: flex;
         flex-direction: column;
         gap: 0.2rem;
-        margin-top: 0.35rem;
+        padding: 0 1rem 0.75rem calc(1rem + 18px + 0.75rem);
     }
 
     .operation-secondary {

--- a/src/MauiSherpa/Components/MultiOperationModal.razor
+++ b/src/MauiSherpa/Components/MultiOperationModal.razor
@@ -14,16 +14,6 @@
     <div class="multi-op-content" id="multi-op-modal">
         <p class="description">@ModalService.Description</p>
 
-        @if (ModalService.IsConfirming && !ModalService.IsRunning && ModalService.HasSecondaryOptions)
-        {
-            <div class="secondary-bulk">
-                <span class="secondary-bulk-label">Clean up older versions:</span>
-                <button type="button" class="link-btn" @onclick="@(() => SetAllSecondary(true))">Select all</button>
-                <span class="secondary-bulk-sep">·</span>
-                <button type="button" class="link-btn" @onclick="@(() => SetAllSecondary(false))">Deselect all</button>
-            </div>
-        }
-
         <div class="operations-list">
             @foreach (var op in ModalService.Operations)
             {
@@ -76,6 +66,14 @@
                                 @if (showSecondary)
                                 {
                                     <div class="operation-secondary-list" @onclick:stopPropagation="true">
+                                        @if (op.SecondaryOptions.Count > 1)
+                                        {
+                                            <div class="secondary-bulk">
+                                                <button type="button" class="link-btn" @onclick="@(() => SetAllSecondary(op.Id, true))">Select all</button>
+                                                <span class="secondary-bulk-sep">·</span>
+                                                <button type="button" class="link-btn" @onclick="@(() => SetAllSecondary(op.Id, false))">Deselect all</button>
+                                            </div>
+                                        }
                                         @foreach (var opt in op.SecondaryOptions)
                                         {
                                             <label class="operation-secondary">
@@ -336,12 +334,11 @@
         display: flex;
         align-items: center;
         gap: 0.4rem;
-        font-size: 0.75rem;
+        font-size: 0.72rem;
         color: var(--text-secondary, #718096);
-        margin: -0.25rem 0 0 0;
+        margin: 0 0 0.1rem 0;
     }
 
-    .secondary-bulk-label { font-weight: 500; }
     .secondary-bulk-sep { opacity: 0.5; }
 
     .secondary-bulk .link-btn {
@@ -562,9 +559,9 @@
         StateHasChanged();
     }
 
-    private void SetAllSecondary(bool enabled)
+    private void SetAllSecondary(string operationId, bool enabled)
     {
-        ModalService.SetAllSecondaryOptions(enabled);
+        ModalService.SetAllSecondaryOptions(operationId, enabled);
         StateHasChanged();
     }
 

--- a/src/MauiSherpa/Components/MultiOperationModal.razor
+++ b/src/MauiSherpa/Components/MultiOperationModal.razor
@@ -21,9 +21,13 @@
                                 (ModalService.IsRunning && ModalService.CurrentOperationIndex >= 0 && 
                                  ModalService.Operations[ModalService.CurrentOperationIndex].Id == op.Id);
                 var canToggle = !ModalService.IsRunning && op.CanDisable && ModalService.IsConfirming;
+                var hasExpandableContent = op.Log.Any() ||
+                    (!string.IsNullOrEmpty(op.ErrorMessage) && op.State == OperationItemState.Failed);
+                var showSecondary = !string.IsNullOrEmpty(op.SecondaryOptionLabel)
+                    && ModalService.IsConfirming && !ModalService.IsRunning;
 
                 <div class="operation-card @GetOperationCardClass(op) @(isExpanded ? "expanded" : "")">
-                    <div class="operation-header" @onclick="() => ToggleExpanded(op.Id)">
+                    <div class="operation-header @(hasExpandableContent ? "clickable" : "")" @onclick="@(() => { if (hasExpandableContent) ToggleExpanded(op.Id); })">
                         <div class="operation-left">
                             @if (ModalService.IsConfirming && !ModalService.IsRunning)
                             {
@@ -59,6 +63,16 @@
                             <div class="operation-info">
                                 <span class="operation-name">@op.Name</span>
                                 <span class="operation-desc">@op.Description</span>
+                                @if (showSecondary)
+                                {
+                                    <label class="operation-secondary" @onclick:stopPropagation="true">
+                                        <input type="checkbox"
+                                               checked="@op.SecondaryOptionEnabled"
+                                               disabled="@(!op.IsEnabled)"
+                                               @onchange="@(e => HandleSecondaryToggle(op.Id, (bool)(e.Value ?? false)))" />
+                                        <span>@op.SecondaryOptionLabel</span>
+                                    </label>
+                                }
                             </div>
                         </div>
                         <div class="operation-right">
@@ -66,7 +80,10 @@
                             {
                                 <span class="duration">@op.Duration.Value.ToString(@"mm\:ss\.f")</span>
                             }
-                            <i class="fas @(isExpanded ? "fa-chevron-up" : "fa-chevron-down") expand-icon"></i>
+                            @if (hasExpandableContent)
+                            {
+                                <i class="fas @(isExpanded ? "fa-chevron-up" : "fa-chevron-down") expand-icon"></i>
+                            }
                         </div>
                     </div>
                     
@@ -226,13 +243,15 @@
         justify-content: space-between;
         align-items: center;
         padding: 0.75rem 1rem;
-        cursor: pointer;
+        cursor: default;
         background: var(--card-bg, #f7fafc);
     }
 
+    .operation-header.clickable { cursor: pointer; }
+
     .operation-card.running .operation-header { background: #ebf8ff; }
 
-    .operation-header:hover { background: var(--bg-tertiary, #edf2f7); }
+    .operation-header.clickable:hover { background: var(--bg-tertiary, #edf2f7); }
 
     .operation-left {
         display: flex;
@@ -271,6 +290,26 @@
         font-size: 0.75rem;
         color: #718096;
     }
+
+    .operation-secondary {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        margin-top: 0.35rem;
+        font-size: 0.75rem;
+        color: var(--text-secondary, #718096);
+        cursor: pointer;
+        user-select: none;
+    }
+
+    .operation-secondary input[type="checkbox"] {
+        width: 14px;
+        height: 14px;
+        cursor: pointer;
+    }
+
+    .operation-secondary input[type="checkbox"]:disabled { cursor: not-allowed; }
+    .operation-secondary:has(input:disabled) { opacity: 0.5; cursor: not-allowed; }
 
     .operation-right {
         display: flex;
@@ -469,6 +508,12 @@
     private void HandleToggle(string operationId, bool enabled)
     {
         ModalService.ToggleOperation(operationId, enabled);
+        StateHasChanged();
+    }
+
+    private void HandleSecondaryToggle(string operationId, bool enabled)
+    {
+        ModalService.ToggleSecondaryOption(operationId, enabled);
         StateHasChanged();
     }
 

--- a/src/MauiSherpa/Components/MultiOperationModal.razor
+++ b/src/MauiSherpa/Components/MultiOperationModal.razor
@@ -14,6 +14,16 @@
     <div class="multi-op-content" id="multi-op-modal">
         <p class="description">@ModalService.Description</p>
 
+        @if (ModalService.IsConfirming && !ModalService.IsRunning && ModalService.HasSecondaryOptions)
+        {
+            <div class="secondary-bulk">
+                <span class="secondary-bulk-label">Clean up older versions:</span>
+                <button type="button" class="link-btn" @onclick="@(() => SetAllSecondary(true))">Select all</button>
+                <span class="secondary-bulk-sep">·</span>
+                <button type="button" class="link-btn" @onclick="@(() => SetAllSecondary(false))">Deselect all</button>
+            </div>
+        }
+
         <div class="operations-list">
             @foreach (var op in ModalService.Operations)
             {
@@ -23,7 +33,7 @@
                 var canToggle = !ModalService.IsRunning && op.CanDisable && ModalService.IsConfirming;
                 var hasExpandableContent = op.Log.Any() ||
                     (!string.IsNullOrEmpty(op.ErrorMessage) && op.State == OperationItemState.Failed);
-                var showSecondary = !string.IsNullOrEmpty(op.SecondaryOptionLabel)
+                var showSecondary = op.SecondaryOptions.Count > 0
                     && ModalService.IsConfirming && !ModalService.IsRunning;
 
                 <div class="operation-card @GetOperationCardClass(op) @(isExpanded ? "expanded" : "")">
@@ -65,13 +75,18 @@
                                 <span class="operation-desc">@op.Description</span>
                                 @if (showSecondary)
                                 {
-                                    <label class="operation-secondary" @onclick:stopPropagation="true">
-                                        <input type="checkbox"
-                                               checked="@op.SecondaryOptionEnabled"
-                                               disabled="@(!op.IsEnabled)"
-                                               @onchange="@(e => HandleSecondaryToggle(op.Id, (bool)(e.Value ?? false)))" />
-                                        <span>@op.SecondaryOptionLabel</span>
-                                    </label>
+                                    <div class="operation-secondary-list" @onclick:stopPropagation="true">
+                                        @foreach (var opt in op.SecondaryOptions)
+                                        {
+                                            <label class="operation-secondary">
+                                                <input type="checkbox"
+                                                       checked="@opt.Enabled"
+                                                       disabled="@(!op.IsEnabled)"
+                                                       @onchange="@(e => HandleSecondaryToggle(op.Id, opt.Id, (bool)(e.Value ?? false)))" />
+                                                <span>@opt.Label</span>
+                                            </label>
+                                        }
+                                    </div>
                                 }
                             </div>
                         </div>
@@ -291,11 +306,17 @@
         color: #718096;
     }
 
+    .operation-secondary-list {
+        display: flex;
+        flex-direction: column;
+        gap: 0.2rem;
+        margin-top: 0.35rem;
+    }
+
     .operation-secondary {
         display: inline-flex;
         align-items: center;
         gap: 0.4rem;
-        margin-top: 0.35rem;
         font-size: 0.75rem;
         color: var(--text-secondary, #718096);
         cursor: pointer;
@@ -310,6 +331,30 @@
 
     .operation-secondary input[type="checkbox"]:disabled { cursor: not-allowed; }
     .operation-secondary:has(input:disabled) { opacity: 0.5; cursor: not-allowed; }
+
+    .secondary-bulk {
+        display: flex;
+        align-items: center;
+        gap: 0.4rem;
+        font-size: 0.75rem;
+        color: var(--text-secondary, #718096);
+        margin: -0.25rem 0 0 0;
+    }
+
+    .secondary-bulk-label { font-weight: 500; }
+    .secondary-bulk-sep { opacity: 0.5; }
+
+    .secondary-bulk .link-btn {
+        background: none;
+        border: none;
+        padding: 0;
+        font-size: 0.75rem;
+        color: var(--accent-primary, #4299e1);
+        cursor: pointer;
+        text-decoration: none;
+    }
+
+    .secondary-bulk .link-btn:hover { text-decoration: underline; }
 
     .operation-right {
         display: flex;
@@ -511,9 +556,15 @@
         StateHasChanged();
     }
 
-    private void HandleSecondaryToggle(string operationId, bool enabled)
+    private void HandleSecondaryToggle(string operationId, string optionId, bool enabled)
     {
-        ModalService.ToggleSecondaryOption(operationId, enabled);
+        ModalService.ToggleSecondaryOption(operationId, optionId, enabled);
+        StateHasChanged();
+    }
+
+    private void SetAllSecondary(bool enabled)
+    {
+        ModalService.SetAllSecondaryOptions(enabled);
         StateHasChanged();
     }
 

--- a/src/MauiSherpa/Pages/AndroidSdk.razor
+++ b/src/MauiSherpa/Pages/AndroidSdk.razor
@@ -1579,17 +1579,19 @@ else if (!ViewModel.IsSdkInstalled)
                 : new List<SdkPackageInfo>();
 
             string description;
-            string? secondaryLabel = null;
+            List<OperationSecondaryOption>? secondaryOptions = null;
             if (isSideBySide)
             {
                 hasSideBySide = true;
                 description = $"Install v{newVersion} (keeps existing version{(olderVersions.Count == 1 ? "" : "s")})";
                 if (olderVersions.Count > 0)
                 {
-                    var versionsList = string.Join(", ", olderVersions.Select(p => p.Version));
-                    secondaryLabel = olderVersions.Count == 1
-                        ? $"Remove older version {versionsList} after updating"
-                        : $"Remove {olderVersions.Count} older versions ({versionsList}) after updating";
+                    secondaryOptions = olderVersions
+                        .Select(p => new OperationSecondaryOption(
+                            Id: p.Path,
+                            Label: $"Remove older version {p.Version}",
+                            DefaultEnabled: false))
+                        .ToList();
                 }
             }
             else
@@ -1623,10 +1625,14 @@ else if (!ViewModel.IsSdkInstalled)
 
                     ctx.LogSuccess($"Installed {updatePath}");
 
-                    // Optionally clean up older side-by-side versions.
-                    if (isSideBySide && ctx.SecondaryOptionEnabled && olderVersions.Count > 0)
+                    // Clean up only the older side-by-side versions the user selected.
+                    if (isSideBySide && olderVersions.Count > 0)
                     {
-                        foreach (var older in olderVersions)
+                        var toRemove = olderVersions
+                            .Where(o => ctx.EnabledSecondaryOptionIds.Contains(o.Path))
+                            .ToList();
+
+                        foreach (var older in toRemove)
                         {
                             ctx.LogInfo($"Removing older version: {older.Path}");
                             var removed = await SdkService.UninstallPackageAsync(older.Path);
@@ -1635,25 +1641,24 @@ else if (!ViewModel.IsSdkInstalled)
                             else
                                 ctx.LogWarning($"Could not remove {older.Path}");
                         }
-                    }
-                    else if (isSideBySide && olderVersions.Count > 0)
-                    {
-                        ctx.LogInfo($"Keeping {olderVersions.Count} older version(s) installed.");
+
+                        var kept = olderVersions.Count - toRemove.Count;
+                        if (kept > 0)
+                            ctx.LogInfo($"Keeping {kept} older version(s) installed.");
                     }
 
                     return true;
                 },
                 IsEnabled: true,
                 CanDisable: true,
-                SecondaryOptionLabel: secondaryLabel,
-                SecondaryOptionDefault: false
+                SecondaryOptions: secondaryOptions
             );
         }).ToList();
 
         var description = $"The following {updatable.Count} package(s) have updates available. Uncheck any you want to skip.";
         if (hasSideBySide)
         {
-            description += " Side-by-side tools (build-tools, NDK, CMake) install alongside existing versions — use the per-item option to remove older ones.";
+            description += " Side-by-side tools (build-tools, NDK, CMake) install alongside existing versions — tick the older versions you want removed.";
         }
 
         var result = await MultiOpModal.RunAsync(

--- a/src/MauiSherpa/Pages/AndroidSdk.razor
+++ b/src/MauiSherpa/Pages/AndroidSdk.razor
@@ -1,6 +1,7 @@
 @page "/android-sdk"
 @using MauiSherpa.Core.ViewModels
 @using MauiSherpa.Core.Interfaces
+@using MauiSherpa.Core.Services
 @using MauiSherpa.Services
 @inject AndroidSdkViewModel ViewModel
 @inject IAndroidSdkService SdkService
@@ -34,12 +35,13 @@
         <button class="btn btn-primary" @onclick="RefreshData" disabled="@ViewModel.IsLoading">
             <i class="fas fa-sync-alt"></i> @(ViewModel.IsLoading ? "Loading..." : "Refresh")
         </button>
-        @if (GetUpdatablePackages().Any())
-        {
-            <button class="btn btn-success" @onclick="UpdateAllPackages" disabled="@ViewModel.IsLoading">
-                <i class="fas fa-arrow-up"></i> Update All (@GetUpdatablePackages().Count())
-            </button>
-        }
+        <button class="btn btn-success" @onclick="UpdatePackages" disabled="@ViewModel.IsLoading">
+            <i class="fas fa-arrow-up"></i> Update Packages
+            @if (GetUpdatablePackages().Any())
+            {
+                <span class="toolbar-update-count">@GetUpdatablePackages().Count()</span>
+            }
+        </button>
     }
 </div>
 }
@@ -169,6 +171,9 @@ else if (!ViewModel.IsSdkInstalled)
 @if (ViewModel.IsSdkInstalled)
 {
     <div class="tabs">
+        <button class="tab @(activeTab == "all" ? "active" : "")" @onclick="@(() => activeTab = "all")">
+            All (@FilteredAllPackages.Count())
+        </button>
         <button class="tab @(activeTab == "installed" ? "active" : "")" @onclick="@(() => activeTab = "installed")">
             Installed (@FilteredInstalledPackages.Count())
             @if (GetUpdatablePackages().Any())
@@ -239,14 +244,16 @@ else if (!ViewModel.IsSdkInstalled)
                             <span class="group-name">@group.Key</span>
                             @if (groupUpdates > 0)
                             {
-                                <span class="group-update-badge">@groupUpdates update@(groupUpdates > 1 ? "s" : "")</span>
+                                <span class="section-update-flag" title="@groupUpdates update@(groupUpdates > 1 ? "s" : "") available">
+                                    <i class="fas fa-circle-arrow-up"></i> @groupUpdates update@(groupUpdates > 1 ? "s" : "")
+                                </span>
                             }
                             <span class="group-count">@group.Count()</span>
                         </div>
                         @if (IsGroupExpanded(group.Key))
                         {
                             <div class="group-content">
-                                @foreach (var package in group.OrderBy(p => p.Path))
+                                @foreach (var package in OrderPackagesByNewestVersion(group))
                                 {
                                     var availableUpdate = GetAvailableUpdate(package);
                                     var hasUpdate = availableUpdate != null;
@@ -256,7 +263,9 @@ else if (!ViewModel.IsSdkInstalled)
                                                 <span class="package-path">@GetPackageShortName(package.Path)</span>
                                                 @if (hasUpdate)
                                                 {
-                                                    <span class="update-indicator"><i class="fas fa-arrow-up"></i> Update</span>
+                                                    <span class="item-update-flag" title="Newer version available">
+                                                        <i class="fas fa-circle-arrow-up"></i> Update available
+                                                    </span>
                                                 }
                                             </div>
                                             <span class="package-description">@package.Description</span>
@@ -272,15 +281,106 @@ else if (!ViewModel.IsSdkInstalled)
                                             </div>
                                         </div>
                                         <div class="package-actions">
-                                            @if (hasUpdate)
-                                            {
-                                                <button class="btn btn-success btn-sm" @onclick="@(() => InstallPackage(package.Path))" disabled="@ViewModel.IsLoading">
-                                                    <i class="fas fa-arrow-up"></i> Update
-                                                </button>
-                                            }
                                             <button class="btn btn-danger btn-sm" @onclick="@(() => UninstallPackage(package.Path))" disabled="@ViewModel.IsLoading">
                                                 <i class="fas fa-trash"></i> Uninstall
                                             </button>
+                                        </div>
+                                    </div>
+                                }
+                            </div>
+                        }
+                    </div>
+                }
+            }
+        </div>
+    }
+
+    @if (activeTab == "all")
+    {
+        <div class="package-groups">
+            @if (!FilteredAllPackages.Any())
+            {
+                <div class="empty-state">
+                    <div class="empty-icon"><i class="fas fa-search"></i></div>
+                    <div class="empty-title">No matching packages</div>
+                    <div class="empty-description">No packages match your search or filters. Try adjusting your criteria.</div>
+                </div>
+            }
+            else
+            {
+                @foreach (var group in GetUnifiedPackageGroups(FilteredAllPackages))
+                {
+                    var groupHasStableUpdates = group.Any(p => p.HasUpdate);
+                    <div class="package-group">
+                        <div class="group-header" @onclick="@(() => ToggleGroup("all_" + group.Key))">
+                            <span class="group-chevron">@(IsGroupExpanded("all_" + group.Key) ? "▼" : "▶")</span>
+                            <span class="group-name">@group.Key</span>
+                            @if (groupHasStableUpdates)
+                            {
+                                <span class="section-update-flag" title="Updates available in this section">
+                                    <i class="fas fa-circle-arrow-up"></i> Updates available
+                                </span>
+                            }
+                            <span class="group-count">@group.Count()</span>
+                        </div>
+                        @if (IsGroupExpanded("all_" + group.Key))
+                        {
+                            <div class="group-content">
+                                @foreach (var package in OrderUnifiedPackagesByNewestVersion(group))
+                                {
+                                    var installedVersion = package.InstalledPackage?.Version;
+                                    var availableVersion = package.AvailablePackage?.Version;
+                                    var hasUpdate = package.HasUpdate;
+                                    var isInstalled = package.InstalledPackage != null;
+
+                                    <div class="package-item @(hasUpdate ? "has-update" : "") @(isInstalled && !hasUpdate ? "is-installed" : "")">
+                                        <div class="package-info">
+                                            <div class="package-name-row">
+                                                <span class="package-path">@GetPackageShortName(package.Path)</span>
+                                                @if (hasUpdate)
+                                                {
+                                                    <span class="item-update-flag" title="Newer version available">
+                                                        <i class="fas fa-circle-arrow-up"></i> Update available
+                                                    </span>
+                                                }
+                                                else if (isInstalled)
+                                                {
+                                                    <span class="installed-indicator">Installed</span>
+                                                }
+                                                else
+                                                {
+                                                    <span class="available-indicator">Available</span>
+                                                }
+                                            </div>
+                                            <span class="package-description">@package.Description</span>
+                                            <div class="version-row">
+                                                @if (package.InstalledPackage != null && !string.IsNullOrEmpty(installedVersion))
+                                                {
+                                                    <span class="package-version">Installed v@(installedVersion)</span>
+                                                }
+                                                @if (hasUpdate && !string.IsNullOrEmpty(availableVersion))
+                                                {
+                                                    <span class="update-version">→ v@(availableVersion)</span>
+                                                }
+                                                else if (!isInstalled && package.AvailablePackage != null && !string.IsNullOrEmpty(availableVersion))
+                                                {
+                                                    <span class="package-version">Available v@(availableVersion)</span>
+                                                }
+                                            </div>
+                                        </div>
+                                        <div class="package-actions">
+                                            @if (isInstalled)
+                                            {
+                                                <button class="btn btn-danger btn-sm" @onclick="@(() => UninstallPackage(package.Path))" disabled="@ViewModel.IsLoading">
+                                                    <i class="fas fa-trash"></i> Uninstall
+                                                </button>
+                                            }
+                                            else
+                                            {
+                                                <button class="btn btn-primary btn-sm" @onclick="@(() => InstallPackage(package.Path))" disabled="@ViewModel.IsLoading">
+                                                    <i class="fas fa-download"></i> Install
+                                                </button>
+                                            }
                                         </div>
                                     </div>
                                 }
@@ -307,37 +407,61 @@ else if (!ViewModel.IsSdkInstalled)
             {
                 @foreach (var group in GetPackageGroups(FilteredAvailablePackages))
                 {
+                    var groupHasUpdates = group.Any(p => GetInstalledVersion(p.Path) != null);
                     <div class="package-group">
                         <div class="group-header" @onclick="@(() => ToggleGroup("avail_" + group.Key))">
                             <span class="group-chevron">@(IsGroupExpanded("avail_" + group.Key) ? "▼" : "▶")</span>
                             <span class="group-name">@group.Key</span>
+                            @if (groupHasUpdates)
+                            {
+                                <span class="section-update-flag" title="Updates available in this section">
+                                    <i class="fas fa-circle-arrow-up"></i> Updates available
+                                </span>
+                            }
                             <span class="group-count">@group.Count()</span>
                         </div>
                         @if (IsGroupExpanded("avail_" + group.Key))
                         {
                             <div class="group-content">
-                                @foreach (var package in group.OrderBy(p => p.Path))
+                                @foreach (var package in OrderPackagesByNewestVersion(group))
                                 {
                                     var installedVersion = GetInstalledVersion(package.Path);
                                     var isUpdate = installedVersion != null;
-                                    <div class="package-item @(isUpdate ? "is-update" : "")">
+                                    <div class="package-item @(isUpdate ? "has-update" : "")">
                                         <div class="package-info">
                                             <div class="package-name-row">
                                                 <span class="package-path">@GetPackageShortName(package.Path)</span>
                                                 @if (isUpdate)
                                                 {
-                                                    <span class="installed-indicator">Installed: v@(installedVersion)</span>
+                                                    <span class="item-update-flag" title="Newer version available">
+                                                        <i class="fas fa-circle-arrow-up"></i> Update available
+                                                    </span>
                                                 }
                                             </div>
                                             <span class="package-description">@package.Description</span>
-                                            @if (!string.IsNullOrEmpty(package.Version))
+                                            <div class="version-row">
+                                                @if (isUpdate)
+                                                {
+                                                    <span class="package-version">Installed v@(installedVersion)</span>
+                                                    @if (!string.IsNullOrEmpty(package.Version))
+                                                    {
+                                                        <span class="update-version">→ v@(package.Version)</span>
+                                                    }
+                                                }
+                                                else if (!string.IsNullOrEmpty(package.Version))
+                                                {
+                                                    <span class="package-version">v@(package.Version)</span>
+                                                }
+                                            </div>
+                                        </div>
+                                        <div class="package-actions">
+                                            @if (!isUpdate)
                                             {
-                                                <span class="package-version">v@(package.Version)</span>
+                                                <button class="btn btn-primary btn-sm" @onclick="@(() => InstallPackage(package.Path))" disabled="@ViewModel.IsLoading">
+                                                    <i class="fas fa-download"></i> Install
+                                                </button>
                                             }
                                         </div>
-                                        <button class="btn @(isUpdate ? "btn-success" : "btn-primary") btn-sm" @onclick="@(() => InstallPackage(package.Path))" disabled="@ViewModel.IsLoading">
-                                            <i class="fas @(isUpdate ? "fa-arrow-up" : "fa-download")"></i> @(isUpdate ? "Update" : "Install")
-                                        </button>
                                     </div>
                                 }
                             </div>
@@ -730,14 +854,33 @@ else if (!ViewModel.IsSdkInstalled)
         font-weight: 500;
     }
 
-    .group-update-badge {
-        background: var(--status-warning-bg);
-        color: var(--status-warning-text);
-        padding: 2px 0.625rem;
-        border-radius: 0.75rem;
+    .section-update-flag {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.3rem;
+        color: var(--accent-warning);
         font-size: 0.6875rem;
-        font-weight: 500;
-        margin-right: 0.5rem;
+        font-weight: 600;
+        margin-right: 0.625rem;
+    }
+
+    .section-update-flag i {
+        font-size: 0.625rem;
+    }
+
+    .toolbar-update-count {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-width: 1.1rem;
+        height: 1.1rem;
+        padding: 0 0.35rem;
+        margin-left: 0.4rem;
+        background: rgba(255, 255, 255, 0.25);
+        border-radius: 999px;
+        font-size: 0.6875rem;
+        font-weight: 700;
+        line-height: 1;
     }
 
     .group-content {
@@ -761,11 +904,11 @@ else if (!ViewModel.IsSdkInstalled)
     }
 
     .package-item.has-update {
-        background: var(--status-warning-bg);
+        border-left: 3px solid var(--accent-warning);
     }
 
-    .package-item.is-update {
-        background: var(--status-success-bg);
+    .package-item.is-installed {
+        background: var(--bg-secondary);
     }
 
     .package-info {
@@ -809,22 +952,37 @@ else if (!ViewModel.IsSdkInstalled)
         font-weight: 500;
     }
 
-    .update-indicator {
-        background: var(--status-warning-bg);
-        color: var(--status-warning-text);
-        padding: 1px 0.375rem;
-        border-radius: 0.25rem;
+    .item-update-flag {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.3rem;
+        color: var(--accent-warning);
         font-size: 0.625rem;
         font-weight: 600;
+    }
+
+    .item-update-flag i {
+        font-size: 0.5625rem;
     }
 
     .installed-indicator {
         background: var(--status-success-bg);
         color: var(--status-success-text);
-        padding: 1px 0.375rem;
-        border-radius: 0.25rem;
+        padding: 0.18rem 0.45rem;
+        border-radius: 999px;
         font-size: 0.625rem;
-        font-weight: 500;
+        font-weight: 600;
+        border: 1px solid var(--border-color);
+    }
+
+    .available-indicator {
+        background: var(--status-info-bg);
+        color: var(--status-info-text);
+        padding: 0.18rem 0.45rem;
+        border-radius: 999px;
+        font-size: 0.625rem;
+        font-weight: 600;
+        border: 1px solid var(--border-color);
     }
 
     .package-actions {
@@ -922,7 +1080,7 @@ else if (!ViewModel.IsSdkInstalled)
 </style>
 
 @code {
-    private string activeTab = "installed";
+    private string activeTab = "all";
     private HashSet<string> expandedGroups = new();
     private bool hasInitialized = false;
     private string recommendedSdkPath = "";
@@ -985,6 +1143,40 @@ else if (!ViewModel.IsSdkInstalled)
         }
     }
 
+    private IList<PackageListItem> FilteredAllPackages
+    {
+        get
+        {
+            var packages = BuildAllPackageItems();
+
+            if (!string.IsNullOrWhiteSpace(searchQuery))
+            {
+                var query = searchQuery.ToLowerInvariant();
+                packages = packages.Where(p =>
+                    p.Path.ToLowerInvariant().Contains(query) ||
+                    (p.Description?.ToLowerInvariant().Contains(query) ?? false) ||
+                    (p.InstalledPackage?.Version?.ToLowerInvariant().Contains(query) ?? false) ||
+                    (p.AvailablePackage?.Version?.ToLowerInvariant().Contains(query) ?? false));
+            }
+
+            if (!string.IsNullOrEmpty(filterCategory))
+            {
+                packages = packages.Where(p => p.GroupKey == filterCategory);
+            }
+
+            if (filterUpdates == "updates")
+            {
+                packages = packages.Where(p => p.HasUpdate);
+            }
+            else if (filterUpdates == "current")
+            {
+                packages = packages.Where(p => !p.HasUpdate && p.InstalledPackage != null);
+            }
+
+            return packages.ToList();
+        }
+    }
+
     private IList<SdkPackageInfo> FilteredAvailablePackages
     {
         get
@@ -1022,7 +1214,7 @@ else if (!ViewModel.IsSdkInstalled)
     {
         ToolbarService.SetItems(
             new ToolbarAction("refresh", "Refresh", "arrow.clockwise"),
-            new ToolbarAction("update-all", "Update All", "square.and.arrow.up")
+            new ToolbarAction("update-all", "Update Packages", "square.and.arrow.up")
         );
         ToolbarService.SetSearch("Search packages...");
         ToolbarService.SetFilters(
@@ -1081,7 +1273,7 @@ else if (!ViewModel.IsSdkInstalled)
                     try { await RefreshData(); } finally { ToolbarService.SetItemEnabled("refresh", true); }
                     break;
                 case "update-all":
-                    await UpdateAllPackages();
+                    await UpdatePackages();
                     break;
             }
             StateHasChanged();
@@ -1102,6 +1294,42 @@ else if (!ViewModel.IsSdkInstalled)
             .OrderBy(g => g.Key);
     }
 
+    private IEnumerable<IGrouping<string, PackageListItem>> GetUnifiedPackageGroups(IEnumerable<PackageListItem> packages)
+    {
+        return packages
+            .GroupBy(p => p.GroupKey)
+            .OrderBy(g => g.Key);
+    }
+
+    private IEnumerable<PackageListItem> BuildAllPackageItems()
+    {
+        var installedByPath = ViewModel.InstalledPackages
+            .ToDictionary(p => p.Path, StringComparer.OrdinalIgnoreCase);
+
+        var items = new List<PackageListItem>();
+
+        foreach (var installed in ViewModel.InstalledPackages)
+        {
+            var available = GetAvailableUpdate(installed);
+            var hasUpdate = available != null;
+            items.Add(new PackageListItem(installed, available, hasUpdate, GetPackageGroup(installed.Path)));
+        }
+
+        foreach (var available in ViewModel.AvailablePackages.Where(a => !installedByPath.ContainsKey(a.Path)))
+        {
+            items.Add(new PackageListItem(null, available, false, GetPackageGroup(available.Path)));
+        }
+
+        return items;
+    }
+
+    private IEnumerable<PackageListItem> OrderUnifiedPackagesByNewestVersion(IEnumerable<PackageListItem> packages)
+    {
+        return packages
+            .OrderByDescending(p => p.PrimaryPackage, SdkPackageComparer.Instance)
+            .ThenBy(p => p.Path, StringComparer.OrdinalIgnoreCase);
+    }
+
     private string GetPackageGroup(string path)
     {
         var parts = path.Split(';');
@@ -1114,9 +1342,24 @@ else if (!ViewModel.IsSdkInstalled)
         return parts.Length > 1 ? string.Join(";", parts.Skip(1)) : path;
     }
 
+    private IEnumerable<SdkPackageInfo> OrderPackagesByNewestVersion(IEnumerable<SdkPackageInfo> packages)
+    {
+        return packages
+            .OrderByDescending(p => p, SdkPackageComparer.Instance)
+            .ThenBy(p => p.Path, StringComparer.OrdinalIgnoreCase);
+    }
+
     private bool IsGroupExpanded(string groupKey)
     {
         return expandedGroups.Contains(groupKey);
+    }
+
+    private sealed record PackageListItem(SdkPackageInfo? InstalledPackage, SdkPackageInfo? AvailablePackage, bool HasUpdate, string GroupKey)
+    {
+        public string Path => InstalledPackage?.Path ?? AvailablePackage?.Path ?? string.Empty;
+        public string Description => InstalledPackage?.Description ?? AvailablePackage?.Description ?? string.Empty;
+        public string? Version => InstalledPackage?.Version ?? AvailablePackage?.Version;
+        public SdkPackageInfo? PrimaryPackage => InstalledPackage ?? AvailablePackage;
     }
 
     private void ToggleGroup(string groupKey)
@@ -1127,63 +1370,54 @@ else if (!ViewModel.IsSdkInstalled)
             expandedGroups.Add(groupKey);
     }
 
-    // Check if an installed package has an update available
+    private sealed class SdkPackageComparer : IComparer<SdkPackageInfo?>
+    {
+        public static SdkPackageComparer Instance { get; } = new();
+
+        public int Compare(SdkPackageInfo? x, SdkPackageInfo? y)
+        {
+            if (ReferenceEquals(x, y)) return 0;
+            if (x is null) return -1;
+            if (y is null) return 1;
+
+            var versionComparison = CompareVersionStrings(x.Version, y.Version);
+            if (versionComparison != 0)
+                return versionComparison;
+
+            var pathComparison = string.Compare(x.Path, y.Path, StringComparison.OrdinalIgnoreCase);
+            if (pathComparison != 0)
+                return pathComparison;
+
+            return string.Compare(x.Description, y.Description, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static int CompareVersionStrings(string? version1, string? version2)
+            => AndroidSdkPackageVersioning.CompareVersions(version1, version2);
+    }
+
+    // Check if an installed package has a genuine in-place update available.
     private bool HasUpdate(SdkPackageInfo installedPackage)
     {
         return GetAvailableUpdate(installedPackage) != null;
     }
 
-    // Get the available update for an installed package
-    private SdkPackageInfo? GetAvailableUpdate(SdkPackageInfo installedPackage)
+    // Get the available stable in-place update for an installed package.
+    // Delegates to the central, audited classifier: an update is the same exact
+    // package Path with a newer stable Version. Side-by-side groups (build-tools,
+    // ndk, cmake) embed their version in the Path and never produce updates.
+    private SdkPackageInfo? GetAvailableUpdate(SdkPackageInfo installedPackage, bool requireStable = true)
     {
-        var available = ViewModel.AvailablePackages
-            .FirstOrDefault(a => a.Path == installedPackage.Path);
-        
-        if (available == null) return null;
-        
-        // Compare versions - only return if available is actually newer
-        if (string.IsNullOrEmpty(installedPackage.Version) || string.IsNullOrEmpty(available.Version))
+        if (installedPackage == null || ViewModel?.AvailablePackages == null)
             return null;
-            
-        if (IsNewerVersion(available.Version, installedPackage.Version))
-        {
-            return available;
-        }
-        
-        return null;
+
+        return AndroidSdkPackageVersioning.GetInPlaceUpdate(
+            installedPackage, ViewModel.AvailablePackages, requireStable);
     }
 
     // Compare version strings, returns true if version1 > version2
     private bool IsNewerVersion(string version1, string version2)
     {
-        // Try parsing as Version objects first
-        var parts1 = version1.Split('.', '-', '_');
-        var parts2 = version2.Split('.', '-', '_');
-        
-        var maxParts = Math.Max(parts1.Length, parts2.Length);
-        
-        for (int i = 0; i < maxParts; i++)
-        {
-            var p1 = i < parts1.Length ? parts1[i] : "0";
-            var p2 = i < parts2.Length ? parts2[i] : "0";
-            
-            // Try numeric comparison first
-            if (int.TryParse(p1, out var n1) && int.TryParse(p2, out var n2))
-            {
-                if (n1 > n2) return true;
-                if (n1 < n2) return false;
-                // Equal, continue to next part
-            }
-            else
-            {
-                // String comparison as fallback
-                var cmp = string.Compare(p1, p2, StringComparison.OrdinalIgnoreCase);
-                if (cmp > 0) return true;
-                if (cmp < 0) return false;
-            }
-        }
-        
-        return false; // Versions are equal
+        return AndroidSdkPackageVersioning.CompareVersions(version1, version2) > 0;
     }
 
     // Get installed version for an available package (to show on Available tab)
@@ -1194,10 +1428,11 @@ else if (!ViewModel.IsSdkInstalled)
         return installed?.Version;
     }
 
-    // Get all packages that have updates
+    // Get all installed packages that have a genuine in-place update available.
     private IEnumerable<SdkPackageInfo> GetUpdatablePackages()
     {
-        return ViewModel.InstalledPackages.Where(p => HasUpdate(p));
+        return AndroidSdkPackageVersioning.GetUpdates(
+            ViewModel.InstalledPackages, ViewModel.AvailablePackages);
     }
 
     private async Task RefreshData()
@@ -1303,10 +1538,14 @@ else if (!ViewModel.IsSdkInstalled)
         }
     }
 
-    private async Task UpdateAllPackages()
+    private async Task UpdatePackages()
     {
         var updatable = GetUpdatablePackages().ToList();
-        if (!updatable.Any()) return;
+        if (!updatable.Any())
+        {
+            await AlertService.ShowAlertAsync("Up to Date", "All installed packages are up to date.", "OK");
+            return;
+        }
 
         // Build operation items for each updatable package
         var operations = updatable.Select(pkg =>
@@ -1319,7 +1558,7 @@ else if (!ViewModel.IsSdkInstalled)
             return new OperationItem(
                 Id: pkg.Path,
                 Name: GetPackageDisplayName(pkg.Path),
-                Description: $"Update from {pkg.Version} to {newVersion}",
+                Description: $"v{pkg.Version} → v{newVersion}",
                 Execute: async ctx =>
                 {
                     ctx.LogInfo($"Updating {pkg.Path}");

--- a/src/MauiSherpa/Pages/AndroidSdk.razor
+++ b/src/MauiSherpa/Pages/AndroidSdk.razor
@@ -1551,6 +1551,8 @@ else if (!ViewModel.IsSdkInstalled)
             return;
         }
 
+        var hasSideBySide = false;
+
         // Build operation items for each updatable package
         var operations = updatable.Select(pkg =>
         {
@@ -1558,11 +1560,47 @@ else if (!ViewModel.IsSdkInstalled)
             var newVersion = update?.Version ?? "latest";
             // Use the available package's path which may include version info
             var updatePath = update?.Path ?? pkg.Path;
-            
+
+            var isSideBySide = AndroidSdkPackageVersioning.Classify(pkg.Path)
+                == SdkPackageVersioningStrategy.SideBySide;
+
+            // For side-by-side groups (build-tools, ndk, cmake, numbered
+            // cmdline-tools) the newer release installs into its own path and
+            // older versions remain unless the user opts to clean them up.
+            var olderVersions = isSideBySide
+                ? ViewModel.InstalledPackages
+                    .Where(p => string.Equals(
+                        AndroidSdkPackageVersioning.GetGroup(p.Path),
+                        AndroidSdkPackageVersioning.GetGroup(pkg.Path),
+                        StringComparison.OrdinalIgnoreCase))
+                    .Where(p => !string.Equals(p.Path, updatePath, StringComparison.OrdinalIgnoreCase))
+                    .OrderByDescending(p => p, SdkPackageComparer.Instance)
+                    .ToList()
+                : new List<SdkPackageInfo>();
+
+            string description;
+            string? secondaryLabel = null;
+            if (isSideBySide)
+            {
+                hasSideBySide = true;
+                description = $"Install v{newVersion} (keeps existing version{(olderVersions.Count == 1 ? "" : "s")})";
+                if (olderVersions.Count > 0)
+                {
+                    var versionsList = string.Join(", ", olderVersions.Select(p => p.Version));
+                    secondaryLabel = olderVersions.Count == 1
+                        ? $"Remove older version {versionsList} after updating"
+                        : $"Remove {olderVersions.Count} older versions ({versionsList}) after updating";
+                }
+            }
+            else
+            {
+                description = $"v{pkg.Version} → v{newVersion}";
+            }
+
             return new OperationItem(
                 Id: pkg.Path,
                 Name: GetPackageDisplayName(pkg.Path),
-                Description: $"v{pkg.Version} → v{newVersion}",
+                Description: description,
                 Execute: async ctx =>
                 {
                     ctx.LogInfo($"Updating {pkg.Path}");
@@ -1570,31 +1608,57 @@ else if (!ViewModel.IsSdkInstalled)
                     ctx.LogInfo($"Available path: {updatePath}");
                     ctx.LogInfo($"Current version: {pkg.Version}");
                     ctx.LogInfo($"New version: {newVersion}");
-                    
+
                     // Use the available package path for installation
                     var success = await SdkService.InstallPackageAsync(updatePath, new Progress<string>(msg =>
                     {
                         ctx.LogInfo(msg);
                     }));
-                    
-                    if (success)
-                    {
-                        ctx.LogSuccess($"Updated {pkg.Path}");
-                    }
-                    else
+
+                    if (!success)
                     {
                         ctx.LogError($"Failed to update {pkg.Path}");
+                        return false;
                     }
-                    return success;
+
+                    ctx.LogSuccess($"Installed {updatePath}");
+
+                    // Optionally clean up older side-by-side versions.
+                    if (isSideBySide && ctx.SecondaryOptionEnabled && olderVersions.Count > 0)
+                    {
+                        foreach (var older in olderVersions)
+                        {
+                            ctx.LogInfo($"Removing older version: {older.Path}");
+                            var removed = await SdkService.UninstallPackageAsync(older.Path);
+                            if (removed)
+                                ctx.LogSuccess($"Removed {older.Path}");
+                            else
+                                ctx.LogWarning($"Could not remove {older.Path}");
+                        }
+                    }
+                    else if (isSideBySide && olderVersions.Count > 0)
+                    {
+                        ctx.LogInfo($"Keeping {olderVersions.Count} older version(s) installed.");
+                    }
+
+                    return true;
                 },
                 IsEnabled: true,
-                CanDisable: true
+                CanDisable: true,
+                SecondaryOptionLabel: secondaryLabel,
+                SecondaryOptionDefault: false
             );
         }).ToList();
 
+        var description = $"The following {updatable.Count} package(s) have updates available. Uncheck any you want to skip.";
+        if (hasSideBySide)
+        {
+            description += " Side-by-side tools (build-tools, NDK, CMake) install alongside existing versions — use the per-item option to remove older ones.";
+        }
+
         var result = await MultiOpModal.RunAsync(
             "Update SDK Packages",
-            $"The following {updatable.Count} package(s) have updates available. Uncheck any you want to skip.",
+            description,
             operations);
 
         if (result.Completed > 0)

--- a/src/MauiSherpa/Pages/AndroidSdk.razor
+++ b/src/MauiSherpa/Pages/AndroidSdk.razor
@@ -1395,23 +1395,26 @@ else if (!ViewModel.IsSdkInstalled)
             => AndroidSdkPackageVersioning.CompareVersions(version1, version2);
     }
 
-    // Check if an installed package has a genuine in-place update available.
+    // Check if an installed package has an update available (in-place or a newer
+    // side-by-side release).
     private bool HasUpdate(SdkPackageInfo installedPackage)
     {
         return GetAvailableUpdate(installedPackage) != null;
     }
 
-    // Get the available stable in-place update for an installed package.
-    // Delegates to the central, audited classifier: an update is the same exact
-    // package Path with a newer stable Version. Side-by-side groups (build-tools,
-    // ndk, cmake) embed their version in the Path and never produce updates.
+    // Get the available stable update for an installed package. Delegates to the
+    // central, audited classifier: for in-place groups (emulator, platform-tools,
+    // platforms, system-images, ...) this is the same Path with a newer stable
+    // Version; for side-by-side groups (build-tools, ndk, cmake, numbered
+    // cmdline-tools) this is the newest available stable release in the group,
+    // anchored on the newest installed package.
     private SdkPackageInfo? GetAvailableUpdate(SdkPackageInfo installedPackage, bool requireStable = true)
     {
-        if (installedPackage == null || ViewModel?.AvailablePackages == null)
+        if (installedPackage == null || ViewModel?.AvailablePackages == null || ViewModel.InstalledPackages == null)
             return null;
 
-        return AndroidSdkPackageVersioning.GetInPlaceUpdate(
-            installedPackage, ViewModel.AvailablePackages, requireStable);
+        return AndroidSdkPackageVersioning.GetUpdate(
+            installedPackage, ViewModel.InstalledPackages, ViewModel.AvailablePackages, requireStable);
     }
 
     // Compare version strings, returns true if version1 > version2
@@ -1428,7 +1431,8 @@ else if (!ViewModel.IsSdkInstalled)
         return installed?.Version;
     }
 
-    // Get all installed packages that have a genuine in-place update available.
+    // Get all installed packages that have an update available (in-place or a newer
+    // side-by-side release).
     private IEnumerable<SdkPackageInfo> GetUpdatablePackages()
     {
         return AndroidSdkPackageVersioning.GetUpdates(

--- a/src/MauiSherpa/Services/MultiOperationModalService.cs
+++ b/src/MauiSherpa/Services/MultiOperationModalService.cs
@@ -74,8 +74,14 @@ public class MultiOperationModalService : IMultiOperationModalService
                 IsEnabled = op.IsEnabled,
                 CanDisable = op.CanDisable,
                 State = OperationItemState.Pending,
-                SecondaryOptionLabel = op.SecondaryOptionLabel,
-                SecondaryOptionEnabled = op.SecondaryOptionDefault
+                SecondaryOptions = op.SecondaryOptions?
+                    .Select(o => new OperationSecondaryOptionStatus
+                    {
+                        Id = o.Id,
+                        Label = o.Label,
+                        Enabled = o.DefaultEnabled
+                    })
+                    .ToList() ?? new List<OperationSecondaryOptionStatus>()
             });
         }
 
@@ -122,14 +128,37 @@ public class MultiOperationModalService : IMultiOperationModalService
     }
 
     /// <summary>
-    /// Toggle an operation's optional secondary choice (called from UI)
+    /// Whether any operation offers secondary options (used to show the
+    /// global select/deselect-all control)
     /// </summary>
-    public void ToggleSecondaryOption(string operationId, bool enabled)
+    public bool HasSecondaryOptions => Operations.Any(o => o.SecondaryOptions.Count > 0);
+
+    /// <summary>
+    /// Toggle a single secondary option on an operation (called from UI)
+    /// </summary>
+    public void ToggleSecondaryOption(string operationId, string optionId, bool enabled)
     {
         var op = Operations.FirstOrDefault(o => o.Id == operationId);
-        if (op != null && op.SecondaryOptionLabel != null && !IsRunning)
+        var option = op?.SecondaryOptions.FirstOrDefault(o => o.Id == optionId);
+        if (op != null && option != null && !IsRunning)
         {
-            op.SecondaryOptionEnabled = enabled;
+            option.Enabled = enabled;
+            OnOperationStateChanged?.Invoke(op);
+        }
+    }
+
+    /// <summary>
+    /// Select or deselect every secondary option across all operations
+    /// </summary>
+    public void SetAllSecondaryOptions(bool enabled)
+    {
+        if (IsRunning) return;
+
+        foreach (var op in Operations)
+        {
+            if (op.SecondaryOptions.Count == 0) continue;
+            foreach (var option in op.SecondaryOptions)
+                option.Enabled = enabled;
             OnOperationStateChanged?.Invoke(op);
         }
     }
@@ -186,7 +215,11 @@ public class MultiOperationModalService : IMultiOperationModalService
             {
                 if (opLookup.TryGetValue(status.Id, out var operation))
                 {
-                    var context = new OperationItemContext(this, status.Id, _cts!.Token, status.SecondaryOptionEnabled);
+                    var enabledSecondary = status.SecondaryOptions
+                        .Where(o => o.Enabled)
+                        .Select(o => o.Id)
+                        .ToList();
+                    var context = new OperationItemContext(this, status.Id, _cts!.Token, enabledSecondary);
                     var success = await operation.Execute(context);
                     
                     status.Duration = DateTime.Now - opStartTime;
@@ -312,14 +345,14 @@ public class MultiOperationModalService : IMultiOperationModalService
 
         public CancellationToken CancellationToken { get; }
         public bool IsCancellationRequested => CancellationToken.IsCancellationRequested;
-        public bool SecondaryOptionEnabled { get; }
+        public IReadOnlyCollection<string> EnabledSecondaryOptionIds { get; }
 
-        public OperationItemContext(MultiOperationModalService service, string operationId, CancellationToken cancellationToken, bool secondaryOptionEnabled = false)
+        public OperationItemContext(MultiOperationModalService service, string operationId, CancellationToken cancellationToken, IReadOnlyCollection<string>? enabledSecondaryOptionIds = null)
         {
             _service = service;
             _operationId = operationId;
             CancellationToken = cancellationToken;
-            SecondaryOptionEnabled = secondaryOptionEnabled;
+            EnabledSecondaryOptionIds = enabledSecondaryOptionIds ?? Array.Empty<string>();
         }
 
         public void Log(string message, OperationLogLevel level = OperationLogLevel.Info)

--- a/src/MauiSherpa/Services/MultiOperationModalService.cs
+++ b/src/MauiSherpa/Services/MultiOperationModalService.cs
@@ -128,12 +128,6 @@ public class MultiOperationModalService : IMultiOperationModalService
     }
 
     /// <summary>
-    /// Whether any operation offers secondary options (used to show the
-    /// global select/deselect-all control)
-    /// </summary>
-    public bool HasSecondaryOptions => Operations.Any(o => o.SecondaryOptions.Count > 0);
-
-    /// <summary>
     /// Toggle a single secondary option on an operation (called from UI)
     /// </summary>
     public void ToggleSecondaryOption(string operationId, string optionId, bool enabled)
@@ -148,19 +142,18 @@ public class MultiOperationModalService : IMultiOperationModalService
     }
 
     /// <summary>
-    /// Select or deselect every secondary option across all operations
+    /// Select or deselect every secondary option on a single operation
     /// </summary>
-    public void SetAllSecondaryOptions(bool enabled)
+    public void SetAllSecondaryOptions(string operationId, bool enabled)
     {
         if (IsRunning) return;
 
-        foreach (var op in Operations)
-        {
-            if (op.SecondaryOptions.Count == 0) continue;
-            foreach (var option in op.SecondaryOptions)
-                option.Enabled = enabled;
-            OnOperationStateChanged?.Invoke(op);
-        }
+        var op = Operations.FirstOrDefault(o => o.Id == operationId);
+        if (op == null || op.SecondaryOptions.Count == 0) return;
+
+        foreach (var option in op.SecondaryOptions)
+            option.Enabled = enabled;
+        OnOperationStateChanged?.Invoke(op);
     }
 
     /// <summary>

--- a/src/MauiSherpa/Services/MultiOperationModalService.cs
+++ b/src/MauiSherpa/Services/MultiOperationModalService.cs
@@ -73,7 +73,9 @@ public class MultiOperationModalService : IMultiOperationModalService
                 Description = op.Description,
                 IsEnabled = op.IsEnabled,
                 CanDisable = op.CanDisable,
-                State = OperationItemState.Pending
+                State = OperationItemState.Pending,
+                SecondaryOptionLabel = op.SecondaryOptionLabel,
+                SecondaryOptionEnabled = op.SecondaryOptionDefault
             });
         }
 
@@ -115,6 +117,19 @@ public class MultiOperationModalService : IMultiOperationModalService
         if (op != null && op.CanDisable && !IsRunning)
         {
             op.IsEnabled = enabled;
+            OnOperationStateChanged?.Invoke(op);
+        }
+    }
+
+    /// <summary>
+    /// Toggle an operation's optional secondary choice (called from UI)
+    /// </summary>
+    public void ToggleSecondaryOption(string operationId, bool enabled)
+    {
+        var op = Operations.FirstOrDefault(o => o.Id == operationId);
+        if (op != null && op.SecondaryOptionLabel != null && !IsRunning)
+        {
+            op.SecondaryOptionEnabled = enabled;
             OnOperationStateChanged?.Invoke(op);
         }
     }
@@ -171,7 +186,7 @@ public class MultiOperationModalService : IMultiOperationModalService
             {
                 if (opLookup.TryGetValue(status.Id, out var operation))
                 {
-                    var context = new OperationItemContext(this, status.Id, _cts!.Token);
+                    var context = new OperationItemContext(this, status.Id, _cts!.Token, status.SecondaryOptionEnabled);
                     var success = await operation.Execute(context);
                     
                     status.Duration = DateTime.Now - opStartTime;
@@ -297,12 +312,14 @@ public class MultiOperationModalService : IMultiOperationModalService
 
         public CancellationToken CancellationToken { get; }
         public bool IsCancellationRequested => CancellationToken.IsCancellationRequested;
+        public bool SecondaryOptionEnabled { get; }
 
-        public OperationItemContext(MultiOperationModalService service, string operationId, CancellationToken cancellationToken)
+        public OperationItemContext(MultiOperationModalService service, string operationId, CancellationToken cancellationToken, bool secondaryOptionEnabled = false)
         {
             _service = service;
             _operationId = operationId;
             CancellationToken = cancellationToken;
+            SecondaryOptionEnabled = secondaryOptionEnabled;
         }
 
         public void Log(string message, OperationLogLevel level = OperationLogLevel.Info)

--- a/src/MauiSherpa/Services/OperationModalService.cs
+++ b/src/MauiSherpa/Services/OperationModalService.cs
@@ -231,6 +231,7 @@ public class OperationModalService : IOperationModalService
         
         public CancellationToken CancellationToken { get; }
         public bool IsCancellationRequested => CancellationToken.IsCancellationRequested;
+        public bool SecondaryOptionEnabled => false;
 
         public OperationContext(OperationModalService service, CancellationToken cancellationToken)
         {

--- a/src/MauiSherpa/Services/OperationModalService.cs
+++ b/src/MauiSherpa/Services/OperationModalService.cs
@@ -231,7 +231,7 @@ public class OperationModalService : IOperationModalService
         
         public CancellationToken CancellationToken { get; }
         public bool IsCancellationRequested => CancellationToken.IsCancellationRequested;
-        public bool SecondaryOptionEnabled => false;
+        public IReadOnlyCollection<string> EnabledSecondaryOptionIds => Array.Empty<string>();
 
         public OperationContext(OperationModalService service, CancellationToken cancellationToken)
         {

--- a/tests/MauiSherpa.Core.Tests/Services/AndroidSdkPackageVersioningTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/AndroidSdkPackageVersioningTests.cs
@@ -216,29 +216,150 @@ public class AndroidSdkPackageVersioningTests
             .Should().BeNull();
     }
 
+    // ---- GetSideBySideUpdate / GetUpdate ----
+
+    [Fact]
+    public void GetSideBySideUpdate_AnchorNewestInstalled_ReturnsNewestAvailable()
+    {
+        var installed = Pkg("build-tools;36.1.0", "36.1.0", installed: true);
+        var installedAll = new[] { installed };
+        var available = new[]
+        {
+            Pkg("build-tools;36.1.0", "36.1.0"),
+            Pkg("build-tools;37.0.0", "37.0.0"),
+        };
+
+        var update = AndroidSdkPackageVersioning.GetSideBySideUpdate(installed, installedAll, available);
+
+        update.Should().NotBeNull();
+        update!.Path.Should().Be("build-tools;37.0.0");
+        update.Version.Should().Be("37.0.0");
+    }
+
+    [Fact]
+    public void GetSideBySideUpdate_NonAnchorOlderInstalled_ReturnsNull()
+    {
+        // Both 36.1.0 and 37.0.0 are installed; only the newest (37.0.0) is the anchor.
+        var older = Pkg("build-tools;36.1.0", "36.1.0", installed: true);
+        var newer = Pkg("build-tools;37.0.0", "37.0.0", installed: true);
+        var installedAll = new[] { older, newer };
+        var available = new[]
+        {
+            Pkg("build-tools;36.1.0", "36.1.0"),
+            Pkg("build-tools;37.0.0", "37.0.0"),
+            Pkg("build-tools;38.0.0", "38.0.0"),
+        };
+
+        // The older installed package is not the anchor -> no update surfaced on it.
+        AndroidSdkPackageVersioning.GetSideBySideUpdate(older, installedAll, available)
+            .Should().BeNull();
+
+        // The newest installed package is the anchor -> points at 38.0.0.
+        var update = AndroidSdkPackageVersioning.GetSideBySideUpdate(newer, installedAll, available);
+        update.Should().NotBeNull();
+        update!.Path.Should().Be("build-tools;38.0.0");
+    }
+
+    [Fact]
+    public void GetSideBySideUpdate_NewestInstalledEqualsNewestAvailable_ReturnsNull()
+    {
+        var installed = Pkg("build-tools;37.0.0", "37.0.0", installed: true);
+        var installedAll = new[] { installed };
+        var available = new[] { Pkg("build-tools;37.0.0", "37.0.0") };
+
+        AndroidSdkPackageVersioning.GetSideBySideUpdate(installed, installedAll, available)
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public void GetSideBySideUpdate_PrereleaseFilteredByDefault()
+    {
+        var installed = Pkg("build-tools;36.1.0", "36.1.0", installed: true);
+        var installedAll = new[] { installed };
+        var available = new[] { Pkg("build-tools;37.0.0-rc1", "37.0.0-rc1") };
+
+        AndroidSdkPackageVersioning.GetSideBySideUpdate(installed, installedAll, available)
+            .Should().BeNull();
+
+        AndroidSdkPackageVersioning.GetSideBySideUpdate(installed, installedAll, available, requireStable: false)
+            .Should().NotBeNull();
+    }
+
+    [Fact]
+    public void GetUpdate_DispatchesByStrategy()
+    {
+        // In-place (FixedPath): same path, newer version.
+        var emulator = Pkg("emulator", "36.4.10", installed: true);
+        var emulatorAvail = new[] { Pkg("emulator", "36.6.11") };
+        AndroidSdkPackageVersioning.GetUpdate(emulator, new[] { emulator }, emulatorAvail)!
+            .Version.Should().Be("36.6.11");
+
+        // Side-by-side: newer release is a distinct path.
+        var buildTools = Pkg("build-tools;36.1.0", "36.1.0", installed: true);
+        var buildToolsAvail = new[]
+        {
+            Pkg("build-tools;36.1.0", "36.1.0"),
+            Pkg("build-tools;37.0.0", "37.0.0"),
+        };
+        AndroidSdkPackageVersioning.GetUpdate(buildTools, new[] { buildTools }, buildToolsAvail)!
+            .Path.Should().Be("build-tools;37.0.0");
+    }
+
+    [Fact]
+    public void GetInPlaceUpdate_StillIgnoresSideBySide()
+    {
+        // GetInPlaceUpdate remains pure in-place: a newer build-tools path is never
+        // an in-place update even though GetUpdate/GetSideBySideUpdate surfaces it.
+        var installed = Pkg("build-tools;36.1.0", "36.1.0", installed: true);
+        var available = new[] { Pkg("build-tools;37.0.0", "37.0.0") };
+
+        AndroidSdkPackageVersioning.GetInPlaceUpdate(installed, available).Should().BeNull();
+    }
+
     // ---- GetUpdates ----
 
     [Fact]
-    public void GetUpdates_ReturnsOnlyGenuineInPlaceUpdates()
+    public void GetUpdates_IncludesInPlaceAndSideBySide()
     {
         var installed = new[]
         {
-            Pkg("emulator", "36.4.10", installed: true),                         // update -> 36.6.11
-            Pkg("platform-tools", "36.0.0", installed: true),                    // update -> 37.0.0
-            Pkg("build-tools;36.1.0", "36.1.0", installed: true),                // NOT an update (side-by-side)
+            Pkg("emulator", "36.4.10", installed: true),                         // in-place -> 36.6.11
+            Pkg("platform-tools", "36.0.0", installed: true),                    // in-place -> 37.0.0
+            Pkg("build-tools;36.1.0", "36.1.0", installed: true),                // side-by-side anchor -> 37.0.0
             Pkg("platforms;android-33", "3", installed: true),                   // already newest revision
         };
         var available = new[]
         {
             Pkg("emulator", "36.6.11"),
             Pkg("platform-tools", "37.0.0"),
+            Pkg("build-tools;36.1.0", "36.1.0"),
             Pkg("build-tools;37.0.0", "37.0.0"),
             Pkg("platforms;android-33", "3"),
         };
 
         var updates = AndroidSdkPackageVersioning.GetUpdates(installed, available).ToList();
 
-        updates.Select(u => u.Path).Should().BeEquivalentTo("emulator", "platform-tools");
+        updates.Select(u => u.Path)
+            .Should().BeEquivalentTo("emulator", "platform-tools", "build-tools;36.1.0");
+    }
+
+    [Fact]
+    public void GetUpdates_SideBySide_OnlyAnchorWhenMultipleInstalled()
+    {
+        var installed = new[]
+        {
+            Pkg("build-tools;35.0.0", "35.0.0", installed: true),
+            Pkg("build-tools;36.1.0", "36.1.0", installed: true), // anchor
+        };
+        var available = new[]
+        {
+            Pkg("build-tools;36.1.0", "36.1.0"),
+            Pkg("build-tools;37.0.0", "37.0.0"),
+        };
+
+        var updates = AndroidSdkPackageVersioning.GetUpdates(installed, available).ToList();
+
+        updates.Select(u => u.Path).Should().BeEquivalentTo("build-tools;36.1.0");
     }
 
     // ---- CompareVersions ----

--- a/tests/MauiSherpa.Core.Tests/Services/AndroidSdkPackageVersioningTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/AndroidSdkPackageVersioningTests.cs
@@ -1,0 +1,296 @@
+using FluentAssertions;
+using MauiSherpa.Core.Interfaces;
+using MauiSherpa.Core.Services;
+
+namespace MauiSherpa.Core.Tests.Services;
+
+public class AndroidSdkPackageVersioningTests
+{
+    private static SdkPackageInfo Pkg(string path, string? version, bool installed = false) =>
+        new(path, Description: path, Version: version, Location: installed ? "/sdk/" + path : null, IsInstalled: installed);
+
+    // ---- GetGroup ----
+
+    [Theory]
+    [InlineData("emulator", "emulator")]
+    [InlineData("platform-tools", "platform-tools")]
+    [InlineData("build-tools;36.1.0", "build-tools")]
+    [InlineData("system-images;android-33;google_apis;arm64-v8a", "system-images")]
+    [InlineData("cmdline-tools;latest", "cmdline-tools")]
+    [InlineData("", "")]
+    public void GetGroup_ReturnsLeadingSegment(string path, string expected)
+    {
+        AndroidSdkPackageVersioning.GetGroup(path).Should().Be(expected);
+    }
+
+    // ---- Classification ----
+
+    [Theory]
+    [InlineData("emulator")]
+    [InlineData("platform-tools")]
+    [InlineData("tools")]
+    [InlineData("docs")]
+    [InlineData("ndk-bundle")]
+    [InlineData("extras;google;m2repository")]
+    [InlineData("build;templates")]
+    [InlineData("patcher;v4")]
+    [InlineData("cmdline-tools;latest")]
+    public void Classify_FixedPathGroups(string path)
+    {
+        AndroidSdkPackageVersioning.Classify(path)
+            .Should().Be(SdkPackageVersioningStrategy.FixedPath);
+    }
+
+    [Theory]
+    [InlineData("platforms;android-33")]
+    [InlineData("sources;android-36")]
+    [InlineData("system-images;android-33;google_apis;arm64-v8a")]
+    [InlineData("skiaparser;3")]
+    [InlineData("add-ons;addon-google_apis-google-24")]
+    [InlineData("some-unknown-future-group;variant")]
+    public void Classify_RevisionGroups(string path)
+    {
+        AndroidSdkPackageVersioning.Classify(path)
+            .Should().Be(SdkPackageVersioningStrategy.Revision);
+    }
+
+    [Theory]
+    [InlineData("build-tools;36.1.0")]
+    [InlineData("build-tools;37.0.0")]
+    [InlineData("ndk;27.0.12077973")]
+    [InlineData("cmake;3.22.1")]
+    [InlineData("cmdline-tools;13.0")]
+    public void Classify_SideBySideGroups(string path)
+    {
+        AndroidSdkPackageVersioning.Classify(path)
+            .Should().Be(SdkPackageVersioningStrategy.SideBySide);
+    }
+
+    [Fact]
+    public void Classify_CmdlineToolsLatestVsNumbered()
+    {
+        AndroidSdkPackageVersioning.Classify("cmdline-tools;latest")
+            .Should().Be(SdkPackageVersioningStrategy.FixedPath);
+        AndroidSdkPackageVersioning.Classify("cmdline-tools;13.0")
+            .Should().Be(SdkPackageVersioningStrategy.SideBySide);
+    }
+
+    [Theory]
+    [InlineData("emulator", true)]
+    [InlineData("platforms;android-33", true)]
+    [InlineData("build-tools;36.1.0", false)]
+    [InlineData("ndk;27.0.12077973", false)]
+    [InlineData("cmake;3.22.1", false)]
+    public void SupportsInPlaceUpdate(string path, bool expected)
+    {
+        AndroidSdkPackageVersioning.SupportsInPlaceUpdate(path).Should().Be(expected);
+    }
+
+    // ---- GetInPlaceUpdate / HasInPlaceUpdate (positives) ----
+
+    [Fact]
+    public void GetInPlaceUpdate_Emulator_FindsNewerVersion()
+    {
+        var installed = Pkg("emulator", "36.4.10", installed: true);
+        var available = new[]
+        {
+            Pkg("emulator", "36.4.10"),
+            Pkg("emulator", "36.6.11"),
+        };
+
+        var update = AndroidSdkPackageVersioning.GetInPlaceUpdate(installed, available);
+
+        update.Should().NotBeNull();
+        update!.Version.Should().Be("36.6.11");
+    }
+
+    [Fact]
+    public void GetInPlaceUpdate_PlatformTools_FindsNewerVersion()
+    {
+        var installed = Pkg("platform-tools", "36.0.0", installed: true);
+        var available = new[] { Pkg("platform-tools", "37.0.0") };
+
+        AndroidSdkPackageVersioning.HasInPlaceUpdate(installed, available).Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetInPlaceUpdate_Platforms_RevisionBump()
+    {
+        var installed = Pkg("platforms;android-33", "3", installed: true);
+        var available = new[] { Pkg("platforms;android-33", "4") };
+
+        var update = AndroidSdkPackageVersioning.GetInPlaceUpdate(installed, available);
+
+        update.Should().NotBeNull();
+        update!.Version.Should().Be("4");
+    }
+
+    [Fact]
+    public void GetInPlaceUpdate_SystemImages_RevisionBump()
+    {
+        var installed = Pkg("system-images;android-33;google_apis;arm64-v8a", "17", installed: true);
+        var available = new[] { Pkg("system-images;android-33;google_apis;arm64-v8a", "18") };
+
+        AndroidSdkPackageVersioning.HasInPlaceUpdate(installed, available).Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetInPlaceUpdate_PicksHighestStableWhenMultipleNewer()
+    {
+        var installed = Pkg("emulator", "36.0.0", installed: true);
+        var available = new[]
+        {
+            Pkg("emulator", "36.4.10"),
+            Pkg("emulator", "36.6.11"),
+            Pkg("emulator", "36.2.0"),
+        };
+
+        var update = AndroidSdkPackageVersioning.GetInPlaceUpdate(installed, available);
+
+        update!.Version.Should().Be("36.6.11");
+    }
+
+    // ---- GetInPlaceUpdate (negatives) ----
+
+    [Fact]
+    public void GetInPlaceUpdate_SideBySide_NeverUpdates()
+    {
+        // build-tools;36.1.0 installed; build-tools;37.0.0 is a DISTINCT package, not an update.
+        var installed = Pkg("build-tools;36.1.0", "36.1.0", installed: true);
+        var available = new[]
+        {
+            Pkg("build-tools;36.1.0", "36.1.0"),
+            Pkg("build-tools;37.0.0", "37.0.0"),
+        };
+
+        AndroidSdkPackageVersioning.GetInPlaceUpdate(installed, available).Should().BeNull();
+    }
+
+    [Fact]
+    public void GetInPlaceUpdate_EqualVersion_NoUpdate()
+    {
+        var installed = Pkg("emulator", "36.6.11", installed: true);
+        var available = new[] { Pkg("emulator", "36.6.11") };
+
+        AndroidSdkPackageVersioning.GetInPlaceUpdate(installed, available).Should().BeNull();
+    }
+
+    [Fact]
+    public void GetInPlaceUpdate_OlderAvailable_NoUpdate()
+    {
+        var installed = Pkg("emulator", "36.6.11", installed: true);
+        var available = new[] { Pkg("emulator", "36.4.10") };
+
+        AndroidSdkPackageVersioning.GetInPlaceUpdate(installed, available).Should().BeNull();
+    }
+
+    [Fact]
+    public void GetInPlaceUpdate_PrereleaseFilteredByDefault()
+    {
+        var installed = Pkg("emulator", "36.4.10", installed: true);
+        var available = new[] { Pkg("emulator", "36.6.11-rc1") };
+
+        // Default requireStable: the rc build is ignored.
+        AndroidSdkPackageVersioning.GetInPlaceUpdate(installed, available).Should().BeNull();
+
+        // When stability isn't required, it is returned.
+        AndroidSdkPackageVersioning.GetInPlaceUpdate(installed, available, requireStable: false)
+            .Should().NotBeNull();
+    }
+
+    [Fact]
+    public void GetInPlaceUpdate_NewApiLevel_NotAnUpdate()
+    {
+        // A brand-new platform (different Path) is not an update to an older platform.
+        var installed = Pkg("platforms;android-33", "3", installed: true);
+        var available = new[] { Pkg("platforms;android-34", "1") };
+
+        AndroidSdkPackageVersioning.GetInPlaceUpdate(installed, available).Should().BeNull();
+    }
+
+    [Fact]
+    public void GetInPlaceUpdate_NullOrEmptyInputs_NoUpdate()
+    {
+        var installed = Pkg("emulator", null, installed: true);
+        AndroidSdkPackageVersioning.GetInPlaceUpdate(installed, new[] { Pkg("emulator", "37.0.0") })
+            .Should().BeNull();
+    }
+
+    // ---- GetUpdates ----
+
+    [Fact]
+    public void GetUpdates_ReturnsOnlyGenuineInPlaceUpdates()
+    {
+        var installed = new[]
+        {
+            Pkg("emulator", "36.4.10", installed: true),                         // update -> 36.6.11
+            Pkg("platform-tools", "36.0.0", installed: true),                    // update -> 37.0.0
+            Pkg("build-tools;36.1.0", "36.1.0", installed: true),                // NOT an update (side-by-side)
+            Pkg("platforms;android-33", "3", installed: true),                   // already newest revision
+        };
+        var available = new[]
+        {
+            Pkg("emulator", "36.6.11"),
+            Pkg("platform-tools", "37.0.0"),
+            Pkg("build-tools;37.0.0", "37.0.0"),
+            Pkg("platforms;android-33", "3"),
+        };
+
+        var updates = AndroidSdkPackageVersioning.GetUpdates(installed, available).ToList();
+
+        updates.Select(u => u.Path).Should().BeEquivalentTo("emulator", "platform-tools");
+    }
+
+    // ---- CompareVersions ----
+
+    [Theory]
+    [InlineData("10", "3", 1)]
+    [InlineData("3", "10", -1)]
+    [InlineData("18", "17", 1)]
+    [InlineData("36.6.11", "36.4.10", 1)]
+    [InlineData("36.4.10", "36.6.11", -1)]
+    [InlineData("37.0.0", "36.0.0", 1)]
+    [InlineData("36.6.11", "36.6.11", 0)]
+    public void CompareVersions_OrdersCorrectly(string a, string b, int expectedSign)
+    {
+        Math.Sign(AndroidSdkPackageVersioning.CompareVersions(a, b)).Should().Be(expectedSign);
+    }
+
+    [Fact]
+    public void CompareVersions_NullHandling()
+    {
+        AndroidSdkPackageVersioning.CompareVersions(null, null).Should().Be(0);
+        AndroidSdkPackageVersioning.CompareVersions(null, "1").Should().BeLessThan(0);
+        AndroidSdkPackageVersioning.CompareVersions("1", null).Should().BeGreaterThan(0);
+    }
+
+    // ---- IsStableVersion ----
+
+    [Theory]
+    [InlineData("36.6.11", true)]
+    [InlineData("3", true)]
+    [InlineData("37.0.0", true)]
+    [InlineData("36.0.0-rc1", false)]
+    [InlineData("1.0.0-beta", false)]
+    [InlineData("2.1-alpha02", false)]
+    [InlineData("36.6.11-canary", false)]
+    public void IsStableVersion_DetectsPrereleases(string version, bool expected)
+    {
+        AndroidSdkPackageVersioning.IsStableVersion(version).Should().Be(expected);
+    }
+
+    [Fact]
+    public void IsStableVersion_DoesNotFalseMatchSubstrings()
+    {
+        // "rc" should not match inside a plain numeric version; these are all stable.
+        AndroidSdkPackageVersioning.IsStableVersion("36.0.0").Should().BeTrue();
+        AndroidSdkPackageVersioning.IsStableVersion("17").Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsStableVersion_NullOrEmpty_IsFalse()
+    {
+        AndroidSdkPackageVersioning.IsStableVersion(null).Should().BeFalse();
+        AndroidSdkPackageVersioning.IsStableVersion("").Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Why

The Android SDK page needed a clear way to see what's installed versus available, and to keep packages up to date. Android's packaging is inconsistent (some tools version via their package path, some via a revision field, some both), so "what counts as an update" and "what happens to the old version" varies by package group. This PR adds a packages view with accurate update detection and an update flow that makes those semantics explicit.

## What

**Packages view**
- New unified "All" tab showing installed and available packages together, with sections sorted newest-version-first.
- Subtle per-item and per-section indicators when a newer stable version is available (no inline update buttons cluttering the list).

**Update detection (`AndroidSdkPackageVersioning`)**
- Central classifier that buckets each package into one of three versioning strategies:
  - `FixedPath` (e.g. emulator, cmdline-tools;latest) - updates in place via the revision field.
  - `Revision` - same idea, single path, version moves forward.
  - `SideBySide` (build-tools, NDK, CMake, numbered cmdline-tools) - new releases install into their own path and coexist with older versions.
- Only stable (non pre-release) versions are considered for update suggestions. Fully unit tested (68 cases).

**Update dialog**
- A top-level "Update Packages" toolbar action opens a dedicated multi-operation dialog instead of per-row update buttons.
- For in-place packages the item simply reads `vOld -> vNew`.
- For side-by-side groups the dialog is explicit that the new version installs alongside existing ones, and offers a per-older-version checkbox so you can clean up some, all, or none of the older versions. Each group with multiple older versions gets its own "Select all / Deselect all" control. Default is to keep older versions (matches `sdkmanager`, avoids breaking version-pinned projects).

**Shared modal improvements**
- Removed a dead expand/collapse chevron that appeared on every row during confirmation when there was nothing to expand; it now only shows when an operation has a log or error to reveal.
- Generalized the modal with a reusable per-item "secondary options" list (`OperationItem.SecondaryOptions` surfaced via `IOperationContext.EnabledSecondaryOptionIds`), so any batch operation can offer independently-selectable sub-choices.
- Fixed checkbox vertical alignment so the main package checkbox centers against the title and description, not the full row including the cleanup list.

## Notes for reviewers

- The side-by-side keep/cleanup default is intentionally "keep". When cleanup is selected for a group, all older installed versions in that group are removed after the new one installs, leaving only the newest.
- The cleanup choice is threaded generically through the shared `MultiOperationModal`, so the change touches `Interfaces.cs` and both `IOperationContext` implementations (multi-op threads the real selection; single-op returns empty).
- UI was verified via build, unit tests, and clean app startup. Visual verification of the dialog in the running app was not possible in this environment (DevFlow/screencapture unreachable), so a careful look at the dialog in both light and dark mode would be appreciated.

All 496 tests pass; Mac Catalyst and macOS head both build clean.