### PR TITLE
Audit modal/dialog colors, flatten cards, fix content padding

### DIFF
--- a/src/MauiSherpa.Core/MauiSherpa.Core.csproj
+++ b/src/MauiSherpa.Core/MauiSherpa.Core.csproj
@@ -46,8 +46,8 @@
     <PackageReference Include="Octokit" Version="14.0.0" />
     <PackageReference Include="SharpKml.Core" Version="6.1.0" />
     <PackageReference Include="Shiny.DocumentDb.Sqlite.SqlCipher" Version="5.2.2" />
-    <PackageReference Include="Shiny.Mediator" Version="6.6.2" />
-    <PackageReference Include="Shiny.Mediator.AppSupport" Version="6.6.2" />
+    <PackageReference Include="Shiny.Mediator" Version="6.1.1" />
+    <PackageReference Include="Shiny.Mediator.AppSupport" Version="6.1.1" />
     <PackageReference Include="Sodium.Core" Version="1.4.1" />
   </ItemGroup>
 

--- a/src/MauiSherpa/Components/AndroidAppsTab.razor
+++ b/src/MauiSherpa/Components/AndroidAppsTab.razor
@@ -129,7 +129,6 @@
         padding: 0.375rem 0.75rem;
         transition: background 0.1s;
     }
-    .android-app-row:hover { background: var(--bg-tertiary); }
     .android-app-row.user-app { border-left: 3px solid var(--accent-primary); }
 
     .android-app-icon { font-size: 1rem; color: var(--text-secondary); width: 1.5rem; text-align: center; }

--- a/src/MauiSherpa/Components/AppleAppsTab.razor
+++ b/src/MauiSherpa/Components/AppleAppsTab.razor
@@ -192,7 +192,6 @@
         padding: 0.375rem 0.75rem;
         transition: background 0.1s;
     }
-    .sim-app-row:hover { background: var(--bg-tertiary); }
     .sim-app-row.user-app { border-left: 3px solid var(--accent-primary); }
 
     .sim-app-icon { font-size: 1rem; color: var(--text-secondary); width: 1.5rem; text-align: center; }

--- a/src/MauiSherpa/Components/CISecretsWizard.razor
+++ b/src/MauiSherpa/Components/CISecretsWizard.razor
@@ -931,7 +931,7 @@
     }
 
     .option-card {
-        border: 2px solid var(--border-color, #e2e8f0);
+        border: 2px solid transparent;
         border-radius: 0.5rem;
         padding: 1.25rem;
         text-align: center;
@@ -939,7 +939,6 @@
         transition: all 0.15s;
     }
 
-    .option-card:hover { border-color: #8b5cf6; }
     .option-card.selected { border-color: #8b5cf6; background: #faf5ff; }
     .option-card input { display: none; }
     .option-card i { font-size: 2rem; color: #8b5cf6; margin-bottom: 0.75rem; }
@@ -958,13 +957,12 @@
         align-items: flex-start;
         gap: 0.75rem;
         padding: 0.875rem;
-        border: 1px solid var(--border-color, #e2e8f0);
+        border: 1px solid transparent;
         border-radius: 0.5rem;
         cursor: pointer;
         transition: all 0.15s;
     }
 
-    .option-item:hover { border-color: #8b5cf6; }
     .option-item.selected { border-color: #8b5cf6; background: #faf5ff; }
     .option-item input[type="radio"] { margin-top: 3px; accent-color: #8b5cf6; }
     .option-content { flex: 1; }
@@ -1026,7 +1024,6 @@
     }
 
     .wizard-dialog .selection-item:last-child { border-bottom: none; }
-    .wizard-dialog .selection-item:hover { background: var(--bg-hover, #f7fafc); }
     .wizard-dialog .selection-item.selected { background: #faf5ff; }
     .wizard-dialog .selection-item input[type="radio"] { margin-top: 2px; accent-color: #8b5cf6; }
 
@@ -1101,7 +1098,6 @@
     }
 
     .cert-item:last-child { border-bottom: none; }
-    .cert-item:hover { background: var(--bg-hover, #f7fafc); }
     .cert-item.selected { background: #faf5ff; }
     .cert-item.no-key { opacity: 0.6; }
     .cert-item input { accent-color: #8b5cf6; }
@@ -1181,7 +1177,6 @@
     }
 
     .secret-card {
-        border: 1px solid var(--border-color, #e2e8f0);
         border-radius: 0.5rem;
         padding: 0.875rem;
     }
@@ -1614,13 +1609,11 @@
 
     .theme-dark .resource-missing { background: var(--status-warning-bg, #744210); color: var(--status-warning-text, #fbd38d); }
 
-    .theme-dark .wizard-dialog .selection-item:hover { background: var(--bg-hover, #2d3748); }
     .theme-dark .wizard-dialog .selection-item.selected { background: rgba(139, 92, 246, 0.15); }
 
     .theme-dark .form-select,
     .theme-dark .form-input { background: var(--input-bg, #374151); color: var(--text-primary, #e2e8f0); }
 
-    .theme-dark .cert-item:hover { background: var(--bg-hover, #2d3748); }
     .theme-dark .cert-item.selected { background: rgba(139, 92, 246, 0.15); }
 
     .theme-dark .cert-item input[type="radio"],

--- a/src/MauiSherpa/Components/CopilotModalLayout.razor
+++ b/src/MauiSherpa/Components/CopilotModalLayout.razor
@@ -40,7 +40,7 @@
         try
         {
             var cls = ThemeService.IsDarkMode ? "theme-dark" : "theme-light";
-            var bg = ThemeService.IsDarkMode ? "#1a202c" : "#f7fafc";
+            var bg = ThemeService.IsDarkMode ? "#242628" : "#FFFFFF";
             await JS.InvokeVoidAsync("eval", $"document.body.className = '{cls}'; document.body.style.backgroundColor='{bg}';");
         }
         catch { }
@@ -86,9 +86,9 @@
 
     /* Reuse theme variables from MainLayout */
     .theme-light {
-        --bg-primary: #f7fafc;
+        --bg-primary: #FFFFFF;
         --bg-secondary: #ffffff;
-        --bg-tertiary: #edf2f7;
+        --bg-tertiary: #ECECEC;
         --text-primary: #2d3748;
         --text-secondary: #4a5568;
         --text-muted: #718096;
@@ -97,23 +97,23 @@
         --card-shadow: none;
         --input-bg: #ffffff;
         --input-border: #e2e8f0;
-        --hover-bg: #f7fafc;
+        --hover-bg: #F0F0F0;
         --accent-bg: #faf5ff;
     }
 
     .theme-dark {
-        --bg-primary: #1a202c;
-        --bg-secondary: #2d3748;
-        --bg-tertiary: #4a5568;
+        --bg-primary: #242628;
+        --bg-secondary: #2C2C2C;
+        --bg-tertiary: #424242;
         --text-primary: #e2e8f0;
         --text-secondary: #cbd5e0;
         --text-muted: #a0aec0;
         --border-color: #24292B;
-        --card-bg: #2B2F31;
+        --card-bg: #383838;
         --card-shadow: none;
         --input-bg: #2d3748;
         --input-border: #4a5568;
-        --hover-bg: #4a5568;
+        --hover-bg: #4E4E4E;
         --accent-bg: #312e81;
     }
 

--- a/src/MauiSherpa/Components/CreateProfileDialog.razor
+++ b/src/MauiSherpa/Components/CreateProfileDialog.razor
@@ -597,7 +597,6 @@
     }
 
     .selection-item:last-child { border-bottom: none; }
-    .selection-item:hover { background: var(--bg-hover, #f7fafc); }
     .selection-item.selected { background: #faf5ff; }
     .selection-item.disabled { opacity: 0.5; cursor: not-allowed; }
 
@@ -829,13 +828,11 @@
         background: rgba(139, 92, 246, 0.15);
     }
 
-    .theme-dark .type-option:hover,
-    .theme-dark .selection-item:hover {
+    .theme-dark .type-option:hover {
         background: rgba(255, 255, 255, 0.06);
     }
 
-    .theme-dark .type-option.selected:hover,
-    .theme-dark .selection-item.selected:hover {
+    .theme-dark .type-option.selected:hover {
         background: rgba(139, 92, 246, 0.2);
     }
 

--- a/src/MauiSherpa/Components/DataGrid.razor
+++ b/src/MauiSherpa/Components/DataGrid.razor
@@ -354,10 +354,6 @@
         padding: 0.2rem 0;
     }
 
-    .dg-row:hover {
-        background: var(--bg-tertiary);
-    }
-
     .dg-row.selected {
         background: rgba(59, 130, 246, 0.08);
     }

--- a/src/MauiSherpa/Components/EditProfileDialog.razor
+++ b/src/MauiSherpa/Components/EditProfileDialog.razor
@@ -387,7 +387,6 @@
     }
 
     .selection-item:last-child { border-bottom: none; }
-    .selection-item:hover { background: var(--hover-bg, #f7fafc); }
     .selection-item.selected { background: var(--accent-bg, #faf5ff); }
     .selection-item.disabled { opacity: 0.5; cursor: not-allowed; }
 

--- a/src/MauiSherpa/Components/FileExplorerTab.razor
+++ b/src/MauiSherpa/Components/FileExplorerTab.razor
@@ -160,7 +160,6 @@
         border-bottom: 1px solid var(--border-subtle, rgba(0,0,0,0.04));
         transition: background 0.1s;
     }
-    .file-row:hover { background: var(--bg-tertiary, #f7fafc); }
     .file-row-dir { font-weight: 500; }
     .file-col-icon { width: 28px; text-align: center; flex-shrink: 0; color: var(--text-muted); }
     .file-row-dir .file-col-icon { color: #eab308; }

--- a/src/MauiSherpa/Components/LogcatContent.razor
+++ b/src/MauiSherpa/Components/LogcatContent.razor
@@ -302,10 +302,6 @@
         white-space: nowrap;
     }
     .grid-row > .col-message { flex: 1; flex-shrink: 1; }
-    .grid-row:hover {
-        background: rgba(255,255,255,0.05) !important;
-    }
-
     /* Column colors */
     .col-time { color: var(--text-muted); }
     .col-level { text-align: center; }

--- a/src/MauiSherpa/Components/MainLayout.razor
+++ b/src/MauiSherpa/Components/MainLayout.razor
@@ -516,9 +516,9 @@
 
     /* Light theme (default) */
     .theme-light {
-        --bg-primary: #f7fafc;
+        --bg-primary: #FFFFFF;
         --bg-secondary: #ffffff;
-        --bg-tertiary: #edf2f7;
+        --bg-tertiary: #ECECEC;
         --text-primary: #2d3748;
         --text-secondary: #4a5568;
         --text-muted: #718096;
@@ -527,24 +527,24 @@
         --card-shadow: none;
         --input-bg: #ffffff;
         --input-border: #e2e8f0;
-        --hover-bg: #f7fafc;
+        --hover-bg: #F0F0F0;
         --accent-bg: #faf5ff;
     }
 
     /* Dark theme */
     .theme-dark {
-        --bg-primary: #1a202c;
-        --bg-secondary: #2d3748;
-        --bg-tertiary: #4a5568;
+        --bg-primary: #1E1E1E;
+        --bg-secondary: #2C2C2C;
+        --bg-tertiary: #424242;
         --text-primary: #e2e8f0;
         --text-secondary: #cbd5e0;
         --text-muted: #a0aec0;
         --border-color: #24292B;
-        --card-bg: #2B2F31;
+        --card-bg: #383838;
         --card-shadow: none;
         --input-bg: #2d3748;
         --input-border: #4a5568;
-        --hover-bg: #4a5568;
+        --hover-bg: #4E4E4E;
         --accent-bg: #312e81;
     }
 

--- a/src/MauiSherpa/Components/ModalLayout.razor
+++ b/src/MauiSherpa/Components/ModalLayout.razor
@@ -67,7 +67,7 @@
         try
         {
             var cls = ThemeService.IsDarkMode ? "theme-dark" : "theme-light";
-            var bg = ThemeService.IsDarkMode ? "#1a202c" : "#f7fafc";
+            var bg = ThemeService.IsDarkMode ? "#242628" : "#FFFFFF";
             await JS.InvokeVoidAsync("eval", $"document.body.className = '{cls}'; document.body.style.backgroundColor='{bg}';");
         }
         catch { }
@@ -88,8 +88,12 @@
         background: transparent;
         color: var(--text-primary);
         overflow-y: auto;
-        padding: 1rem 1.25rem;
+        padding: 0;
         margin: 0;
+    }
+
+    .modal-layout.theme-dark {
+        --bg-primary: #242628;
     }
 
     html, body, #app {

--- a/src/MauiSherpa/Components/MultiOperationModal.razor
+++ b/src/MauiSherpa/Components/MultiOperationModal.razor
@@ -160,7 +160,7 @@
         height: 100%;
         display: flex;
         flex-direction: column;
-        padding: 1.25rem;
+        padding: 1rem 1.25rem;
         overflow-y: auto;
         gap: 1rem;
     }
@@ -177,7 +177,7 @@
         align-items: center;
         padding: 0.75rem 1rem;
         border-radius: var(--card-radius, 1rem);
-        background: #f7fafc;
+        background: #ECECEC;
     }
 
     .result-summary.text-success { background: #f0fff4; }
@@ -264,8 +264,6 @@
     .operation-header.clickable { cursor: pointer; }
 
     .operation-card.running .operation-header { background: #ebf8ff; }
-
-    .operation-header.clickable:hover { background: var(--bg-tertiary, #edf2f7); }
 
     .operation-left {
         display: flex;
@@ -429,11 +427,10 @@
     .theme-dark .summary-stats .stat { color: #a0aec0; }
     .theme-dark .summary-stats .stat.success { color: #9ae6b4; }
     .theme-dark .summary-stats .stat.error { color: #feb2b2; }
-    .theme-dark .operation-card { background: var(--bg-tertiary, #374151); }
+    .theme-dark .operation-card { background: var(--card-bg, #374151); }
     .theme-dark .operation-card.running { background: rgba(66, 153, 225, 0.1); }
-    .theme-dark .operation-header { background: var(--bg-tertiary, #374151); }
+    .theme-dark .operation-header { background: var(--card-bg, #374151); }
     .theme-dark .operation-card.running .operation-header { background: rgba(66, 153, 225, 0.15); }
-    .theme-dark .operation-header:hover { background: #4a5568; }
     .theme-dark .operation-name { color: var(--text-primary, #e2e8f0); }
 </style>
 

--- a/src/MauiSherpa/Components/OperationModal.razor
+++ b/src/MauiSherpa/Components/OperationModal.razor
@@ -77,7 +77,7 @@
         height: 100%;
         display: flex;
         flex-direction: column;
-        padding: 1.25rem;
+        padding: 1rem 1.25rem;
         overflow: auto;
         gap: 1rem;
     }
@@ -199,7 +199,7 @@
         justify-content: space-between;
         align-items: center;
         padding: 0.5rem 0.75rem;
-        background: #f7fafc;
+        background: #ECECEC;
         border-bottom: 1px solid #e2e8f0;
         font-size: 0.8125rem;
         font-weight: 500;

--- a/src/MauiSherpa/Components/ProcessExecutionModal.razor
+++ b/src/MauiSherpa/Components/ProcessExecutionModal.razor
@@ -102,7 +102,7 @@
         height: 100%;
         display: flex;
         flex-direction: column;
-        padding: 1.25rem;
+        padding: 1rem 1.25rem;
         overflow: auto;
     }
 
@@ -165,7 +165,7 @@
 
     .working-dir code {
         font-family: monospace;
-        background: #f7fafc;
+        background: #ECECEC;
         padding: 2px 0.375rem;
         border-radius: 0.25rem;
     }
@@ -313,7 +313,7 @@
     .theme-dark .result-status.cancelled .result-text { color: #fbd38d; }
     .theme-dark .detail-item { color: #a0aec0; }
     .theme-dark .btn-secondary { background: var(--btn-secondary-bg); color: var(--text-primary, #e2e8f0); }
-    .theme-dark .btn-secondary:hover:not(:disabled) { background: #4a5568; }
+    .theme-dark .btn-secondary:hover:not(:disabled) { background: #454545; }
 </style>
 
 @code {

--- a/src/MauiSherpa/Components/SimAppsTab.razor
+++ b/src/MauiSherpa/Components/SimAppsTab.razor
@@ -135,7 +135,6 @@
         padding: 0.375rem 0.75rem;
         transition: background 0.1s;
     }
-    .sim-app-row:hover { background: var(--bg-tertiary); }
     .sim-app-row.user-app { border-left: 3px solid var(--accent-primary); }
 
     .sim-app-icon { font-size: 1rem; color: var(--text-secondary); width: 1.5rem; text-align: center; }

--- a/src/MauiSherpa/Components/SimCaptureTab.razor
+++ b/src/MauiSherpa/Components/SimCaptureTab.razor
@@ -90,14 +90,10 @@
     }
 
     .sim-capture-card {
-        border: 1px solid var(--border-color);
         border-radius: 0.5rem;
         overflow: hidden;
         background: var(--bg-tertiary);
         transition: box-shadow 0.15s;
-    }
-    .sim-capture-card:hover {
-        box-shadow: 0 2px 0.5rem rgba(0,0,0,0.12);
     }
 
     .sim-capture-preview {

--- a/src/MauiSherpa/Components/SimLogContent.razor
+++ b/src/MauiSherpa/Components/SimLogContent.razor
@@ -256,10 +256,6 @@
         white-space: nowrap;
     }
     .simlog-grid .grid-row > .col-message { flex: 1; flex-shrink: 1; }
-    .simlog-grid .grid-row:hover {
-        background: rgba(255,255,255,0.05) !important;
-    }
-
     /* Column colors */
     .simlog-grid .col-time { color: var(--text-muted); }
     .simlog-grid .col-level { text-align: center; }

--- a/src/MauiSherpa/Components/SimPermissionsTab.razor
+++ b/src/MauiSherpa/Components/SimPermissionsTab.razor
@@ -236,8 +236,6 @@
         border-bottom: 1px solid var(--border-subtle, rgba(0,0,0,0.04));
     }
     .perm-row:last-child { border-bottom: none; }
-    .perm-row:hover { background: var(--bg-hover, rgba(0,0,0,0.02)); }
-
     .perm-info {
         display: flex;
         align-items: center;

--- a/src/MauiSherpa/Components/ToastContainer.razor
+++ b/src/MauiSherpa/Components/ToastContainer.razor
@@ -33,7 +33,7 @@
         gap: 0.75rem;
         padding: 0.75rem 1rem;
         border-radius: 0.5rem;
-        background: #2d3748;
+        background: #2C2C2C;
         color: #fff;
         box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.3);
         min-width: 280px;

--- a/src/MauiSherpa/Pages/AndroidInspector.razor
+++ b/src/MauiSherpa/Pages/AndroidInspector.razor
@@ -127,13 +127,9 @@
         gap: 0.25rem;
         padding: 3px 0.5rem;
         border-radius: 0.375rem;
-        border: 1px solid var(--border-color, #e2e8f0);
         background: var(--bg-secondary, #fff);
         cursor: pointer;
         flex-shrink: 0;
-    }
-    .inspector-device-selector:hover {
-        border-color: var(--accent-primary, #4299e1);
     }
     .inspector-device-icon {
         color: #3ddc84;

--- a/src/MauiSherpa/Pages/AndroidSdk.razor
+++ b/src/MauiSherpa/Pages/AndroidSdk.razor
@@ -562,7 +562,6 @@ else if (!ViewModel.IsSdkInstalled)
         gap: 0.75rem;
         padding: 0.875rem 1rem;
         border-radius: 0.75rem;
-        border: 1px solid var(--border-color);
         background: var(--bg-secondary);
     }
 
@@ -828,10 +827,6 @@ else if (!ViewModel.IsSdkInstalled)
         user-select: none;
     }
 
-    .group-header:hover {
-        background: var(--bg-tertiary);
-    }
-
     .group-chevron {
         width: 1.25rem;
         color: var(--text-muted);
@@ -897,10 +892,6 @@ else if (!ViewModel.IsSdkInstalled)
 
     .package-item:last-child {
         border-bottom: none;
-    }
-
-    .package-item:hover {
-        background: var(--bg-tertiary);
     }
 
     .package-item.has-update {

--- a/src/MauiSherpa/Pages/AppleInspector.razor
+++ b/src/MauiSherpa/Pages/AppleInspector.razor
@@ -145,13 +145,9 @@
         gap: 0.25rem;
         padding: 3px 0.5rem;
         border-radius: 0.375rem;
-        border: 1px solid var(--border-color, #e2e8f0);
         background: var(--bg-secondary, #fff);
         cursor: pointer;
         flex-shrink: 0;
-    }
-    .inspector-device-selector:hover {
-        border-color: var(--accent-primary, #4299e1);
     }
     .inspector-device-icon {
         color: var(--text-secondary);

--- a/src/MauiSherpa/Pages/Copilot.razor
+++ b/src/MauiSherpa/Pages/Copilot.razor
@@ -690,7 +690,7 @@ else
     }
 
     .step-content code {
-        background: #1a202c;
+        background: #1E1E1E;
         color: #68d391;
         padding: 2px 0.5rem;
         border-radius: 0.25rem;
@@ -702,7 +702,7 @@ else
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: #1a202c;
+        background: #1E1E1E;
         padding: 0.75rem 1rem;
         border-radius: 0.375rem;
     }

--- a/src/MauiSherpa/Pages/Dashboard.razor
+++ b/src/MauiSherpa/Pages/Dashboard.razor
@@ -233,13 +233,8 @@
         gap: 0.75rem;
         padding: 0.75rem 1rem;
         background: var(--card-bg);
-        border: none;
         border-radius: 0.75rem;
         transition: border-color 0.15s;
-    }
-
-    .device-card:hover {
-        border-color: var(--text-muted);
     }
 
     .device-card-icon {
@@ -371,7 +366,6 @@
 
     .release-card {
         background: var(--card-bg);
-        border: none;
         border-radius: 0.75rem;
         margin-bottom: 0.5rem;
         overflow: hidden;

--- a/src/MauiSherpa/Pages/DevFlow.razor
+++ b/src/MauiSherpa/Pages/DevFlow.razor
@@ -443,11 +443,6 @@
         background: var(--bg-tertiary);
     }
 
-    .direct-connect-card:hover {
-        transform: none;
-        box-shadow: none;
-    }
-
     .direct-icon {
         background: rgba(107, 114, 128, 0.12);
         color: #6b7280;
@@ -481,11 +476,6 @@
     .hint-card {
         cursor: default;
         background: var(--bg-tertiary);
-    }
-
-    .hint-card:hover {
-        transform: none;
-        box-shadow: none;
     }
 
     .hint-icon {
@@ -535,26 +525,15 @@
         gap: 0.75rem;
         padding: 0.75rem 1rem;
         background: var(--card-bg);
-        border: none;
         border-radius: 22px;
         cursor: pointer;
         transition: all 0.2s ease;
-    }
-
-    .agent-card:hover {
-        box-shadow: 0 2px 12px rgba(0,0,0,0.12);
-        transform: translateY(-1px);
     }
 
     /* Unsupported (outdated) agent cards */
     .agent-card.agent-unsupported {
         opacity: 0.5;
         cursor: not-allowed;
-    }
-
-    .agent-card.agent-unsupported:hover {
-        transform: none;
-        box-shadow: none;
     }
 
     .agent-outdated-badge {

--- a/src/MauiSherpa/Pages/Doctor.razor
+++ b/src/MauiSherpa/Pages/Doctor.razor
@@ -703,7 +703,7 @@ else
 
     .copilot-output {
         flex: 1;
-        background: #1a202c;
+        background: #1E1E1E;
         border-radius: 0.5rem;
         padding: 1rem;
         font-family: 'SF Mono', Menlo, Monaco, 'Courier New', monospace;

--- a/src/MauiSherpa/Pages/Forms/FormTheme.cs
+++ b/src/MauiSherpa/Pages/Forms/FormTheme.cs
@@ -24,27 +24,27 @@ public static class FormTheme
     public const string ButtonOutlineBorder = "FormButtonOutlineBorder";
 
     // Light theme values (from app.css :root)
-    static readonly Color LightPageBg = Color.FromArgb("#f7fafc");
+    static readonly Color LightPageBg = Color.FromArgb("#FFFFFF");
     static readonly Color LightTextPrimary = Color.FromArgb("#2d3748");
     static readonly Color LightTextSecondary = Color.FromArgb("#4a5568");
     static readonly Color LightTextMuted = Color.FromArgb("#718096");
     static readonly Color LightInputBg = Color.FromArgb("#ffffff");
     static readonly Color LightInputBorder = Color.FromArgb("#e2e8f0");
-    static readonly Color LightCardBg = Color.FromArgb("#ffffff");
-    static readonly Color LightSeparator = Color.FromArgb("#e2e8f0");
+    static readonly Color LightCardBg = Color.FromArgb("#F7F7F7");
+    static readonly Color LightSeparator = Color.FromArgb("#E0E0E0");
     static readonly Color LightAccentPrimary = Color.FromArgb("#9f7aea");
     static readonly Color LightAccentDanger = Color.FromArgb("#e53e3e");
     static readonly Color LightButtonOutlineBorder = Color.FromArgb("#e2e8f0");
 
     // Dark theme values (from app.css .theme-dark)
-    static readonly Color DarkPageBg = Color.FromArgb("#1a202c");
+    static readonly Color DarkPageBg = Color.FromArgb("#242628");
     static readonly Color DarkTextPrimary = Color.FromArgb("#e2e8f0");
     static readonly Color DarkTextSecondary = Color.FromArgb("#cbd5e0");
     static readonly Color DarkTextMuted = Color.FromArgb("#a0aec0");
     static readonly Color DarkInputBg = Color.FromArgb("#374151");
     static readonly Color DarkInputBorder = Color.FromArgb("#4a5568");
-    static readonly Color DarkCardBg = Color.FromArgb("#2d3748");
-    static readonly Color DarkSeparator = Color.FromArgb("#4a5568");
+    static readonly Color DarkCardBg = Color.FromArgb("#2C2C2C");
+    static readonly Color DarkSeparator = Color.FromArgb("#454545");
     static readonly Color DarkAccentPrimary = Color.FromArgb("#b794f4");
     static readonly Color DarkAccentDanger = Color.FromArgb("#fc8181");
     static readonly Color DarkButtonOutlineBorder = Color.FromArgb("#4a5568");

--- a/src/MauiSherpa/Pages/Modals/AddPublisherModal.razor
+++ b/src/MauiSherpa/Pages/Modals/AddPublisherModal.razor
@@ -93,7 +93,7 @@
 }
 
 <style>
-    .form-content { display: flex; flex-direction: column; gap: 0.75rem; }
+    .form-content { display: flex; flex-direction: column; gap: 0.75rem; padding: 1rem 1.25rem; }
     .search-box {
         display: flex; align-items: center; gap: 0.5rem;
         background: var(--input-bg, #edf2f7); border-radius: 6px; padding: 0.5rem 0.75rem;
@@ -117,7 +117,6 @@
         padding: 0.5rem 0.75rem; border-radius: 6px; cursor: pointer;
         transition: background 0.15s;
     }
-    .selection-item:hover:not(.disabled) { background: var(--hover-bg, rgba(0,0,0,0.04)); }
     .selection-item.selected { background: var(--accent-bg, rgba(139,92,246,0.08)); }
     .selection-item.disabled { opacity: 0.5; cursor: not-allowed; }
     .item-content { flex: 1; min-width: 0; }

--- a/src/MauiSherpa/Pages/Modals/AppleConfigWizardModal.razor
+++ b/src/MauiSherpa/Pages/Modals/AppleConfigWizardModal.razor
@@ -365,7 +365,7 @@
         display: flex;
         flex-direction: column;
         height: 100%;
-        padding: 0 16px;
+        padding: 1rem 1.25rem;
     }
 
     .wizard-body {
@@ -495,7 +495,7 @@
         padding: 16px;
         border-radius: 0.75rem;
         background: var(--card-bg, #fff);
-        border: 2px solid var(--border-color, #e2e8f0);
+        border: 2px solid transparent;
         cursor: pointer;
         text-align: center;
         transition: all 0.15s;
@@ -503,11 +503,6 @@
         flex-direction: column;
         align-items: center;
         gap: 6px;
-    }
-
-    .option-card:hover {
-        border-color: var(--accent-color, #3b82f6);
-        background: var(--bg-secondary, #f8f9fa);
     }
 
     .option-card.selected {
@@ -551,13 +546,9 @@
         padding: 10px 12px;
         border-radius: 0.75rem;
         background: var(--card-bg, #fff);
-        border: 2px solid var(--border-color, #e2e8f0);
+        border: 2px solid transparent;
         cursor: pointer;
         transition: all 0.15s;
-    }
-
-    .cert-item:hover {
-        border-color: var(--accent-color, #3b82f6);
     }
 
     .cert-item.selected {

--- a/src/MauiSherpa/Pages/Modals/AppleIdentityPickerModal.razor
+++ b/src/MauiSherpa/Pages/Modals/AppleIdentityPickerModal.razor
@@ -56,7 +56,7 @@
 }
 
 <style>
-    .form-content { display: flex; flex-direction: column; gap: 0.75rem; }
+    .form-content { display: flex; flex-direction: column; gap: 0.75rem; padding: 1rem 1.25rem; }
     .search-box {
         display: flex; align-items: center; gap: 0.5rem;
         background: var(--input-bg, #edf2f7); border-radius: 6px; padding: 0.5rem 0.75rem;
@@ -80,7 +80,6 @@
         padding: 0.5rem 0.75rem; border-radius: 6px; cursor: pointer;
         transition: background 0.15s;
     }
-    .selection-item:hover:not(.disabled) { background: var(--hover-bg, rgba(0,0,0,0.04)); }
     .selection-item.selected { background: var(--accent-bg, rgba(139,92,246,0.08)); }
     .selection-item.disabled { opacity: 0.5; cursor: not-allowed; }
     .item-content { flex: 1; min-width: 0; }

--- a/src/MauiSherpa/Pages/Modals/CISecretsWizardModal.razor
+++ b/src/MauiSherpa/Pages/Modals/CISecretsWizardModal.razor
@@ -830,7 +830,7 @@
         padding: 1rem 0.75rem;
         background: var(--bg-secondary, #f7fafc);
         gap: 0.25rem;
-        margin: -1rem -1.25rem 0 -1.25rem;
+        margin: 0;
     }
 
     .step {
@@ -916,7 +916,7 @@
     }
 
     .option-card {
-        border: 2px solid var(--border-color, #e2e8f0);
+        border: 2px solid transparent;
         border-radius: 0.75rem;
         padding: 1.25rem;
         text-align: center;
@@ -924,7 +924,6 @@
         transition: all 0.15s;
     }
 
-    .option-card:hover { border-color: #8b5cf6; }
     .option-card.selected { border-color: #8b5cf6; background: #faf5ff; }
     .option-card input { display: none; }
     .option-card i { font-size: 2rem; color: #8b5cf6; margin-bottom: 0.75rem; }
@@ -943,13 +942,12 @@
         align-items: flex-start;
         gap: 0.75rem;
         padding: 0.875rem;
-        border: 1px solid var(--border-color, #e2e8f0);
+        border: 1px solid transparent;
         border-radius: 0.75rem;
         cursor: pointer;
         transition: all 0.15s;
     }
 
-    .option-item:hover { border-color: #8b5cf6; }
     .option-item.selected { border-color: #8b5cf6; background: #faf5ff; }
     .option-item input[type="radio"] { margin-top: 3px; accent-color: #8b5cf6; }
     .option-content { flex: 1; }
@@ -1009,7 +1007,6 @@
     }
 
     .step-content .selection-item:last-child { border-bottom: none; }
-    .step-content .selection-item:hover { background: var(--bg-hover, #f7fafc); }
     .step-content .selection-item.selected { background: #faf5ff; }
     .step-content .selection-item input[type="radio"] { margin-top: 2px; accent-color: #8b5cf6; }
 
@@ -1084,7 +1081,6 @@
     }
 
     .cert-item:last-child { border-bottom: none; }
-    .cert-item:hover { background: var(--bg-hover, #f7fafc); }
     .cert-item.selected { background: #faf5ff; }
     .cert-item.no-key { opacity: 0.6; }
     .cert-item input { accent-color: #8b5cf6; }
@@ -1164,7 +1160,6 @@
     }
 
     .secret-card {
-        border: 1px solid var(--border-color, #e2e8f0);
         border-radius: 0.75rem;
         padding: 0.875rem;
     }
@@ -1601,13 +1596,11 @@
 
     .theme-dark .resource-missing { background: var(--status-warning-bg, #744210); color: var(--status-warning-text, #fbd38d); }
 
-    .theme-dark .step-content .selection-item:hover { background: var(--bg-hover, #2d3748); }
     .theme-dark .step-content .selection-item.selected { background: rgba(139, 92, 246, 0.15); }
 
     .theme-dark .form-select,
     .theme-dark .form-input { background: var(--input-bg, #374151); color: var(--text-primary, #e2e8f0); }
 
-    .theme-dark .cert-item:hover { background: var(--bg-hover, #2d3748); }
     .theme-dark .cert-item.selected { background: rgba(139, 92, 246, 0.15); }
 
     .theme-dark .cert-item input[type="radio"],

--- a/src/MauiSherpa/Pages/Modals/CloudProviderModal.razor
+++ b/src/MauiSherpa/Pages/Modals/CloudProviderModal.razor
@@ -188,8 +188,7 @@
     .help-text { margin-top: 0.375rem; font-size: 0.75rem; color: var(--text-muted); }
 
     .provider-type-selector { display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 0.75rem; margin-top: 0.5rem; }
-    .provider-type-card { display: flex; flex-direction: column; align-items: center; padding: 1rem 0.75rem; border: 2px solid var(--border-color); border-radius: 0.75rem; cursor: pointer; transition: all 0.2s ease; background: var(--bg-tertiary); }
-    .provider-type-card:hover { border-color: var(--accent-primary); background: rgba(66, 153, 225, 0.05); }
+    .provider-type-card { display: flex; flex-direction: column; align-items: center; padding: 1rem 0.75rem; border: 2px solid transparent; border-radius: 0.75rem; cursor: pointer; transition: all 0.2s ease; background: var(--bg-tertiary); }
     .provider-type-card.selected { border-color: var(--accent-primary); background: rgba(66, 153, 225, 0.1); box-shadow: 0 0 0 3px rgba(66, 153, 225, 0.15); }
     .provider-type-card .provider-icon { font-size: 1.75rem; margin-bottom: 0.5rem; color: var(--text-secondary); }
     .provider-type-card.selected .provider-icon { color: var(--accent-primary); }

--- a/src/MauiSherpa/Pages/Modals/CreateProfileModal.razor
+++ b/src/MauiSherpa/Pages/Modals/CreateProfileModal.razor
@@ -473,7 +473,6 @@
     }
 
     .selection-item:last-child { border-bottom: none; }
-    .selection-item:hover { background: var(--bg-hover, #f7fafc); }
     .selection-item.selected { background: var(--accent-bg, #faf5ff); }
     .selection-item.disabled { opacity: 0.5; cursor: not-allowed; }
     .selection-item input { margin-top: 2px; accent-color: var(--accent-primary, #8b5cf6); }

--- a/src/MauiSherpa/Pages/Modals/EditProfileModal.razor
+++ b/src/MauiSherpa/Pages/Modals/EditProfileModal.razor
@@ -321,7 +321,6 @@
     }
 
     .selection-item:last-child { border-bottom: none; }
-    .selection-item:hover { background: var(--bg-hover, #f7fafc); }
     .selection-item.selected { background: var(--accent-bg, #faf5ff); }
     .selection-item.disabled { opacity: 0.5; cursor: not-allowed; }
 

--- a/src/MauiSherpa/Pages/Modals/EditSecretModal.razor
+++ b/src/MauiSherpa/Pages/Modals/EditSecretModal.razor
@@ -337,7 +337,7 @@
         display: flex;
         flex-direction: column;
         gap: 16px;
-        padding: 8px 4px;
+        padding: 1rem 1.25rem;
     }
     .form-group {
         display: flex;

--- a/src/MauiSherpa/Pages/Modals/GoogleIdentityPickerModal.razor
+++ b/src/MauiSherpa/Pages/Modals/GoogleIdentityPickerModal.razor
@@ -56,7 +56,7 @@
 }
 
 <style>
-    .form-content { display: flex; flex-direction: column; gap: 0.75rem; }
+    .form-content { display: flex; flex-direction: column; gap: 0.75rem; padding: 1rem 1.25rem; }
     .search-box {
         display: flex; align-items: center; gap: 0.5rem;
         background: var(--input-bg, #edf2f7); border-radius: 6px; padding: 0.5rem 0.75rem;
@@ -80,7 +80,6 @@
         padding: 0.5rem 0.75rem; border-radius: 6px; cursor: pointer;
         transition: background 0.15s;
     }
-    .selection-item:hover:not(.disabled) { background: var(--hover-bg, rgba(0,0,0,0.04)); }
     .selection-item.selected { background: var(--accent-bg, rgba(139,92,246,0.08)); }
     .selection-item.disabled { opacity: 0.5; cursor: not-allowed; }
     .item-content { flex: 1; min-width: 0; }

--- a/src/MauiSherpa/Pages/Modals/KeystoreSignaturesModal.razor
+++ b/src/MauiSherpa/Pages/Modals/KeystoreSignaturesModal.razor
@@ -145,7 +145,7 @@
 }
 
 <style>
-    .form-content { padding: 8px 4px; }
+    .form-content { padding: 1rem 1.25rem; }
 
     .loading-card { text-align: center; padding: 40px; color: var(--text-muted); }
     .alert { padding: 12px 16px; border-radius: 8px; margin-bottom: 16px; display: flex; align-items: center; gap: 8px; }

--- a/src/MauiSherpa/Pages/Modals/LocalVaultIntroModal.razor
+++ b/src/MauiSherpa/Pages/Modals/LocalVaultIntroModal.razor
@@ -204,9 +204,9 @@
     .vault-intro {
         display: flex;
         flex-direction: column;
-        height: calc(100% + 2rem);
-        width: calc(100% + 2.5rem);
-        margin: -1rem -1.25rem;
+        height: 100%;
+        width: 100%;
+        margin: 0;
         color: var(--text-primary);
         background: var(--bg-primary);
         font-size: 13px;

--- a/src/MauiSherpa/Pages/Modals/PepkExportModal.razor
+++ b/src/MauiSherpa/Pages/Modals/PepkExportModal.razor
@@ -102,7 +102,7 @@
         display: flex;
         flex-direction: column;
         gap: 16px;
-        padding: 8px 4px;
+        padding: 1rem 1.25rem;
     }
 
     .help-text { color: var(--text-muted); font-size: 13px; margin-bottom: 16px; }

--- a/src/MauiSherpa/Pages/Modals/ProfilingCaptureWizardModal.razor
+++ b/src/MauiSherpa/Pages/Modals/ProfilingCaptureWizardModal.razor
@@ -1585,7 +1585,7 @@
 
 <style>
     .form-content {
-        padding: 0;
+        padding: 1rem 1.25rem;
     }
 
     .step-content {

--- a/src/MauiSherpa/Pages/Modals/PublishProfileEditorModal.razor
+++ b/src/MauiSherpa/Pages/Modals/PublishProfileEditorModal.razor
@@ -578,7 +578,7 @@
         display: flex;
         flex-direction: column;
         height: 100%;
-        padding: 0 16px;
+        padding: 1rem 1.25rem;
         position: relative;
     }
 
@@ -1059,10 +1059,6 @@
 
     .selection-item:last-child {
         border-bottom: none;
-    }
-
-    .selection-item:hover {
-        background: var(--bg-secondary, #f8f9fa);
     }
 
     .selection-item.selected {

--- a/src/MauiSherpa/Pages/Modals/PublishReviewModal.razor
+++ b/src/MauiSherpa/Pages/Modals/PublishReviewModal.razor
@@ -243,7 +243,7 @@
         display: flex;
         flex-direction: column;
         height: 100%;
-        padding: 0 16px;
+        padding: 1rem 1.25rem;
     }
 
     .publish-review h3 {
@@ -329,7 +329,6 @@
     }
 
     .check-item:hover {
-        background: var(--bg-hover, #f3f4f6);
         border-radius: 0.25rem;
     }
 
@@ -498,7 +497,6 @@
     }
 
     .selection-item:hover {
-        background: var(--bg-hover, #f3f4f6);
         border-radius: 0.25rem;
     }
 

--- a/src/MauiSherpa/Pages/Modals/PublishSecretsModal.razor
+++ b/src/MauiSherpa/Pages/Modals/PublishSecretsModal.razor
@@ -162,7 +162,7 @@
         flex: 1;
         overflow: hidden;
         min-height: 0;
-        padding: 0 4px;
+        padding: 1rem 1.25rem;
     }
 
     .step-content h3 {
@@ -231,7 +231,6 @@
         transition: background 0.1s;
     }
     .selection-item:last-child { border-bottom: none; }
-    .selection-item:hover { background: var(--bg-hover, #f7fafc); }
     .selection-item.selected { background: var(--accent-bg, #faf5ff); }
     .item-content { flex: 1; min-width: 0; }
     .item-name { font-weight: 500; color: var(--text-primary, #1a202c); font-size: 0.875rem; }

--- a/src/MauiSherpa/Pages/Modals/PublisherModal.razor
+++ b/src/MauiSherpa/Pages/Modals/PublisherModal.razor
@@ -153,8 +153,7 @@
     .help-text a { color: var(--accent-primary); }
 
     .provider-type-selector { display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 0.75rem; margin-top: 0.5rem; }
-    .provider-type-card { display: flex; flex-direction: column; align-items: center; padding: 1rem 0.75rem; border: 2px solid var(--border-color); border-radius: 0.75rem; cursor: pointer; transition: all 0.2s ease; background: var(--bg-tertiary); }
-    .provider-type-card:hover { border-color: var(--accent-primary); background: rgba(66, 153, 225, 0.05); }
+    .provider-type-card { display: flex; flex-direction: column; align-items: center; padding: 1rem 0.75rem; border: 2px solid transparent; border-radius: 0.75rem; cursor: pointer; transition: all 0.2s ease; background: var(--bg-tertiary); }
     .provider-type-card.selected { border-color: var(--accent-primary); background: rgba(66, 153, 225, 0.1); box-shadow: 0 0 0 3px rgba(66, 153, 225, 0.15); }
     .provider-type-card .provider-icon { font-size: 1.75rem; margin-bottom: 0.5rem; color: var(--text-secondary); }
     .provider-type-card.selected .provider-icon { color: var(--accent-primary); }

--- a/src/MauiSherpa/Pages/Modals/RuntimePickerModal.razor
+++ b/src/MauiSherpa/Pages/Modals/RuntimePickerModal.razor
@@ -101,6 +101,7 @@
         display: flex;
         flex-direction: column;
         gap: 0.875rem;
+        padding: 1rem 1.25rem;
     }
 
     .runtime-picker-toolbar {
@@ -202,7 +203,6 @@
         align-items: flex-start;
         gap: 0.875rem;
         padding: 0.875rem 1rem;
-        border: none;
         border-radius: 0;
         background: transparent;
         cursor: pointer;
@@ -221,10 +221,6 @@
     .runtime-item:last-child {
         border-bottom-left-radius: calc(0.875rem - 1px);
         border-bottom-right-radius: calc(0.875rem - 1px);
-    }
-
-    .runtime-item:hover:not(.disabled) {
-        background: var(--hover-bg, rgba(0, 0, 0, 0.04));
     }
 
     .runtime-item.selected {

--- a/src/MauiSherpa/Pages/Modals/SecretPickerModal.razor
+++ b/src/MauiSherpa/Pages/Modals/SecretPickerModal.razor
@@ -54,7 +54,7 @@
 }
 
 <style>
-    .form-content { display: flex; flex-direction: column; gap: 0.75rem; }
+    .form-content { display: flex; flex-direction: column; gap: 0.75rem; padding: 1rem 1.25rem; }
     .search-box {
         display: flex; align-items: center; gap: 0.5rem;
         background: var(--input-bg, #edf2f7); border-radius: 6px; padding: 0.5rem 0.75rem;
@@ -78,7 +78,6 @@
         padding: 0.5rem 0.75rem; border-radius: 6px; cursor: pointer;
         transition: background 0.15s;
     }
-    .selection-item:hover:not(.disabled) { background: var(--hover-bg, rgba(0,0,0,0.04)); }
     .selection-item.selected { background: var(--accent-bg, rgba(139,92,246,0.08)); }
     .selection-item.disabled { opacity: 0.5; cursor: not-allowed; }
     .item-content { flex: 1; min-width: 0; }

--- a/src/MauiSherpa/Pages/Modals/XcodeDownloadAuthModal.razor
+++ b/src/MauiSherpa/Pages/Modals/XcodeDownloadAuthModal.razor
@@ -295,7 +295,7 @@
         display: flex;
         flex-direction: column;
         height: 100%;
-        padding: 0 16px;
+        padding: 1rem 1.25rem;
     }
 
     .step-indicator {

--- a/src/MauiSherpa/Pages/Profiling.razor
+++ b/src/MauiSherpa/Pages/Profiling.razor
@@ -598,14 +598,10 @@
 
     .session-card {
         background: var(--card-bg, var(--bg-secondary));
-        border: 1px solid var(--border-color);
+        border: 1px solid transparent;
         border-radius: 14px;
         overflow: hidden;
         transition: box-shadow 0.15s;
-    }
-
-    .session-card:hover {
-        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
     }
 
     .session-card.expanded {

--- a/src/MauiSherpa/Pages/RootCertificates.razor
+++ b/src/MauiSherpa/Pages/RootCertificates.razor
@@ -223,10 +223,6 @@ else
         transition: all 0.15s;
     }
 
-    .cert-item:hover {
-        filter: brightness(0.97);
-    }
-
     .cert-item.installed {
         background: var(--status-success-bg);
     }

--- a/src/MauiSherpa/Pages/Secrets.razor
+++ b/src/MauiSherpa/Pages/Secrets.razor
@@ -1147,10 +1147,6 @@ else
         text-align: left;
     }
 
-    .folder-card:hover {
-        background: var(--bg-secondary);
-    }
-
     .folder-open-action {
         border: 0;
         background: transparent;

--- a/src/MauiSherpa/Pages/Settings.razor
+++ b/src/MauiSherpa/Pages/Settings.razor
@@ -800,7 +800,6 @@
 
     .settings-container {
         background: var(--card-bg);
-        border: 1px solid var(--border-color-light);
         padding: 1rem 1.25rem;
         border-radius: var(--card-radius);
     }
@@ -991,7 +990,6 @@
     /* Connected list pattern - items share one card with separators */
     .connected-list {
         background: var(--card-bg);
-        border: 1px solid var(--border-color-light);
         border-radius: var(--card-radius);
         overflow: hidden;
     }
@@ -1000,10 +998,6 @@
         padding: 1rem 1.25rem;
         position: relative;
         transition: background 0.15s ease;
-    }
-
-    .connected-list-item:hover {
-        background: var(--bg-hover);
     }
 
     .connected-list-item:not(:last-child)::after {
@@ -1018,7 +1012,6 @@
 
     .connected-list-item.active {
         box-shadow: inset 4px 0 0 var(--accent-primary);
-        background: var(--bg-secondary);
     }
 
     .section-add-action {
@@ -1026,7 +1019,6 @@
     }
 
     .identity-card {
-        border: 1px solid var(--border-color);
         border-radius: 0.5rem;
         padding: 1rem;
         background: var(--bg-tertiary);
@@ -1254,7 +1246,6 @@
         padding: 1rem;
         margin-bottom: 1rem;
         background: var(--card-bg);
-        border: 1px solid var(--border-color-light);
         border-radius: var(--card-radius, 1rem);
     }
     .vault-access-content {
@@ -1290,7 +1281,7 @@
     .provider-list { display: flex; flex-direction: column; gap: 1rem; }
     
     .provider-card {
-        border: 1px solid var(--border-color);
+        border: 1px solid transparent;
         border-radius: 0.5rem;
         padding: 1rem;
         background: var(--bg-tertiary);
@@ -1381,7 +1372,6 @@
         gap: 1.25rem;
         padding: 1.25rem;
         background: var(--card-bg);
-        border: 1px solid var(--border-color-light);
         border-radius: var(--card-radius, 1rem);
     }
 

--- a/src/MauiSherpa/Pages/XcodeManagement.razor
+++ b/src/MauiSherpa/Pages/XcodeManagement.razor
@@ -693,7 +693,6 @@ else
         padding: 3rem 1.5rem;
         background: var(--card-bg);
         border-radius: var(--card-radius);
-        border: 1px solid var(--border-color);
     }
     .loading-spinner { font-size: 2rem; color: var(--accent-primary); margin-bottom: 1rem; }
     .loading-title, .empty-state h3 { font-size: 1.125rem; font-weight: 600; color: var(--text-primary); margin-bottom: 0.5rem; }
@@ -709,11 +708,9 @@ else
         gap: 1rem;
         padding: 1rem 1.25rem;
         background: var(--card-bg);
-        border: none;
         border-radius: var(--card-radius);
         transition: all 0.15s ease;
     }
-    .xcode-card:hover { box-shadow: 0 2px 8px rgba(0,0,0,0.06); }
     .xcode-card.selected { background: var(--status-success-bg); }
     .xcode-card.downloading { background: rgba(66, 153, 225, 0.03); }
 

--- a/src/MauiSherpa/wwwroot/css/app.css
+++ b/src/MauiSherpa/wwwroot/css/app.css
@@ -3,11 +3,11 @@
 /* Extended CSS Variables for comprehensive theming */
 :root {
     color-scheme: light;
-    /* Primary backgrounds */
-    --bg-primary: #f7fafc;
+    /* Primary backgrounds - neutral greys to match macOS (no blue tint) */
+    --bg-primary: #FFFFFF;
     --bg-secondary: #ffffff;
-    --bg-tertiary: #edf2f7;
-    --bg-hover: #f7fafc;
+    --bg-tertiary: #ECECEC;
+    --bg-hover: #F0F0F0;
     
     /* Text colors */
     --text-primary: #2d3748;
@@ -59,7 +59,7 @@
     /* Specific UI elements */
     --progress-bar-bg: #ebf8ff;
     --progress-bar-text: #2b6cb0;
-    --sdk-item-bg: #f7fafc;
+    --sdk-item-bg: #FAFAFA;
     --sdk-item-installed-bg: #f0fff4;
     --modal-overlay: rgba(0, 0, 0, 0.5);
     
@@ -91,11 +91,11 @@
 /* Dark theme variable overrides */
 .theme-dark {
     color-scheme: dark;
-    /* Primary backgrounds */
-    --bg-primary: #1a202c;
-    --bg-secondary: #2d3748;
-    --bg-tertiary: #374151;
-    --bg-hover: #4a5568;
+    /* Primary backgrounds - neutral dark greys to match macOS (no blue tint) */
+    --bg-primary: #1E1E1E;
+    --bg-secondary: #2C2C2C;
+    --bg-tertiary: #424242;
+    --bg-hover: #4E4E4E;
     
     /* Text colors */
     --text-primary: #e2e8f0;
@@ -108,7 +108,7 @@
     --border-color-light: #374151;
     
     /* Card styles */
-    --card-bg: #2B2F31;
+    --card-bg: #383838;
     --card-shadow: none;
     --card-shadow-lg: none;
     --card-radius: 1rem;
@@ -147,7 +147,7 @@
     /* Specific UI elements */
     --progress-bar-bg: #2a4365;
     --progress-bar-text: #90cdf4;
-    --sdk-item-bg: #374151;
+    --sdk-item-bg: #383838;
     --sdk-item-installed-bg: #276749;
     --modal-overlay: rgba(0, 0, 0, 0.7);
     

--- a/src/MauiSherpa/wwwroot/index.html
+++ b/src/MauiSherpa/wwwroot/index.html
@@ -28,16 +28,16 @@
         html, body {
             height: 100%;
             font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-            background-color: #1a202c;
+            background-color: #1E1E1E;
             color: #333;
         }
 
         body.theme-light {
-            background-color: #f7fafc;
+            background-color: #FFFFFF;
         }
 
         body.theme-dark {
-            background-color: #1a202c;
+            background-color: #1E1E1E;
         }
 
         #app {


### PR DESCRIPTION
## Why

The hybrid Blazor surfaces had drifted out of sync visually: card backgrounds used a grey that clashed with content backgrounds in modals, several dialogs had a blue tint that fought the unified grey, cards carried inconsistent hover effects and borders, and modal content had double padding that pushed scrollbars inward and shortened their tracks. This is a focused polish pass to make everything consistent with the macOS native window chrome.

## What changed

**Color unification**
- Card surfaces now consistently use the shared `--card-bg` / `--bg-tertiary` greys, and the WebView/body backgrounds match the macOS native window (`#1E1E1E` dark / `#FFFFFF` light).
- Removed blue-tinted dialog/content backgrounds so modal content blends into the native dialog instead of clashing with the card grey.

**Flat cards**
- Removed hover shadows, blur, and background shifts on cards across pages and modals.
- Removed stray borders/outlines on content cards and empty states, while preserving selected/active-state indicators.

**Modal content padding + scrollbar**
- `ModalLayout`'s scroll container padding is now `0`, so each modal's own root is the edge-to-edge scroll container and owns a single consistent `1rem 1.25rem` content inset. Scrollbars now sit flush to the right edge with a full-height track.
- Removed two negative-margin hacks (Local Vault intro, CI Secrets step banner) that existed only to cancel the old layout padding and would otherwise pull content off-canvas.
- Full-chrome dialogs (those drawing their own header/body/footer) are intentionally full-bleed for a clean standard-dialog look.

**Targeted fixes**
- Settings: dropped the `.settings-container` border; fixed the active Secrets Storage row that used a white background in light mode and erased the card surface (now relies on the card background plus the left accent bar).
- Xcode management: removed the border on the empty/loading state so it matches the borderless empty states used elsewhere.

## Note for reviewers

This PR also pins `Shiny.Mediator` and `Shiny.Mediator.AppSupport` from `6.6.2` back to `6.1.1`. That downgrade resolves a launch crash introduced by `6.6.2` and was bundled here because it blocked verifying the UI changes at runtime. Builds clean with 0 errors on `net10.0-macos`. All changes are CSS/markup only (plus the one package pin); verified visually in both light and dark themes.