### PR TITLE
Integrate dotnetup: .NET SDK Manager page + Doctor awareness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ MauiSherpa is a .NET 10 MAUI Blazor Hybrid desktop application for managing deve
 - Android Keystores (creation, signatures, PEPK export, cloud sync)
 - Apple Developer Tools (certificates, profiles, devices, bundle IDs)
 - .NET MAUI Doctor (dependency checking and workload management)
+- .NET SDK management via `dotnetup` (install/update SDKs & runtimes — see `docs/dotnet-sdk-management.md`)
 - GitHub Copilot integration
 
 **Platforms:** Mac Catalyst, Windows
@@ -138,6 +139,7 @@ builder.Services.AddSingleton<MyViewModel>();
 | `IAppleConnectService` | App Store Connect API |
 | `IAppleIdentityService` | Apple credential management |
 | `IDoctorService` | MAUI dependency checking |
+| `IDotnetUpService` | Bootstraps & drives `dotnetup` to install/update .NET SDKs & runtimes |
 | `ICloudSecretsService` | Cloud secret storage (uses `byte[]` for values) |
 | `ISecureStorageService` | Local secure storage (Keychain on macOS) |
 

--- a/docs/dotnet-sdk-management.md
+++ b/docs/dotnet-sdk-management.md
@@ -3,7 +3,7 @@
 MAUI Sherpa can install and update .NET SDKs and runtimes for you by bootstrapping and
 driving [`dotnetup`](https://github.com/dotnet/sdk/tree/release/dnup/documentation/general/dotnetup),
 the .NET user-level toolchain manager. This powers the **Doctor** "Update available" fix and a
-dedicated **.NET → SDK Manager** page.
+dedicated **Tools → .NET SDK Manager** page.
 
 ## What `dotnetup` is
 
@@ -32,7 +32,7 @@ https://aka.ms/dotnet/dotnetup/{quality}/dotnetup-{rid}[.exe]   (+ ".sha512")
 ### Doctor integration
 - The `.NET SDK` "Update available" check is now **fixable**. Its `FixAction` is
   `dotnetup-update-sdk:<version>`; applying it bootstraps `dotnetup` if missing, then runs
-  `sdk install <version> --set-default-install --no-progress` (Terminal Mode).
+  `sdk install <version> --set-default-install` (Terminal Mode).
 - A **dotnetup presence** check (Info) shows the installed version, or offers an
   `install-dotnetup` fix when it is missing.
 - Doctor reconciles **dotnetup-managed SDKs** into the installed-SDK set
@@ -41,10 +41,94 @@ https://aka.ms/dotnet/dotnetup/{quality}/dotnetup-{rid}[.exe]   (+ ".sha512")
   `~/Library/Application Support/dotnet` — which `LocalSdkService` does not otherwise scan.
 
 ### SDK Manager page (`/dotnet-sdk`)
-Full management UI: install/reinstall `dotnetup`; install an SDK by channel
-(`latest`, `lts`, `preview`, feature bands like `10.0.1xx`, `daily`, or a custom channel);
-update all / update SDKs / update runtimes; list managed installs grouped by install root;
-uninstall a component; view tracked channels (install specs).
+
+The global page is machine-scoped and uses progressive disclosure:
+
+- A passive **dotnetup** status control sits beside the page title. Its outlined status icon keeps
+  tool health visible without adding another card. Selecting it opens a native hybrid details dialog
+  with version, binary path, managed roots, architecture, install/update, and reinstall actions.
+- **Tracked channels** shows SDK channel chips and automatically checks the official release feeds
+  for updates. Expanding it shows the exact SDK/runtime/ASP.NET Core/Windows Desktop specs, update
+  previews, scoped update actions, source paths, and untrack actions. Each channel row keeps its
+  resolved version and check-mark/update state together instead of using a separate aggregate
+  "everything is up to date" panel.
+- **Installed components** always groups concrete installs into collapsed `.NET X.Y` sections.
+  Expanding a version shows spaced SDK/runtime cards, uninstall actions, and workload feature-band
+  details directly in the version body without another nested expander.
+
+The toolbar contains only **Refresh** and **Open project folder**. Choosing a folder opens a large,
+folder-scoped modal instead of changing the global page. The modal shows the nearest `global.json`,
+requested SDK policy, resolved/installed versions, rolling-channel update readiness, the exact
+resolved install root and architecture, related runtime-line components, and the matching workload
+feature band. It supports only project-relevant operations: install/track/update the project SDK,
+edit its workload-set pin, and restore workloads. Closing it returns to the unchanged global view.
+
+## Workload management
+
+`dotnetup` acquires SDKs and runtimes. Workloads are managed by the selected SDK's own
+`dotnet workload` commands. Sherpa always invokes the full muxer path from the selected
+dotnetup install root and isolates it with `DOTNET_ROOT`, `DOTNET_MULTILEVEL_LOOKUP=0`, and
+an exact SDK-pinning command context.
+
+### Feature-band model
+
+Workload state belongs to:
+
+```
+install root + architecture + SDK feature band
+```
+
+SDK patches in the same feature band share workload state. For example, `10.0.301` and
+`10.0.302` both use the `10.0.300` workload state, while `10.0.200` remains separate.
+Prerelease SDK bands preserve their prerelease identity.
+
+Each `.NET X.Y` section shows a Workloads card with one row per feature-band target. A row
+reports workload-set or loose-manifest mode, the active set/hash, recorded workload IDs,
+available updates, and diagnostics.
+
+### Supported operations
+
+- Add workload IDs: `<root>/dotnet workload install <ids>`
+- Remove recorded workload IDs: `<root>/dotnet workload uninstall <ids>`
+- Change to an exact set: `<root>/dotnet workload update --version <set>`
+- Update to the latest compatible set: `<root>/dotnet workload update`
+- Repair installed workload packs: `<root>/dotnet workload repair`
+- Restore a project's workloads: `<root>/dotnet workload restore`
+
+Workload and set selection uses native hybrid dialogs. The **Workloads** dialog shows installed
+IDs selectable for removal and available IDs selectable for installation, then returns both groups
+through one **Review & apply changes** action. Its default available list is curated to the common
+top-level workloads, with **Show all** exposing the complete compatible list. Linux recommends
+`maui-android`, `android`, and `wasm-tools`; macOS and Windows recommend `maui`, the platform
+workloads, `android`, and `wasm-tools`.
+
+The **Sets** action opens the workload-set version picker. When an update is available, the button
+adds a blue update indicator segment instead of presenting a separate update action. Loose-manifest
+targets must explicitly choose a set, which switches that feature band to workload-set mode. Every
+command operation uses the hybrid process dialog for its preview, exact command, elevation warning,
+terminal output, and completion state. Workload update mode is read from the SDK's
+per-feature-band install-state file, avoiding
+the `workload config` command's installer initialization and unnecessary permission failures.
+Mutations detect whether the workload metadata is writable and request administrator access only
+when needed. Sherpa does not edit SDK marker files, manifests, packs, or registry state, and does
+not invent a workload-set uninstall operation. The SDK remains responsible for transactions,
+rollback, install records, and garbage collection.
+
+### Workload definitions, composition, and pack aliases
+
+Workload IDs can recursively `extend` other workload IDs. The selection dialog calls these
+relationships **Includes** and removes redundant child selections when an aggregate workload is
+selected. A workload redirect is displayed separately. Pack `alias-to` entries resolve a logical
+pack to a RID-specific package; they are pack aliases, not workload aliases.
+
+### Project workload-set pins
+
+The project-context modal reads the official `sdk.workloadVersion` property from `global.json`
+and recognizes the older `workloadSet.version` shape for migration. Pin/change/remove operations
+show the exact JSON diff, preserve JSONC comments, trailing commas, indentation, newline style,
+and unknown properties, then replace the file atomically. **Pin & restore** runs
+`dotnet workload restore` from the project folder so the project's real SDK and workload-set pin
+participate in resolution.
 
 ## CLI surface (verified against the shipping binary)
 
@@ -63,7 +147,9 @@ uninstall a component; view tracked channels (install specs).
     (components: `runtime`, `aspnetcore`)
   - `dotnetup update` updates everything.
 - **Terminal Mode** is `--set-default-install` on install (writes the shell profile). Sherpa's
-  one-step path is `sdk install <channel> --set-default-install --no-progress`.
+  one-step path is `sdk install <channel> --set-default-install`. On Apple platforms, Sherpa
+  hosts dotnetup in a pseudo-terminal and streams its live ANSI progress into the terminal panel.
+  Redirected platforms keep using `--no-progress` and receive phase-by-phase output.
 - Always resolve the managed install root from `list --format Json` `installRoot` rather than
   hardcoding a path — it differs per OS.
 
@@ -71,16 +157,25 @@ uninstall a component; view tracked channels (install specs).
 
 - **`MauiSherpa.Workloads`** (platform-agnostic, unit-tested) — the riskiest, pure logic:
   - `Models/DotnetUpModels.cs` — `DotnetUpComponent`, `DotnetUpInstallSource`,
-    `DotnetUpInstallation`, `DotnetUpInstallSpec`, `DotnetUpListResult`, `DotnetUpToolInfo`.
+    `DotnetUpInstallation`, `DotnetUpInstallSpec`, `DotnetUpListResult`, `DotnetUpToolInfo`,
+    and dotnetup self-update metadata.
   - `Services/DotnetUpRuntimeIdentifier.cs` — RID detection + download/checksum URL builders.
   - `Services/DotnetUpParser.cs` — `ParseList` (`list --format Json`) and `ParseInfo` (`--info` text).
   - `Services/DotnetUpDownloader.cs` — download + SHA-512 verification.
   - `Services/DotnetUpArguments.cs` — pure command/argument builders.
+  - `Models/SdkFeatureBand.cs` and `Models/DotnetWorkloadModels.cs` — SDK-compatible target,
+    inventory, graph, preview, and project-pin models.
+  - `Services/DotnetWorkloadParser.cs` and `Services/WorkloadGraphResolver.cs` — structured/table
+    CLI parsing plus aggregate workload, redirect, and RID pack resolution.
+  - `Services/GlobalJsonWorkloadPinEditor.cs` — JSONC-preserving atomic
+    `sdk.workloadVersion` edits.
 - **`MauiSherpa.Core`** — `IDotnetUpService` (`Interfaces.cs`) + `DotnetUpService`: resolves the
   exe, bootstraps (`EnsureInstalledAsync`), queries (`GetToolInfoAsync`, `GetListAsync`), and
-  builds `ProcessRequest`s for install/update/uninstall. Registered in `MauiProgram.cs`.
-- **Doctor** (`DoctorService`) consumes `IDotnetUpService` (injected optionally) to enrich the
-  context, reconcile managed SDKs, and dispatch the two new fix actions.
+  builds `ProcessRequest`s for install/update/uninstall. `IDotnetWorkloadService` discovers
+  feature-band targets, orchestrates inventory queries, builds workload process requests, and
+  invalidates per-root caches after writes. Both app heads register these services.
+- **Doctor** consumes the same `IDotnetWorkloadService` target, availability result, environment,
+  command builder, and refresh path as the SDK Manager so the two surfaces cannot disagree.
 
 ## Testing
 

--- a/docs/dotnet-sdk-management.md
+++ b/docs/dotnet-sdk-management.md
@@ -82,9 +82,15 @@ SDK patches in the same feature band share workload state. For example, `10.0.30
 `10.0.302` both use the `10.0.300` workload state, while `10.0.200` remains separate.
 Prerelease SDK bands preserve their prerelease identity.
 
+The SDK records only workload IDs that were installed directly. Aggregate workloads install packs
+through their transitive `extends` graph without writing child installation records. For example,
+installing `maui` records `maui` while effectively installing `android`, `ios`, and `maccatalyst`.
+Sherpa mirrors the SDK's `InstalledAndExtendedWorkloads` semantics by retaining the direct records
+for commands and resolving a separate effective installed set for presentation.
+
 Each `.NET X.Y` section shows a Workloads card with one row per feature-band target. A row
-reports workload-set or loose-manifest mode, the active set/hash, recorded workload IDs,
-available updates, and diagnostics.
+reports workload-set or loose-manifest mode, the active set/hash, direct and included workload
+counts, available updates, and diagnostics.
 
 ### Supported operations
 
@@ -95,9 +101,12 @@ available updates, and diagnostics.
 - Repair installed workload packs: `<root>/dotnet workload repair`
 - Restore a project's workloads: `<root>/dotnet workload restore`
 
-Workload and set selection uses native hybrid dialogs. The **Workloads** dialog shows installed
-IDs selectable for removal and available IDs selectable for installation, then returns both groups
-through one **Review & apply changes** action. Its default available list is curated to the common
+Workload and set selection uses native hybrid dialogs. The **Workloads** dialog shows directly
+installed IDs as checked and removable. Transitively included workloads are also shown under
+Installed, but remain checked and disabled with an **Included by `<aggregate>`** label. Only direct
+records are sent to `dotnet workload uninstall`, and the full effective installed set is excluded
+from Available. Available IDs can be selected for installation, then both mutation groups return
+through one **Review & apply changes** action. The default available list is curated to the common
 top-level workloads, with **Show all** exposing the complete compatible list. Linux recommends
 `maui-android`, `android`, and `wasm-tools`; macOS and Windows recommend `maui`, the platform
 workloads, `android`, and `wasm-tools`.
@@ -118,8 +127,12 @@ rollback, install records, and garbage collection.
 
 Workload IDs can recursively `extend` other workload IDs. The selection dialog calls these
 relationships **Includes** and removes redundant child selections when an aggregate workload is
-selected. A workload redirect is displayed separately. Pack `alias-to` entries resolve a logical
-pack to a RID-specific package; they are pack aliases, not workload aliases.
+selected. The same transitive closure classifies child workloads as effectively installed when an
+aggregate has a direct SDK record. Explicit state wins if a child also has its own record, and all
+including roots are retained for display. Redirects resolve through their replacement graph while
+redirect-only and abstract definitions remain hidden from install choices. Pack `alias-to` entries
+resolve a logical pack to a RID-specific package; pack folders are never used to infer workload
+ownership.
 
 ### Project workload-set pins
 
@@ -167,6 +180,9 @@ participate in resolution.
     inventory, graph, preview, and project-pin models.
   - `Services/DotnetWorkloadParser.cs` and `Services/WorkloadGraphResolver.cs` — structured/table
     CLI parsing plus aggregate workload, redirect, and RID pack resolution.
+  - `Services/WorkloadInstallationStateResolver.cs` — overlays direct SDK installation records on
+    the active transitive workload graph to classify explicit, included, and available IDs without
+    inferring state from shared pack folders.
   - `Services/GlobalJsonWorkloadPinEditor.cs` — JSONC-preserving atomic
     `sdk.workloadVersion` edits.
 - **`MauiSherpa.Core`** — `IDotnetUpService` (`Interfaces.cs`) + `DotnetUpService`: resolves the

--- a/docs/dotnet-sdk-management.md
+++ b/docs/dotnet-sdk-management.md
@@ -1,0 +1,89 @@
+# .NET SDK Management with `dotnetup`
+
+MAUI Sherpa can install and update .NET SDKs and runtimes for you by bootstrapping and
+driving [`dotnetup`](https://github.com/dotnet/sdk/tree/release/dnup/documentation/general/dotnetup),
+the .NET user-level toolchain manager. This powers the **Doctor** "Update available" fix and a
+dedicated **.NET → SDK Manager** page.
+
+## What `dotnetup` is
+
+`dotnetup` is a single self-contained executable that installs .NET SDKs/runtimes into a
+**user-level** location (no admin required) and, in *Terminal Mode*, configures your shell
+profile (`PATH` / `DOTNET_ROOT`) so the command-line `dotnet` resolves to the managed install.
+
+Sherpa never relies on shell `PATH` — it always invokes `dotnetup` by full path
+(`~/.dotnetup/dotnetup[.exe]`).
+
+## How Sherpa uses it
+
+### Acquisition
+Sherpa downloads the binary directly from `aka.ms` and verifies its SHA-512 before use
+(no piping a remote script into a shell):
+
+```
+https://aka.ms/dotnet/dotnetup/{quality}/dotnetup-{rid}[.exe]   (+ ".sha512")
+```
+
+- `quality` defaults to `daily` (the only published quality today; configurable).
+- RIDs: `win-x64 win-arm64 linux-x64 linux-arm64 linux-musl-x64 linux-musl-arm64 osx-x64 osx-arm64`.
+  macOS architecture is detected via `hw.optional.arm64` (uname lies under Rosetta).
+- Installed into `~/.dotnetup` (matches the official installer, so an existing install is reused).
+
+### Doctor integration
+- The `.NET SDK` "Update available" check is now **fixable**. Its `FixAction` is
+  `dotnetup-update-sdk:<version>`; applying it bootstraps `dotnetup` if missing, then runs
+  `sdk install <version> --set-default-install --no-progress` (Terminal Mode).
+- A **dotnetup presence** check (Info) shows the installed version, or offers an
+  `install-dotnetup` fix when it is missing.
+- Doctor reconciles **dotnetup-managed SDKs** into the installed-SDK set
+  (`MergeManagedSdks`) so an applied update actually clears the warning. This matters because
+  the GUI Doctor does not read shell `PATH`, and on macOS the managed root defaults to
+  `~/Library/Application Support/dotnet` — which `LocalSdkService` does not otherwise scan.
+
+### SDK Manager page (`/dotnet-sdk`)
+Full management UI: install/reinstall `dotnetup`; install an SDK by channel
+(`latest`, `lts`, `preview`, feature bands like `10.0.1xx`, `daily`, or a custom channel);
+update all / update SDKs / update runtimes; list managed installs grouped by install root;
+uninstall a component; view tracked channels (install specs).
+
+## CLI surface (verified against the shipping binary)
+
+> The published docs are ahead of the current `daily` binary. Build to these real facts.
+
+- **Machine-readable output = `dotnetup list --format Json`** (note: `--format <Json|Text>`,
+  **not** `--json`). It returns both:
+  - `installSpecs[]` — tracked channels: `{ component, versionOrChannel, source, globalJsonPath, installRoot, architecture }`
+  - `installations[]` — concrete installs: `{ component, version, installRoot, architecture, isValid, frameworkName }`
+  - Component values: `SDK`, `Runtime`, `ASPNETCore`, `WindowsDesktop`. Source values: `Explicit`, `GlobalJson`, `All`.
+- **`dotnetup --info` is text only** (no `--json`): Version / Commit / Architecture / RID lines.
+- Mutating commands are **non-interactive by default** (interactivity is opt-in via `--interactive`):
+  - `dotnetup sdk install [<channel>...] [--set-default-install] [--update-global-json] [--no-progress] [...]`
+  - `dotnetup sdk update [--no-progress]`, `dotnetup sdk uninstall <channel> [--source All|Explicit|GlobalJson]`
+  - `dotnetup runtime install|update|uninstall <spec>` where spec = `<channel>` or `component@version`
+    (components: `runtime`, `aspnetcore`)
+  - `dotnetup update` updates everything.
+- **Terminal Mode** is `--set-default-install` on install (writes the shell profile). Sherpa's
+  one-step path is `sdk install <channel> --set-default-install --no-progress`.
+- Always resolve the managed install root from `list --format Json` `installRoot` rather than
+  hardcoding a path — it differs per OS.
+
+## Architecture
+
+- **`MauiSherpa.Workloads`** (platform-agnostic, unit-tested) — the riskiest, pure logic:
+  - `Models/DotnetUpModels.cs` — `DotnetUpComponent`, `DotnetUpInstallSource`,
+    `DotnetUpInstallation`, `DotnetUpInstallSpec`, `DotnetUpListResult`, `DotnetUpToolInfo`.
+  - `Services/DotnetUpRuntimeIdentifier.cs` — RID detection + download/checksum URL builders.
+  - `Services/DotnetUpParser.cs` — `ParseList` (`list --format Json`) and `ParseInfo` (`--info` text).
+  - `Services/DotnetUpDownloader.cs` — download + SHA-512 verification.
+  - `Services/DotnetUpArguments.cs` — pure command/argument builders.
+- **`MauiSherpa.Core`** — `IDotnetUpService` (`Interfaces.cs`) + `DotnetUpService`: resolves the
+  exe, bootstraps (`EnsureInstalledAsync`), queries (`GetToolInfoAsync`, `GetListAsync`), and
+  builds `ProcessRequest`s for install/update/uninstall. Registered in `MauiProgram.cs`.
+- **Doctor** (`DoctorService`) consumes `IDotnetUpService` (injected optionally) to enrich the
+  context, reconcile managed SDKs, and dispatch the two new fix actions.
+
+## Testing
+
+Pure helpers are covered by unit tests in `tests/MauiSherpa.Workloads.Tests` (RID/URL building,
+SHA-512 verify, `list`/`--info` parsing, argument building). Doctor reconciliation and the new
+dependency-status shapes are covered in `tests/MauiSherpa.Core.Tests/Services/DoctorDotnetUpTests.cs`.

--- a/src/MauiSherpa.Cli/Commands/DoctorCommand.cs
+++ b/src/MauiSherpa.Cli/Commands/DoctorCommand.cs
@@ -23,6 +23,7 @@ public static class DoctorCommand
         var checks = new List<HealthCheck>();
 
         checks.Add(await CheckDotNetAsync());
+        checks.Add(await CheckDotnetUpAsync());
         checks.Add(await CheckAndroidSdkAsync());
         checks.Add(await CheckJdkAsync());
 
@@ -110,6 +111,50 @@ public static class DoctorCommand
         catch
         {
             return new HealthCheck(".NET SDK", "error", "dotnet not found on PATH");
+        }
+    }
+
+    private static async Task<HealthCheck> CheckDotnetUpAsync()
+    {
+        // dotnetup is the optional .NET user-level toolchain manager (~/.dotnetup/dotnetup).
+        // It is never required, so this check stays "ok" whether or not it is present.
+        try
+        {
+            var rid = MauiSherpa.Workloads.Services.DotnetUpRuntimeIdentifier.DetectCurrent();
+            var exeName = MauiSherpa.Workloads.Services.DotnetUpRuntimeIdentifier.GetExecutableFileName(rid);
+            var exePath = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".dotnetup", exeName);
+
+            if (!File.Exists(exePath))
+            {
+                return new HealthCheck("dotnetup", "ok",
+                    "not installed (optional — manage .NET SDKs via MAUI Sherpa)");
+            }
+
+            var infoResult = await ProcessRunner.RunAsync(exePath, "--info");
+            var info = MauiSherpa.Workloads.Services.DotnetUpParser.ParseInfo(infoResult.Output);
+
+            var details = new List<string>();
+            var listResult = await ProcessRunner.RunAsync(exePath, "list --format Json");
+            if (listResult.ExitCode == 0)
+            {
+                var parsed = MauiSherpa.Workloads.Services.DotnetUpParser.ParseList(listResult.Output);
+                var sdks = parsed.Installations
+                    .Where(i => i.Component == MauiSherpa.Workloads.Models.DotnetUpComponent.Sdk)
+                    .Select(i => i.Version)
+                    .ToArray();
+                if (sdks.Length > 0)
+                    details.Add($"Managed SDKs: {string.Join(", ", sdks)}");
+                foreach (var root in parsed.InstallRoots)
+                    details.Add($"Install root: {root}");
+            }
+
+            var version = info?.Version ?? "installed";
+            return new HealthCheck("dotnetup", "ok", $"v{version}", details.Count > 0 ? details.ToArray() : null);
+        }
+        catch
+        {
+            return new HealthCheck("dotnetup", "ok", "not installed (optional)");
         }
     }
 

--- a/src/MauiSherpa.Core/Interfaces.cs
+++ b/src/MauiSherpa.Core/Interfaces.cs
@@ -1774,7 +1774,10 @@ public record DoctorContext(
     bool IsPreviewSdk = false,
     string? ActiveSdkVersion = null,
     string? RollForwardPolicy = null,
-    string? ResolvedSdkVersion = null
+    string? ResolvedSdkVersion = null,
+    bool DotnetUpInstalled = false,
+    string? DotnetUpVersion = null,
+    string? DotnetUpManagedInstallRoot = null
 );
 
 /// <summary>
@@ -1901,6 +1904,72 @@ public interface IDoctorService
     string GetDotNetExecutablePath();
 }
 
+
+/// <summary>
+/// Manages the <c>dotnetup</c> user-level .NET toolchain manager: downloading/bootstrapping
+/// the binary, querying its installed SDKs/runtimes, and building process requests that drive
+/// install/update/uninstall operations. Sherpa always invokes <c>dotnetup</c> by full path so
+/// it never depends on the user's shell PATH.
+/// </summary>
+public interface IDotnetUpService
+{
+    /// <summary>The directory the dotnetup binary lives in (Sherpa-managed, default <c>~/.dotnetup</c>).</summary>
+    string ToolDirectory { get; }
+
+    /// <summary>The full path to the dotnetup executable within <see cref="ToolDirectory"/>.</summary>
+    string ExecutablePath { get; }
+
+    /// <summary>True when the dotnetup binary is present on disk.</summary>
+    bool IsInstalled { get; }
+
+    /// <summary>
+    /// Ensures the dotnetup binary is present, downloading and SHA-512 verifying it from aka.ms
+    /// when missing (or always when <paramref name="force"/> is true). Returns true on success.
+    /// </summary>
+    Task<bool> EnsureInstalledAsync(
+        bool force = false,
+        IProgress<string>? progress = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Reads <c>dotnetup --info</c> and returns parsed tool diagnostics, or null when the tool is
+    /// missing or the call fails.
+    /// </summary>
+    Task<MauiSherpa.Workloads.Models.DotnetUpToolInfo?> GetToolInfoAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Reads <c>dotnetup list --format Json</c> and returns parsed installations/specs, or null
+    /// when the tool is missing or the call fails.
+    /// </summary>
+    Task<MauiSherpa.Workloads.Models.DotnetUpListResult?> GetListAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Builds a <see cref="ProcessRequest"/> for arbitrary dotnetup arguments.</summary>
+    ProcessRequest CreateProcessRequest(IReadOnlyList<string> arguments, string? title = null, string? description = null);
+
+    /// <summary>
+    /// Builds a request to install (or update to) an SDK channel. When <paramref name="terminalMode"/>
+    /// is true, passes <c>--set-default-install</c> so dotnetup configures PATH/DOTNET_ROOT.
+    /// </summary>
+    ProcessRequest InstallSdkRequest(string? channel = null, bool terminalMode = true);
+
+    /// <summary>Builds a request to update all tracked SDKs.</summary>
+    ProcessRequest UpdateSdksRequest();
+
+    /// <summary>Builds a request to uninstall an SDK channel.</summary>
+    ProcessRequest UninstallSdkRequest(string channel, MauiSherpa.Workloads.Models.DotnetUpInstallSource? source = null);
+
+    /// <summary>Builds a request to install a runtime spec (channel or <c>component@version</c>).</summary>
+    ProcessRequest InstallRuntimeRequest(string? spec = null);
+
+    /// <summary>Builds a request to update all tracked runtimes.</summary>
+    ProcessRequest UpdateRuntimesRequest();
+
+    /// <summary>Builds a request to uninstall a runtime spec.</summary>
+    ProcessRequest UninstallRuntimeRequest(string spec);
+
+    /// <summary>Builds a request to update every tracked component.</summary>
+    ProcessRequest UpdateAllRequest();
+}
 
 // ============================================================================
 // Process Execution Service - CLI Tool Execution with Terminal UI

--- a/src/MauiSherpa.Core/Interfaces.cs
+++ b/src/MauiSherpa.Core/Interfaces.cs
@@ -1943,8 +1943,36 @@ public interface IDotnetUpService
     /// </summary>
     Task<MauiSherpa.Workloads.Models.DotnetUpListResult?> GetListAsync(CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Resolves every tracked channel in <paramref name="list"/> against the official .NET release
+    /// metadata and returns a preview of which channels have a newer version available. Performs no
+    /// installs — this is a read-only "what would update change?" check.
+    /// </summary>
+    Task<IReadOnlyList<MauiSherpa.Workloads.Models.DotnetUpdatePreview>> GetUpdatePreviewAsync(
+        MauiSherpa.Workloads.Models.DotnetUpListResult list,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Resolves the <c>global.json</c> that applies to <paramref name="folderPath"/> (walking up to
+    /// the nearest one, like the <c>dotnet</c> host), derives the dotnetup channel, and reports
+    /// whether an installed SDK satisfies it and whether dotnetup already tracks it. Read-only.
+    /// </summary>
+    Task<MauiSherpa.Workloads.Models.GlobalJsonResolution> InspectProjectFolderAsync(
+        string folderPath,
+        MauiSherpa.Workloads.Models.DotnetUpListResult list,
+        CancellationToken cancellationToken = default);
+
     /// <summary>Builds a <see cref="ProcessRequest"/> for arbitrary dotnetup arguments.</summary>
-    ProcessRequest CreateProcessRequest(IReadOnlyList<string> arguments, string? title = null, string? description = null);
+    ProcessRequest CreateProcessRequest(
+        IReadOnlyList<string> arguments, string? title = null, string? description = null,
+        string? workingDirectory = null);
+
+    /// <summary>
+    /// Builds a request that installs the SDK required by the <c>global.json</c> in
+    /// <paramref name="folderPath"/>, run with that folder as the working directory so dotnetup
+    /// resolves and tracks the project's requirement (without changing the default install).
+    /// </summary>
+    ProcessRequest InstallForProjectRequest(string folderPath);
 
     /// <summary>
     /// Builds a request to install (or update to) an SDK channel. When <paramref name="terminalMode"/>

--- a/src/MauiSherpa.Core/Interfaces.cs
+++ b/src/MauiSherpa.Core/Interfaces.cs
@@ -1777,7 +1777,8 @@ public record DoctorContext(
     string? ResolvedSdkVersion = null,
     bool DotnetUpInstalled = false,
     string? DotnetUpVersion = null,
-    string? DotnetUpManagedInstallRoot = null
+    string? DotnetUpManagedInstallRoot = null,
+    string? DotNetArchitecture = null
 );
 
 /// <summary>
@@ -1898,12 +1899,84 @@ public interface IDoctorService
     Task<bool> UpdateWorkloadsAsync(string workloadSetVersion, IProgress<string>? progress = null);
 
     /// <summary>
+    /// Builds a workload-set update request for the same install root, architecture, and SDK
+    /// feature band used by Doctor's workload status.
+    /// </summary>
+    Task<ProcessRequest?> GetWorkloadUpdateRequestAsync(
+        string featureBand,
+        string? workingDirectory,
+        string workloadSetVersion,
+        string? installRoot = null,
+        string? architecture = null,
+        string? sdkVersion = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Resolves the full path to the dotnet executable.
     /// GUI apps on macOS don't inherit the user's shell PATH, so bare "dotnet" won't resolve.
     /// </summary>
     string GetDotNetExecutablePath();
 }
 
+
+/// <summary>
+/// Reads and mutates workload state for dotnetup-managed SDK roots. Workload state is keyed by
+/// install root, architecture, and SDK feature band rather than by exact SDK patch.
+/// </summary>
+public interface IDotnetWorkloadService
+{
+    Task<IReadOnlyList<MauiSherpa.Workloads.Models.DotnetWorkloadTarget>> GetTargetsAsync(
+        MauiSherpa.Workloads.Models.DotnetUpListResult? list = null,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<MauiSherpa.Workloads.Models.DotnetWorkloadInventory>> GetInventoriesAsync(
+        MauiSherpa.Workloads.Models.DotnetUpListResult? list = null,
+        bool forceRefresh = false,
+        CancellationToken cancellationToken = default);
+
+    Task<MauiSherpa.Workloads.Models.DotnetWorkloadInventory> GetInventoryAsync(
+        MauiSherpa.Workloads.Models.DotnetWorkloadTarget target,
+        string? workingDirectory = null,
+        bool forceRefresh = false,
+        CancellationToken cancellationToken = default);
+
+    Task<MauiSherpa.Workloads.Models.DotnetWorkloadSetPreview> GetWorkloadSetPreviewAsync(
+        MauiSherpa.Workloads.Models.DotnetWorkloadTarget target,
+        string workloadSetVersion,
+        CancellationToken cancellationToken = default);
+
+    ProcessRequest CreateInstallRequest(
+        MauiSherpa.Workloads.Models.DotnetWorkloadTarget target,
+        IReadOnlyList<string> workloadIds,
+        string? workloadSetVersion = null);
+
+    ProcessRequest CreateUninstallRequest(
+        MauiSherpa.Workloads.Models.DotnetWorkloadTarget target,
+        IReadOnlyList<string> workloadIds);
+
+    ProcessRequest CreateUpdateSetRequest(
+        MauiSherpa.Workloads.Models.DotnetWorkloadTarget target,
+        string workloadSetVersion);
+
+    ProcessRequest CreateLatestSetUpdateRequest(
+        MauiSherpa.Workloads.Models.DotnetWorkloadTarget target);
+
+    ProcessRequest CreateRepairRequest(MauiSherpa.Workloads.Models.DotnetWorkloadTarget target);
+
+    ProcessRequest CreateRestoreRequest(
+        MauiSherpa.Workloads.Models.DotnetWorkloadTarget target,
+        string projectDirectory);
+
+    MauiSherpa.Workloads.Models.GlobalJsonWorkloadPinPreview PreviewProjectWorkloadPin(
+        string projectDirectory,
+        string? workloadSetVersion);
+
+    Task ApplyProjectWorkloadPinAsync(
+        MauiSherpa.Workloads.Models.GlobalJsonWorkloadPinPreview preview,
+        CancellationToken cancellationToken = default);
+
+    void Invalidate(string? installRoot = null);
+}
 
 /// <summary>
 /// Manages the <c>dotnetup</c> user-level .NET toolchain manager: downloading/bootstrapping
@@ -1938,6 +2011,14 @@ public interface IDotnetUpService
     Task<MauiSherpa.Workloads.Models.DotnetUpToolInfo?> GetToolInfoAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Compares the installed dotnetup binary with the latest published artifact by SHA-512,
+    /// without downloading the binary.
+    /// </summary>
+    Task<MauiSherpa.Workloads.Models.DotnetUpToolUpdateInfo?> GetToolUpdateInfoAsync(
+        MauiSherpa.Workloads.Models.DotnetUpToolInfo? installedInfo = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Reads <c>dotnetup list --format Json</c> and returns parsed installations/specs, or null
     /// when the tool is missing or the call fails.
     /// </summary>
@@ -1965,7 +2046,7 @@ public interface IDotnetUpService
     /// <summary>Builds a <see cref="ProcessRequest"/> for arbitrary dotnetup arguments.</summary>
     ProcessRequest CreateProcessRequest(
         IReadOnlyList<string> arguments, string? title = null, string? description = null,
-        string? workingDirectory = null);
+        string? workingDirectory = null, bool usePseudoTerminal = false);
 
     /// <summary>
     /// Builds a request that installs the SDK required by the <c>global.json</c> in
@@ -2028,7 +2109,10 @@ public record ProcessRequest(
     string? ElevationPrompt = null,
     Dictionary<string, string>? Environment = null,
     string? Title = null,
-    string? Description = null
+    string? Description = null,
+    bool UsePseudoTerminal = false,
+    string? ConfirmationDetails = null,
+    string? ConfirmationButtonText = null
 )
 {
     /// <summary>
@@ -2062,12 +2146,14 @@ public class ProcessOutputEventArgs : EventArgs
 {
     public string Data { get; }
     public bool IsError { get; }
+    public bool IsRaw { get; }
     public DateTime Timestamp { get; }
 
-    public ProcessOutputEventArgs(string data, bool isError = false)
+    public ProcessOutputEventArgs(string data, bool isError = false, bool isRaw = false)
     {
         Data = data;
         IsError = isError;
+        IsRaw = isRaw;
         Timestamp = DateTime.Now;
     }
 }

--- a/src/MauiSherpa.Core/MauiSherpa.Core.csproj
+++ b/src/MauiSherpa.Core/MauiSherpa.Core.csproj
@@ -46,8 +46,8 @@
     <PackageReference Include="Octokit" Version="14.0.0" />
     <PackageReference Include="SharpKml.Core" Version="6.1.0" />
     <PackageReference Include="Shiny.DocumentDb.Sqlite.SqlCipher" Version="5.2.2" />
-    <PackageReference Include="Shiny.Mediator" Version="6.1.1" />
-    <PackageReference Include="Shiny.Mediator.AppSupport" Version="6.1.1" />
+    <PackageReference Include="Shiny.Mediator" Version="6.6.2" />
+    <PackageReference Include="Shiny.Mediator.AppSupport" Version="6.6.2" />
     <PackageReference Include="Sodium.Core" Version="1.4.1" />
   </ItemGroup>
 

--- a/src/MauiSherpa.Core/Services/DoctorService.cs
+++ b/src/MauiSherpa.Core/Services/DoctorService.cs
@@ -19,6 +19,7 @@ public class DoctorService : IDoctorService
     private readonly ILoggingService _loggingService;
     private readonly IOpenJdkSettingsService _jdkSettingsService;
     private readonly IAndroidSdkSettingsService? _androidSdkSettingsService;
+    private readonly IDotnetUpService? _dotnetUpService;
     private readonly IDebugFlagService? _debugFlags;
     private readonly ILogger<DoctorService> _logger;
     private readonly ILoggerFactory _loggerFactory;
@@ -30,13 +31,14 @@ public class DoctorService : IDoctorService
     private WorkloadSetService? _workloadSetService;
     private SdkVersionService? _sdkVersionService;
     
-    public DoctorService(IAndroidSdkService androidSdkService, ILoggingService loggingService, IOpenJdkSettingsService jdkSettingsService, ILoggerFactory? loggerFactory = null, IDebugFlagService? debugFlags = null, IAndroidSdkSettingsService? androidSdkSettingsService = null)
+    public DoctorService(IAndroidSdkService androidSdkService, ILoggingService loggingService, IOpenJdkSettingsService jdkSettingsService, ILoggerFactory? loggerFactory = null, IDebugFlagService? debugFlags = null, IAndroidSdkSettingsService? androidSdkSettingsService = null, IDotnetUpService? dotnetUpService = null)
     {
         _androidSdkService = androidSdkService;
         _loggingService = loggingService;
         _jdkSettingsService = jdkSettingsService;
         _debugFlags = debugFlags;
         _androidSdkSettingsService = androidSdkSettingsService;
+        _dotnetUpService = dotnetUpService;
         _loggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
         _logger = _loggerFactory.CreateLogger<DoctorService>();
     }
@@ -128,6 +130,20 @@ public class DoctorService : IDoctorService
             }
         }
         
+        // Query dotnetup (if available) so the Doctor is aware of the user-level toolchain
+        // manager and the SDKs it manages (which may live outside LocalSdkService's scan paths).
+        bool dotnetUpInstalled = false;
+        string? dotnetUpVersion = null;
+        string? dotnetUpManagedRoot = null;
+        if (_dotnetUpService is { IsInstalled: true })
+        {
+            dotnetUpInstalled = true;
+            var info = await TryGetDotnetUpInfoAsync();
+            dotnetUpVersion = info?.Version;
+            var list = await TryGetDotnetUpListAsync();
+            dotnetUpManagedRoot = list?.InstallRoots.FirstOrDefault();
+        }
+
         return new DoctorContext(
             WorkingDirectory: effectiveDir,
             DotNetSdkPath: sdkPath,
@@ -138,14 +154,74 @@ public class DoctorService : IDoctorService
             IsPreviewSdk: isPreviewSdk,
             ActiveSdkVersion: activeSdkVersion,
             RollForwardPolicy: globalJson?.RollForward,
-            ResolvedSdkVersion: resolvedSdkVersion
+            ResolvedSdkVersion: resolvedSdkVersion,
+            DotnetUpInstalled: dotnetUpInstalled,
+            DotnetUpVersion: dotnetUpVersion,
+            DotnetUpManagedInstallRoot: dotnetUpManagedRoot
         );
+    }
+
+    private async Task<MauiSherpa.Workloads.Models.DotnetUpToolInfo?> TryGetDotnetUpInfoAsync()
+    {
+        if (_dotnetUpService is null)
+            return null;
+        try
+        {
+            return await _dotnetUpService.GetToolInfoAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning($"Failed to query dotnetup --info: {ex.Message}");
+            return null;
+        }
+    }
+
+    private async Task<MauiSherpa.Workloads.Models.DotnetUpListResult?> TryGetDotnetUpListAsync()
+    {
+        if (_dotnetUpService is null)
+            return null;
+        try
+        {
+            return await _dotnetUpService.GetListAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning($"Failed to query dotnetup list: {ex.Message}");
+            return null;
+        }
     }
     
     /// <summary>
-    /// Resolves the effective SDK version based on the rollForward policy from global.json.
-    /// See: https://learn.microsoft.com/dotnet/core/tools/global-json#rollforward
+    /// Merges dotnetup-managed SDK versions into the locally discovered set, de-duplicating by
+    /// version string and re-sorting descending so the "latest installed" reflects dotnetup installs.
     /// </summary>
+    internal static IReadOnlyList<SdkVersion> MergeManagedSdks(
+        IReadOnlyList<SdkVersion> localSdks, MauiSherpa.Workloads.Models.DotnetUpListResult dotnetUpList)
+    {
+        var byVersion = new Dictionary<string, SdkVersion>(StringComparer.OrdinalIgnoreCase);
+        foreach (var sdk in localSdks)
+            byVersion[sdk.Version] = sdk;
+
+        foreach (var managed in DotnetUpParser.GetManagedSdkVersions(dotnetUpList))
+        {
+            if (byVersion.ContainsKey(managed))
+                continue;
+            if (SdkVersion.TryParse(managed, out var parsed) && parsed != null)
+                byVersion[managed] = parsed;
+        }
+
+        return byVersion.Values
+            .OrderByDescending(v => v.Major)
+            .ThenByDescending(v => v.Minor)
+            .ThenByDescending(v => v.Patch)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Resolves the effective SDK version based on the rollForward policy from global.json.</summary>
+    /// <remarks>
+    /// See: https://learn.microsoft.com/dotnet/core/tools/global-json#rollforward
+    /// </remarks>
     private static SdkVersion? ResolveRollForward(
         string pinnedVersion, string? rollForward, IReadOnlyList<SdkVersion> installedSdks)
     {
@@ -209,6 +285,17 @@ public class DoctorService : IDoctorService
         
         // Get installed SDKs
         var sdkVersions = localSdkService.GetInstalledSdkVersions();
+
+        // Merge in SDKs managed by dotnetup. dotnetup installs to a user-level root
+        // (e.g. ~/Library/Application Support/dotnet on macOS) that LocalSdkService does not
+        // scan, so without this the GUI Doctor would never "see" a dotnetup-applied update.
+        var dotnetUpList = await TryGetDotnetUpListAsync();
+        var dotnetUpInstalled = _dotnetUpService is { IsInstalled: true };
+        if (dotnetUpList != null)
+        {
+            sdkVersions = MergeManagedSdks(sdkVersions, dotnetUpList);
+        }
+
         var sdkInfos = sdkVersions.Select(s => new SdkVersionInfo(
             s.Version, s.FeatureBand, s.Major, s.Minor, s.IsPreview
         )).ToList();
@@ -265,6 +352,9 @@ public class DoctorService : IDoctorService
                 var isLatestForMajor = latestAvailableForMajor == null 
                     || latestSdk.Version == latestAvailableForMajor.Version;
                 
+                // dotnetup can fix an out-of-date preview by installing the recommended version.
+                var canFix = !isLatestForMajor && _dotnetUpService != null && latestAvailableForMajor != null;
+
                 // Add an informational status about being on a preview SDK
                 dependencies.Add(new DependencyStatus(
                     ".NET SDK",
@@ -276,7 +366,8 @@ public class DoctorService : IDoctorService
                     isLatestForMajor
                         ? $"Preview SDK ({latestSdk.Version})"
                         : $"Update available: {latestAvailableForMajor?.Version}",
-                    IsFixable: false
+                    IsFixable: canFix,
+                    FixAction: canFix ? $"dotnetup-update-sdk:{latestAvailableForMajor!.Version}" : null
                 ));
             }
             else
@@ -284,7 +375,10 @@ public class DoctorService : IDoctorService
                 var latestAvailable = availableSdkVersions?
                     .FirstOrDefault(s => !s.IsPreview);
                 var isLatest = latestAvailable == null || latestSdk.Version == latestAvailable.Version;
-                
+
+                // dotnetup can fix an out-of-date stable SDK by installing the latest.
+                var canFix = !isLatest && _dotnetUpService != null && latestAvailable != null;
+
                 dependencies.Add(new DependencyStatus(
                     ".NET SDK",
                     DependencyCategory.DotNetSdk,
@@ -295,7 +389,40 @@ public class DoctorService : IDoctorService
                     isLatest 
                         ? $"{sdkVersions.Count} SDK(s) installed, using {latestSdk.Version}"
                         : $"Update available: {latestAvailable?.Version}",
+                    IsFixable: canFix,
+                    FixAction: canFix ? $"dotnetup-update-sdk:{latestAvailable!.Version}" : null
+                ));
+            }
+        }
+
+        // dotnetup presence check — informational, with an install action when missing.
+        if (_dotnetUpService != null)
+        {
+            if (dotnetUpInstalled)
+            {
+                var version = context.DotnetUpVersion;
+                dependencies.Add(new DependencyStatus(
+                    "dotnetup",
+                    DependencyCategory.DotNetSdk,
+                    null, null,
+                    version,
+                    DependencyStatusType.Info,
+                    version != null
+                        ? $"Installed ({version}) — manages .NET SDKs & runtimes"
+                        : "Installed — manages .NET SDKs & runtimes",
                     IsFixable: false
+                ));
+            }
+            else
+            {
+                dependencies.Add(new DependencyStatus(
+                    "dotnetup",
+                    DependencyCategory.DotNetSdk,
+                    null, null, null,
+                    DependencyStatusType.Info,
+                    "Not installed — install to manage .NET SDKs & runtimes",
+                    IsFixable: true,
+                    FixAction: "install-dotnetup"
                 ));
             }
         }
@@ -1049,6 +1176,42 @@ public class DoctorService : IDoctorService
                 
                 return acquired;
             }
+
+            if (dependency.FixAction == "install-dotnetup")
+            {
+                if (_dotnetUpService == null)
+                {
+                    progress?.Report("dotnetup service unavailable");
+                    return false;
+                }
+                progress?.Report("Downloading and verifying dotnetup...");
+                return await _dotnetUpService.EnsureInstalledAsync(progress: progress);
+            }
+
+            if (dependency.FixAction.StartsWith("dotnetup-update-sdk"))
+            {
+                if (_dotnetUpService == null)
+                {
+                    progress?.Report("dotnetup service unavailable");
+                    return false;
+                }
+
+                if (!_dotnetUpService.IsInstalled)
+                {
+                    progress?.Report("Downloading and verifying dotnetup...");
+                    if (!await _dotnetUpService.EnsureInstalledAsync(progress: progress))
+                        return false;
+                }
+
+                string? channel = null;
+                var colon = dependency.FixAction.IndexOf(':');
+                if (colon >= 0 && colon < dependency.FixAction.Length - 1)
+                    channel = dependency.FixAction[(colon + 1)..];
+
+                progress?.Report($"Installing .NET SDK ({channel ?? "latest"}) via dotnetup...");
+                var request = _dotnetUpService.InstallSdkRequest(channel);
+                return await RunProcessRequestAsync(request, progress);
+            }
             
             if (dependency.FixAction == "install-workloads")
             {
@@ -1243,6 +1406,60 @@ public class DoctorService : IDoctorService
         catch (Exception ex)
         {
             _logger.LogError($"Failed to switch workload mode: {ex.Message}", ex);
+            progress?.Report($"Error: {ex.Message}");
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Runs a <see cref="ProcessRequest"/> (used for dotnetup commands), streaming combined
+    /// stdout/stderr lines to <paramref name="progress"/>. Returns true on a zero exit code.
+    /// </summary>
+    private async Task<bool> RunProcessRequestAsync(ProcessRequest request, IProgress<string>? progress = null)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = request.Command,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                WorkingDirectory = request.WorkingDirectory ?? string.Empty
+            };
+            foreach (var arg in request.Arguments)
+                psi.ArgumentList.Add(arg);
+            if (request.Environment != null)
+            {
+                foreach (var kvp in request.Environment)
+                    psi.Environment[kvp.Key] = kvp.Value;
+            }
+
+            using var process = Process.Start(psi);
+            if (process == null)
+            {
+                progress?.Report("Failed to start process.");
+                return false;
+            }
+
+            process.OutputDataReceived += (_, e) => { if (e.Data != null) progress?.Report(e.Data); };
+            process.ErrorDataReceived += (_, e) => { if (e.Data != null) progress?.Report(e.Data); };
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+
+            await process.WaitForExitAsync();
+
+            if (process.ExitCode != 0)
+            {
+                _logger.LogWarning($"Process exited with code {process.ExitCode}: {request.CommandLine}");
+                return false;
+            }
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"Failed to run process: {ex.Message}", ex);
             progress?.Report($"Error: {ex.Message}");
             return false;
         }

--- a/src/MauiSherpa.Core/Services/DoctorService.cs
+++ b/src/MauiSherpa.Core/Services/DoctorService.cs
@@ -20,6 +20,7 @@ public class DoctorService : IDoctorService
     private readonly IOpenJdkSettingsService _jdkSettingsService;
     private readonly IAndroidSdkSettingsService? _androidSdkSettingsService;
     private readonly IDotnetUpService? _dotnetUpService;
+    private readonly IDotnetWorkloadService? _dotnetWorkloadService;
     private readonly IDebugFlagService? _debugFlags;
     private readonly ILogger<DoctorService> _logger;
     private readonly ILoggerFactory _loggerFactory;
@@ -31,7 +32,15 @@ public class DoctorService : IDoctorService
     private WorkloadSetService? _workloadSetService;
     private SdkVersionService? _sdkVersionService;
     
-    public DoctorService(IAndroidSdkService androidSdkService, ILoggingService loggingService, IOpenJdkSettingsService jdkSettingsService, ILoggerFactory? loggerFactory = null, IDebugFlagService? debugFlags = null, IAndroidSdkSettingsService? androidSdkSettingsService = null, IDotnetUpService? dotnetUpService = null)
+    public DoctorService(
+        IAndroidSdkService androidSdkService,
+        ILoggingService loggingService,
+        IOpenJdkSettingsService jdkSettingsService,
+        ILoggerFactory? loggerFactory = null,
+        IDebugFlagService? debugFlags = null,
+        IAndroidSdkSettingsService? androidSdkSettingsService = null,
+        IDotnetUpService? dotnetUpService = null,
+        IDotnetWorkloadService? dotnetWorkloadService = null)
     {
         _androidSdkService = androidSdkService;
         _loggingService = loggingService;
@@ -39,6 +48,7 @@ public class DoctorService : IDoctorService
         _debugFlags = debugFlags;
         _androidSdkSettingsService = androidSdkSettingsService;
         _dotnetUpService = dotnetUpService;
+        _dotnetWorkloadService = dotnetWorkloadService;
         _loggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
         _logger = _loggerFactory.CreateLogger<DoctorService>();
     }
@@ -81,9 +91,20 @@ public class DoctorService : IDoctorService
         // Check for global.json
         var globalJson = globalJsonService.GetGlobalJson(effectiveDir);
         
+        bool dotnetUpInstalled = false;
+        string? dotnetUpVersion = null;
+        DotnetUpListResult? dotnetUpList = null;
+        if (_dotnetUpService is { IsInstalled: true })
+        {
+            dotnetUpInstalled = true;
+            var info = await TryGetDotnetUpInfoAsync();
+            dotnetUpVersion = info?.Version;
+            dotnetUpList = await TryGetDotnetUpListAsync();
+        }
+
         // Get SDK path - LocalSdkService already checks for .dotnet/, DOTNET_ROOT, etc.
-        // But we may want to look relative to workingDirectory first
         string? sdkPath = null;
+        var sdkArchitecture = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
         
         // Check for local .dotnet in working directory
         var localDotnet = Path.Combine(effectiveDir, ".dotnet");
@@ -96,52 +117,68 @@ public class DoctorService : IDoctorService
             sdkPath = localSdkService.GetDotNetSdkPath();
         }
         
-        // Determine effective feature band
+        // Resolve against local and dotnetup-managed SDKs before choosing the exact root.
         string? featureBand = null;
         bool isPreviewSdk = false;
         string? activeSdkVersion = null;
         string? resolvedSdkVersion = null;
-        if (sdkPath != null)
+        var sdks = localSdkService.GetInstalledSdkVersions();
+        if (dotnetUpList != null)
+            sdks = MergeManagedSdks(sdks, dotnetUpList);
+        if (sdks.Count > 0)
         {
-            var sdks = localSdkService.GetInstalledSdkVersions();
-            if (sdks.Count > 0)
+            SdkVersion effectiveSdk;
+            if (globalJson?.SdkVersion != null)
             {
-                // If SDK is pinned, try to match that version's feature band
-                if (globalJson?.SdkVersion != null)
+                var pinned = sdks.FirstOrDefault(s => s.Version == globalJson.SdkVersion);
+                var resolved = ResolveRollForward(globalJson.SdkVersion, globalJson.RollForward, sdks);
+                resolvedSdkVersion = resolved?.Version;
+                effectiveSdk = resolved ?? pinned ?? sdks[0];
+            }
+            else
+            {
+                effectiveSdk = sdks[0];
+            }
+
+            featureBand = effectiveSdk.FeatureBand;
+            isPreviewSdk = effectiveSdk.IsPreview;
+            activeSdkVersion = effectiveSdk.Version;
+
+            var localRootContainsSdk = sdkPath != null &&
+                                       Directory.Exists(Path.Combine(sdkPath, "sdk", effectiveSdk.Version));
+            var matchingSpec = globalJson?.Path == null || dotnetUpList == null
+                ? null
+                : dotnetUpList.InstallSpecs.FirstOrDefault(spec =>
+                    spec.Component == DotnetUpComponent.Sdk &&
+                    string.Equals(spec.GlobalJsonPath, globalJson.Path, StringComparison.OrdinalIgnoreCase));
+            if (dotnetUpList != null && (matchingSpec != null || !localRootContainsSdk))
+            {
+                var managedInstallation = dotnetUpList.Installations
+                    .Where(installation =>
+                        installation.Component == DotnetUpComponent.Sdk &&
+                        installation.IsValid &&
+                        string.Equals(
+                            installation.Version,
+                            effectiveSdk.Version,
+                            StringComparison.OrdinalIgnoreCase))
+                    .OrderByDescending(installation =>
+                        matchingSpec != null &&
+                        string.Equals(
+                            installation.InstallRoot,
+                            matchingSpec.InstallRoot,
+                            StringComparison.OrdinalIgnoreCase) &&
+                        (string.IsNullOrWhiteSpace(matchingSpec.Architecture) ||
+                         string.Equals(
+                             installation.Architecture,
+                             matchingSpec.Architecture,
+                             StringComparison.OrdinalIgnoreCase)))
+                    .FirstOrDefault();
+                if (managedInstallation != null)
                 {
-                    var pinned = sdks.FirstOrDefault(s => s.Version == globalJson.SdkVersion);
-                    
-                    // Resolve the effective SDK based on rollForward policy
-                    var resolved = ResolveRollForward(globalJson.SdkVersion, globalJson.RollForward, sdks);
-                    resolvedSdkVersion = resolved?.Version;
-                    
-                    var effectiveSdk = resolved ?? pinned ?? sdks[0];
-                    featureBand = effectiveSdk.FeatureBand;
-                    isPreviewSdk = effectiveSdk.IsPreview;
-                    activeSdkVersion = effectiveSdk.Version;
-                }
-                else
-                {
-                    // Use the newest SDK's feature band
-                    featureBand = sdks[0].FeatureBand;
-                    isPreviewSdk = sdks[0].IsPreview;
-                    activeSdkVersion = sdks[0].Version;
+                    sdkPath = managedInstallation.InstallRoot;
+                    sdkArchitecture = managedInstallation.Architecture ?? sdkArchitecture;
                 }
             }
-        }
-        
-        // Query dotnetup (if available) so the Doctor is aware of the user-level toolchain
-        // manager and the SDKs it manages (which may live outside LocalSdkService's scan paths).
-        bool dotnetUpInstalled = false;
-        string? dotnetUpVersion = null;
-        string? dotnetUpManagedRoot = null;
-        if (_dotnetUpService is { IsInstalled: true })
-        {
-            dotnetUpInstalled = true;
-            var info = await TryGetDotnetUpInfoAsync();
-            dotnetUpVersion = info?.Version;
-            var list = await TryGetDotnetUpListAsync();
-            dotnetUpManagedRoot = list?.InstallRoots.FirstOrDefault();
         }
 
         return new DoctorContext(
@@ -157,7 +194,8 @@ public class DoctorService : IDoctorService
             ResolvedSdkVersion: resolvedSdkVersion,
             DotnetUpInstalled: dotnetUpInstalled,
             DotnetUpVersion: dotnetUpVersion,
-            DotnetUpManagedInstallRoot: dotnetUpManagedRoot
+            DotnetUpManagedInstallRoot: dotnetUpList?.InstallRoots.FirstOrDefault(),
+            DotNetArchitecture: sdkArchitecture
         );
     }
 
@@ -436,43 +474,68 @@ public class DoctorService : IDoctorService
         {
             progress?.Report("Checking workload set...");
             _logger.LogInformation("Checking workload set for feature band: {FeatureBand}", context.EffectiveFeatureBand);
-            
-            var workloadSet = await localSdkService.GetInstalledWorkloadSetAsync(context.EffectiveFeatureBand);
-            workloadSetVersion = workloadSet?.Version;
-            _logger.LogInformation("Got workload set version: {Version}", workloadSetVersion ?? "NULL");
-            
-            // Get available workload set versions
-            // Auto-enable prerelease when active SDK is a preview
-            try
+
+            var workloadInventory = await TryGetWorkloadInventoryAsync(
+                context.EffectiveFeatureBand,
+                context.WorkingDirectory,
+                dotnetUpList,
+                context.DotNetSdkPath,
+                context.DotNetArchitecture,
+                context.ActiveSdkVersion);
+            if (workloadInventory != null)
             {
-                progress?.Report("Checking available workload updates...");
-                availableWorkloadSets = await GetAvailableWorkloadSetVersionsAsync(
-                    context.EffectiveFeatureBand, context.IsPreviewSdk);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning("Failed to get available workload sets: {Message}", ex.Message);
-            }
-            
-            // Check workload set status
-            if (workloadSetVersion == null)
-            {
-                var latestAvailable = availableWorkloadSets?.FirstOrDefault();
+                workloadSetVersion = workloadInventory.UpdateMode == DotnetWorkloadUpdateMode.WorkloadSet
+                    ? workloadInventory.ActiveWorkloadVersion
+                    : null;
+                availableWorkloadSets = workloadInventory.AvailableSetVersions
+                    .Select(version => version.Version)
+                    .ToList();
+
+                var latestAvailable = workloadInventory.LatestAvailableSetVersion;
+                var hasUpdate = workloadInventory.UpdateAvailable || workloadInventory.WorkloadUpdates.Count > 0;
+                var isLoose = workloadInventory.UpdateMode == DotnetWorkloadUpdateMode.Manifests;
+                var isUnknownMode = workloadInventory.UpdateMode == DotnetWorkloadUpdateMode.Unknown;
+                var isProjectPinned = workloadInventory.VersionSource == DotnetWorkloadVersionSource.GlobalJson;
+                var message = isProjectPinned && hasUpdate
+                    ? $"Project pins {workloadInventory.ActiveWorkloadVersion}; change the pin in .NET SDK Manager"
+                    : isUnknownMode
+                        ? "Workload update mode could not be determined"
+                    : isLoose
+                    ? "Using loose manifest mode"
+                    : hasUpdate
+                        ? $"Update available: {latestAvailable ?? "new workload manifests"}"
+                        : "Up to date";
                 dependencies.Add(new DependencyStatus(
                     "Workload Set",
                     DependencyCategory.Workload,
-                    null, latestAvailable, null,
-                    DependencyStatusType.Warning,
-                    "No workload set installed (loose manifest mode)",
-                    IsFixable: true,
-                    FixAction: "install-workloads"
-                ));
+                    null,
+                    latestAvailable,
+                    workloadSetVersion,
+                    hasUpdate || isLoose || isUnknownMode ? DependencyStatusType.Warning : DependencyStatusType.Ok,
+                    message,
+                    IsFixable: !isProjectPinned && latestAvailable != null && (hasUpdate || isLoose),
+                    FixAction: !isProjectPinned && latestAvailable != null && (hasUpdate || isLoose)
+                        ? (isLoose ? "install-workloads" : "update-workloads")
+                        : null));
             }
             else
             {
-                var isLatest = availableWorkloadSets?.Count > 0 && availableWorkloadSets[0] == workloadSetVersion;
+                var workloadSet = await localSdkService.GetInstalledWorkloadSetAsync(context.EffectiveFeatureBand);
+                workloadSetVersion = workloadSet?.Version;
+                try
+                {
+                    progress?.Report("Checking available workload updates...");
+                    availableWorkloadSets = await GetAvailableWorkloadSetVersionsAsync(
+                        context.EffectiveFeatureBand, context.IsPreviewSdk);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning("Failed to get available workload sets: {Message}", ex.Message);
+                }
+
                 var latestAvailable = availableWorkloadSets?.FirstOrDefault();
-                
+                var isLatest = workloadSetVersion != null &&
+                    string.Equals(latestAvailable, workloadSetVersion, StringComparison.OrdinalIgnoreCase);
                 dependencies.Add(new DependencyStatus(
                     "Workload Set",
                     DependencyCategory.Workload,
@@ -480,10 +543,13 @@ public class DoctorService : IDoctorService
                     latestAvailable,
                     workloadSetVersion,
                     isLatest ? DependencyStatusType.Ok : DependencyStatusType.Warning,
-                    isLatest ? "Up to date" : $"Update available: {latestAvailable}",
-                    IsFixable: !isLatest,
-                    FixAction: isLatest ? null : "update-workloads"
-                ));
+                    workloadSetVersion == null
+                        ? "No workload set installed (loose manifest mode)"
+                        : isLatest ? "Up to date" : $"Update available: {latestAvailable}",
+                    IsFixable: !isLatest && latestAvailable != null,
+                    FixAction: !isLatest && latestAvailable != null
+                        ? (workloadSetVersion == null ? "install-workloads" : "update-workloads")
+                        : null));
             }
             
             // Get installed manifests
@@ -1081,6 +1147,107 @@ public class DoctorService : IDoctorService
         // Convert NuGet versions (e.g., 10.102.0) to workload versions (e.g., 10.0.102)
         return versions.Select(v => ConvertNuGetToWorkloadVersion(v.ToString())).ToList();
     }
+
+    public async Task<ProcessRequest?> GetWorkloadUpdateRequestAsync(
+        string featureBand,
+        string? workingDirectory,
+        string workloadSetVersion,
+        string? installRoot = null,
+        string? architecture = null,
+        string? sdkVersion = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(featureBand);
+        ArgumentException.ThrowIfNullOrWhiteSpace(workloadSetVersion);
+        var inventory = await TryGetWorkloadInventoryAsync(
+            featureBand,
+            workingDirectory,
+            await TryGetDotnetUpListAsync().ConfigureAwait(false),
+            installRoot,
+            architecture,
+            sdkVersion,
+            cancellationToken).ConfigureAwait(false);
+        return inventory == null
+            ? null
+            : _dotnetWorkloadService!.CreateUpdateSetRequest(inventory.Target, workloadSetVersion);
+    }
+
+    private async Task<DotnetWorkloadInventory?> TryGetWorkloadInventoryAsync(
+        string featureBand,
+        string? workingDirectory,
+        DotnetUpListResult? list,
+        string? preferredInstallRoot = null,
+        string? preferredArchitecture = null,
+        string? preferredSdkVersion = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (_dotnetWorkloadService == null || list == null ||
+            !SdkFeatureBand.TryParse(featureBand, out var parsedBand))
+            return null;
+
+        try
+        {
+            var targets = await _dotnetWorkloadService.GetTargetsAsync(list, cancellationToken)
+                .ConfigureAwait(false);
+            var candidates = targets
+                .Where(candidate => candidate.FeatureBand.Equals(parsedBand))
+                .ToList();
+
+            var matchingInstallation = string.IsNullOrWhiteSpace(preferredSdkVersion)
+                ? null
+                : list.Installations.FirstOrDefault(installation =>
+                    installation.Component == DotnetUpComponent.Sdk &&
+                    installation.IsValid &&
+                    string.Equals(
+                        installation.Version,
+                        preferredSdkVersion,
+                        StringComparison.OrdinalIgnoreCase) &&
+                    (string.IsNullOrWhiteSpace(preferredInstallRoot) ||
+                     string.Equals(
+                         installation.InstallRoot,
+                         preferredInstallRoot,
+                         StringComparison.OrdinalIgnoreCase)) &&
+                    (string.IsNullOrWhiteSpace(preferredArchitecture) ||
+                     string.Equals(
+                         installation.Architecture,
+                         preferredArchitecture,
+                         StringComparison.OrdinalIgnoreCase)));
+            preferredInstallRoot ??= matchingInstallation?.InstallRoot;
+            preferredArchitecture ??= matchingInstallation?.Architecture;
+
+            if (!string.IsNullOrWhiteSpace(preferredInstallRoot))
+                candidates = candidates
+                    .Where(candidate => string.Equals(
+                        candidate.InstallRoot,
+                        preferredInstallRoot,
+                        StringComparison.OrdinalIgnoreCase))
+                    .ToList();
+            if (!string.IsNullOrWhiteSpace(preferredArchitecture))
+                candidates = candidates
+                    .Where(candidate => string.Equals(
+                        candidate.Architecture,
+                        preferredArchitecture,
+                        StringComparison.OrdinalIgnoreCase))
+                    .ToList();
+
+            var target = candidates.Count == 1 ? candidates[0] : null;
+            if (target == null)
+                return null;
+            return await _dotnetWorkloadService.GetInventoryAsync(
+                target,
+                workingDirectory,
+                forceRefresh: true,
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                "Failed to query workload inventory for {FeatureBand}: {Message}",
+                featureBand,
+                ex.Message);
+            return null;
+        }
+    }
     
     /// <summary>
     /// Converts NuGet package version format to workload set version format.
@@ -1213,28 +1380,7 @@ public class DoctorService : IDoctorService
                 return await RunProcessRequestAsync(request, progress);
             }
             
-            if (dependency.FixAction == "install-workloads")
-            {
-                progress?.Report("Switching to workload set mode...");
-                var modeSwitch = await SwitchToWorkloadSetModeAsync(progress);
-                if (!modeSwitch)
-                {
-                    _logger.LogError("Failed to switch to workload set mode");
-                    return false;
-                }
-                
-                if (string.IsNullOrEmpty(dependency.RecommendedVersion))
-                {
-                    _logger.LogWarning("No workload set version available to install");
-                    progress?.Report("No workload set version available");
-                    return false;
-                }
-                
-                progress?.Report($"Installing workload set version {dependency.RecommendedVersion}...");
-                return await UpdateWorkloadsAsync(dependency.RecommendedVersion, progress);
-            }
-            
-            if (dependency.FixAction == "update-workloads")
+            if (dependency.FixAction is "install-workloads" or "update-workloads")
             {
                 if (string.IsNullOrEmpty(dependency.RecommendedVersion))
                 {
@@ -1242,7 +1388,27 @@ public class DoctorService : IDoctorService
                     progress?.Report("No recommended workload version available");
                     return false;
                 }
-                
+
+                var context = await GetContextAsync().ConfigureAwait(false);
+                if (context.EffectiveFeatureBand != null)
+                {
+                    var request = await GetWorkloadUpdateRequestAsync(
+                        context.EffectiveFeatureBand,
+                        context.WorkingDirectory,
+                        dependency.RecommendedVersion,
+                        context.DotNetSdkPath,
+                        context.DotNetArchitecture,
+                        context.ActiveSdkVersion).ConfigureAwait(false);
+                    if (request != null)
+                    {
+                        progress?.Report($"Updating feature band {context.EffectiveFeatureBand} to workload set {dependency.RecommendedVersion}...");
+                        var success = await RunProcessRequestAsync(request, progress).ConfigureAwait(false);
+                        if (success && request.Environment?.GetValueOrDefault("DOTNET_ROOT") is { } root)
+                            _dotnetWorkloadService?.Invalidate(root);
+                        return success;
+                    }
+                }
+
                 progress?.Report($"Updating to workload set version {dependency.RecommendedVersion}...");
                 return await UpdateWorkloadsAsync(dependency.RecommendedVersion, progress);
             }

--- a/src/MauiSherpa.Core/Services/DotnetUpService.cs
+++ b/src/MauiSherpa.Core/Services/DotnetUpService.cs
@@ -1,0 +1,241 @@
+using System.Diagnostics;
+using MauiSherpa.Core.Interfaces;
+using MauiSherpa.Workloads.Models;
+using MauiSherpa.Workloads.Services;
+
+namespace MauiSherpa.Core.Services;
+
+/// <summary>
+/// Drives the <c>dotnetup</c> user-level .NET toolchain manager. Bootstraps the binary
+/// (download + SHA-512 verify into <c>~/.dotnetup</c>), queries installed SDKs/runtimes, and
+/// builds <see cref="ProcessRequest"/>s for install/update/uninstall operations.
+///
+/// Sherpa always invokes dotnetup by full path so it never depends on the user's shell PATH.
+/// </summary>
+public class DotnetUpService : IDotnetUpService
+{
+    private readonly ILoggingService _logger;
+    private readonly Lazy<HttpClient> _httpClient;
+    private readonly string _rid;
+    private readonly string _toolDirectory;
+
+    public DotnetUpService(ILoggingService logger)
+    {
+        _logger = logger;
+        _httpClient = new Lazy<HttpClient>(CreateHttpClient);
+
+        try
+        {
+            _rid = DotnetUpRuntimeIdentifier.DetectCurrent();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"Failed to detect dotnetup RID: {ex.Message}", ex);
+            _rid = string.Empty;
+        }
+
+        _toolDirectory = ResolveDefaultToolDirectory();
+    }
+
+    /// <summary>Default dotnetup binary directory: <c>~/.dotnetup</c> (matches the official installer).</summary>
+    private static string ResolveDefaultToolDirectory()
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        return Path.Combine(home, ".dotnetup");
+    }
+
+    private static HttpClient CreateHttpClient()
+    {
+        var client = new HttpClient
+        {
+            Timeout = TimeSpan.FromMinutes(10)
+        };
+        client.DefaultRequestHeaders.UserAgent.ParseAdd("MauiSherpa-dotnetup");
+        return client;
+    }
+
+    public string ToolDirectory => _toolDirectory;
+
+    public string ExecutablePath
+    {
+        get
+        {
+            var exeName = string.IsNullOrEmpty(_rid)
+                ? (OperatingSystem.IsWindows() ? "dotnetup.exe" : "dotnetup")
+                : DotnetUpRuntimeIdentifier.GetExecutableFileName(_rid);
+            return Path.Combine(_toolDirectory, exeName);
+        }
+    }
+
+    public bool IsInstalled => File.Exists(ExecutablePath);
+
+    public async Task<bool> EnsureInstalledAsync(
+        bool force = false,
+        IProgress<string>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (IsInstalled && !force)
+        {
+            progress?.Report("dotnetup is already installed.");
+            return true;
+        }
+
+        if (string.IsNullOrEmpty(_rid) || !DotnetUpRuntimeIdentifier.IsSupportedRid(_rid))
+        {
+            _logger.LogError($"dotnetup is not available for this platform (RID '{_rid}').");
+            progress?.Report($"dotnetup is not available for this platform (RID '{_rid}').");
+            return false;
+        }
+
+        try
+        {
+            Directory.CreateDirectory(_toolDirectory);
+            var downloader = new DotnetUpDownloader(_httpClient.Value);
+            await downloader.DownloadAndVerifyAsync(
+                _rid, ExecutablePath, quality: null, progress, cancellationToken).ConfigureAwait(false);
+
+            _logger.LogInformation($"dotnetup installed at {ExecutablePath}");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"Failed to install dotnetup: {ex.Message}", ex);
+            progress?.Report($"Error: {ex.Message}");
+            return false;
+        }
+    }
+
+    public async Task<DotnetUpToolInfo?> GetToolInfoAsync(CancellationToken cancellationToken = default)
+    {
+        if (!IsInstalled)
+            return null;
+
+        try
+        {
+            var (exitCode, output, error) = await RunAsync(
+                DotnetUpArguments.Info(), cancellationToken).ConfigureAwait(false);
+            if (exitCode != 0)
+            {
+                _logger.LogWarning($"dotnetup --info exited with code {exitCode}: {error}");
+                return null;
+            }
+
+            return DotnetUpParser.ParseInfo(output);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"Failed to read dotnetup --info: {ex.Message}", ex);
+            return null;
+        }
+    }
+
+    public async Task<DotnetUpListResult?> GetListAsync(CancellationToken cancellationToken = default)
+    {
+        if (!IsInstalled)
+            return null;
+
+        try
+        {
+            var (exitCode, output, error) = await RunAsync(
+                DotnetUpArguments.List(), cancellationToken).ConfigureAwait(false);
+            if (exitCode != 0)
+            {
+                _logger.LogWarning($"dotnetup list exited with code {exitCode}: {error}");
+                return null;
+            }
+
+            return DotnetUpParser.ParseList(output);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"Failed to read dotnetup list: {ex.Message}", ex);
+            return null;
+        }
+    }
+
+    public ProcessRequest CreateProcessRequest(
+        IReadOnlyList<string> arguments, string? title = null, string? description = null) =>
+        new(
+            Command: ExecutablePath,
+            Arguments: arguments.ToArray(),
+            WorkingDirectory: null,
+            RequiresElevation: false,
+            ElevationPrompt: null,
+            Environment: null,
+            Title: title,
+            Description: description);
+
+    public ProcessRequest InstallSdkRequest(string? channel = null, bool terminalMode = true) =>
+        CreateProcessRequest(
+            DotnetUpArguments.SdkInstall(channel, setDefaultInstall: terminalMode),
+            title: "Install .NET SDK",
+            description: channel is null
+                ? "Installing the latest .NET SDK via dotnetup"
+                : $"Installing .NET SDK channel '{channel}' via dotnetup");
+
+    public ProcessRequest UpdateSdksRequest() =>
+        CreateProcessRequest(
+            DotnetUpArguments.SdkUpdate(),
+            title: "Update .NET SDKs",
+            description: "Updating tracked .NET SDKs via dotnetup");
+
+    public ProcessRequest UninstallSdkRequest(string channel, DotnetUpInstallSource? source = null) =>
+        CreateProcessRequest(
+            DotnetUpArguments.SdkUninstall(channel, source),
+            title: "Uninstall .NET SDK",
+            description: $"Uninstalling .NET SDK channel '{channel}' via dotnetup");
+
+    public ProcessRequest InstallRuntimeRequest(string? spec = null) =>
+        CreateProcessRequest(
+            DotnetUpArguments.RuntimeInstall(spec),
+            title: "Install .NET Runtime",
+            description: spec is null
+                ? "Installing the latest .NET runtime via dotnetup"
+                : $"Installing .NET runtime '{spec}' via dotnetup");
+
+    public ProcessRequest UpdateRuntimesRequest() =>
+        CreateProcessRequest(
+            DotnetUpArguments.RuntimeUpdate(),
+            title: "Update .NET Runtimes",
+            description: "Updating tracked .NET runtimes via dotnetup");
+
+    public ProcessRequest UninstallRuntimeRequest(string spec) =>
+        CreateProcessRequest(
+            DotnetUpArguments.RuntimeUninstall(spec),
+            title: "Uninstall .NET Runtime",
+            description: $"Uninstalling .NET runtime '{spec}' via dotnetup");
+
+    public ProcessRequest UpdateAllRequest() =>
+        CreateProcessRequest(
+            DotnetUpArguments.UpdateAll(),
+            title: "Update .NET tools",
+            description: "Updating all tracked .NET SDKs and runtimes via dotnetup");
+
+    private async Task<(int ExitCode, string Output, string Error)> RunAsync(
+        IReadOnlyList<string> arguments, CancellationToken cancellationToken)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = ExecutablePath,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        foreach (var arg in arguments)
+            psi.ArgumentList.Add(arg);
+
+        using var process = Process.Start(psi);
+        if (process == null)
+            return (-1, string.Empty, "Failed to start dotnetup process.");
+
+        var outputTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var errorTask = process.StandardError.ReadToEndAsync(cancellationToken);
+
+        await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+
+        var output = await outputTask.ConfigureAwait(false);
+        var error = await errorTask.ConfigureAwait(false);
+        return (process.ExitCode, output, error);
+    }
+}

--- a/src/MauiSherpa.Core/Services/DotnetUpService.cs
+++ b/src/MauiSherpa.Core/Services/DotnetUpService.cs
@@ -131,6 +131,41 @@ public class DotnetUpService : IDotnetUpService
         }
     }
 
+    public async Task<DotnetUpToolUpdateInfo?> GetToolUpdateInfoAsync(
+        DotnetUpToolInfo? installedInfo = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (!IsInstalled || string.IsNullOrEmpty(_rid))
+            return null;
+
+        try
+        {
+            installedInfo ??= await GetToolInfoAsync(cancellationToken).ConfigureAwait(false);
+            if (installedInfo is null)
+                return null;
+
+            var downloader = new DotnetUpDownloader(_httpClient.Value);
+            var published = await downloader.GetPublishedArtifactAsync(
+                _rid, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            await using var executable = File.OpenRead(ExecutablePath);
+            var installedHash = await DotnetUpDownloader.ComputeSha512Async(
+                executable, cancellationToken).ConfigureAwait(false);
+
+            return new DotnetUpToolUpdateInfo
+            {
+                InstalledVersion = installedInfo.Version,
+                AvailableVersion = published.Version,
+                UpdateAvailable = !DotnetUpDownloader.HashesEqual(installedHash, published.Sha512)
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning($"Could not check for dotnetup updates: {ex.Message}");
+            return null;
+        }
+    }
+
     public async Task<DotnetUpListResult?> GetListAsync(CancellationToken cancellationToken = default)
     {
         if (!IsInstalled)
@@ -171,11 +206,25 @@ public class DotnetUpService : IDotnetUpService
         if (parsed.Channel is not { Length: > 0 } channel)
             return parsed;
 
-        var alreadyTracked = list.InstallSpecs.Any(s =>
+        var matchingGlobalJsonSpecs = parsed.GlobalJsonPath == null
+            ? []
+            : list.InstallSpecs.Where(s =>
+                s.Component == DotnetUpComponent.Sdk &&
+                string.Equals(
+                    s.GlobalJsonPath,
+                    parsed.GlobalJsonPath,
+                    StringComparison.OrdinalIgnoreCase))
+                .ToList();
+        var matchingChannelSpecs = list.InstallSpecs.Where(s =>
             s.Component == DotnetUpComponent.Sdk &&
-            ((parsed.GlobalJsonPath != null &&
-              string.Equals(s.GlobalJsonPath, parsed.GlobalJsonPath, StringComparison.OrdinalIgnoreCase)) ||
-             string.Equals(s.VersionOrChannel.Trim(), channel, StringComparison.OrdinalIgnoreCase)));
+            string.Equals(
+                s.VersionOrChannel.Trim(),
+                channel,
+                StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        var matchingSpec = SelectUnambiguousInstallSpec(matchingGlobalJsonSpecs) ??
+            SelectUnambiguousInstallSpec(matchingChannelSpecs);
+        var alreadyTracked = matchingGlobalJsonSpecs.Count > 0 || matchingChannelSpecs.Count > 0;
 
         try
         {
@@ -183,12 +232,19 @@ public class DotnetUpService : IDotnetUpService
             var (available, installed) = await resolver
                 .ResolveChannelAsync(DotnetUpComponent.Sdk, channel, list, cancellationToken)
                 .ConfigureAwait(false);
+            var installedSdk = installed == null
+                ? null
+                : SelectInstalledSdkTarget(list.Installations, installed, matchingSpec);
 
             return parsed with
             {
                 ResolvedVersion = available,
                 InstalledVersion = installed,
+                InstalledSdkInstallRoot = installedSdk?.InstallRoot,
+                InstalledSdkArchitecture = installedSdk?.Architecture,
                 Satisfied = installed != null,
+                UpdateAvailable = !parsed.IsPinned &&
+                    DotnetUpdateResolver.IsUpdateAvailable(available, installed),
                 AlreadyTracked = alreadyTracked,
                 Status = available == null ? GlobalJsonStatus.Unresolved : GlobalJsonStatus.Resolved,
             };
@@ -204,9 +260,56 @@ public class DotnetUpService : IDotnetUpService
         }
     }
 
+    private static DotnetUpInstallSpec? SelectUnambiguousInstallSpec(
+        IReadOnlyList<DotnetUpInstallSpec> specs)
+    {
+        var targets = specs
+            .GroupBy(
+                spec => $"{spec.InstallRoot}|{spec.Architecture}",
+                StringComparer.OrdinalIgnoreCase)
+            .Select(group => group.First())
+            .ToList();
+        return targets.Count == 1 ? targets[0] : null;
+    }
+
+    internal static DotnetUpInstallation? SelectInstalledSdkTarget(
+        IReadOnlyList<DotnetUpInstallation> installations,
+        string version,
+        DotnetUpInstallSpec? matchingSpec)
+    {
+        var candidates = installations
+            .Where(installation =>
+                installation.Component == DotnetUpComponent.Sdk &&
+                installation.IsValid &&
+                string.Equals(installation.Version, version, StringComparison.OrdinalIgnoreCase))
+            .GroupBy(
+                installation => $"{installation.InstallRoot}|{installation.Architecture}",
+                StringComparer.OrdinalIgnoreCase)
+            .Select(group => group.First())
+            .ToList();
+
+        if (matchingSpec != null)
+        {
+            candidates = candidates
+                .Where(installation =>
+                    string.Equals(
+                        installation.InstallRoot,
+                        matchingSpec.InstallRoot,
+                        StringComparison.OrdinalIgnoreCase) &&
+                    (string.IsNullOrWhiteSpace(matchingSpec.Architecture) ||
+                     string.Equals(
+                         installation.Architecture,
+                         matchingSpec.Architecture,
+                         StringComparison.OrdinalIgnoreCase)))
+                .ToList();
+        }
+
+        return candidates.Count == 1 ? candidates[0] : null;
+    }
+
     public ProcessRequest CreateProcessRequest(
         IReadOnlyList<string> arguments, string? title = null, string? description = null,
-        string? workingDirectory = null) =>
+        string? workingDirectory = null, bool usePseudoTerminal = false) =>
         new(
             Command: ExecutablePath,
             Arguments: arguments.ToArray(),
@@ -215,31 +318,44 @@ public class DotnetUpService : IDotnetUpService
             ElevationPrompt: null,
             Environment: null,
             Title: title,
-            Description: description);
+            Description: description,
+            UsePseudoTerminal: usePseudoTerminal);
+
+    private static bool SupportsTerminalProgress =>
+        OperatingSystem.IsMacOS() || OperatingSystem.IsMacCatalyst();
 
     public ProcessRequest InstallForProjectRequest(string folderPath) =>
         CreateProcessRequest(
             // No channel + working directory = the folder → dotnetup resolves its global.json and
             // records the spec with source = that global.json path. No --set-default-install: this
             // installs the project's SDK without changing the user's default/terminal install.
-            DotnetUpArguments.SdkInstall(channel: null, setDefaultInstall: false),
+            DotnetUpArguments.SdkInstall(
+                channel: null,
+                setDefaultInstall: false,
+                noProgress: !SupportsTerminalProgress),
             title: "Install project SDK",
             description: $"Installing the .NET SDK required by global.json in '{folderPath}'",
-            workingDirectory: folderPath);
+            workingDirectory: folderPath,
+            usePseudoTerminal: SupportsTerminalProgress);
 
     public ProcessRequest InstallSdkRequest(string? channel = null, bool terminalMode = true) =>
         CreateProcessRequest(
-            DotnetUpArguments.SdkInstall(channel, setDefaultInstall: terminalMode),
+            DotnetUpArguments.SdkInstall(
+                channel,
+                setDefaultInstall: terminalMode,
+                noProgress: !SupportsTerminalProgress),
             title: "Install .NET SDK",
             description: channel is null
                 ? "Installing the latest .NET SDK via dotnetup"
-                : $"Installing .NET SDK channel '{channel}' via dotnetup");
+                : $"Installing .NET SDK channel '{channel}' via dotnetup",
+            usePseudoTerminal: SupportsTerminalProgress);
 
     public ProcessRequest UpdateSdksRequest() =>
         CreateProcessRequest(
-            DotnetUpArguments.SdkUpdate(),
+            DotnetUpArguments.SdkUpdate(noProgress: !SupportsTerminalProgress),
             title: "Update .NET SDKs",
-            description: "Updating tracked .NET SDKs via dotnetup");
+            description: "Updating tracked .NET SDKs via dotnetup",
+            usePseudoTerminal: SupportsTerminalProgress);
 
     public ProcessRequest UninstallSdkRequest(string channel, DotnetUpInstallSource? source = null) =>
         CreateProcessRequest(
@@ -249,17 +365,19 @@ public class DotnetUpService : IDotnetUpService
 
     public ProcessRequest InstallRuntimeRequest(string? spec = null) =>
         CreateProcessRequest(
-            DotnetUpArguments.RuntimeInstall(spec),
+            DotnetUpArguments.RuntimeInstall(spec, noProgress: !SupportsTerminalProgress),
             title: "Install .NET Runtime",
             description: spec is null
                 ? "Installing the latest .NET runtime via dotnetup"
-                : $"Installing .NET runtime '{spec}' via dotnetup");
+                : $"Installing .NET runtime '{spec}' via dotnetup",
+            usePseudoTerminal: SupportsTerminalProgress);
 
     public ProcessRequest UpdateRuntimesRequest() =>
         CreateProcessRequest(
-            DotnetUpArguments.RuntimeUpdate(),
+            DotnetUpArguments.RuntimeUpdate(noProgress: !SupportsTerminalProgress),
             title: "Update .NET Runtimes",
-            description: "Updating tracked .NET runtimes via dotnetup");
+            description: "Updating tracked .NET runtimes via dotnetup",
+            usePseudoTerminal: SupportsTerminalProgress);
 
     public ProcessRequest UninstallRuntimeRequest(string spec) =>
         CreateProcessRequest(
@@ -269,9 +387,10 @@ public class DotnetUpService : IDotnetUpService
 
     public ProcessRequest UpdateAllRequest() =>
         CreateProcessRequest(
-            DotnetUpArguments.UpdateAll(),
+            DotnetUpArguments.UpdateAll(noProgress: !SupportsTerminalProgress),
             title: "Update .NET tools",
-            description: "Updating all tracked .NET SDKs and runtimes via dotnetup");
+            description: "Updating all tracked .NET SDKs and runtimes via dotnetup",
+            usePseudoTerminal: SupportsTerminalProgress);
 
     private async Task<(int ExitCode, string Output, string Error)> RunAsync(
         IReadOnlyList<string> arguments, CancellationToken cancellationToken)

--- a/src/MauiSherpa.Core/Services/DotnetUpService.cs
+++ b/src/MauiSherpa.Core/Services/DotnetUpService.cs
@@ -18,6 +18,8 @@ public class DotnetUpService : IDotnetUpService
     private readonly Lazy<HttpClient> _httpClient;
     private readonly string _rid;
     private readonly string _toolDirectory;
+    private DotnetUpdateResolver? _updateResolver;
+    private GlobalJsonResolver? _globalJsonResolver;
 
     public DotnetUpService(ILoggingService logger)
     {
@@ -153,17 +155,77 @@ public class DotnetUpService : IDotnetUpService
         }
     }
 
+    public async Task<IReadOnlyList<DotnetUpdatePreview>> GetUpdatePreviewAsync(
+        DotnetUpListResult list, CancellationToken cancellationToken = default)
+    {
+        var resolver = _updateResolver ??= new DotnetUpdateResolver();
+        return await resolver.GetUpdatePreviewAsync(list, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<GlobalJsonResolution> InspectProjectFolderAsync(
+        string folderPath, DotnetUpListResult list, CancellationToken cancellationToken = default)
+    {
+        var parsed = (_globalJsonResolver ??= new GlobalJsonResolver()).Resolve(folderPath);
+
+        // Nothing to resolve against the feed when there's no SDK version pinned.
+        if (parsed.Channel is not { Length: > 0 } channel)
+            return parsed;
+
+        var alreadyTracked = list.InstallSpecs.Any(s =>
+            s.Component == DotnetUpComponent.Sdk &&
+            ((parsed.GlobalJsonPath != null &&
+              string.Equals(s.GlobalJsonPath, parsed.GlobalJsonPath, StringComparison.OrdinalIgnoreCase)) ||
+             string.Equals(s.VersionOrChannel.Trim(), channel, StringComparison.OrdinalIgnoreCase)));
+
+        try
+        {
+            var resolver = _updateResolver ??= new DotnetUpdateResolver();
+            var (available, installed) = await resolver
+                .ResolveChannelAsync(DotnetUpComponent.Sdk, channel, list, cancellationToken)
+                .ConfigureAwait(false);
+
+            return parsed with
+            {
+                ResolvedVersion = available,
+                InstalledVersion = installed,
+                Satisfied = installed != null,
+                AlreadyTracked = alreadyTracked,
+                Status = available == null ? GlobalJsonStatus.Unresolved : GlobalJsonStatus.Resolved,
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning($"Failed to resolve global.json channel '{channel}': {ex.Message}");
+            return parsed with
+            {
+                AlreadyTracked = alreadyTracked,
+                Status = GlobalJsonStatus.Unresolved,
+            };
+        }
+    }
+
     public ProcessRequest CreateProcessRequest(
-        IReadOnlyList<string> arguments, string? title = null, string? description = null) =>
+        IReadOnlyList<string> arguments, string? title = null, string? description = null,
+        string? workingDirectory = null) =>
         new(
             Command: ExecutablePath,
             Arguments: arguments.ToArray(),
-            WorkingDirectory: null,
+            WorkingDirectory: workingDirectory,
             RequiresElevation: false,
             ElevationPrompt: null,
             Environment: null,
             Title: title,
             Description: description);
+
+    public ProcessRequest InstallForProjectRequest(string folderPath) =>
+        CreateProcessRequest(
+            // No channel + working directory = the folder → dotnetup resolves its global.json and
+            // records the spec with source = that global.json path. No --set-default-install: this
+            // installs the project's SDK without changing the user's default/terminal install.
+            DotnetUpArguments.SdkInstall(channel: null, setDefaultInstall: false),
+            title: "Install project SDK",
+            description: $"Installing the .NET SDK required by global.json in '{folderPath}'",
+            workingDirectory: folderPath);
 
     public ProcessRequest InstallSdkRequest(string? channel = null, bool terminalMode = true) =>
         CreateProcessRequest(

--- a/src/MauiSherpa.Core/Services/DotnetWorkloadService.cs
+++ b/src/MauiSherpa.Core/Services/DotnetWorkloadService.cs
@@ -421,6 +421,11 @@ public sealed class DotnetWorkloadService : IDotnetWorkloadService
             availableWorkloads = [];
         }
 
+        var installationState = WorkloadInstallationStateResolver.Resolve(
+            workloadList.Installed,
+            availableWorkloads);
+        diagnostics.AddRange(installationState.Diagnostics);
+
         return new DotnetWorkloadInventory
         {
             Target = target,
@@ -428,6 +433,7 @@ public sealed class DotnetWorkloadService : IDotnetWorkloadService
             VersionSource = versionSource,
             ActiveWorkloadVersion = workloadVersion,
             InstalledWorkloads = workloadList.Installed,
+            EffectiveInstalledWorkloads = installationState.States,
             AvailableWorkloads = availableWorkloads,
             ManifestVersions = manifestVersions,
             AvailableSetVersions = availableSets,

--- a/src/MauiSherpa.Core/Services/DotnetWorkloadService.cs
+++ b/src/MauiSherpa.Core/Services/DotnetWorkloadService.cs
@@ -1,0 +1,790 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.Json;
+using MauiSherpa.Core.Interfaces;
+using MauiSherpa.Workloads.Models;
+using MauiSherpa.Workloads.Services;
+using NuGet.Versioning;
+
+namespace MauiSherpa.Core.Services;
+
+public sealed class DotnetWorkloadService : IDotnetWorkloadService
+{
+    private readonly IDotnetUpService _dotnetUp;
+    private readonly ILoggingService _logger;
+    private readonly IGlobalJsonWorkloadPinEditor _pinEditor;
+    private readonly ConcurrentDictionary<string, Lazy<Task<DotnetWorkloadInventory>>> _inventoryCache = new();
+    private readonly string _runtimeIdentifier;
+
+    public DotnetWorkloadService(
+        IDotnetUpService dotnetUp,
+        ILoggingService logger,
+        IGlobalJsonWorkloadPinEditor? pinEditor = null)
+    {
+        _dotnetUp = dotnetUp;
+        _logger = logger;
+        _pinEditor = pinEditor ?? new GlobalJsonWorkloadPinEditor();
+        try
+        {
+            _runtimeIdentifier = DotnetUpRuntimeIdentifier.DetectCurrent();
+        }
+        catch
+        {
+            _runtimeIdentifier = "any";
+        }
+    }
+
+    public async Task<IReadOnlyList<DotnetWorkloadTarget>> GetTargetsAsync(
+        DotnetUpListResult? list = null,
+        CancellationToken cancellationToken = default)
+    {
+        list ??= await _dotnetUp.GetListAsync(cancellationToken).ConfigureAwait(false);
+        if (list == null)
+            return [];
+
+        return list.Installations
+            .Where(installation =>
+                installation.Component == DotnetUpComponent.Sdk &&
+                installation.IsValid &&
+                SdkFeatureBand.TryParse(installation.Version, out _))
+            .GroupBy(
+                installation =>
+                {
+                    var featureBand = new SdkFeatureBand(installation.Version);
+                    return $"{installation.InstallRoot}|{installation.Architecture}|{featureBand}";
+                },
+                StringComparer.OrdinalIgnoreCase)
+            .Select(group =>
+            {
+                var representative = group
+                    .OrderByDescending(
+                        item => NuGetVersion.TryParse(item.Version, out var version)
+                            ? version
+                            : new NuGetVersion(0, 0, 0))
+                    .First();
+                var architecture = string.IsNullOrWhiteSpace(representative.Architecture)
+                    ? RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant()
+                    : representative.Architecture!;
+                var dotnetPath = Path.Combine(
+                    representative.InstallRoot,
+                    OperatingSystem.IsWindows() ? "dotnet.exe" : "dotnet");
+
+                return new DotnetWorkloadTarget
+                {
+                    InstallRoot = representative.InstallRoot,
+                    DotnetPath = dotnetPath,
+                    Architecture = architecture,
+                    FeatureBand = new SdkFeatureBand(representative.Version),
+                    RepresentativeSdkVersion = representative.Version,
+                    IsManagedByDotnetUp = true,
+                    CanWrite = CanWriteWorkloadState(representative.InstallRoot)
+                };
+            })
+            .OrderByDescending(target => target.FeatureBand)
+            .ThenBy(target => target.InstallRoot, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    public async Task<IReadOnlyList<DotnetWorkloadInventory>> GetInventoriesAsync(
+        DotnetUpListResult? list = null,
+        bool forceRefresh = false,
+        CancellationToken cancellationToken = default)
+    {
+        var targets = await GetTargetsAsync(list, cancellationToken).ConfigureAwait(false);
+        return await Task.WhenAll(targets.Select(target =>
+            GetInventoryAsync(target, forceRefresh: forceRefresh, cancellationToken: cancellationToken)))
+            .ConfigureAwait(false);
+    }
+
+    public async Task<DotnetWorkloadInventory> GetInventoryAsync(
+        DotnetWorkloadTarget target,
+        string? workingDirectory = null,
+        bool forceRefresh = false,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        var cacheKey = $"{target.Key}|{Path.GetFullPath(workingDirectory ?? GetCommandContext(target))}";
+        if (forceRefresh)
+            _inventoryCache.TryRemove(cacheKey, out _);
+
+        var lazy = _inventoryCache.GetOrAdd(
+            cacheKey,
+            _ => new Lazy<Task<DotnetWorkloadInventory>>(
+                () => ReadInventoryAsync(target, workingDirectory, cancellationToken),
+                LazyThreadSafetyMode.ExecutionAndPublication));
+
+        try
+        {
+            return await lazy.Value.ConfigureAwait(false);
+        }
+        catch
+        {
+            _inventoryCache.TryRemove(cacheKey, out _);
+            throw;
+        }
+    }
+
+    public ProcessRequest CreateInstallRequest(
+        DotnetWorkloadTarget target,
+        IReadOnlyList<string> workloadIds,
+        string? workloadSetVersion = null)
+    {
+        var ids = ValidateWorkloadIds(workloadIds);
+        var arguments = new List<string> { "workload", "install" };
+        arguments.AddRange(ids);
+        if (!string.IsNullOrWhiteSpace(workloadSetVersion))
+        {
+            arguments.Add("--version");
+            arguments.Add(workloadSetVersion);
+        }
+
+        return CreateMutationRequest(
+            target,
+            arguments,
+            "Install .NET workloads",
+            $"Installing {string.Join(", ", ids)} for SDK feature band {target.FeatureBand}",
+            confirmationButtonText: "Install");
+    }
+
+    public async Task<DotnetWorkloadSetPreview> GetWorkloadSetPreviewAsync(
+        DotnetWorkloadTarget target,
+        string workloadSetVersion,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workloadSetVersion);
+        var inventory = await GetInventoryAsync(target, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+        var result = await RunCaptureAsync(
+            target,
+            ["workload", "search", "version", workloadSetVersion, "--format", "json"],
+            GetCommandContext(target),
+            cancellationToken).ConfigureAwait(false);
+        if (result.ExitCode != 0)
+            throw CreateCliException(target, $"workload set {workloadSetVersion}", result);
+
+        var targetManifests = DotnetWorkloadParser.ParseManifestVersions(result.Output);
+        var current = inventory.ManifestVersions.ToDictionary(
+            manifest => manifest.ManifestId,
+            manifest => manifest.Version,
+            StringComparer.OrdinalIgnoreCase);
+        var next = targetManifests.ToDictionary(
+            manifest => manifest.ManifestId,
+            manifest => manifest.Version,
+            StringComparer.OrdinalIgnoreCase);
+        var changes = current.Keys
+            .Concat(next.Keys)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Select(id => new DotnetManifestVersionChange
+            {
+                ManifestId = id,
+                CurrentVersion = current.GetValueOrDefault(id),
+                TargetVersion = next.GetValueOrDefault(id)
+            })
+            .Where(change => !string.Equals(
+                change.CurrentVersion,
+                change.TargetVersion,
+                StringComparison.OrdinalIgnoreCase))
+            .OrderBy(change => change.ManifestId, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        return new DotnetWorkloadSetPreview
+        {
+            Target = target,
+            CurrentVersion = inventory.ActiveWorkloadVersion,
+            TargetVersion = workloadSetVersion,
+            ManifestChanges = changes,
+            InstalledWorkloadIds = inventory.InstalledWorkloads.Select(workload => workload.Id).ToList(),
+            CommandLine = $"{target.DotnetPath} workload update --version {workloadSetVersion}"
+        };
+    }
+
+    public ProcessRequest CreateUninstallRequest(
+        DotnetWorkloadTarget target,
+        IReadOnlyList<string> workloadIds)
+    {
+        var ids = ValidateWorkloadIds(workloadIds);
+        var arguments = new List<string> { "workload", "uninstall" };
+        arguments.AddRange(ids);
+        return CreateMutationRequest(
+            target,
+            arguments,
+            "Uninstall .NET workloads",
+            $"Removing {string.Join(", ", ids)} from SDK feature band {target.FeatureBand}",
+            confirmationButtonText: "Uninstall");
+    }
+
+    public ProcessRequest CreateUpdateSetRequest(
+        DotnetWorkloadTarget target,
+        string workloadSetVersion)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workloadSetVersion);
+        return CreateMutationRequest(
+            target,
+            ["workload", "update", "--version", workloadSetVersion],
+            "Change .NET workload set",
+            $"Updating feature band {target.FeatureBand} to workload set {workloadSetVersion}",
+            confirmationButtonText: "Change set");
+    }
+
+    public ProcessRequest CreateLatestSetUpdateRequest(DotnetWorkloadTarget target) =>
+        CreateMutationRequest(
+            target,
+            target.FeatureBand.IsPrerelease
+                ? ["workload", "update", "--include-previews"]
+                : ["workload", "update"],
+            "Update .NET workload set",
+            $"Updating feature band {target.FeatureBand} to its latest compatible workload set",
+            confirmationButtonText: "Update set");
+
+    public ProcessRequest CreateRepairRequest(DotnetWorkloadTarget target) =>
+        CreateMutationRequest(
+            target,
+            ["workload", "repair"],
+            "Repair .NET workloads",
+            $"Repairing installed workloads for SDK feature band {target.FeatureBand}",
+            confirmationButtonText: "Repair");
+
+    public ProcessRequest CreateRestoreRequest(
+        DotnetWorkloadTarget target,
+        string projectDirectory)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectDirectory);
+        return CreateMutationRequest(
+            target,
+            ["workload", "restore"],
+            "Restore project workloads",
+            $"Restoring workloads for '{projectDirectory}'",
+            Path.GetFullPath(projectDirectory),
+            confirmationButtonText: "Restore");
+    }
+
+    public GlobalJsonWorkloadPinPreview PreviewProjectWorkloadPin(
+        string projectDirectory,
+        string? workloadSetVersion) =>
+        _pinEditor.Preview(projectDirectory, workloadSetVersion);
+
+    public Task ApplyProjectWorkloadPinAsync(
+        GlobalJsonWorkloadPinPreview preview,
+        CancellationToken cancellationToken = default) =>
+        _pinEditor.ApplyAsync(preview, cancellationToken);
+
+    public void Invalidate(string? installRoot = null)
+    {
+        if (string.IsNullOrWhiteSpace(installRoot))
+        {
+            _inventoryCache.Clear();
+            return;
+        }
+
+        foreach (var key in _inventoryCache.Keys.Where(
+                     key => key.StartsWith(installRoot, StringComparison.OrdinalIgnoreCase)))
+            _inventoryCache.TryRemove(key, out _);
+    }
+
+    private async Task<DotnetWorkloadInventory> ReadInventoryAsync(
+        DotnetWorkloadTarget target,
+        string? workingDirectory,
+        CancellationToken cancellationToken)
+    {
+        if (!File.Exists(target.DotnetPath))
+            throw new FileNotFoundException("The selected dotnet executable no longer exists.", target.DotnetPath);
+
+        var diagnostics = new List<string>();
+        var commandDirectory = Path.GetFullPath(workingDirectory ?? GetCommandContext(target));
+
+        var versionResult = await RunCaptureAsync(
+            target,
+            ["workload", "--version"],
+            commandDirectory,
+            cancellationToken).ConfigureAwait(false);
+        if (versionResult.ExitCode != 0)
+            throw CreateCliException(target, "dotnet workload --version", versionResult);
+
+        var workloadVersion = DotnetWorkloadParser.ParseWorkloadVersion(versionResult.Output);
+        var globalJson = workingDirectory == null
+            ? null
+            : new GlobalJsonService().GetGlobalJson(workingDirectory);
+        var updateMode = ResolveUpdateMode(target, globalJson, diagnostics);
+        var versionSource = globalJson?.WorkloadSetVersion != null
+            ? DotnetWorkloadVersionSource.GlobalJson
+            : updateMode == DotnetWorkloadUpdateMode.WorkloadSet
+                ? DotnetWorkloadVersionSource.MachineDefault
+                : updateMode == DotnetWorkloadUpdateMode.Manifests
+                    ? DotnetWorkloadVersionSource.LooseManifests
+                    : DotnetWorkloadVersionSource.Unknown;
+
+        DotnetWorkloadListResult workloadList;
+        var machineList = await RunCaptureAsync(
+            target,
+            ["workload", "list", "--machine-readable"],
+            commandDirectory,
+            cancellationToken).ConfigureAwait(false);
+        var machineReadable = machineList.ExitCode == 0;
+        if (machineReadable)
+        {
+            try
+            {
+                workloadList = DotnetWorkloadParser.ParseMachineReadableList(machineList.Output);
+            }
+            catch (FormatException ex)
+            {
+                diagnostics.Add($"Machine-readable workload list was not understood: {ex.Message}");
+                machineReadable = false;
+                workloadList = await ReadPlainListAsync(target, commandDirectory, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+        }
+        else
+        {
+            diagnostics.Add("This SDK does not support the machine-readable workload list; using the table fallback.");
+            workloadList = await ReadPlainListAsync(target, commandDirectory, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        IReadOnlyList<DotnetWorkloadSetVersion> availableSets = [];
+        var versionsResult = await RunCaptureAsync(
+            target,
+            ["workload", "search", "version", "--take", "20", "--format", "json", "--include-previews"],
+            commandDirectory,
+            cancellationToken).ConfigureAwait(false);
+        var jsonVersionSearch = versionsResult.ExitCode == 0;
+        if (jsonVersionSearch)
+        {
+            try
+            {
+                availableSets = DotnetWorkloadParser.ParseAvailableSetVersions(versionsResult.Output);
+            }
+            catch (FormatException ex)
+            {
+                diagnostics.Add($"Available workload-set versions were not understood: {ex.Message}");
+                jsonVersionSearch = false;
+            }
+        }
+        else
+        {
+            diagnostics.Add($"Available workload-set versions could not be queried: {FirstError(versionsResult)}");
+        }
+
+        IReadOnlyList<DotnetManifestVersion> manifestVersions = [];
+        if (updateMode == DotnetWorkloadUpdateMode.WorkloadSet)
+        {
+            var manifestResult = await RunCaptureAsync(
+                target,
+                ["workload", "search", "version", workloadVersion, "--format", "json"],
+                commandDirectory,
+                cancellationToken).ConfigureAwait(false);
+            if (manifestResult.ExitCode == 0)
+            {
+                try
+                {
+                    manifestVersions = DotnetWorkloadParser.ParseManifestVersions(manifestResult.Output);
+                }
+                catch (FormatException ex)
+                {
+                    diagnostics.Add($"The active workload-set manifest map was not understood: {ex.Message}");
+                }
+            }
+            else
+            {
+                diagnostics.Add($"The active workload-set manifest map could not be queried: {FirstError(manifestResult)}");
+            }
+        }
+        else if (updateMode == DotnetWorkloadUpdateMode.Manifests)
+        {
+            try
+            {
+                manifestVersions = WorkloadInstallStateReader.ReadManifestVersions(target);
+            }
+            catch (FormatException ex)
+            {
+                diagnostics.Add($"The loose-manifest install state was not understood: {ex.Message}");
+            }
+        }
+
+        var (manifests, discoveredVersions) = await LoadActiveManifestsAsync(
+            target,
+            manifestVersions,
+            cancellationToken).ConfigureAwait(false);
+        if (manifestVersions.Count == 0)
+            manifestVersions = discoveredVersions;
+
+        IReadOnlyList<ResolvedWorkloadDefinition> availableWorkloads;
+        try
+        {
+            availableWorkloads = WorkloadGraphResolver.Resolve(manifests, _runtimeIdentifier);
+        }
+        catch (InvalidDataException ex)
+        {
+            diagnostics.Add(ex.Message);
+            availableWorkloads = [];
+        }
+
+        return new DotnetWorkloadInventory
+        {
+            Target = target,
+            UpdateMode = updateMode,
+            VersionSource = versionSource,
+            ActiveWorkloadVersion = workloadVersion,
+            InstalledWorkloads = workloadList.Installed,
+            AvailableWorkloads = availableWorkloads,
+            ManifestVersions = manifestVersions,
+            AvailableSetVersions = availableSets,
+            WorkloadUpdates = workloadList.Updates,
+            Capabilities = new DotnetWorkloadCapabilities
+            {
+                MachineReadableList = machineReadable,
+                WorkloadVersion = true,
+                JsonVersionSearch = jsonVersionSearch
+            },
+            Diagnostics = diagnostics
+        };
+    }
+
+    private async Task<DotnetWorkloadListResult> ReadPlainListAsync(
+        DotnetWorkloadTarget target,
+        string workingDirectory,
+        CancellationToken cancellationToken)
+    {
+        var result = await RunCaptureAsync(
+            target,
+            ["workload", "list"],
+            workingDirectory,
+            cancellationToken).ConfigureAwait(false);
+        if (result.ExitCode != 0)
+            throw CreateCliException(target, "dotnet workload list", result);
+        return DotnetWorkloadParser.ParsePlainList(result.Output);
+    }
+
+    private static async Task<(IReadOnlyList<WorkloadManifest> Manifests, IReadOnlyList<DotnetManifestVersion> Versions)>
+        LoadActiveManifestsAsync(
+            DotnetWorkloadTarget target,
+            IReadOnlyList<DotnetManifestVersion> manifestVersions,
+            CancellationToken cancellationToken)
+    {
+        var manifests = new List<WorkloadManifest>();
+        var versions = new List<DotnetManifestVersion>();
+
+        if (manifestVersions.Count > 0)
+        {
+            foreach (var item in manifestVersions)
+            {
+                var file = Path.Combine(
+                    target.InstallRoot,
+                    "sdk-manifests",
+                    item.FeatureBand,
+                    item.ManifestId,
+                    item.Version,
+                    "WorkloadManifest.json");
+                await AddManifestAsync(file, item, manifests, versions, cancellationToken).ConfigureAwait(false);
+            }
+            return (manifests, versions);
+        }
+
+        var manifestBand = target.FeatureBand.ToString();
+        var bandRoot = Path.Combine(target.InstallRoot, "sdk-manifests", manifestBand);
+        if (!Directory.Exists(bandRoot))
+            return (manifests, versions);
+
+        foreach (var manifestDirectory in Directory.GetDirectories(bandRoot))
+        {
+            var versionDirectory = Directory.GetDirectories(manifestDirectory)
+                .OrderByDescending(path =>
+                    NuGetVersion.TryParse(Path.GetFileName(path), out var version)
+                        ? version
+                        : new NuGetVersion(0, 0, 0))
+                .FirstOrDefault();
+            if (versionDirectory == null)
+                continue;
+
+            var item = new DotnetManifestVersion
+            {
+                ManifestId = Path.GetFileName(manifestDirectory),
+                Version = Path.GetFileName(versionDirectory),
+                FeatureBand = manifestBand
+            };
+            await AddManifestAsync(
+                Path.Combine(versionDirectory, "WorkloadManifest.json"),
+                item,
+                manifests,
+                versions,
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        return (manifests, versions);
+    }
+
+    private static async Task AddManifestAsync(
+        string file,
+        DotnetManifestVersion item,
+        ICollection<WorkloadManifest> manifests,
+        ICollection<DotnetManifestVersion> versions,
+        CancellationToken cancellationToken)
+    {
+        if (!File.Exists(file))
+            return;
+
+        var json = await File.ReadAllTextAsync(file, cancellationToken).ConfigureAwait(false);
+        var manifest = WorkloadManifestService.ParseManifest(json);
+        if (manifest == null)
+            return;
+        manifests.Add(manifest);
+        versions.Add(item);
+    }
+
+    private ProcessRequest CreateMutationRequest(
+        DotnetWorkloadTarget target,
+        IReadOnlyList<string> arguments,
+        string title,
+        string description,
+        string? workingDirectory = null,
+        string? confirmationButtonText = null)
+    {
+        var directory = Path.GetFullPath(workingDirectory ?? GetCommandContext(target));
+        return new ProcessRequest(
+            Command: target.DotnetPath,
+            Arguments: arguments.ToArray(),
+            WorkingDirectory: directory,
+            RequiresElevation: !target.CanWrite,
+            ElevationPrompt: target.CanWrite
+                ? null
+                : $"Workload changes require permission to write to {target.InstallRoot}.",
+            Environment: CreateEnvironment(target),
+            Title: title,
+            Description: description,
+            UsePseudoTerminal: SupportsTerminalProgress,
+            ConfirmationButtonText: confirmationButtonText);
+    }
+
+    private static DotnetWorkloadUpdateMode ResolveUpdateMode(
+        DotnetWorkloadTarget target,
+        GlobalJsonInfo? globalJson,
+        ICollection<string> diagnostics)
+    {
+        if (!string.IsNullOrWhiteSpace(globalJson?.WorkloadsUpdateMode))
+        {
+            if (string.Equals(
+                    globalJson.WorkloadsUpdateMode,
+                    "workload-set",
+                    StringComparison.OrdinalIgnoreCase))
+                return DotnetWorkloadUpdateMode.WorkloadSet;
+            if (string.Equals(
+                    globalJson.WorkloadsUpdateMode,
+                    "manifests",
+                    StringComparison.OrdinalIgnoreCase))
+                return DotnetWorkloadUpdateMode.Manifests;
+
+            diagnostics.Add(
+                $"global.json specifies an unsupported sdk.workloads-update-mode value: '{globalJson.WorkloadsUpdateMode}'.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(globalJson?.WorkloadSetVersion))
+            return DotnetWorkloadUpdateMode.WorkloadSet;
+
+        try
+        {
+            return WorkloadInstallStateReader.ReadUpdateMode(target);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException or FormatException)
+        {
+            diagnostics.Add($"The workload install state could not be read: {ex.Message}");
+            return DotnetWorkloadUpdateMode.Unknown;
+        }
+    }
+
+    private static IReadOnlyList<string> ValidateWorkloadIds(IReadOnlyList<string> workloadIds)
+    {
+        ArgumentNullException.ThrowIfNull(workloadIds);
+        var result = workloadIds
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Select(id => id.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        if (result.Count == 0)
+            throw new ArgumentException("At least one workload ID is required.", nameof(workloadIds));
+        if (result.Any(id => id.Any(char.IsWhiteSpace)))
+            throw new ArgumentException("Workload IDs cannot contain whitespace.", nameof(workloadIds));
+        return result;
+    }
+
+    private string GetCommandContext(DotnetWorkloadTarget target)
+    {
+        var safeVersion = string.Concat(target.RepresentativeSdkVersion.Select(
+            character => char.IsLetterOrDigit(character) || character is '.' or '-' ? character : '_'));
+        var directory = Path.Combine(
+            Path.GetTempPath(),
+            "MauiSherpa",
+            "workload-contexts",
+            safeVersion);
+        Directory.CreateDirectory(directory);
+        var path = Path.Combine(directory, "global.json");
+        var allowPrerelease = target.FeatureBand.IsPrerelease ? ",\n    \"allowPrerelease\": true" : string.Empty;
+        var content = $"{{\n  \"sdk\": {{\n    \"version\": \"{target.RepresentativeSdkVersion}\",\n    \"rollForward\": \"disable\"{allowPrerelease}\n  }}\n}}\n";
+        if (!File.Exists(path) || !string.Equals(File.ReadAllText(path), content, StringComparison.Ordinal))
+            File.WriteAllText(path, content);
+        return directory;
+    }
+
+    private static Dictionary<string, string> CreateEnvironment(DotnetWorkloadTarget target)
+    {
+        var separator = OperatingSystem.IsWindows() ? ';' : ':';
+        var existingPath = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+        return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["DOTNET_ROOT"] = target.InstallRoot,
+            ["DOTNET_MULTILEVEL_LOOKUP"] = "0",
+            ["DOTNET_CLI_USE_MSBUILD_SERVER"] = "0",
+            ["MSBUILDDISABLENODEREUSE"] = "1",
+            ["PATH"] = $"{target.InstallRoot}{separator}{existingPath}"
+        };
+    }
+
+    private static bool CanWriteWorkloadState(string installRoot)
+    {
+        var metadataRoot = Path.Combine(installRoot, "metadata");
+        var workloadMetadata = Path.Combine(metadataRoot, "workloads");
+        var statePath = Directory.Exists(workloadMetadata)
+            ? workloadMetadata
+            : Directory.Exists(metadataRoot)
+                ? metadataRoot
+                : installRoot;
+        return CanWriteDirectory(installRoot) && CanWriteDirectory(statePath);
+    }
+
+    private static bool CanWriteDirectory(string path) =>
+        OperatingSystem.IsWindows()
+            ? WindowsAccess(path, WriteAccess) == 0
+            : UnixAccess(path, WriteAccess) == 0;
+
+    private const int WriteAccess = 2;
+
+    [DllImport("libc", EntryPoint = "access", SetLastError = true)]
+    private static extern int UnixAccess(string path, int mode);
+
+    [DllImport("msvcrt", EntryPoint = "_waccess", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern int WindowsAccess(string path, int mode);
+
+    private async Task<CaptureResult> RunCaptureAsync(
+        DotnetWorkloadTarget target,
+        IReadOnlyList<string> arguments,
+        string workingDirectory,
+        CancellationToken cancellationToken)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = target.DotnetPath,
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        foreach (var argument in arguments)
+            startInfo.ArgumentList.Add(argument);
+        foreach (var value in CreateEnvironment(target))
+            startInfo.Environment[value.Key] = value.Value;
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException($"Failed to launch {target.DotnetPath}.");
+        var command = string.Join(' ', arguments);
+        _logger.LogDebug($"Reading workload state: {target.FeatureBand} - dotnet {command}");
+
+        var output = new StringBuilder();
+        var error = new StringBuilder();
+        var outputClosed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var errorClosed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var exited = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        process.OutputDataReceived += (_, eventArgs) =>
+        {
+            if (eventArgs.Data == null)
+                outputClosed.TrySetResult();
+            else
+                lock (output)
+                    output.AppendLine(eventArgs.Data);
+        };
+        process.ErrorDataReceived += (_, eventArgs) =>
+        {
+            if (eventArgs.Data == null)
+                errorClosed.TrySetResult();
+            else
+                lock (error)
+                    error.AppendLine(eventArgs.Data);
+        };
+        process.EnableRaisingEvents = true;
+        process.Exited += (_, _) => exited.TrySetResult();
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+        if (process.HasExited)
+            exited.TrySetResult();
+
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(TimeSpan.FromSeconds(45));
+
+        try
+        {
+            await exited.Task.WaitAsync(timeout.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            if (!process.HasExited)
+                process.Kill(entireProcessTree: true);
+            throw new TimeoutException(
+                $"dotnet {command} did not finish within 45 seconds for SDK feature band {target.FeatureBand}.");
+        }
+        catch (OperationCanceledException)
+        {
+            if (!process.HasExited)
+                process.Kill(entireProcessTree: true);
+            throw;
+        }
+
+        var streamsClosed = Task.WhenAll(outputClosed.Task, errorClosed.Task);
+        if (await Task.WhenAny(streamsClosed, Task.Delay(500, CancellationToken.None)).ConfigureAwait(false) != streamsClosed)
+        {
+            try
+            {
+                process.CancelOutputRead();
+            }
+            catch (InvalidOperationException)
+            {
+            }
+
+            try
+            {
+                process.CancelErrorRead();
+            }
+            catch (InvalidOperationException)
+            {
+            }
+        }
+
+        string outputText;
+        string errorText;
+        lock (output)
+            outputText = output.ToString();
+        lock (error)
+            errorText = error.ToString();
+        _logger.LogDebug($"Read workload state: {target.FeatureBand} - dotnet {command} exited {process.ExitCode}");
+
+        return new CaptureResult(
+            process.ExitCode,
+            outputText,
+            errorText);
+    }
+
+    private static InvalidOperationException CreateCliException(
+        DotnetWorkloadTarget target,
+        string operation,
+        CaptureResult result) =>
+        new($"{operation} failed for {target.FeatureBand}: {FirstError(result)}");
+
+    private static string FirstError(CaptureResult result) =>
+        (string.IsNullOrWhiteSpace(result.Error) ? result.Output : result.Error).Trim();
+
+    private static bool SupportsTerminalProgress =>
+        OperatingSystem.IsMacOS() || OperatingSystem.IsMacCatalyst();
+
+    private sealed record CaptureResult(int ExitCode, string Output, string Error);
+}

--- a/src/MauiSherpa.Core/Services/MacElevatedProcessScriptBuilder.cs
+++ b/src/MauiSherpa.Core/Services/MacElevatedProcessScriptBuilder.cs
@@ -1,0 +1,53 @@
+using System.Text;
+using MauiSherpa.Core.Interfaces;
+
+namespace MauiSherpa.Core.Services;
+
+public static class MacElevatedProcessScriptBuilder
+{
+    public static string Build(ProcessRequest request, string outputFile)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrWhiteSpace(outputFile);
+
+        var command = string.Join(
+            " ",
+            new[] { request.Command }
+                .Concat(request.Arguments)
+                .Select(EscapeForShell));
+        if (request.UsePseudoTerminal)
+            command = $"/usr/bin/script -q /dev/null {command}";
+
+        var script = new StringBuilder();
+        script.AppendLine("#!/bin/bash");
+        script.AppendLine("set -o pipefail");
+        script.AppendLine($"exec > >(tee -a {EscapeForShell(outputFile)}) 2>&1");
+
+        if (!string.IsNullOrWhiteSpace(request.WorkingDirectory))
+            script.AppendLine($"cd {EscapeForShell(request.WorkingDirectory)} || exit 1");
+
+        if (request.Environment != null)
+        {
+            foreach (var (name, value) in request.Environment.OrderBy(item => item.Key, StringComparer.Ordinal))
+            {
+                if (!IsValidEnvironmentName(name))
+                    throw new ArgumentException($"'{name}' is not a valid environment variable name.");
+                script.AppendLine($"export {name}={EscapeForShell(value)}");
+            }
+        }
+
+        script.AppendLine(command);
+        script.AppendLine("EXIT_CODE=$?");
+        script.AppendLine($"printf '\\n__EXIT_CODE__:%s\\n' \"$EXIT_CODE\" >> {EscapeForShell(outputFile)}");
+        script.AppendLine("exit $EXIT_CODE");
+        return script.ToString();
+    }
+
+    private static bool IsValidEnvironmentName(string name) =>
+        !string.IsNullOrWhiteSpace(name) &&
+        (char.IsLetter(name[0]) || name[0] == '_') &&
+        name.Skip(1).All(character => char.IsLetterOrDigit(character) || character == '_');
+
+    private static string EscapeForShell(string value) =>
+        $"'{value.Replace("'", "'\\''", StringComparison.Ordinal)}'";
+}

--- a/src/MauiSherpa.Core/Services/WindowsElevatedProcessScriptBuilder.cs
+++ b/src/MauiSherpa.Core/Services/WindowsElevatedProcessScriptBuilder.cs
@@ -1,0 +1,42 @@
+using System.Text;
+using MauiSherpa.Core.Interfaces;
+
+namespace MauiSherpa.Core.Services;
+
+public static class WindowsElevatedProcessScriptBuilder
+{
+    public static string Build(ProcessRequest request, string outputFile)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrWhiteSpace(outputFile);
+
+        var script = new StringBuilder();
+        script.AppendLine("$ErrorActionPreference = 'Stop'");
+        script.AppendLine($"Set-Location -LiteralPath {Quote(request.WorkingDirectory ?? Environment.CurrentDirectory)}");
+
+        if (request.Environment != null)
+        {
+            foreach (var (key, value) in request.Environment)
+                script.AppendLine($"Set-Item -LiteralPath {Quote($"Env:{key}")} -Value {Quote(value)}");
+        }
+
+        script.AppendLine("$exitCode = 1");
+        script.AppendLine("try {");
+        script.Append("  & ").Append(Quote(request.Command));
+        foreach (var argument in request.Arguments)
+            script.Append(' ').Append(Quote(argument));
+        script.Append(" 2>&1 | Tee-Object -FilePath ").AppendLine(Quote(outputFile));
+        script.AppendLine("  $exitCode = if ($null -eq $LASTEXITCODE) { if ($?) { 0 } else { 1 } } else { $LASTEXITCODE }");
+        script.AppendLine("}");
+        script.AppendLine("catch {");
+        script.AppendLine($"  $_ | Out-String | Add-Content -LiteralPath {Quote(outputFile)}");
+        script.AppendLine("}");
+        script.AppendLine("finally {");
+        script.AppendLine($"  Add-Content -LiteralPath {Quote(outputFile)} -Value \"__EXIT_CODE__:$exitCode\"");
+        script.AppendLine("}");
+        script.AppendLine("exit $exitCode");
+        return script.ToString();
+    }
+
+    private static string Quote(string value) => $"'{value.Replace("'", "''", StringComparison.Ordinal)}'";
+}

--- a/src/MauiSherpa.MacOS/BlazorContentPage.cs
+++ b/src/MauiSherpa.MacOS/BlazorContentPage.cs
@@ -985,6 +985,7 @@ public class BlazorContentPage : ContentPage
                 ("delete-folder", "Delete Folder", "trash"),
                 ("up-folder", "Up Folder", "arrow.up"),
                 ("import", "Import", "square.and.arrow.down"),
+                ("open-project", "Open Project Folder", "folder"),
                 ("install-missing", "Install Missing", "arrow.down.circle"),
                 ("save", "Save", "checkmark"),
                 ("reset", "Reset to Defaults", "trash"),

--- a/src/MauiSherpa.MacOS/MacOSApp.cs
+++ b/src/MauiSherpa.MacOS/MacOSApp.cs
@@ -172,14 +172,6 @@ class MacOSApp : Application
             new() { Title = "Dashboard", SystemImage = "house.fill", Tag = "/" },
             new MacOSSidebarItem
             {
-                Title = ".NET",
-                Children = new List<MacOSSidebarItem>
-                {
-                    new() { Title = "SDK Manager", SystemImage = "square.stack.3d.up.fill", Tag = "/dotnet-sdk" },
-                }
-            },
-            new MacOSSidebarItem
-            {
                 Title = "Android",
                 Children = new List<MacOSSidebarItem>
                 {
@@ -219,6 +211,7 @@ class MacOSApp : Application
                 Title = "Tools",
                 Children = new List<MacOSSidebarItem>
                 {
+                    new() { Title = ".NET SDK Manager", SystemImage = "square.stack.3d.up.fill", Tag = "/dotnet-sdk" },
                     new() { Title = "Profiling", SystemImage = "chart.bar.xaxis", Tag = "/profiling" },
                     new() { Title = "App Inspector", SystemImage = "wand.and.stars", Tag = "/devflow" },
 #if DEBUG

--- a/src/MauiSherpa.MacOS/MacOSApp.cs
+++ b/src/MauiSherpa.MacOS/MacOSApp.cs
@@ -172,6 +172,14 @@ class MacOSApp : Application
             new() { Title = "Dashboard", SystemImage = "house.fill", Tag = "/" },
             new MacOSSidebarItem
             {
+                Title = ".NET",
+                Children = new List<MacOSSidebarItem>
+                {
+                    new() { Title = "SDK Manager", SystemImage = "square.stack.3d.up.fill", Tag = "/dotnet-sdk" },
+                }
+            },
+            new MacOSSidebarItem
+            {
                 Title = "Android",
                 Children = new List<MacOSSidebarItem>
                 {

--- a/src/MauiSherpa.MacOS/MacOSMauiProgram.cs
+++ b/src/MauiSherpa.MacOS/MacOSMauiProgram.cs
@@ -4,6 +4,7 @@ using MauiSherpa.Services;
 using MauiSherpa.Core.ViewModels;
 using MauiSherpa.Core.Interfaces;
 using MauiSherpa.Core.Services;
+using MauiSherpa.Workloads.Services;
 using Microsoft.Maui.Platforms.MacOS.Hosting;
 using Microsoft.Maui.Platforms.MacOS.Handlers;
 using Microsoft.Maui.Platforms.MacOS.Essentials;
@@ -144,6 +145,8 @@ public static class MacOSMauiProgram
         builder.Services.AddSingleton<IDebugFlagService, DebugFlagService>();
         builder.Services.AddSingleton<IDoctorService, DoctorService>();
         builder.Services.AddSingleton<IDotnetUpService, DotnetUpService>();
+        builder.Services.AddSingleton<IGlobalJsonWorkloadPinEditor, GlobalJsonWorkloadPinEditor>();
+        builder.Services.AddSingleton<IDotnetWorkloadService, DotnetWorkloadService>();
         builder.Services.AddSingleton<IProfilingContextService, ProfilingContextService>();
         builder.Services.AddSingleton<ICopilotToolsService, CopilotToolsService>();
         builder.Services.AddSingleton<ICopilotService, CopilotService>();

--- a/src/MauiSherpa.MacOS/MacOSMauiProgram.cs
+++ b/src/MauiSherpa.MacOS/MacOSMauiProgram.cs
@@ -143,6 +143,7 @@ public static class MacOSMauiProgram
         builder.Services.AddSingleton<ProfilingViewerService>();
         builder.Services.AddSingleton<IDebugFlagService, DebugFlagService>();
         builder.Services.AddSingleton<IDoctorService, DoctorService>();
+        builder.Services.AddSingleton<IDotnetUpService, DotnetUpService>();
         builder.Services.AddSingleton<IProfilingContextService, ProfilingContextService>();
         builder.Services.AddSingleton<ICopilotToolsService, CopilotToolsService>();
         builder.Services.AddSingleton<ICopilotService, CopilotService>();

--- a/src/MauiSherpa.MacOS/MacOSMauiProgram.cs
+++ b/src/MauiSherpa.MacOS/MacOSMauiProgram.cs
@@ -229,6 +229,12 @@ public static class MacOSMauiProgram
         builder.Services.AddSingleton<CopilotViewModel>();
         builder.Services.AddSingleton<SettingsViewModel>();
 
+        // Shiny.Mediator 6.6.x serializes the persistent cache via Shiny.Json, which is strict
+        // (source-gen contexts only) and throws "No JsonTypeInfo registered" for any cached type.
+        // We don't ship [ShinyJsonInclude]/source-gen contexts, so register the reflection-based
+        // resolver to restore plain serialization for all cached request/response types.
+        Shiny.Json.AddResolver(new System.Text.Json.Serialization.Metadata.DefaultJsonTypeInfoResolver());
+
         // Shiny Mediator with caching
         builder.AddShinyMediator(cfg =>
         {

--- a/src/MauiSherpa.MacOS/MauiSherpa.MacOS.csproj
+++ b/src/MauiSherpa.MacOS/MauiSherpa.MacOS.csproj
@@ -40,11 +40,11 @@
     <PackageReference Include="Markdig" Version="0.44.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="10.0.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.41" />
+    <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.60" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
     <PackageReference Include="Sentry.Maui" Version="6.4.0" />
-    <PackageReference Include="Shiny.Mediator.Caching.MicrosoftMemoryCache" Version="6.1.1" />
-    <PackageReference Include="Shiny.Mediator.Maui" Version="6.1.1" />
+    <PackageReference Include="Shiny.Mediator.Caching.MicrosoftMemoryCache" Version="6.6.2" />
+    <PackageReference Include="Shiny.Mediator.Maui" Version="6.6.2" />
     <PackageReference Include="Microsoft.Maui.DevFlow.Agent" Version="0.1.0-preview.7.26230.1" Condition="'$(Configuration)' == 'Debug'" />
     <PackageReference Include="Microsoft.Maui.DevFlow.Blazor" Version="0.1.0-preview.7.26230.1" Condition="'$(Configuration)' == 'Debug'" />
   </ItemGroup>

--- a/src/MauiSherpa.Workloads/Models/DotnetSdkPresentationModels.cs
+++ b/src/MauiSherpa.Workloads/Models/DotnetSdkPresentationModels.cs
@@ -1,0 +1,78 @@
+namespace MauiSherpa.Workloads.Models;
+
+public record DotnetSdkManagerSummary
+{
+    public IReadOnlyList<DotnetMajorMinorGroupSummary> InstalledGroups { get; init; } = [];
+    public IReadOnlyList<DotnetTrackedSdkChannelSummary> TrackedSdkChannels { get; init; } = [];
+    public IReadOnlyList<DotnetTrackedNonSdkSpecSummary> TrackedNonSdkSpecs { get; init; } = [];
+    public DotnetUpdateAggregateSummary Updates { get; init; } = new();
+    public DotnetProjectWorkloadMatchSummary? ProjectWorkloads { get; init; }
+}
+
+public record DotnetMajorMinorGroupSummary
+{
+    public required string MajorMinor { get; init; }
+    public string DisplayName => $".NET {MajorMinor}";
+    public string? NewestSdkVersion { get; init; }
+    public required DotnetInstalledComponentCounts Counts { get; init; }
+    public bool HasInvalidComponents { get; init; }
+    public int WorkloadFeatureBandCount { get; init; }
+    public IReadOnlyList<DotnetUpInstallation> Installations { get; init; } = [];
+    public IReadOnlyList<DotnetWorkloadInventory> WorkloadInventories { get; init; } = [];
+}
+
+public record DotnetInstalledComponentCounts
+{
+    public int Total { get; init; }
+    public int Sdk { get; init; }
+    public int Runtime { get; init; }
+    public int AspNetCore { get; init; }
+    public int WindowsDesktop { get; init; }
+    public int Unknown { get; init; }
+}
+
+public record DotnetTrackedSdkChannelSummary
+{
+    public required string Channel { get; init; }
+    public DotnetUpInstallSource Source { get; init; }
+    public string? GlobalJsonPath { get; init; }
+    public required string InstallRoot { get; init; }
+    public string? Architecture { get; init; }
+    public bool IsPinned { get; init; }
+}
+
+public record DotnetTrackedNonSdkSpecSummary
+{
+    public required DotnetUpComponent Component { get; init; }
+    public required string VersionOrChannel { get; init; }
+    public DotnetUpInstallSource Source { get; init; }
+    public string? GlobalJsonPath { get; init; }
+    public required string InstallRoot { get; init; }
+    public string? Architecture { get; init; }
+    public bool IsPinned { get; init; }
+}
+
+public record DotnetUpdateAggregateSummary
+{
+    public bool IsChecked { get; init; }
+    public int PreviewCount { get; init; }
+    public int AvailableUpdateCount { get; init; }
+    public int SdkUpdateCount { get; init; }
+    public int RuntimeUpdateCount { get; init; }
+    public int UnresolvedCount { get; init; }
+    public bool HasUpdates => AvailableUpdateCount > 0;
+    public bool HasSdkUpdates => SdkUpdateCount > 0;
+    public bool HasRuntimeUpdates => RuntimeUpdateCount > 0;
+    public bool HasUnresolvedNonPinnedChannels => UnresolvedCount > 0;
+    public IReadOnlyList<DotnetUpdatePreview> Previews { get; init; } = [];
+}
+
+public record DotnetProjectWorkloadMatchSummary
+{
+    public required string InstalledVersion { get; init; }
+    public required SdkFeatureBand FeatureBand { get; init; }
+    public string? InstallRoot { get; init; }
+    public string? Architecture { get; init; }
+    public IReadOnlyList<DotnetWorkloadInventory> MatchingInventories { get; init; } = [];
+    public DotnetWorkloadInventory? SelectedInventory { get; init; }
+}

--- a/src/MauiSherpa.Workloads/Models/DotnetUpModels.cs
+++ b/src/MauiSherpa.Workloads/Models/DotnetUpModels.cs
@@ -107,6 +107,28 @@ public record DotnetUpToolInfo
 }
 
 /// <summary>
+/// Metadata for the latest dotnetup artifact published through aka.ms.
+/// </summary>
+public record DotnetUpPublishedArtifact
+{
+    public required string Version { get; init; }
+
+    public required string Sha512 { get; init; }
+}
+
+/// <summary>
+/// Read-only comparison of the installed dotnetup binary with the latest published artifact.
+/// </summary>
+public record DotnetUpToolUpdateInfo
+{
+    public required string InstalledVersion { get; init; }
+
+    public required string AvailableVersion { get; init; }
+
+    public required bool UpdateAvailable { get; init; }
+}
+
+/// <summary>
 /// Preview of whether a tracked channel has a newer version available, computed by resolving the
 /// channel against the official .NET release metadata — <b>without</b> running any install/update.
 /// </summary>
@@ -171,6 +193,11 @@ public record GlobalJsonResolution
     /// <summary>The <c>sdk.allowPrerelease</c> value, if specified.</summary>
     public bool? AllowPrerelease { get; init; }
 
+    /// <summary>The official <c>sdk.workloadVersion</c> value, or a legacy value when present.</summary>
+    public string? WorkloadVersion { get; init; }
+
+    public bool UsesLegacyWorkloadSetProperty { get; init; }
+
     /// <summary>The dotnetup channel derived from version + rollForward (e.g. "10.0.1xx", "latest", "10.0.100").</summary>
     public string? Channel { get; init; }
 
@@ -183,8 +210,17 @@ public record GlobalJsonResolution
     /// <summary>The newest installed SDK that satisfies the channel, or null when none is installed.</summary>
     public string? InstalledVersion { get; init; }
 
+    /// <summary>The install root containing <see cref="InstalledVersion"/>, when resolved.</summary>
+    public string? InstalledSdkInstallRoot { get; init; }
+
+    /// <summary>The architecture of the resolved installed SDK, when reported by dotnetup.</summary>
+    public string? InstalledSdkArchitecture { get; init; }
+
     /// <summary>True when an installed SDK satisfies this project's requirement.</summary>
     public bool Satisfied { get; init; }
+
+    /// <summary>True when the project's rolling channel resolves to a newer SDK than the installed match.</summary>
+    public bool UpdateAvailable { get; init; }
 
     /// <summary>True when dotnetup already tracks a spec sourced from this <c>global.json</c> (or matching channel).</summary>
     public bool AlreadyTracked { get; init; }

--- a/src/MauiSherpa.Workloads/Models/DotnetUpModels.cs
+++ b/src/MauiSherpa.Workloads/Models/DotnetUpModels.cs
@@ -1,0 +1,107 @@
+namespace MauiSherpa.Workloads.Models;
+
+/// <summary>
+/// The type of .NET component managed by dotnetup.
+/// Mirrors the <c>component</c> field of <c>dotnetup list --format Json</c>.
+/// </summary>
+public enum DotnetUpComponent
+{
+    Sdk,
+    Runtime,
+    AspNetCore,
+    WindowsDesktop,
+    Unknown
+}
+
+/// <summary>
+/// How a dotnetup install spec was registered.
+/// Mirrors the <c>source</c> field of an install spec.
+/// </summary>
+public enum DotnetUpInstallSource
+{
+    Explicit,
+    GlobalJson,
+    All,
+    Unknown
+}
+
+/// <summary>
+/// A concrete .NET version installed and managed by dotnetup.
+/// Mirrors an entry in the <c>installations</c> array of <c>dotnetup list --format Json</c>.
+/// </summary>
+public record DotnetUpInstallation
+{
+    public required DotnetUpComponent Component { get; init; }
+
+    /// <summary>Raw component string as reported by dotnetup (e.g. "SDK", "ASPNETCore").</summary>
+    public required string ComponentRaw { get; init; }
+
+    public required string Version { get; init; }
+
+    public required string InstallRoot { get; init; }
+
+    public string? Architecture { get; init; }
+
+    public bool IsValid { get; init; } = true;
+
+    /// <summary>Framework name for runtimes (e.g. "Microsoft.NETCore.App"). Null for SDKs.</summary>
+    public string? FrameworkName { get; init; }
+}
+
+/// <summary>
+/// A tracked dotnetup install spec (channel) that determines what gets installed/updated.
+/// Mirrors an entry in the <c>installSpecs</c> array of <c>dotnetup list --format Json</c>.
+/// </summary>
+public record DotnetUpInstallSpec
+{
+    public required DotnetUpComponent Component { get; init; }
+
+    /// <summary>Raw component string as reported by dotnetup (e.g. "SDK", "ASPNETCore").</summary>
+    public required string ComponentRaw { get; init; }
+
+    /// <summary>The channel or pinned version (e.g. "latest", "10.0.1xx", "9.0.304").</summary>
+    public required string VersionOrChannel { get; init; }
+
+    public DotnetUpInstallSource Source { get; init; } = DotnetUpInstallSource.Explicit;
+
+    /// <summary>Path to the global.json that introduced this spec, when <see cref="Source"/> is GlobalJson.</summary>
+    public string? GlobalJsonPath { get; init; }
+
+    public required string InstallRoot { get; init; }
+
+    public string? Architecture { get; init; }
+}
+
+/// <summary>
+/// Parsed result of <c>dotnetup list --format Json</c>.
+/// </summary>
+public record DotnetUpListResult
+{
+    public IReadOnlyList<DotnetUpInstallSpec> InstallSpecs { get; init; } = Array.Empty<DotnetUpInstallSpec>();
+
+    public IReadOnlyList<DotnetUpInstallation> Installations { get; init; } = Array.Empty<DotnetUpInstallation>();
+
+    /// <summary>
+    /// The dotnetup-managed install root(s) discovered from the listed entries.
+    /// </summary>
+    public IReadOnlyList<string> InstallRoots =>
+        InstallSpecs.Select(s => s.InstallRoot)
+            .Concat(Installations.Select(i => i.InstallRoot))
+            .Where(r => !string.IsNullOrEmpty(r))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+}
+
+/// <summary>
+/// Diagnostic information about the dotnetup tool itself, parsed from <c>dotnetup --info</c>.
+/// </summary>
+public record DotnetUpToolInfo
+{
+    public required string Version { get; init; }
+
+    public string? Commit { get; init; }
+
+    public string? Architecture { get; init; }
+
+    public string? Rid { get; init; }
+}

--- a/src/MauiSherpa.Workloads/Models/DotnetUpModels.cs
+++ b/src/MauiSherpa.Workloads/Models/DotnetUpModels.cs
@@ -105,3 +105,90 @@ public record DotnetUpToolInfo
 
     public string? Rid { get; init; }
 }
+
+/// <summary>
+/// Preview of whether a tracked channel has a newer version available, computed by resolving the
+/// channel against the official .NET release metadata — <b>without</b> running any install/update.
+/// </summary>
+public record DotnetUpdatePreview
+{
+    public required DotnetUpComponent Component { get; init; }
+
+    /// <summary>The tracked channel or pinned version this preview was computed for (e.g. "latest", "9.0.3xx").</summary>
+    public required string Channel { get; init; }
+
+    /// <summary>The newest installed version that currently satisfies this channel, or null when none matched.</summary>
+    public string? InstalledVersion { get; init; }
+
+    /// <summary>The newest available version the channel resolves to, or null when it couldn't be resolved (offline/unknown).</summary>
+    public string? AvailableVersion { get; init; }
+
+    /// <summary>True when <see cref="AvailableVersion"/> is newer than <see cref="InstalledVersion"/>.</summary>
+    public bool UpdateAvailable { get; init; }
+
+    /// <summary>True when the spec is a pinned exact version, so no channel update applies.</summary>
+    public bool IsPinned { get; init; }
+}
+
+/// <summary>
+/// The outcome of resolving a folder's <c>global.json</c> context.
+/// </summary>
+public enum GlobalJsonStatus
+{
+    /// <summary>No <c>global.json</c> was found walking up from the folder.</summary>
+    NoGlobalJson,
+
+    /// <summary>A <c>global.json</c> was found but it has no <c>sdk.version</c>, so no channel is pinned.</summary>
+    NoSdkVersion,
+
+    /// <summary>A channel was derived and resolved against the release feed.</summary>
+    Resolved,
+
+    /// <summary>A channel was derived but it couldn't be resolved (offline / unknown).</summary>
+    Unresolved,
+}
+
+/// <summary>
+/// Read-only resolution of the .NET SDK a project folder requires via its <c>global.json</c> —
+/// computed without running dotnetup. dotnetup walks up from a directory to the nearest
+/// <c>global.json</c> (the same algorithm as the <c>dotnet</c> host) and maps
+/// <c>sdk.version</c> + <c>sdk.rollForward</c> to a channel.
+/// </summary>
+public record GlobalJsonResolution
+{
+    /// <summary>The folder the user picked to inspect.</summary>
+    public required string FolderPath { get; init; }
+
+    /// <summary>Full path to the nearest <c>global.json</c> found walking up, or null when none exists.</summary>
+    public string? GlobalJsonPath { get; init; }
+
+    /// <summary>The <c>sdk.version</c> value from <c>global.json</c>, if present.</summary>
+    public string? RequestedVersion { get; init; }
+
+    /// <summary>The <c>sdk.rollForward</c> policy (e.g. "latestPatch"), defaulted to "latestPatch" when omitted.</summary>
+    public string? RollForward { get; init; }
+
+    /// <summary>The <c>sdk.allowPrerelease</c> value, if specified.</summary>
+    public bool? AllowPrerelease { get; init; }
+
+    /// <summary>The dotnetup channel derived from version + rollForward (e.g. "10.0.1xx", "latest", "10.0.100").</summary>
+    public string? Channel { get; init; }
+
+    /// <summary>True when the derived channel is a pinned exact version that never auto-updates.</summary>
+    public bool IsPinned { get; init; }
+
+    /// <summary>The newest version the channel resolves to from the release feed, or null when unresolved.</summary>
+    public string? ResolvedVersion { get; init; }
+
+    /// <summary>The newest installed SDK that satisfies the channel, or null when none is installed.</summary>
+    public string? InstalledVersion { get; init; }
+
+    /// <summary>True when an installed SDK satisfies this project's requirement.</summary>
+    public bool Satisfied { get; init; }
+
+    /// <summary>True when dotnetup already tracks a spec sourced from this <c>global.json</c> (or matching channel).</summary>
+    public bool AlreadyTracked { get; init; }
+
+    /// <summary>Overall resolution status.</summary>
+    public required GlobalJsonStatus Status { get; init; }
+}

--- a/src/MauiSherpa.Workloads/Models/DotnetWorkloadModels.cs
+++ b/src/MauiSherpa.Workloads/Models/DotnetWorkloadModels.cs
@@ -1,0 +1,152 @@
+namespace MauiSherpa.Workloads.Models;
+
+public enum DotnetWorkloadUpdateMode
+{
+    Unknown,
+    WorkloadSet,
+    Manifests
+}
+
+public enum DotnetWorkloadVersionSource
+{
+    Unknown,
+    MachineDefault,
+    GlobalJson,
+    LooseManifests
+}
+
+public record DotnetWorkloadTarget
+{
+    public required string InstallRoot { get; init; }
+    public required string DotnetPath { get; init; }
+    public required string Architecture { get; init; }
+    public required SdkFeatureBand FeatureBand { get; init; }
+    public required string RepresentativeSdkVersion { get; init; }
+    public bool IsManagedByDotnetUp { get; init; }
+    public bool CanWrite { get; init; }
+
+    public string RuntimeVersion => $"{FeatureBand.Major}.{FeatureBand.Minor}";
+    public string Key => $"{InstallRoot}|{Architecture}|{FeatureBand}";
+}
+
+public record DotnetInstalledWorkload
+{
+    public required string Id { get; init; }
+    public string? ManifestVersion { get; init; }
+    public string? InstallationSource { get; init; }
+}
+
+public record DotnetWorkloadUpdate
+{
+    public required string WorkloadId { get; init; }
+    public string? Description { get; init; }
+    public string? ExistingManifestVersion { get; init; }
+    public string? AvailableManifestVersion { get; init; }
+}
+
+public record DotnetWorkloadListResult
+{
+    public IReadOnlyList<DotnetInstalledWorkload> Installed { get; init; } = [];
+    public IReadOnlyList<DotnetWorkloadUpdate> Updates { get; init; } = [];
+    public bool UsedMachineReadableOutput { get; init; }
+}
+
+public record DotnetWorkloadSetVersion
+{
+    public required string Version { get; init; }
+    public bool IsPrerelease { get; init; }
+}
+
+public record DotnetManifestVersion
+{
+    public required string ManifestId { get; init; }
+    public required string Version { get; init; }
+    public required string FeatureBand { get; init; }
+}
+
+public record ResolvedPackDefinition
+{
+    public required string Id { get; init; }
+    public required string Version { get; init; }
+    public required string Kind { get; init; }
+    public string? ResolvedPackageId { get; init; }
+}
+
+public record ResolvedWorkloadDefinition
+{
+    public required string Id { get; init; }
+    public string? Description { get; init; }
+    public bool IsAbstract { get; init; }
+    public string Kind { get; init; } = "dev";
+    public IReadOnlyList<string> Platforms { get; init; } = [];
+    public IReadOnlyList<string> DirectExtends { get; init; } = [];
+    public IReadOnlyList<string> TransitiveIncludes { get; init; } = [];
+    public IReadOnlyList<ResolvedPackDefinition> Packs { get; init; } = [];
+    public string? RedirectTarget { get; init; }
+}
+
+public record DotnetWorkloadCapabilities
+{
+    public bool MachineReadableList { get; init; }
+    public bool WorkloadVersion { get; init; }
+    public bool JsonVersionSearch { get; init; }
+}
+
+public record DotnetWorkloadInventory
+{
+    public required DotnetWorkloadTarget Target { get; init; }
+    public DotnetWorkloadUpdateMode UpdateMode { get; init; }
+    public DotnetWorkloadVersionSource VersionSource { get; init; }
+    public string? ActiveWorkloadVersion { get; init; }
+    public IReadOnlyList<DotnetInstalledWorkload> InstalledWorkloads { get; init; } = [];
+    public IReadOnlyList<ResolvedWorkloadDefinition> AvailableWorkloads { get; init; } = [];
+    public IReadOnlyList<DotnetManifestVersion> ManifestVersions { get; init; } = [];
+    public IReadOnlyList<DotnetWorkloadSetVersion> AvailableSetVersions { get; init; } = [];
+    public IReadOnlyList<DotnetWorkloadUpdate> WorkloadUpdates { get; init; } = [];
+    public DotnetWorkloadCapabilities Capabilities { get; init; } = new();
+    public IReadOnlyList<string> Diagnostics { get; init; } = [];
+
+    public string? LatestAvailableSetVersion => AvailableSetVersions
+        .FirstOrDefault(version => Target.FeatureBand.IsPrerelease || !version.IsPrerelease)
+        ?.Version;
+    public bool UpdateAvailable =>
+        UpdateMode == DotnetWorkloadUpdateMode.WorkloadSet &&
+        LatestAvailableSetVersion is { } latest &&
+        ActiveWorkloadVersion is { } active &&
+        !string.Equals(latest, active, StringComparison.OrdinalIgnoreCase);
+}
+
+public record DotnetManifestVersionChange
+{
+    public required string ManifestId { get; init; }
+    public string? CurrentVersion { get; init; }
+    public string? TargetVersion { get; init; }
+}
+
+public record DotnetWorkloadSetPreview
+{
+    public required DotnetWorkloadTarget Target { get; init; }
+    public string? CurrentVersion { get; init; }
+    public required string TargetVersion { get; init; }
+    public IReadOnlyList<DotnetManifestVersionChange> ManifestChanges { get; init; } = [];
+    public IReadOnlyList<string> InstalledWorkloadIds { get; init; } = [];
+    public required string CommandLine { get; init; }
+}
+
+public record WorkloadSelectionResult(
+    IReadOnlyList<string> InstallIds,
+    IReadOnlyList<string> UninstallIds);
+
+public record GlobalJsonWorkloadPinPreview
+{
+    public required string Path { get; init; }
+    public required string OriginalContent { get; init; }
+    public required string UpdatedContent { get; init; }
+    public string? WorkloadVersion { get; init; }
+    public bool Changed => !string.Equals(OriginalContent, UpdatedContent, StringComparison.Ordinal);
+
+    public string Diff =>
+        WorkloadVersion == null
+            ? $"- sdk.workloadVersion\n  {Path}"
+            : $"+ sdk.workloadVersion: {WorkloadVersion}\n  {Path}";
+}

--- a/src/MauiSherpa.Workloads/Models/DotnetWorkloadModels.cs
+++ b/src/MauiSherpa.Workloads/Models/DotnetWorkloadModels.cs
@@ -36,6 +36,33 @@ public record DotnetInstalledWorkload
     public string? InstallationSource { get; init; }
 }
 
+public enum DotnetWorkloadInstallKind
+{
+    Explicit,
+    Included
+}
+
+public record DotnetWorkloadInstallationState
+{
+    public required string Id { get; init; }
+    public required DotnetWorkloadInstallKind Kind { get; init; }
+    public DotnetInstalledWorkload? InstallationRecord { get; init; }
+    public ResolvedWorkloadDefinition? Definition { get; init; }
+    public IReadOnlyList<string> IncludedBy { get; init; } = [];
+
+    public bool IsExplicit => Kind == DotnetWorkloadInstallKind.Explicit;
+    public bool CanUninstall => IsExplicit && InstallationRecord != null;
+    public bool IsUserVisible =>
+        IsExplicit ||
+        (Definition?.IsUserInstallable ?? false);
+}
+
+public record DotnetWorkloadInstallationResolution
+{
+    public IReadOnlyList<DotnetWorkloadInstallationState> States { get; init; } = [];
+    public IReadOnlyList<string> Diagnostics { get; init; } = [];
+}
+
 public record DotnetWorkloadUpdate
 {
     public required string WorkloadId { get; init; }
@@ -83,6 +110,11 @@ public record ResolvedWorkloadDefinition
     public IReadOnlyList<string> TransitiveIncludes { get; init; } = [];
     public IReadOnlyList<ResolvedPackDefinition> Packs { get; init; } = [];
     public string? RedirectTarget { get; init; }
+
+    public bool IsUserInstallable =>
+        !IsAbstract &&
+        RedirectTarget == null &&
+        Packs.Count > 0;
 }
 
 public record DotnetWorkloadCapabilities
@@ -99,12 +131,38 @@ public record DotnetWorkloadInventory
     public DotnetWorkloadVersionSource VersionSource { get; init; }
     public string? ActiveWorkloadVersion { get; init; }
     public IReadOnlyList<DotnetInstalledWorkload> InstalledWorkloads { get; init; } = [];
+    public IReadOnlyList<DotnetWorkloadInstallationState> EffectiveInstalledWorkloads { get; init; } = [];
     public IReadOnlyList<ResolvedWorkloadDefinition> AvailableWorkloads { get; init; } = [];
     public IReadOnlyList<DotnetManifestVersion> ManifestVersions { get; init; } = [];
     public IReadOnlyList<DotnetWorkloadSetVersion> AvailableSetVersions { get; init; } = [];
     public IReadOnlyList<DotnetWorkloadUpdate> WorkloadUpdates { get; init; } = [];
     public DotnetWorkloadCapabilities Capabilities { get; init; } = new();
     public IReadOnlyList<string> Diagnostics { get; init; } = [];
+
+    public IReadOnlyList<DotnetWorkloadInstallationState> IncludedWorkloads =>
+        EffectiveInstalledWorkloads
+            .Where(workload => workload.Kind == DotnetWorkloadInstallKind.Included)
+            .ToList();
+
+    public IReadOnlyList<string> EffectiveInstalledWorkloadIds =>
+        EffectiveInstalledWorkloads
+            .Select(workload => workload.Id)
+            .ToList();
+
+    public IReadOnlyList<ResolvedWorkloadDefinition> InstallableWorkloads
+    {
+        get
+        {
+            var installedIds = EffectiveInstalledWorkloads
+                .Select(workload => workload.Id)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            return AvailableWorkloads
+                .Where(workload =>
+                    workload.IsUserInstallable &&
+                    !installedIds.Contains(workload.Id))
+                .ToList();
+        }
+    }
 
     public string? LatestAvailableSetVersion => AvailableSetVersions
         .FirstOrDefault(version => Target.FeatureBand.IsPrerelease || !version.IsPrerelease)

--- a/src/MauiSherpa.Workloads/Models/PackDefinition.cs
+++ b/src/MauiSherpa.Workloads/Models/PackDefinition.cs
@@ -45,30 +45,35 @@ internal class PackDefinitionJson
     public string? Kind { get; set; }
 
     [JsonPropertyName("alias-to")]
-    public PackAliasJson? AliasTo { get; set; }
+    public System.Text.Json.JsonElement AliasTo { get; set; }
 
-    public PackDefinition ToModel(string id) => new()
+    public PackDefinition ToModel(string id)
     {
-        Id = id,
-        Version = Version ?? "",
-        Kind = Kind ?? "Sdk",
-        AliasTo = AliasTo?.Id,
-        AliasToByPlatform = AliasTo?.Platforms
-    };
-}
+        string? directAlias = null;
+        Dictionary<string, string>? platformAliases = null;
 
-/// <summary>
-/// JSON structure for pack alias.
-/// </summary>
-internal class PackAliasJson
-{
-    [JsonPropertyName("id")]
-    public string? Id { get; set; }
+        if (AliasTo.ValueKind == System.Text.Json.JsonValueKind.String)
+        {
+            directAlias = AliasTo.GetString();
+        }
+        else if (AliasTo.ValueKind == System.Text.Json.JsonValueKind.Object)
+        {
+            platformAliases = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var property in AliasTo.EnumerateObject())
+            {
+                var value = property.Value.GetString();
+                if (!string.IsNullOrWhiteSpace(value))
+                    platformAliases[property.Name] = value;
+            }
+        }
 
-    [JsonExtensionData]
-    public Dictionary<string, object>? ExtensionData { get; set; }
-
-    public Dictionary<string, string>? Platforms =>
-        ExtensionData?.Where(kvp => kvp.Key != "id")
-            .ToDictionary(kvp => kvp.Key, kvp => kvp.Value?.ToString() ?? "");
+        return new PackDefinition
+        {
+            Id = id,
+            Version = Version ?? "",
+            Kind = Kind ?? "Sdk",
+            AliasTo = directAlias,
+            AliasToByPlatform = platformAliases
+        };
+    }
 }

--- a/src/MauiSherpa.Workloads/Models/SdkFeatureBand.cs
+++ b/src/MauiSherpa.Workloads/Models/SdkFeatureBand.cs
@@ -1,0 +1,69 @@
+using NuGet.Versioning;
+
+namespace MauiSherpa.Workloads.Models;
+
+/// <summary>
+/// Identifies the SDK feature band that owns workload state. Prerelease SDKs are
+/// isolated by their first two prerelease labels, matching the .NET SDK resolver.
+/// </summary>
+public readonly record struct SdkFeatureBand : IComparable<SdkFeatureBand>
+{
+    public int Major { get; }
+    public int Minor { get; }
+    public int Patch { get; }
+    public string? Prerelease { get; }
+
+    public bool IsPrerelease => Prerelease != null;
+
+    public SdkFeatureBand(string version)
+    {
+        if (!NuGetVersion.TryParse(version, out var parsed))
+            throw new ArgumentException($"Invalid SDK version: {version}", nameof(version));
+
+        Major = parsed.Major;
+        Minor = parsed.Minor;
+        Patch = (parsed.Patch / 100) * 100;
+
+        var labels = parsed.ReleaseLabels.ToArray();
+        var release = string.Join('.', labels);
+        Prerelease = labels.Length == 0 ||
+                     release.Contains("dev", StringComparison.OrdinalIgnoreCase) ||
+                     release.Contains("ci", StringComparison.OrdinalIgnoreCase) ||
+                     release.Contains("rtm", StringComparison.OrdinalIgnoreCase)
+            ? null
+            : string.Join('.', labels.Take(2));
+    }
+
+    public static bool TryParse(string? version, out SdkFeatureBand featureBand)
+    {
+        if (!string.IsNullOrWhiteSpace(version) && NuGetVersion.TryParse(version, out _))
+        {
+            featureBand = new SdkFeatureBand(version);
+            return true;
+        }
+
+        featureBand = default;
+        return false;
+    }
+
+    public string ToStringWithoutPrerelease() => $"{Major}.{Minor}.{Patch}";
+
+    public override string ToString() =>
+        Prerelease == null
+            ? ToStringWithoutPrerelease()
+            : $"{ToStringWithoutPrerelease()}-{Prerelease}";
+
+    public int CompareTo(SdkFeatureBand other)
+    {
+        var core = Major.CompareTo(other.Major);
+        if (core != 0) return core;
+        core = Minor.CompareTo(other.Minor);
+        if (core != 0) return core;
+        core = Patch.CompareTo(other.Patch);
+        if (core != 0) return core;
+
+        if (Prerelease == null && other.Prerelease != null) return 1;
+        if (Prerelease != null && other.Prerelease == null) return -1;
+        return StringComparer.OrdinalIgnoreCase.Compare(Prerelease, other.Prerelease);
+    }
+}

--- a/src/MauiSherpa.Workloads/Models/SdkVersion.cs
+++ b/src/MauiSherpa.Workloads/Models/SdkVersion.cs
@@ -29,7 +29,9 @@ public record SdkVersion
     /// The feature band (e.g., "9.0.100" for SDK "9.0.105").
     /// The feature band is the SDK version with the last two digits zeroed out.
     /// </summary>
-    public string FeatureBand => $"{Major}.{Minor}.{(Patch / 100) * 100}";
+    public SdkFeatureBand FeatureBandValue => new(Version);
+
+    public string FeatureBand => FeatureBandValue.ToString();
 
     /// <summary>
     /// The runtime version this SDK targets (e.g., "9.0" for SDK "9.0.100").

--- a/src/MauiSherpa.Workloads/Models/WorkloadSet.cs
+++ b/src/MauiSherpa.Workloads/Models/WorkloadSet.cs
@@ -3,7 +3,7 @@ using System.Text.Json.Serialization;
 namespace MauiSherpa.Workloads.Models;
 
 /// <summary>
-/// Represents a workload set that maps workload IDs to their manifest versions.
+/// Represents a workload set that maps manifest IDs to their manifest versions.
 /// This corresponds to the contents of a Microsoft.NET.Workloads.{feature-band} package.
 /// </summary>
 public record WorkloadSet
@@ -19,9 +19,17 @@ public record WorkloadSet
     public required string FeatureBand { get; init; }
 
     /// <summary>
-    /// The workload manifest entries mapping workload IDs to versions.
+    /// The workload manifest entries mapping manifest IDs to versions.
     /// </summary>
-    public IReadOnlyDictionary<string, WorkloadSetEntry> Workloads { get; init; } = new Dictionary<string, WorkloadSetEntry>();
+    public IReadOnlyDictionary<string, WorkloadSetEntry> ManifestEntries { get; init; } = new Dictionary<string, WorkloadSetEntry>();
+
+    /// <summary>Compatibility alias for older callers.</summary>
+    [Obsolete("Workload sets contain manifest entries. Use ManifestEntries.")]
+    public IReadOnlyDictionary<string, WorkloadSetEntry> Workloads
+    {
+        get => ManifestEntries;
+        init => ManifestEntries = value;
+    }
 }
 
 /// <summary>

--- a/src/MauiSherpa.Workloads/Services/DotnetSdkPresentationBuilder.cs
+++ b/src/MauiSherpa.Workloads/Services/DotnetSdkPresentationBuilder.cs
@@ -1,0 +1,369 @@
+using System.Text.RegularExpressions;
+using MauiSherpa.Workloads.Models;
+using NuGet.Versioning;
+
+namespace MauiSherpa.Workloads.Services;
+
+public static partial class DotnetSdkPresentationBuilder
+{
+    public static DotnetSdkManagerSummary Build(
+        DotnetUpListResult? list,
+        IReadOnlyList<DotnetWorkloadInventory>? workloadInventories = null,
+        IReadOnlyList<DotnetUpdatePreview>? updatePreviews = null,
+        GlobalJsonResolution? projectResolution = null)
+    {
+        var safeList = list ?? new DotnetUpListResult();
+        var safeInventories = workloadInventories ?? [];
+        var safePreviews = updatePreviews ?? [];
+
+        return new DotnetSdkManagerSummary
+        {
+            InstalledGroups = BuildInstalledGroups(safeList.Installations, safeInventories),
+            TrackedSdkChannels = BuildTrackedSdkChannels(safeList.InstallSpecs),
+            TrackedNonSdkSpecs = BuildTrackedNonSdkSpecs(safeList.InstallSpecs),
+            Updates = BuildUpdateSummary(updatePreviews),
+            ProjectWorkloads = BuildProjectWorkloads(projectResolution, safeInventories)
+        };
+    }
+
+    public static IReadOnlyList<DotnetWorkloadInventory> FilterProjectWorkloadInventories(
+        GlobalJsonResolution? projectResolution,
+        IReadOnlyList<DotnetWorkloadInventory>? workloadInventories)
+    {
+        if (projectResolution?.InstalledVersion is not { Length: > 0 } installedVersion ||
+            workloadInventories == null ||
+            !SdkFeatureBand.TryParse(installedVersion, out var featureBand))
+        {
+            return [];
+        }
+
+        return workloadInventories
+            .Where(inventory => inventory.Target.FeatureBand.Equals(featureBand))
+            .Where(inventory =>
+                string.IsNullOrWhiteSpace(projectResolution.InstalledSdkInstallRoot) ||
+                string.Equals(
+                    inventory.Target.InstallRoot,
+                    projectResolution.InstalledSdkInstallRoot,
+                    StringComparison.OrdinalIgnoreCase))
+            .Where(inventory =>
+                string.IsNullOrWhiteSpace(projectResolution.InstalledSdkArchitecture) ||
+                string.Equals(
+                    inventory.Target.Architecture,
+                    projectResolution.InstalledSdkArchitecture,
+                    StringComparison.OrdinalIgnoreCase))
+            .OrderByDescending(inventory => inventory.Target.FeatureBand)
+            .ThenBy(inventory => inventory.Target.InstallRoot, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(inventory => inventory.Target.Architecture, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    public static DotnetMajorMinorGroupSummary? BuildProjectInstalledGroup(
+        GlobalJsonResolution? projectResolution,
+        IReadOnlyList<DotnetUpInstallation>? installations,
+        IReadOnlyList<DotnetWorkloadInventory>? workloadInventories)
+    {
+        if (projectResolution?.InstalledVersion is not { Length: > 0 } installedVersion)
+            return null;
+
+        var safeInstallations = installations ?? [];
+        var sdkTargets = safeInstallations
+            .Where(installation =>
+                installation.Component == DotnetUpComponent.Sdk &&
+                VersionsEqual(installation.Version, installedVersion))
+            .Where(installation =>
+                string.IsNullOrWhiteSpace(projectResolution.InstalledSdkInstallRoot) ||
+                string.Equals(
+                    installation.InstallRoot,
+                    projectResolution.InstalledSdkInstallRoot,
+                    StringComparison.OrdinalIgnoreCase))
+            .Where(installation =>
+                string.IsNullOrWhiteSpace(projectResolution.InstalledSdkArchitecture) ||
+                string.Equals(
+                    installation.Architecture,
+                    projectResolution.InstalledSdkArchitecture,
+                    StringComparison.OrdinalIgnoreCase))
+            .Select(installation => (installation.InstallRoot, installation.Architecture))
+            .Distinct(TargetKeyComparer.Instance)
+            .ToList();
+
+        if (sdkTargets.Count != 1)
+            return null;
+
+        var target = sdkTargets[0];
+        var majorMinor = ToMajorMinor(installedVersion);
+        var matchingInstallations = safeInstallations
+            .Where(installation =>
+                string.Equals(
+                    installation.InstallRoot,
+                    target.InstallRoot,
+                    StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(
+                    installation.Architecture,
+                    target.Architecture,
+                    StringComparison.OrdinalIgnoreCase))
+            .Where(installation => string.Equals(
+                ToMajorMinor(installation.Version),
+                majorMinor,
+                StringComparison.OrdinalIgnoreCase))
+            .Where(installation =>
+                installation.Component != DotnetUpComponent.Sdk ||
+                VersionsEqual(installation.Version, installedVersion))
+            .OrderBy(installation => ComponentSortOrder(installation.Component))
+            .ThenByDescending(installation => installation.Version, VersionStringComparer.Instance)
+            .ToList();
+
+        var matchingInventories = SdkFeatureBand.TryParse(installedVersion, out var featureBand)
+            ? (workloadInventories ?? [])
+                .Where(inventory => inventory.Target.FeatureBand.Equals(featureBand))
+                .Where(inventory => string.Equals(
+                    inventory.Target.InstallRoot,
+                    target.InstallRoot,
+                    StringComparison.OrdinalIgnoreCase))
+                .Where(inventory => string.Equals(
+                    inventory.Target.Architecture,
+                    target.Architecture,
+                    StringComparison.OrdinalIgnoreCase))
+                .OrderByDescending(
+                    inventory => inventory.Target.RepresentativeSdkVersion,
+                    VersionStringComparer.Instance)
+                .ToList()
+            : [];
+
+        return new DotnetMajorMinorGroupSummary
+        {
+            MajorMinor = majorMinor,
+            NewestSdkVersion = installedVersion,
+            Counts = CountComponents(matchingInstallations),
+            HasInvalidComponents = matchingInstallations.Any(installation => !installation.IsValid),
+            WorkloadFeatureBandCount = matchingInventories
+                .Select(inventory => inventory.Target.FeatureBand)
+                .Distinct()
+                .Count(),
+            Installations = matchingInstallations,
+            WorkloadInventories = matchingInventories
+        };
+    }
+
+    private static IReadOnlyList<DotnetMajorMinorGroupSummary> BuildInstalledGroups(
+        IReadOnlyList<DotnetUpInstallation> installations,
+        IReadOnlyList<DotnetWorkloadInventory> workloadInventories)
+    {
+        return installations
+            .GroupBy(installation => ToMajorMinor(installation.Version), StringComparer.OrdinalIgnoreCase)
+            .OrderByDescending(group => ParseMajorMinor(group.Key), MajorMinorSortComparer.Instance)
+            .ThenByDescending(group => group.Key, StringComparer.OrdinalIgnoreCase)
+            .Select(group =>
+            {
+                var orderedInstallations = group
+                    .OrderBy(installation => ComponentSortOrder(installation.Component))
+                    .ThenByDescending(installation => installation.Version, VersionStringComparer.Instance)
+                    .ToList();
+
+                var matchingWorkloads = workloadInventories
+                    .Where(inventory => string.Equals(
+                        inventory.Target.RuntimeVersion,
+                        group.Key,
+                        StringComparison.OrdinalIgnoreCase))
+                    .OrderByDescending(inventory => inventory.Target.FeatureBand)
+                    .ThenBy(inventory => inventory.Target.InstallRoot, StringComparer.OrdinalIgnoreCase)
+                    .ThenBy(inventory => inventory.Target.Architecture, StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+
+                return new DotnetMajorMinorGroupSummary
+                {
+                    MajorMinor = group.Key,
+                    NewestSdkVersion = orderedInstallations
+                        .Where(installation => installation.Component == DotnetUpComponent.Sdk)
+                        .Select(installation => installation.Version)
+                        .FirstOrDefault(),
+                    Counts = CountComponents(orderedInstallations),
+                    HasInvalidComponents = orderedInstallations.Any(installation => !installation.IsValid),
+                    WorkloadFeatureBandCount = matchingWorkloads
+                        .Select(inventory => inventory.Target.FeatureBand)
+                        .Distinct()
+                        .Count(),
+                    Installations = orderedInstallations,
+                    WorkloadInventories = matchingWorkloads
+                };
+            })
+            .ToList();
+    }
+
+    private static IReadOnlyList<DotnetTrackedSdkChannelSummary> BuildTrackedSdkChannels(
+        IReadOnlyList<DotnetUpInstallSpec> installSpecs)
+    {
+        return installSpecs
+            .Where(spec => spec.Component == DotnetUpComponent.Sdk)
+            .Select(spec => new DotnetTrackedSdkChannelSummary
+            {
+                Channel = spec.VersionOrChannel,
+                Source = spec.Source,
+                GlobalJsonPath = spec.GlobalJsonPath,
+                InstallRoot = spec.InstallRoot,
+                Architecture = spec.Architecture,
+                IsPinned = IsPinnedVersion(spec.VersionOrChannel)
+            })
+            .ToList();
+    }
+
+    private static IReadOnlyList<DotnetTrackedNonSdkSpecSummary> BuildTrackedNonSdkSpecs(
+        IReadOnlyList<DotnetUpInstallSpec> installSpecs)
+    {
+        return installSpecs
+            .Where(spec => spec.Component != DotnetUpComponent.Sdk)
+            .OrderBy(spec => ComponentSortOrder(spec.Component))
+            .ThenByDescending(spec => spec.VersionOrChannel, StringComparer.OrdinalIgnoreCase)
+            .Select(spec => new DotnetTrackedNonSdkSpecSummary
+            {
+                Component = spec.Component,
+                VersionOrChannel = spec.VersionOrChannel,
+                Source = spec.Source,
+                GlobalJsonPath = spec.GlobalJsonPath,
+                InstallRoot = spec.InstallRoot,
+                Architecture = spec.Architecture,
+                IsPinned = IsPinnedVersion(spec.VersionOrChannel)
+            })
+            .ToList();
+    }
+
+    private static DotnetUpdateAggregateSummary BuildUpdateSummary(
+        IReadOnlyList<DotnetUpdatePreview>? updatePreviews)
+    {
+        if (updatePreviews == null)
+            return new DotnetUpdateAggregateSummary();
+
+        var available = updatePreviews.Where(preview => preview.UpdateAvailable).ToList();
+        var unresolvedCount = updatePreviews.Count(preview => !preview.IsPinned && preview.AvailableVersion == null);
+
+        return new DotnetUpdateAggregateSummary
+        {
+            IsChecked = true,
+            PreviewCount = updatePreviews.Count,
+            AvailableUpdateCount = available.Count,
+            SdkUpdateCount = available.Count(preview => preview.Component == DotnetUpComponent.Sdk),
+            RuntimeUpdateCount = available.Count(preview => preview.Component != DotnetUpComponent.Sdk),
+            UnresolvedCount = unresolvedCount,
+            Previews = updatePreviews
+        };
+    }
+
+    private static DotnetProjectWorkloadMatchSummary? BuildProjectWorkloads(
+        GlobalJsonResolution? projectResolution,
+        IReadOnlyList<DotnetWorkloadInventory> workloadInventories)
+    {
+        if (projectResolution?.InstalledVersion is not { Length: > 0 } installedVersion ||
+            !SdkFeatureBand.TryParse(installedVersion, out var featureBand))
+        {
+            return null;
+        }
+
+        var matchingInventories = FilterProjectWorkloadInventories(projectResolution, workloadInventories);
+
+        return new DotnetProjectWorkloadMatchSummary
+        {
+            InstalledVersion = installedVersion,
+            FeatureBand = featureBand,
+            InstallRoot = projectResolution.InstalledSdkInstallRoot,
+            Architecture = projectResolution.InstalledSdkArchitecture,
+            MatchingInventories = matchingInventories,
+            SelectedInventory = matchingInventories.Count == 1 ? matchingInventories[0] : null
+        };
+    }
+
+    private static DotnetInstalledComponentCounts CountComponents(IReadOnlyList<DotnetUpInstallation> installations)
+    {
+        return new DotnetInstalledComponentCounts
+        {
+            Total = installations.Count,
+            Sdk = installations.Count(installation => installation.Component == DotnetUpComponent.Sdk),
+            Runtime = installations.Count(installation => installation.Component == DotnetUpComponent.Runtime),
+            AspNetCore = installations.Count(installation => installation.Component == DotnetUpComponent.AspNetCore),
+            WindowsDesktop = installations.Count(installation => installation.Component == DotnetUpComponent.WindowsDesktop),
+            Unknown = installations.Count(installation => installation.Component == DotnetUpComponent.Unknown)
+        };
+    }
+
+    private static string ToMajorMinor(string version)
+    {
+        if (NuGetVersion.TryParse(version, out var parsed))
+            return $"{parsed.Major}.{parsed.Minor}";
+
+        var parts = version.Split('.');
+        return parts.Length >= 2 ? $"{parts[0]}.{parts[1]}" : version;
+    }
+
+    private static (int Major, int Minor) ParseMajorMinor(string majorMinor)
+    {
+        var parts = majorMinor.Split('.');
+        return (
+            parts.Length > 0 && int.TryParse(parts[0], out var major) ? major : -1,
+            parts.Length > 1 && int.TryParse(parts[1], out var minor) ? minor : -1);
+    }
+
+    private static int ComponentSortOrder(DotnetUpComponent component) => component switch
+    {
+        DotnetUpComponent.Sdk => 0,
+        DotnetUpComponent.Runtime => 1,
+        DotnetUpComponent.AspNetCore => 2,
+        DotnetUpComponent.WindowsDesktop => 3,
+        _ => 4
+    };
+
+    private static bool IsPinnedVersion(string versionOrChannel) => ExactVersionPattern().IsMatch(versionOrChannel.Trim());
+
+    private static bool VersionsEqual(string left, string right) =>
+        NuGetVersion.TryParse(left, out var leftVersion) &&
+        NuGetVersion.TryParse(right, out var rightVersion)
+            ? leftVersion == rightVersion
+            : string.Equals(left, right, StringComparison.OrdinalIgnoreCase);
+
+    private sealed class MajorMinorSortComparer : IComparer<(int Major, int Minor)>
+    {
+        public static MajorMinorSortComparer Instance { get; } = new();
+
+        public int Compare((int Major, int Minor) x, (int Major, int Minor) y)
+        {
+            var major = x.Major.CompareTo(y.Major);
+            return major != 0 ? major : x.Minor.CompareTo(y.Minor);
+        }
+    }
+
+    private sealed class VersionStringComparer : IComparer<string>
+    {
+        public static VersionStringComparer Instance { get; } = new();
+
+        public int Compare(string? x, string? y)
+        {
+            if (ReferenceEquals(x, y))
+                return 0;
+            if (x is null)
+                return -1;
+            if (y is null)
+                return 1;
+
+            if (NuGetVersion.TryParse(x, out var left) && NuGetVersion.TryParse(y, out var right))
+                return left.CompareTo(right);
+
+            return StringComparer.OrdinalIgnoreCase.Compare(x, y);
+        }
+    }
+
+    private sealed class TargetKeyComparer : IEqualityComparer<(string InstallRoot, string Architecture)>
+    {
+        public static TargetKeyComparer Instance { get; } = new();
+
+        public bool Equals(
+            (string InstallRoot, string Architecture) x,
+            (string InstallRoot, string Architecture) y) =>
+            string.Equals(x.InstallRoot, y.InstallRoot, StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(x.Architecture, y.Architecture, StringComparison.OrdinalIgnoreCase);
+
+        public int GetHashCode((string InstallRoot, string Architecture) obj) =>
+            HashCode.Combine(
+                StringComparer.OrdinalIgnoreCase.GetHashCode(obj.InstallRoot),
+                StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Architecture));
+    }
+
+    [GeneratedRegex(@"^\d+\.\d+\.\d+(-[0-9A-Za-z.]+)?$", RegexOptions.Compiled)]
+    private static partial Regex ExactVersionPattern();
+}

--- a/src/MauiSherpa.Workloads/Services/DotnetUpArguments.cs
+++ b/src/MauiSherpa.Workloads/Services/DotnetUpArguments.cs
@@ -1,0 +1,124 @@
+using MauiSherpa.Workloads.Models;
+
+namespace MauiSherpa.Workloads.Services;
+
+/// <summary>
+/// Builds dotnetup command argument lists. Kept pure (no process execution) so the exact
+/// flags Sherpa passes are unit-testable and verified against the real CLI surface.
+///
+/// Verified against dotnetup v0.1.4-preview.6.26323.4:
+/// machine-readable listing is <c>list --format Json</c> (NOT <c>--json</c>); mutating
+/// commands are non-interactive by default; Terminal Mode is selected by
+/// <c>--set-default-install</c>; <c>--no-progress</c> suppresses spinners for captured output.
+/// </summary>
+public static class DotnetUpArguments
+{
+    /// <summary><c>dotnetup list --format Json</c></summary>
+    public static IReadOnlyList<string> List(bool noVerify = false)
+    {
+        var args = new List<string> { "list", "--format", "Json" };
+        if (noVerify)
+            args.Add("--no-verify");
+        return args;
+    }
+
+    /// <summary><c>dotnetup --info</c></summary>
+    public static IReadOnlyList<string> Info() => new[] { "--info" };
+
+    /// <summary>
+    /// <c>dotnetup sdk install [&lt;channel&gt;] [--set-default-install] [--no-progress]</c>.
+    /// When <paramref name="setDefaultInstall"/> is true this is the Terminal-Mode path:
+    /// it installs and updates the user's PATH/DOTNET_ROOT in one step.
+    /// </summary>
+    public static IReadOnlyList<string> SdkInstall(
+        string? channel = null,
+        bool setDefaultInstall = false,
+        bool updateGlobalJson = false,
+        bool noProgress = true)
+    {
+        var args = new List<string> { "sdk", "install" };
+        if (!string.IsNullOrWhiteSpace(channel))
+            args.Add(channel);
+        if (setDefaultInstall)
+            args.Add("--set-default-install");
+        if (updateGlobalJson)
+            args.Add("--update-global-json");
+        if (noProgress)
+            args.Add("--no-progress");
+        return args;
+    }
+
+    /// <summary><c>dotnetup sdk update [--update-global-json] [--no-progress]</c></summary>
+    public static IReadOnlyList<string> SdkUpdate(bool updateGlobalJson = false, bool noProgress = true)
+    {
+        var args = new List<string> { "sdk", "update" };
+        if (updateGlobalJson)
+            args.Add("--update-global-json");
+        if (noProgress)
+            args.Add("--no-progress");
+        return args;
+    }
+
+    /// <summary><c>dotnetup sdk uninstall &lt;channel&gt; [--source &lt;All|Explicit|GlobalJson&gt;]</c></summary>
+    public static IReadOnlyList<string> SdkUninstall(string channel, DotnetUpInstallSource? source = null)
+    {
+        if (string.IsNullOrWhiteSpace(channel))
+            throw new ArgumentException("A channel is required to uninstall.", nameof(channel));
+
+        var args = new List<string> { "sdk", "uninstall", channel };
+        if (source is { } s && s != DotnetUpInstallSource.Unknown)
+        {
+            args.Add("--source");
+            args.Add(s.ToString());
+        }
+        return args;
+    }
+
+    /// <summary>
+    /// <c>dotnetup runtime install [&lt;spec&gt;] [--no-progress]</c>.
+    /// A spec is a channel (e.g. "10.0") or "component@version" (component: runtime, aspnetcore).
+    /// </summary>
+    public static IReadOnlyList<string> RuntimeInstall(string? spec = null, bool noProgress = true)
+    {
+        var args = new List<string> { "runtime", "install" };
+        if (!string.IsNullOrWhiteSpace(spec))
+            args.Add(spec);
+        if (noProgress)
+            args.Add("--no-progress");
+        return args;
+    }
+
+    /// <summary><c>dotnetup runtime update [--no-progress]</c></summary>
+    public static IReadOnlyList<string> RuntimeUpdate(bool noProgress = true)
+    {
+        var args = new List<string> { "runtime", "update" };
+        if (noProgress)
+            args.Add("--no-progress");
+        return args;
+    }
+
+    /// <summary><c>dotnetup runtime uninstall &lt;spec&gt;</c></summary>
+    public static IReadOnlyList<string> RuntimeUninstall(string spec)
+    {
+        if (string.IsNullOrWhiteSpace(spec))
+            throw new ArgumentException("A runtime spec is required to uninstall.", nameof(spec));
+        return new List<string> { "runtime", "uninstall", spec };
+    }
+
+    /// <summary><c>dotnetup update [--no-progress]</c> — updates every tracked component.</summary>
+    public static IReadOnlyList<string> UpdateAll(bool noProgress = true)
+    {
+        var args = new List<string> { "update" };
+        if (noProgress)
+            args.Add("--no-progress");
+        return args;
+    }
+
+    /// <summary><c>dotnetup print-env-script --shell &lt;shell&gt;</c></summary>
+    public static IReadOnlyList<string> PrintEnvScript(string shell)
+    {
+        if (string.IsNullOrWhiteSpace(shell))
+            throw new ArgumentException("A shell is required.", nameof(shell));
+        return new List<string> { "print-env-script", "--shell", shell };
+    }
+}

--- a/src/MauiSherpa.Workloads/Services/DotnetUpDownloader.cs
+++ b/src/MauiSherpa.Workloads/Services/DotnetUpDownloader.cs
@@ -1,4 +1,5 @@
 using System.Security.Cryptography;
+using MauiSherpa.Workloads.Models;
 
 namespace MauiSherpa.Workloads.Services;
 
@@ -42,7 +43,7 @@ public sealed class DotnetUpDownloader
             Directory.CreateDirectory(dir);
 
         progress?.Report($"Downloading checksum from {checksumUrl}…");
-        var expectedHash = await DownloadChecksumAsync(checksumUrl, cancellationToken).ConfigureAwait(false);
+        var expectedHash = (await DownloadChecksumAsync(checksumUrl, cancellationToken).ConfigureAwait(false)).Checksum;
 
         progress?.Report($"Downloading dotnetup ({rid}) from {binaryUrl}…");
         var tempPath = destinationPath + ".download";
@@ -88,10 +89,52 @@ public sealed class DotnetUpDownloader
         }
     }
 
-    private async Task<string> DownloadChecksumAsync(string checksumUrl, CancellationToken ct)
+    public async Task<DotnetUpPublishedArtifact> GetPublishedArtifactAsync(
+        string rid,
+        string? quality = null,
+        CancellationToken cancellationToken = default)
     {
-        var raw = await _httpClient.GetStringAsync(checksumUrl, ct).ConfigureAwait(false);
-        return NormalizeChecksum(raw);
+        if (!DotnetUpRuntimeIdentifier.IsSupportedRid(rid))
+            throw new PlatformNotSupportedException($"dotnetup does not publish a binary for RID '{rid}'.");
+
+        var checksumUrl = DotnetUpRuntimeIdentifier.GetChecksumUrl(rid, quality);
+        var (checksum, effectiveUri) = await DownloadChecksumAsync(
+            checksumUrl, cancellationToken).ConfigureAwait(false);
+        var version = ExtractPublishedVersion(effectiveUri)
+            ?? throw new InvalidOperationException(
+                $"The published dotnetup version could not be determined from '{effectiveUri}'.");
+
+        return new DotnetUpPublishedArtifact
+        {
+            Version = version,
+            Sha512 = checksum
+        };
+    }
+
+    public static string? ExtractPublishedVersion(Uri? artifactUri)
+    {
+        if (artifactUri is null)
+            return null;
+
+        var segments = artifactUri.AbsolutePath.Split(
+            '/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (segments.Length < 3 ||
+            !segments[^1].StartsWith("dotnetup-", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        return Uri.UnescapeDataString(segments[^2]);
+    }
+
+    private async Task<(string Checksum, Uri? EffectiveUri)> DownloadChecksumAsync(
+        string checksumUrl,
+        CancellationToken ct)
+    {
+        using var response = await _httpClient.GetAsync(checksumUrl, ct).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+        var raw = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        return (NormalizeChecksum(raw), response.RequestMessage?.RequestUri);
     }
 
     /// <summary>

--- a/src/MauiSherpa.Workloads/Services/DotnetUpDownloader.cs
+++ b/src/MauiSherpa.Workloads/Services/DotnetUpDownloader.cs
@@ -1,0 +1,140 @@
+using System.Security.Cryptography;
+
+namespace MauiSherpa.Workloads.Services;
+
+/// <summary>
+/// Downloads the dotnetup binary from aka.ms and verifies its SHA-512 checksum,
+/// mirroring the official get-dotnetup install scripts (download binary + companion
+/// <c>.sha512</c>, compare, then mark executable).
+///
+/// The download itself is driven through an injected <see cref="HttpClient"/> so the
+/// verify/compare logic stays unit-testable with a fake handler.
+/// </summary>
+public sealed class DotnetUpDownloader
+{
+    private readonly HttpClient _httpClient;
+
+    public DotnetUpDownloader(HttpClient httpClient)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+    }
+
+    /// <summary>
+    /// Downloads the dotnetup binary for <paramref name="rid"/> to <paramref name="destinationPath"/>,
+    /// verifies its SHA-512 against the published checksum, and marks it executable on Unix.
+    /// Throws <see cref="InvalidOperationException"/> if the checksum does not match.
+    /// </summary>
+    public async Task DownloadAndVerifyAsync(
+        string rid,
+        string destinationPath,
+        string? quality = null,
+        IProgress<string>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (!DotnetUpRuntimeIdentifier.IsSupportedRid(rid))
+            throw new PlatformNotSupportedException($"dotnetup does not publish a binary for RID '{rid}'.");
+
+        var binaryUrl = DotnetUpRuntimeIdentifier.GetDownloadUrl(rid, quality);
+        var checksumUrl = DotnetUpRuntimeIdentifier.GetChecksumUrl(rid, quality);
+
+        var dir = Path.GetDirectoryName(destinationPath);
+        if (!string.IsNullOrEmpty(dir))
+            Directory.CreateDirectory(dir);
+
+        progress?.Report($"Downloading checksum from {checksumUrl}…");
+        var expectedHash = await DownloadChecksumAsync(checksumUrl, cancellationToken).ConfigureAwait(false);
+
+        progress?.Report($"Downloading dotnetup ({rid}) from {binaryUrl}…");
+        var tempPath = destinationPath + ".download";
+        try
+        {
+            string actualHash;
+            using (var response = await _httpClient.GetAsync(
+                       binaryUrl, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false))
+            {
+                response.EnsureSuccessStatusCode();
+                await using var httpStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+                await using var fileStream = new FileStream(
+                    tempPath, FileMode.Create, FileAccess.Write, FileShare.None);
+                await httpStream.CopyToAsync(fileStream, cancellationToken).ConfigureAwait(false);
+            }
+
+            progress?.Report("Verifying SHA-512 checksum…");
+            await using (var verifyStream = new FileStream(tempPath, FileMode.Open, FileAccess.Read, FileShare.Read))
+            {
+                actualHash = await ComputeSha512Async(verifyStream, cancellationToken).ConfigureAwait(false);
+            }
+
+            if (!HashesEqual(expectedHash, actualHash))
+            {
+                throw new InvalidOperationException(
+                    "dotnetup download failed checksum verification. " +
+                    $"Expected SHA-512 {expectedHash} but got {actualHash}.");
+            }
+
+            if (File.Exists(destinationPath))
+                File.Delete(destinationPath);
+            File.Move(tempPath, destinationPath);
+
+            MarkExecutable(destinationPath);
+            progress?.Report("dotnetup downloaded and verified.");
+        }
+        finally
+        {
+            if (File.Exists(tempPath))
+            {
+                try { File.Delete(tempPath); } catch { /* best effort */ }
+            }
+        }
+    }
+
+    private async Task<string> DownloadChecksumAsync(string checksumUrl, CancellationToken ct)
+    {
+        var raw = await _httpClient.GetStringAsync(checksumUrl, ct).ConfigureAwait(false);
+        return NormalizeChecksum(raw);
+    }
+
+    /// <summary>
+    /// Extracts the hex digest from a checksum file. The published file may contain just the
+    /// hash, or "hash  filename" (sha512sum format).
+    /// </summary>
+    public static string NormalizeChecksum(string raw)
+    {
+        var firstToken = raw.Trim().Split(
+            new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+            .FirstOrDefault() ?? string.Empty;
+        return firstToken.Trim();
+    }
+
+    /// <summary>Computes the lowercase hex SHA-512 of a stream.</summary>
+    public static async Task<string> ComputeSha512Async(Stream stream, CancellationToken ct = default)
+    {
+        using var sha = SHA512.Create();
+        var hashBytes = await sha.ComputeHashAsync(stream, ct).ConfigureAwait(false);
+        return Convert.ToHexString(hashBytes).ToLowerInvariant();
+    }
+
+    /// <summary>Case-insensitive comparison of two hex checksum strings.</summary>
+    public static bool HashesEqual(string expected, string actual) =>
+        !string.IsNullOrEmpty(expected) &&
+        !string.IsNullOrEmpty(actual) &&
+        string.Equals(expected.Trim(), actual.Trim(), StringComparison.OrdinalIgnoreCase);
+
+    private static void MarkExecutable(string path)
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        try
+        {
+            var mode = File.GetUnixFileMode(path);
+            File.SetUnixFileMode(
+                path,
+                mode | UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute);
+        }
+        catch
+        {
+            // Best effort; the caller will surface a clear error if exec fails.
+        }
+    }
+}

--- a/src/MauiSherpa.Workloads/Services/DotnetUpParser.cs
+++ b/src/MauiSherpa.Workloads/Services/DotnetUpParser.cs
@@ -1,0 +1,150 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using MauiSherpa.Workloads.Models;
+
+namespace MauiSherpa.Workloads.Services;
+
+/// <summary>
+/// Parses the machine-readable output of the dotnetup CLI:
+/// <list type="bullet">
+///   <item><c>dotnetup list --format Json</c> → <see cref="DotnetUpListResult"/></item>
+///   <item><c>dotnetup --info</c> (text) → <see cref="DotnetUpToolInfo"/></item>
+/// </list>
+/// These helpers are pure so they can be unit-tested against captured fixtures.
+/// </summary>
+public static class DotnetUpParser
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    /// <summary>
+    /// Parses the JSON emitted by <c>dotnetup list --format Json</c>.
+    /// Tolerates missing arrays and unknown component/source values.
+    /// </summary>
+    public static DotnetUpListResult ParseList(string json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+            return new DotnetUpListResult();
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        var specs = new List<DotnetUpInstallSpec>();
+        if (root.TryGetProperty("installSpecs", out var specsEl) && specsEl.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var el in specsEl.EnumerateArray())
+            {
+                var componentRaw = GetString(el, "component") ?? string.Empty;
+                specs.Add(new DotnetUpInstallSpec
+                {
+                    Component = ParseComponent(componentRaw),
+                    ComponentRaw = componentRaw,
+                    VersionOrChannel = GetString(el, "versionOrChannel") ?? string.Empty,
+                    Source = ParseSource(GetString(el, "source")),
+                    GlobalJsonPath = GetString(el, "globalJsonPath"),
+                    InstallRoot = GetString(el, "installRoot") ?? string.Empty,
+                    Architecture = GetString(el, "architecture")
+                });
+            }
+        }
+
+        var installations = new List<DotnetUpInstallation>();
+        if (root.TryGetProperty("installations", out var instEl) && instEl.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var el in instEl.EnumerateArray())
+            {
+                var componentRaw = GetString(el, "component") ?? string.Empty;
+                installations.Add(new DotnetUpInstallation
+                {
+                    Component = ParseComponent(componentRaw),
+                    ComponentRaw = componentRaw,
+                    Version = GetString(el, "version") ?? string.Empty,
+                    InstallRoot = GetString(el, "installRoot") ?? string.Empty,
+                    Architecture = GetString(el, "architecture"),
+                    IsValid = GetBool(el, "isValid") ?? true,
+                    FrameworkName = GetString(el, "frameworkName")
+                });
+            }
+        }
+
+        return new DotnetUpListResult
+        {
+            InstallSpecs = specs,
+            Installations = installations
+        };
+    }
+
+    /// <summary>
+    /// Parses the text emitted by <c>dotnetup --info</c> to extract tool diagnostics.
+    /// Returns null when the version line cannot be located.
+    /// </summary>
+    public static DotnetUpToolInfo? ParseInfo(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            return null;
+
+        var version = MatchField(text, "Version");
+        if (string.IsNullOrEmpty(version))
+            return null;
+
+        return new DotnetUpToolInfo
+        {
+            Version = version!,
+            Commit = MatchField(text, "Commit"),
+            Architecture = MatchField(text, "Architecture"),
+            Rid = MatchField(text, "RID")
+        };
+    }
+
+    /// <summary>
+    /// Returns the set of distinct .NET SDK versions managed by dotnetup, parsed from a list result.
+    /// </summary>
+    public static IReadOnlyList<string> GetManagedSdkVersions(DotnetUpListResult list) =>
+        list.Installations
+            .Where(i => i.Component == DotnetUpComponent.Sdk && i.IsValid)
+            .Select(i => i.Version)
+            .Where(v => !string.IsNullOrEmpty(v))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+    private static string? MatchField(string text, string label)
+    {
+        // Lines look like "  Version:      0.1.4-preview.6.26323.4" (value may have trailing spaces).
+        var m = Regex.Match(
+            text,
+            $@"^\s*{Regex.Escape(label)}\s*:\s*(?<val>\S.*?)\s*$",
+            RegexOptions.Multiline);
+        return m.Success ? m.Groups["val"].Value.Trim() : null;
+    }
+
+    private static DotnetUpComponent ParseComponent(string raw) =>
+        raw.Trim().ToLowerInvariant() switch
+        {
+            "sdk" => DotnetUpComponent.Sdk,
+            "runtime" => DotnetUpComponent.Runtime,
+            "aspnetcore" => DotnetUpComponent.AspNetCore,
+            "windowsdesktop" => DotnetUpComponent.WindowsDesktop,
+            _ => DotnetUpComponent.Unknown
+        };
+
+    private static DotnetUpInstallSource ParseSource(string? raw) =>
+        (raw?.Trim().ToLowerInvariant()) switch
+        {
+            "explicit" => DotnetUpInstallSource.Explicit,
+            "globaljson" => DotnetUpInstallSource.GlobalJson,
+            "all" => DotnetUpInstallSource.All,
+            _ => DotnetUpInstallSource.Unknown
+        };
+
+    private static string? GetString(JsonElement el, string name) =>
+        el.TryGetProperty(name, out var p) && p.ValueKind == JsonValueKind.String
+            ? p.GetString()
+            : null;
+
+    private static bool? GetBool(JsonElement el, string name) =>
+        el.TryGetProperty(name, out var p) && (p.ValueKind == JsonValueKind.True || p.ValueKind == JsonValueKind.False)
+            ? p.GetBoolean()
+            : null;
+}

--- a/src/MauiSherpa.Workloads/Services/DotnetUpRuntimeIdentifier.cs
+++ b/src/MauiSherpa.Workloads/Services/DotnetUpRuntimeIdentifier.cs
@@ -1,0 +1,118 @@
+using System.Runtime.InteropServices;
+
+namespace MauiSherpa.Workloads.Services;
+
+/// <summary>
+/// Resolves dotnetup runtime identifiers (RIDs) and builds the public aka.ms
+/// download URLs used to acquire the dotnetup binary.
+///
+/// Mirrors the detection logic in the official get-dotnetup.sh / get-dotnetup.ps1 scripts:
+/// downloads come from <c>https://aka.ms/dotnet/dotnetup/{quality}/dotnetup-{rid}[.exe]</c>
+/// with a companion <c>.sha512</c> checksum file.
+/// </summary>
+public static class DotnetUpRuntimeIdentifier
+{
+    /// <summary>The default build quality. Only "daily" is published today.</summary>
+    public const string DefaultQuality = "daily";
+
+    private const string BaseUrl = "https://aka.ms/dotnet/dotnetup";
+
+    /// <summary>The set of RIDs for which dotnetup binaries are published.</summary>
+    public static readonly IReadOnlyList<string> SupportedRids = new[]
+    {
+        "win-x64", "win-arm64",
+        "linux-x64", "linux-arm64",
+        "linux-musl-x64", "linux-musl-arm64",
+        "osx-x64", "osx-arm64"
+    };
+
+    /// <summary>
+    /// Detects the current runtime identifier (e.g. "osx-arm64", "win-x64").
+    /// On macOS this accounts for Rosetta (uname/process arch can report x64 on Apple Silicon).
+    /// </summary>
+    public static string DetectCurrent()
+    {
+        var os = DetectOs();
+        var arch = DetectArch();
+        return $"{os}-{arch}";
+    }
+
+    private static string DetectOs()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return "win";
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || OperatingSystem.IsMacCatalyst())
+            return "osx";
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            return IsMusl() ? "linux-musl" : "linux";
+
+        throw new PlatformNotSupportedException(
+            "dotnetup is only available for Windows, macOS, and Linux.");
+    }
+
+    private static string DetectArch()
+    {
+        var arch = RuntimeInformation.OSArchitecture;
+        return arch switch
+        {
+            Architecture.X64 => "x64",
+            Architecture.Arm64 => "arm64",
+            // Under Rosetta the process can report X64; OSArchitecture already reflects the
+            // emulated value, so the env-var override below covers native arm64 detection.
+            _ => throw new PlatformNotSupportedException(
+                $"Unsupported architecture for dotnetup: {arch}.")
+        };
+    }
+
+    private static bool IsMusl()
+    {
+        // Heuristic mirroring the install script: presence of musl loader in /lib.
+        try
+        {
+            if (Directory.Exists("/lib"))
+            {
+                foreach (var f in Directory.EnumerateFileSystemEntries("/lib", "ld-musl-*"))
+                    return true;
+            }
+        }
+        catch
+        {
+            // Best-effort; default to glibc.
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// True when dotnetup publishes a binary for the given RID.
+    /// </summary>
+    public static bool IsSupportedRid(string rid) =>
+        SupportedRids.Contains(rid, StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// The file name of the published binary for a RID (e.g. "dotnetup-osx-arm64",
+    /// "dotnetup-win-x64.exe").
+    /// </summary>
+    public static string GetDownloadFileName(string rid) =>
+        IsWindowsRid(rid) ? $"dotnetup-{rid}.exe" : $"dotnetup-{rid}";
+
+    /// <summary>
+    /// The local file name the binary is installed as ("dotnetup" or "dotnetup.exe").
+    /// </summary>
+    public static string GetExecutableFileName(string rid) =>
+        IsWindowsRid(rid) ? "dotnetup.exe" : "dotnetup";
+
+    /// <summary>
+    /// The aka.ms URL of the dotnetup binary for a RID and quality.
+    /// </summary>
+    public static string GetDownloadUrl(string rid, string? quality = null) =>
+        $"{BaseUrl}/{quality ?? DefaultQuality}/{GetDownloadFileName(rid)}";
+
+    /// <summary>
+    /// The aka.ms URL of the SHA-512 checksum companion file.
+    /// </summary>
+    public static string GetChecksumUrl(string rid, string? quality = null) =>
+        $"{GetDownloadUrl(rid, quality)}.sha512";
+
+    private static bool IsWindowsRid(string rid) =>
+        rid.StartsWith("win-", StringComparison.OrdinalIgnoreCase);
+}

--- a/src/MauiSherpa.Workloads/Services/DotnetUpdateResolver.cs
+++ b/src/MauiSherpa.Workloads/Services/DotnetUpdateResolver.cs
@@ -1,0 +1,226 @@
+using System.Text.RegularExpressions;
+using MauiSherpa.Workloads.Models;
+using Microsoft.Deployment.DotNet.Releases;
+
+namespace MauiSherpa.Workloads.Services;
+
+/// <summary>
+/// Resolves dotnetup channels (e.g. <c>latest</c>, <c>lts</c>, <c>9.0.3xx</c>, <c>10.0</c>) to their
+/// newest available version using <c>Microsoft.Deployment.DotNet.Releases</c>, and compares against
+/// installed versions to compute an update preview. Performs no installs.
+/// </summary>
+public class DotnetUpdateResolver : IDotnetUpdateResolver
+{
+    private static readonly Regex ExactVersion = new(@"^\d+\.\d+\.\d+(-[0-9A-Za-z.]+)?$", RegexOptions.Compiled);
+    private static readonly Regex FeatureBand = new(@"^(\d+)\.(\d+)\.(\d+)xx$", RegexOptions.Compiled);
+    private static readonly Regex MajorMinor = new(@"^(\d+)\.(\d+)$", RegexOptions.Compiled);
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<DotnetUpdatePreview>> GetUpdatePreviewAsync(
+        DotnetUpListResult list,
+        CancellationToken cancellationToken = default)
+    {
+        var ctx = await ResolveContext.CreateAsync();
+
+        var results = new List<DotnetUpdatePreview>();
+        foreach (var spec in list.InstallSpecs)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var (available, installed, isPinned) = await ResolveCoreAsync(ctx, spec.Component, spec.VersionOrChannel, list);
+            results.Add(new DotnetUpdatePreview
+            {
+                Component = spec.Component,
+                Channel = spec.VersionOrChannel.Trim(),
+                InstalledVersion = installed,
+                AvailableVersion = available,
+                UpdateAvailable = !isPinned && available != null && IsNewer(available, installed),
+                IsPinned = isPinned,
+            });
+        }
+        return results;
+    }
+
+    /// <inheritdoc />
+    public async Task<(string? Available, string? Installed)> ResolveChannelAsync(
+        DotnetUpComponent component,
+        string channel,
+        DotnetUpListResult list,
+        CancellationToken cancellationToken = default)
+    {
+        var ctx = await ResolveContext.CreateAsync();
+        var (available, installed, _) = await ResolveCoreAsync(ctx, component, channel, list);
+        return (available, installed);
+    }
+
+    private static async Task<(string? Available, string? Installed, bool IsPinned)> ResolveCoreAsync(
+        ResolveContext ctx, DotnetUpComponent component, string channelRaw, DotnetUpListResult list)
+    {
+        var channel = channelRaw.Trim();
+        var lower = channel.ToLowerInvariant();
+        var isSdk = component == DotnetUpComponent.Sdk;
+
+        // Pinned to an exact version — no channel update applies.
+        if (ExactVersion.IsMatch(channel))
+        {
+            var installedExact = list.Installations
+                .Where(i => i.Component == component && VersionsEqual(i.Version, channel))
+                .Select(i => i.Version)
+                .FirstOrDefault();
+            return (channel, installedExact ?? channel, true);
+        }
+
+        // Resolve the target product (major.minor) and optional feature band.
+        Product? product = null;
+        string? featureBand = null;
+
+        if (lower == "latest")
+        {
+            product = ctx.Products
+                .Where(p => string.IsNullOrEmpty(p.LatestSdkVersion.Prerelease))
+                .OrderByDescending(p => p.LatestSdkVersion)
+                .FirstOrDefault();
+        }
+        else if (lower == "lts")
+        {
+            product = ctx.Products
+                .Where(p => p.ReleaseType == ReleaseType.LTS && string.IsNullOrEmpty(p.LatestSdkVersion.Prerelease))
+                .OrderByDescending(p => p.LatestSdkVersion)
+                .FirstOrDefault();
+        }
+        else if (lower == "sts")
+        {
+            product = ctx.Products
+                .Where(p => p.ReleaseType == ReleaseType.STS && string.IsNullOrEmpty(p.LatestSdkVersion.Prerelease))
+                .OrderByDescending(p => p.LatestSdkVersion)
+                .FirstOrDefault();
+        }
+        else if (lower == "preview")
+        {
+            product = ctx.Products
+                .Where(p => !string.IsNullOrEmpty(p.LatestSdkVersion.Prerelease))
+                .OrderByDescending(p => p.LatestSdkVersion)
+                .FirstOrDefault();
+        }
+        else if (FeatureBand.Match(channel) is { Success: true } fb)
+        {
+            var mm = $"{fb.Groups[1].Value}.{fb.Groups[2].Value}";
+            featureBand = $"{mm}.{int.Parse(fb.Groups[3].Value) * 100}";
+            product = ctx.Products.FirstOrDefault(p => p.ProductVersion == mm);
+        }
+        else if (MajorMinor.IsMatch(channel))
+        {
+            product = ctx.Products.FirstOrDefault(p => p.ProductVersion == channel);
+        }
+        else if (int.TryParse(channel, out var major))
+        {
+            product = ctx.Products
+                .Where(p => ProductMajor(p) == major)
+                .OrderByDescending(p => p.LatestSdkVersion)
+                .FirstOrDefault();
+        }
+
+        if (product == null)
+        {
+            // Couldn't resolve — surface installed but no available version.
+            return (null, BestInstalled(list, component, null, null), false);
+        }
+
+        // Resolve the newest available version for this component.
+        string? available;
+        if (isSdk)
+        {
+            if (featureBand != null)
+            {
+                var sdks = await ctx.AllSdksAsync(product);
+                var match = sdks.Where(v => FeatureBandKey(v) == featureBand).ToList();
+                available = match.Count > 0 ? match.Max()!.ToString() : null;
+            }
+            else
+            {
+                available = product.LatestSdkVersion.ToString();
+            }
+        }
+        else if (component == DotnetUpComponent.AspNetCore)
+        {
+            var aspNet = await ctx.AllAspNetAsync(product);
+            available = aspNet.Count > 0 ? aspNet.Max()!.ToString() : product.LatestRuntimeVersion.ToString();
+        }
+        else
+        {
+            // Runtime / WindowsDesktop track the shared runtime version.
+            available = product.LatestRuntimeVersion.ToString();
+        }
+
+        var installed = BestInstalled(list, component, product.ProductVersion, featureBand);
+        return (available, installed, false);
+    }
+
+    /// <summary>Holds the fetched product collection and lazily-loaded per-product release versions.</summary>
+    private sealed class ResolveContext
+    {
+        public required ProductCollection Products { get; init; }
+        private readonly Dictionary<string, List<ReleaseVersion>> _sdkCache = new();
+        private readonly Dictionary<string, List<ReleaseVersion>> _aspNetCache = new();
+
+        public static async Task<ResolveContext> CreateAsync() =>
+            new() { Products = await ProductCollection.GetAsync() };
+
+        public async Task<List<ReleaseVersion>> AllSdksAsync(Product p)
+        {
+            if (!_sdkCache.TryGetValue(p.ProductVersion, out var versions))
+            {
+                var releases = await p.GetReleasesAsync();
+                versions = releases.SelectMany(r => r.Sdks).Select(s => s.Version).ToList();
+                _sdkCache[p.ProductVersion] = versions;
+            }
+            return versions;
+        }
+
+        public async Task<List<ReleaseVersion>> AllAspNetAsync(Product p)
+        {
+            if (!_aspNetCache.TryGetValue(p.ProductVersion, out var versions))
+            {
+                var releases = await p.GetReleasesAsync();
+                versions = releases.Where(r => r.AspNetCoreRuntime != null)
+                    .Select(r => r.AspNetCoreRuntime!.Version)
+                    .ToList();
+                _aspNetCache[p.ProductVersion] = versions;
+            }
+            return versions;
+        }
+    }
+
+    /// <summary>Newest installed version of <paramref name="component"/> matching a major.minor (and optional feature band).</summary>
+    private static string? BestInstalled(DotnetUpListResult list, DotnetUpComponent component, string? majorMinor, string? featureBand)
+    {
+        return list.Installations
+            .Where(i => i.Component == component)
+            .Where(i => ReleaseVersion.TryParse(i.Version, out _))
+            .Where(i => majorMinor == null || MajorMinorKey(i.Version) == majorMinor)
+            .Where(i => featureBand == null || FeatureBandKey(new ReleaseVersion(i.Version)) == featureBand)
+            .OrderByDescending(i => new ReleaseVersion(i.Version))
+            .Select(i => i.Version)
+            .FirstOrDefault();
+    }
+
+    private static int ProductMajor(Product p) =>
+        int.TryParse(p.ProductVersion.Split('.')[0], out var m) ? m : 0;
+
+    private static string FeatureBandKey(ReleaseVersion v) => $"{v.Major}.{v.Minor}.{v.SdkFeatureBand}";
+
+    private static string MajorMinorKey(string version) =>
+        ReleaseVersion.TryParse(version, out var v) && v != null ? $"{v.Major}.{v.Minor}" : version;
+
+    private static bool VersionsEqual(string a, string b) =>
+        ReleaseVersion.TryParse(a, out var va) && ReleaseVersion.TryParse(b, out var vb) && va != null && vb != null
+            ? va.CompareTo(vb) == 0
+            : string.Equals(a, b, StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsNewer(string available, string? installed)
+    {
+        if (string.IsNullOrEmpty(installed)) return true;
+        if (ReleaseVersion.TryParse(available, out var a) && ReleaseVersion.TryParse(installed, out var i) && a != null && i != null)
+            return a.CompareTo(i) > 0;
+        return !string.Equals(available, installed, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/MauiSherpa.Workloads/Services/DotnetUpdateResolver.cs
+++ b/src/MauiSherpa.Workloads/Services/DotnetUpdateResolver.cs
@@ -47,9 +47,29 @@ public class DotnetUpdateResolver : IDotnetUpdateResolver
         DotnetUpListResult list,
         CancellationToken cancellationToken = default)
     {
+        var normalizedChannel = channel.Trim();
+        if (ExactVersion.IsMatch(normalizedChannel))
+        {
+            var installedExact = list.Installations
+                .Where(installation =>
+                    installation.Component == component &&
+                    VersionsEqual(installation.Version, normalizedChannel))
+                .Select(installation => installation.Version)
+                .FirstOrDefault();
+            return (normalizedChannel, installedExact);
+        }
+
         var ctx = await ResolveContext.CreateAsync();
         var (available, installed, _) = await ResolveCoreAsync(ctx, component, channel, list);
         return (available, installed);
+    }
+
+    public static bool IsUpdateAvailable(string? available, string? installed)
+    {
+        if (string.IsNullOrWhiteSpace(available))
+            return false;
+
+        return IsNewer(available, installed);
     }
 
     private static async Task<(string? Available, string? Installed, bool IsPinned)> ResolveCoreAsync(
@@ -66,7 +86,7 @@ public class DotnetUpdateResolver : IDotnetUpdateResolver
                 .Where(i => i.Component == component && VersionsEqual(i.Version, channel))
                 .Select(i => i.Version)
                 .FirstOrDefault();
-            return (channel, installedExact ?? channel, true);
+            return (channel, installedExact, true);
         }
 
         // Resolve the target product (major.minor) and optional feature band.

--- a/src/MauiSherpa.Workloads/Services/DotnetWorkloadParser.cs
+++ b/src/MauiSherpa.Workloads/Services/DotnetWorkloadParser.cs
@@ -1,0 +1,181 @@
+using System.Text.Json;
+using MauiSherpa.Workloads.Models;
+using NuGet.Versioning;
+
+namespace MauiSherpa.Workloads.Services;
+
+public static class DotnetWorkloadParser
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    public static DotnetWorkloadListResult ParseMachineReadableList(string output)
+    {
+        var json = ExtractJsonObject(output);
+        var payload = JsonSerializer.Deserialize<MachineReadableList>(json, JsonOptions)
+            ?? throw new FormatException("The workload list response was empty.");
+
+        return new DotnetWorkloadListResult
+        {
+            Installed = (payload.Installed ?? [])
+                .Where(id => !string.IsNullOrWhiteSpace(id))
+                .Select(id => new DotnetInstalledWorkload { Id = id })
+                .OrderBy(w => w.Id, StringComparer.OrdinalIgnoreCase)
+                .ToList(),
+            Updates = (payload.UpdateAvailable ?? [])
+                .Where(update => !string.IsNullOrWhiteSpace(update.WorkloadId))
+                .Select(update => new DotnetWorkloadUpdate
+                {
+                    WorkloadId = update.WorkloadId!,
+                    Description = update.Description,
+                    ExistingManifestVersion = update.ExistingManifestVersion,
+                    AvailableManifestVersion = update.AvailableUpdateManifestVersion
+                })
+                .OrderBy(update => update.WorkloadId, StringComparer.OrdinalIgnoreCase)
+                .ToList(),
+            UsedMachineReadableOutput = true
+        };
+    }
+
+    public static DotnetWorkloadListResult ParsePlainList(string output)
+    {
+        var installed = new List<DotnetInstalledWorkload>();
+        var inTable = false;
+
+        foreach (var rawLine in output.Replace("\r\n", "\n").Split('\n'))
+        {
+            var line = rawLine.TrimEnd();
+            if (line.StartsWith("---", StringComparison.Ordinal))
+            {
+                inTable = true;
+                continue;
+            }
+
+            if (!inTable || string.IsNullOrWhiteSpace(line) ||
+                line.StartsWith("Use `dotnet", StringComparison.Ordinal))
+                continue;
+
+            var columns = System.Text.RegularExpressions.Regex.Split(line.Trim(), @"\s{2,}");
+            if (columns.Length < 1 || string.IsNullOrWhiteSpace(columns[0]))
+                continue;
+
+            installed.Add(new DotnetInstalledWorkload
+            {
+                Id = columns[0],
+                ManifestVersion = columns.Length > 1 ? columns[1] : null,
+                InstallationSource = columns.Length > 2 ? columns[2] : null
+            });
+        }
+
+        return new DotnetWorkloadListResult
+        {
+            Installed = installed.OrderBy(w => w.Id, StringComparer.OrdinalIgnoreCase).ToList(),
+            UsedMachineReadableOutput = false
+        };
+    }
+
+    public static string ParseWorkloadVersion(string output)
+    {
+        var value = output.Replace("\r\n", "\n")
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .LastOrDefault();
+        return string.IsNullOrWhiteSpace(value)
+            ? throw new FormatException("The workload version response was empty.")
+            : value;
+    }
+
+    public static DotnetWorkloadUpdateMode ParseConfiguredUpdateMode(string output)
+    {
+        if (output.Contains("workload-set", StringComparison.OrdinalIgnoreCase))
+            return DotnetWorkloadUpdateMode.WorkloadSet;
+        if (output.Contains("manifests", StringComparison.OrdinalIgnoreCase))
+            return DotnetWorkloadUpdateMode.Manifests;
+        throw new FormatException("The workload update mode response was not understood.");
+    }
+
+    public static DotnetWorkloadUpdateMode InferUpdateMode(string workloadVersion) =>
+        !workloadVersion.Contains("-manifests.", StringComparison.OrdinalIgnoreCase) &&
+        NuGetVersion.TryParse(workloadVersion, out _)
+            ? DotnetWorkloadUpdateMode.WorkloadSet
+            : DotnetWorkloadUpdateMode.Unknown;
+
+    public static IReadOnlyList<DotnetWorkloadSetVersion> ParseAvailableSetVersions(string output)
+    {
+        var json = ExtractJsonArray(output);
+        var payload = JsonSerializer.Deserialize<List<WorkloadVersionPayload>>(json, JsonOptions) ?? [];
+        return payload
+            .Where(item => !string.IsNullOrWhiteSpace(item.WorkloadVersion))
+            .Select(item => new DotnetWorkloadSetVersion
+            {
+                Version = item.WorkloadVersion!,
+                IsPrerelease = NuGetVersion.TryParse(item.WorkloadVersion, out var version) && version.IsPrerelease
+            })
+            .OrderByDescending(item => NuGetVersion.TryParse(item.Version, out var version) ? version : new NuGetVersion(0, 0, 0))
+            .ToList();
+    }
+
+    public static IReadOnlyList<DotnetManifestVersion> ParseManifestVersions(string output)
+    {
+        var json = ExtractJsonObject(output);
+        using var document = JsonDocument.Parse(json);
+        if (!document.RootElement.TryGetProperty("manifestVersions", out var versions) ||
+            versions.ValueKind != JsonValueKind.Object)
+            throw new FormatException("The workload set response has no manifestVersions object.");
+
+        var result = new List<DotnetManifestVersion>();
+        foreach (var property in versions.EnumerateObject())
+        {
+            var value = property.Value.GetString();
+            if (string.IsNullOrWhiteSpace(value))
+                continue;
+            var slash = value.LastIndexOf('/');
+            result.Add(new DotnetManifestVersion
+            {
+                ManifestId = property.Name,
+                Version = slash > 0 ? value[..slash] : value,
+                FeatureBand = slash > 0 ? value[(slash + 1)..] : string.Empty
+            });
+        }
+
+        return result.OrderBy(item => item.ManifestId, StringComparer.OrdinalIgnoreCase).ToList();
+    }
+
+    private static string ExtractJsonObject(string output)
+    {
+        var start = output.IndexOf('{');
+        var end = output.LastIndexOf('}');
+        if (start < 0 || end < start)
+            throw new FormatException("No JSON object was found in the workload CLI output.");
+        return output[start..(end + 1)];
+    }
+
+    private static string ExtractJsonArray(string output)
+    {
+        var start = output.IndexOf('[');
+        var end = output.LastIndexOf(']');
+        if (start < 0 || end < start)
+            throw new FormatException("No JSON array was found in the workload CLI output.");
+        return output[start..(end + 1)];
+    }
+
+    private sealed class MachineReadableList
+    {
+        public List<string>? Installed { get; set; }
+        public List<UpdatePayload>? UpdateAvailable { get; set; }
+    }
+
+    private sealed class UpdatePayload
+    {
+        public string? ExistingManifestVersion { get; set; }
+        public string? AvailableUpdateManifestVersion { get; set; }
+        public string? Description { get; set; }
+        public string? WorkloadId { get; set; }
+    }
+
+    private sealed class WorkloadVersionPayload
+    {
+        public string? WorkloadVersion { get; set; }
+    }
+}

--- a/src/MauiSherpa.Workloads/Services/GlobalJsonResolver.cs
+++ b/src/MauiSherpa.Workloads/Services/GlobalJsonResolver.cs
@@ -1,0 +1,160 @@
+using System.Text.Json;
+using MauiSherpa.Workloads.Models;
+
+namespace MauiSherpa.Workloads.Services;
+
+/// <summary>
+/// Default <see cref="IGlobalJsonResolver"/>. Walks up from a folder to the nearest
+/// <c>global.json</c> and derives the dotnetup channel from <c>sdk.version</c> +
+/// <c>sdk.rollForward</c> using the documented mapping. No network or process calls.
+/// </summary>
+public class GlobalJsonResolver : IGlobalJsonResolver
+{
+    /// <inheritdoc />
+    public GlobalJsonResolution Resolve(string folderPath)
+    {
+        var start = NormalizeStartDirectory(folderPath);
+
+        var globalJsonPath = FindGlobalJson(start);
+        if (globalJsonPath == null)
+        {
+            return new GlobalJsonResolution
+            {
+                FolderPath = start,
+                Status = GlobalJsonStatus.NoGlobalJson,
+            };
+        }
+
+        string? version = null;
+        string? rollForward = null;
+        bool? allowPrerelease = null;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(File.ReadAllText(globalJsonPath));
+            if (doc.RootElement.ValueKind == JsonValueKind.Object &&
+                doc.RootElement.TryGetProperty("sdk", out var sdk) &&
+                sdk.ValueKind == JsonValueKind.Object)
+            {
+                if (sdk.TryGetProperty("version", out var v) && v.ValueKind == JsonValueKind.String)
+                    version = v.GetString();
+                if (sdk.TryGetProperty("rollForward", out var rf) && rf.ValueKind == JsonValueKind.String)
+                    rollForward = rf.GetString();
+                if (sdk.TryGetProperty("allowPrerelease", out var ap) &&
+                    (ap.ValueKind == JsonValueKind.True || ap.ValueKind == JsonValueKind.False))
+                    allowPrerelease = ap.GetBoolean();
+            }
+        }
+        catch
+        {
+            // Malformed global.json — treat as present-but-unusable.
+        }
+
+        if (string.IsNullOrWhiteSpace(version))
+        {
+            return new GlobalJsonResolution
+            {
+                FolderPath = start,
+                GlobalJsonPath = globalJsonPath,
+                RollForward = rollForward,
+                AllowPrerelease = allowPrerelease,
+                Status = GlobalJsonStatus.NoSdkVersion,
+            };
+        }
+
+        var (channel, pinned) = DeriveChannel(version!, rollForward);
+
+        return new GlobalJsonResolution
+        {
+            FolderPath = start,
+            GlobalJsonPath = globalJsonPath,
+            RequestedVersion = version,
+            RollForward = string.IsNullOrWhiteSpace(rollForward) ? "latestPatch" : rollForward,
+            AllowPrerelease = allowPrerelease,
+            Channel = channel,
+            IsPinned = pinned,
+            // Status is provisional; the caller upgrades it to Resolved/Unresolved after enrichment.
+            Status = GlobalJsonStatus.Resolved,
+        };
+    }
+
+    /// <summary>
+    /// Maps a global.json <c>sdk.version</c> + <c>rollForward</c> to a dotnetup channel.
+    /// Returns the channel string and whether it is pinned (never auto-updates).
+    /// </summary>
+    public static (string Channel, bool IsPinned) DeriveChannel(string version, string? rollForward)
+    {
+        var policy = (rollForward ?? string.Empty).Trim().ToLowerInvariant();
+        if (string.IsNullOrEmpty(policy))
+            policy = "latestpatch";
+
+        switch (policy)
+        {
+            case "latestpatch":
+                return (FeatureBandChannel(version), false);
+            case "latestfeature":
+                return (MajorMinor(version), false);
+            case "latestminor":
+                return (Major(version), false);
+            case "latestmajor":
+                return ("latest", false);
+            default:
+                // disable / patch / feature / minor / major → pinned to the exact version.
+                return (version.Trim(), true);
+        }
+    }
+
+    private static string FeatureBandChannel(string version)
+    {
+        var (major, minor, third) = SplitVersion(version);
+        // The feature band is the hundreds digit of the patch field (100 -> 1xx, 203 -> 2xx).
+        var bandDigit = third / 100;
+        return $"{major}.{minor}.{bandDigit}xx";
+    }
+
+    private static string MajorMinor(string version)
+    {
+        var (major, minor, _) = SplitVersion(version);
+        return $"{major}.{minor}";
+    }
+
+    private static string Major(string version)
+    {
+        var (major, _, _) = SplitVersion(version);
+        return major.ToString();
+    }
+
+    private static (int Major, int Minor, int Third) SplitVersion(string version)
+    {
+        var core = version.Trim();
+        var dash = core.IndexOf('-');
+        if (dash >= 0) core = core[..dash];
+
+        var parts = core.Split('.');
+        int major = parts.Length > 0 && int.TryParse(parts[0], out var m) ? m : 0;
+        int minor = parts.Length > 1 && int.TryParse(parts[1], out var n) ? n : 0;
+        int third = parts.Length > 2 && int.TryParse(parts[2], out var p) ? p : 0;
+        return (major, minor, third);
+    }
+
+    private static string NormalizeStartDirectory(string folderPath)
+    {
+        var full = Path.GetFullPath(folderPath);
+        if (File.Exists(full))
+            return Path.GetDirectoryName(full) ?? full;
+        return full;
+    }
+
+    private static string? FindGlobalJson(string startDirectory)
+    {
+        var dir = new DirectoryInfo(startDirectory);
+        while (dir != null)
+        {
+            var candidate = Path.Combine(dir.FullName, "global.json");
+            if (File.Exists(candidate))
+                return candidate;
+            dir = dir.Parent;
+        }
+        return null;
+    }
+}

--- a/src/MauiSherpa.Workloads/Services/GlobalJsonResolver.cs
+++ b/src/MauiSherpa.Workloads/Services/GlobalJsonResolver.cs
@@ -27,11 +27,17 @@ public class GlobalJsonResolver : IGlobalJsonResolver
 
         string? version = null;
         string? rollForward = null;
+        string? workloadVersion = null;
         bool? allowPrerelease = null;
+        var usesLegacyWorkloadSetProperty = false;
 
         try
         {
-            using var doc = JsonDocument.Parse(File.ReadAllText(globalJsonPath));
+            using var doc = JsonDocument.Parse(File.ReadAllText(globalJsonPath), new JsonDocumentOptions
+            {
+                CommentHandling = JsonCommentHandling.Skip,
+                AllowTrailingCommas = true
+            });
             if (doc.RootElement.ValueKind == JsonValueKind.Object &&
                 doc.RootElement.TryGetProperty("sdk", out var sdk) &&
                 sdk.ValueKind == JsonValueKind.Object)
@@ -43,6 +49,18 @@ public class GlobalJsonResolver : IGlobalJsonResolver
                 if (sdk.TryGetProperty("allowPrerelease", out var ap) &&
                     (ap.ValueKind == JsonValueKind.True || ap.ValueKind == JsonValueKind.False))
                     allowPrerelease = ap.GetBoolean();
+                if (sdk.TryGetProperty("workloadVersion", out var workload) &&
+                    workload.ValueKind == JsonValueKind.String)
+                    workloadVersion = workload.GetString();
+            }
+            if (workloadVersion == null &&
+                doc.RootElement.TryGetProperty("workloadSet", out var legacy) &&
+                legacy.ValueKind == JsonValueKind.Object &&
+                legacy.TryGetProperty("version", out var legacyVersion) &&
+                legacyVersion.ValueKind == JsonValueKind.String)
+            {
+                workloadVersion = legacyVersion.GetString();
+                usesLegacyWorkloadSetProperty = workloadVersion != null;
             }
         }
         catch
@@ -58,6 +76,8 @@ public class GlobalJsonResolver : IGlobalJsonResolver
                 GlobalJsonPath = globalJsonPath,
                 RollForward = rollForward,
                 AllowPrerelease = allowPrerelease,
+                WorkloadVersion = workloadVersion,
+                UsesLegacyWorkloadSetProperty = usesLegacyWorkloadSetProperty,
                 Status = GlobalJsonStatus.NoSdkVersion,
             };
         }
@@ -71,6 +91,8 @@ public class GlobalJsonResolver : IGlobalJsonResolver
             RequestedVersion = version,
             RollForward = string.IsNullOrWhiteSpace(rollForward) ? "latestPatch" : rollForward,
             AllowPrerelease = allowPrerelease,
+            WorkloadVersion = workloadVersion,
+            UsesLegacyWorkloadSetProperty = usesLegacyWorkloadSetProperty,
             Channel = channel,
             IsPinned = pinned,
             // Status is provisional; the caller upgrades it to Resolved/Unresolved after enrichment.

--- a/src/MauiSherpa.Workloads/Services/GlobalJsonService.cs
+++ b/src/MauiSherpa.Workloads/Services/GlobalJsonService.cs
@@ -56,6 +56,7 @@ public class GlobalJsonService : IGlobalJsonService
             // Parse sdk section
             string? sdkVersion = null;
             string? rollForward = null;
+            string? workloadsUpdateMode = null;
             if (root.TryGetProperty("sdk", out var sdkElement))
             {
                 if (sdkElement.TryGetProperty("version", out var versionElement))
@@ -66,15 +67,26 @@ public class GlobalJsonService : IGlobalJsonService
                 {
                     rollForward = rollForwardElement.GetString();
                 }
+                if (sdkElement.TryGetProperty("workloads-update-mode", out var updateModeElement))
+                {
+                    workloadsUpdateMode = updateModeElement.GetString();
+                }
             }
 
-            // Parse workloadSet section (.NET 9+)
+            // The supported workload-set pin is sdk.workloadVersion.
             string? workloadSetVersion = null;
-            if (root.TryGetProperty("workloadSet", out var workloadSetElement))
+            var usesLegacyWorkloadSetProperty = false;
+            if (root.TryGetProperty("sdk", out sdkElement) &&
+                sdkElement.TryGetProperty("workloadVersion", out var workloadVersionElement))
+            {
+                workloadSetVersion = workloadVersionElement.GetString();
+            }
+            else if (root.TryGetProperty("workloadSet", out var workloadSetElement))
             {
                 if (workloadSetElement.TryGetProperty("version", out var wsVersionElement))
                 {
                     workloadSetVersion = wsVersionElement.GetString();
+                    usesLegacyWorkloadSetProperty = workloadSetVersion != null;
                 }
             }
 
@@ -99,7 +111,9 @@ public class GlobalJsonService : IGlobalJsonService
                 SdkVersion: sdkVersion,
                 RollForward: rollForward,
                 WorkloadSetVersion: workloadSetVersion,
-                MsBuildSdks: msbuildSdks
+                MsBuildSdks: msbuildSdks,
+                UsesLegacyWorkloadSetProperty: usesLegacyWorkloadSetProperty,
+                WorkloadsUpdateMode: workloadsUpdateMode
             );
         }
         catch (JsonException)

--- a/src/MauiSherpa.Workloads/Services/GlobalJsonWorkloadPinEditor.cs
+++ b/src/MauiSherpa.Workloads/Services/GlobalJsonWorkloadPinEditor.cs
@@ -1,0 +1,466 @@
+using System.Text;
+using System.Text.Json;
+using MauiSherpa.Workloads.Models;
+
+namespace MauiSherpa.Workloads.Services;
+
+/// <summary>
+/// Performs a surgical JSONC edit of sdk.workloadVersion. Unrelated bytes, including
+/// comments, trailing commas, indentation, and newline style, are retained.
+/// </summary>
+public sealed class GlobalJsonWorkloadPinEditor : IGlobalJsonWorkloadPinEditor
+{
+    public GlobalJsonWorkloadPinPreview Preview(string projectFolder, string? workloadVersion)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectFolder);
+        var folder = Path.GetFullPath(projectFolder);
+        var service = new GlobalJsonService();
+        var path = service.FindGlobalJson(folder) ?? Path.Combine(folder, "global.json");
+        var original = File.Exists(path) ? File.ReadAllText(path) : string.Empty;
+        var updated = Edit(original, workloadVersion);
+
+        return new GlobalJsonWorkloadPinPreview
+        {
+            Path = path,
+            OriginalContent = original,
+            UpdatedContent = updated,
+            WorkloadVersion = workloadVersion
+        };
+    }
+
+    public async Task ApplyAsync(
+        GlobalJsonWorkloadPinPreview preview,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(preview);
+        if (!preview.Changed)
+            return;
+
+        var directory = Path.GetDirectoryName(preview.Path)
+            ?? throw new InvalidOperationException("The global.json path has no parent directory.");
+        Directory.CreateDirectory(directory);
+
+        var current = File.Exists(preview.Path)
+            ? await File.ReadAllTextAsync(preview.Path, cancellationToken)
+            : string.Empty;
+        if (!string.Equals(current, preview.OriginalContent, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"'{preview.Path}' changed after the workload pin preview was created. Review the current file and try again.");
+        }
+
+        var temporary = $"{preview.Path}.mauisherpa-{Guid.NewGuid():N}.tmp";
+        try
+        {
+            await File.WriteAllTextAsync(
+                temporary,
+                preview.UpdatedContent,
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+                cancellationToken);
+            File.Move(temporary, preview.Path, overwrite: true);
+        }
+        finally
+        {
+            if (File.Exists(temporary))
+                File.Delete(temporary);
+        }
+    }
+
+    internal static string Edit(string original, string? workloadVersion)
+    {
+        if (string.IsNullOrWhiteSpace(original))
+        {
+            return workloadVersion == null
+                ? original
+                : $"{{{Environment.NewLine}  \"sdk\": {{{Environment.NewLine}    \"workloadVersion\": {JsonSerializer.Serialize(workloadVersion)}{Environment.NewLine}  }}{Environment.NewLine}}}{Environment.NewLine}";
+        }
+
+        var bytes = Encoding.UTF8.GetBytes(original);
+        var location = Locate(bytes);
+        var newline = original.Contains("\r\n", StringComparison.Ordinal) ? "\r\n" : "\n";
+
+        if (location.WorkloadValueStart >= 0)
+        {
+            if (workloadVersion != null)
+            {
+                var serialized = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(workloadVersion));
+                return Encoding.UTF8.GetString(Replace(
+                    bytes,
+                    location.WorkloadValueStart,
+                    location.WorkloadValueEnd,
+                    serialized));
+            }
+
+            var updated = RemoveProperty(
+                bytes,
+                location.SdkObjectStart,
+                location.SdkObjectEnd,
+                location.WorkloadPropertyStart,
+                location.WorkloadValueEnd);
+            var relocated = Locate(updated);
+            if (relocated.LegacyWorkloadValueStart >= 0)
+            {
+                updated = RemoveProperty(
+                    updated,
+                    relocated.LegacyWorkloadObjectStart,
+                    relocated.LegacyWorkloadObjectEnd,
+                    relocated.LegacyWorkloadPropertyStart,
+                    relocated.LegacyWorkloadValueEnd);
+            }
+            return Encoding.UTF8.GetString(updated);
+        }
+
+        if (workloadVersion == null)
+        {
+            if (location.LegacyWorkloadValueStart < 0)
+                return original;
+            return Encoding.UTF8.GetString(RemoveProperty(
+                bytes,
+                location.LegacyWorkloadObjectStart,
+                location.LegacyWorkloadObjectEnd,
+                location.LegacyWorkloadPropertyStart,
+                location.LegacyWorkloadValueEnd));
+        }
+
+        var property = $"\"workloadVersion\": {JsonSerializer.Serialize(workloadVersion)}";
+        if (location.SdkObjectStart >= 0)
+        {
+            return Encoding.UTF8.GetString(InsertObjectProperty(
+                bytes,
+                location.SdkObjectStart,
+                location.SdkObjectEnd,
+                location.SdkLastValueEnd,
+                property,
+                newline));
+        }
+
+        var sdkProperty = $"\"sdk\": {{{newline}    {property}{newline}  }}";
+        return Encoding.UTF8.GetString(InsertObjectProperty(
+            bytes,
+            location.RootObjectStart,
+            location.RootObjectEnd,
+            location.RootLastValueEnd,
+            sdkProperty,
+            newline));
+    }
+
+    private static JsonLocation Locate(byte[] bytes)
+    {
+        var reader = new Utf8JsonReader(bytes, new JsonReaderOptions
+        {
+            AllowTrailingCommas = true,
+            CommentHandling = JsonCommentHandling.Skip
+        });
+
+        var result = new JsonLocation();
+        string? pendingProperty = null;
+        var pendingPropertyStart = -1;
+        var sdkDepth = -1;
+        var legacyWorkloadDepth = -1;
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.PropertyName)
+            {
+                pendingProperty = reader.GetString();
+                pendingPropertyStart = checked((int)reader.TokenStartIndex);
+                continue;
+            }
+
+            if (reader.TokenType == JsonTokenType.StartObject)
+            {
+                if (reader.CurrentDepth == 0)
+                    result.RootObjectStart = checked((int)reader.TokenStartIndex);
+                if (pendingProperty == "sdk" && reader.CurrentDepth == 1)
+                {
+                    result.SdkObjectStart = checked((int)reader.TokenStartIndex);
+                    sdkDepth = reader.CurrentDepth;
+                }
+                if (pendingProperty == "workloadSet" && reader.CurrentDepth == 1)
+                {
+                    result.LegacyWorkloadObjectStart = checked((int)reader.TokenStartIndex);
+                    legacyWorkloadDepth = reader.CurrentDepth;
+                }
+            }
+
+            if (pendingProperty == "workloadVersion" &&
+                sdkDepth >= 0 &&
+                reader.CurrentDepth == sdkDepth + 1)
+            {
+                if (reader.TokenType != JsonTokenType.String)
+                    throw new InvalidDataException("sdk.workloadVersion must be a JSON string.");
+                result.WorkloadPropertyStart = pendingPropertyStart;
+                result.WorkloadValueStart = checked((int)reader.TokenStartIndex);
+                result.WorkloadValueEnd = checked((int)reader.BytesConsumed);
+            }
+            if (pendingProperty == "version" &&
+                legacyWorkloadDepth >= 0 &&
+                reader.CurrentDepth == legacyWorkloadDepth + 1)
+            {
+                if (reader.TokenType != JsonTokenType.String)
+                    throw new InvalidDataException("workloadSet.version must be a JSON string.");
+                result.LegacyWorkloadPropertyStart = pendingPropertyStart;
+                result.LegacyWorkloadValueStart = checked((int)reader.TokenStartIndex);
+                result.LegacyWorkloadValueEnd = checked((int)reader.BytesConsumed);
+            }
+
+            if (reader.TokenType == JsonTokenType.EndObject)
+            {
+                if (reader.CurrentDepth == sdkDepth)
+                {
+                    result.SdkObjectEnd = checked((int)reader.TokenStartIndex);
+                    sdkDepth = -1;
+                }
+                if (reader.CurrentDepth == legacyWorkloadDepth)
+                {
+                    result.LegacyWorkloadObjectEnd = checked((int)reader.TokenStartIndex);
+                    legacyWorkloadDepth = -1;
+                }
+                if (reader.CurrentDepth == 0)
+                    result.RootObjectEnd = checked((int)reader.TokenStartIndex);
+            }
+
+            if (IsCompletedValue(reader.TokenType))
+            {
+                if (reader.CurrentDepth == 1)
+                    result.RootLastValueEnd = checked((int)reader.BytesConsumed);
+                if (sdkDepth >= 0 && reader.CurrentDepth == sdkDepth + 1)
+                    result.SdkLastValueEnd = checked((int)reader.BytesConsumed);
+            }
+
+            pendingProperty = null;
+            pendingPropertyStart = -1;
+        }
+
+        if (result.RootObjectStart < 0 || result.RootObjectEnd < 0)
+            throw new InvalidDataException("global.json must contain a JSON object.");
+        return result;
+    }
+
+    private static byte[] InsertObjectProperty(
+        byte[] bytes,
+        int objectStart,
+        int objectEnd,
+        int lastValueEnd,
+        string property,
+        string newline)
+    {
+        if (lastValueEnd >= 0 && FindNextSiblingComma(bytes, lastValueEnd, objectEnd) < 0)
+        {
+            bytes = Replace(bytes, lastValueEnd, lastValueEnd, [(byte)',']);
+            objectEnd++;
+        }
+
+        var contentEnd = objectEnd;
+        while (contentEnd > objectStart + 1 && IsWhitespace(bytes[contentEnd - 1]))
+            contentEnd--;
+
+        var hasContent = contentEnd > objectStart + 1;
+        var closingIndent = GetLineIndent(bytes, objectEnd);
+        var indentUnit = DetectIndentUnit(bytes);
+        var childIndent = closingIndent + indentUnit;
+        var trailing = Encoding.UTF8.GetString(bytes, contentEnd, objectEnd - contentEnd);
+        var trailingHasNewline = trailing.Contains('\n');
+
+        var insertion = new StringBuilder();
+        insertion.Append(newline).Append(childIndent).Append(property);
+        if (!trailingHasNewline)
+            insertion.Append(newline).Append(closingIndent);
+
+        return Replace(
+            bytes,
+            contentEnd,
+            contentEnd,
+            Encoding.UTF8.GetBytes(insertion.ToString()));
+    }
+
+    private static byte[] RemoveProperty(
+        byte[] bytes,
+        int objectStart,
+        int objectEnd,
+        int propertyStart,
+        int valueEnd)
+    {
+        var start = propertyStart;
+        var end = valueEnd;
+
+        var lineStart = start;
+        while (lineStart > objectStart + 1 &&
+               bytes[lineStart - 1] != (byte)'\n' &&
+               IsWhitespace(bytes[lineStart - 1]))
+            lineStart--;
+
+        var next = end;
+        next = SkipTriviaForward(bytes, next, objectEnd);
+        if (next < objectEnd && bytes[next] == (byte)',')
+            return Replace(bytes, lineStart, next + 1, []);
+
+        var previousComma = FindPreviousSiblingComma(bytes, objectStart, lineStart);
+        if (previousComma >= 0)
+        {
+            var trailingEnd = SkipTriviaForward(bytes, end, objectEnd);
+            var withoutProperty = Replace(bytes, lineStart, trailingEnd, []);
+            return Replace(withoutProperty, previousComma, previousComma + 1, []);
+        }
+
+        return Replace(bytes, lineStart, end, []);
+    }
+
+    private static int FindNextSiblingComma(byte[] bytes, int start, int objectEnd)
+    {
+        var next = SkipTriviaForward(bytes, start, objectEnd);
+        return next < objectEnd && bytes[next] == (byte)',' ? next : -1;
+    }
+
+    private static int SkipTriviaForward(byte[] bytes, int start, int end)
+    {
+        var index = start;
+        while (index < end)
+        {
+            if (IsWhitespace(bytes[index]))
+            {
+                index++;
+                continue;
+            }
+
+            if (index + 1 < end && bytes[index] == (byte)'/' && bytes[index + 1] == (byte)'/')
+            {
+                index += 2;
+                while (index < end && bytes[index] != (byte)'\n')
+                    index++;
+                continue;
+            }
+
+            if (index + 1 < end && bytes[index] == (byte)'/' && bytes[index + 1] == (byte)'*')
+            {
+                index += 2;
+                while (index + 1 < end &&
+                       !(bytes[index] == (byte)'*' && bytes[index + 1] == (byte)'/'))
+                    index++;
+                index = Math.Min(index + 2, end);
+                continue;
+            }
+
+            break;
+        }
+        return index;
+    }
+
+    private static int FindPreviousSiblingComma(byte[] bytes, int objectStart, int end)
+    {
+        var depth = 0;
+        var inString = false;
+        var escaped = false;
+        var previousComma = -1;
+
+        for (var index = objectStart + 1; index < end; index++)
+        {
+            var value = bytes[index];
+            if (inString)
+            {
+                if (escaped)
+                    escaped = false;
+                else if (value == (byte)'\\')
+                    escaped = true;
+                else if (value == (byte)'"')
+                    inString = false;
+                continue;
+            }
+
+            if (value == (byte)'"')
+            {
+                inString = true;
+                continue;
+            }
+
+            if (index + 1 < end && value == (byte)'/' && bytes[index + 1] == (byte)'/')
+            {
+                index += 2;
+                while (index < end && bytes[index] != (byte)'\n')
+                    index++;
+                continue;
+            }
+
+            if (index + 1 < end && value == (byte)'/' && bytes[index + 1] == (byte)'*')
+            {
+                index += 2;
+                while (index + 1 < end &&
+                       !(bytes[index] == (byte)'*' && bytes[index + 1] == (byte)'/'))
+                    index++;
+                index++;
+                continue;
+            }
+
+            if (value is (byte)'{' or (byte)'[')
+                depth++;
+            else if (value is (byte)'}' or (byte)']')
+                depth--;
+            else if (value == (byte)',' && depth == 0)
+                previousComma = index;
+        }
+
+        return previousComma;
+    }
+
+    private static byte[] Replace(byte[] source, int start, int end, byte[] replacement)
+    {
+        var result = new byte[source.Length - (end - start) + replacement.Length];
+        Buffer.BlockCopy(source, 0, result, 0, start);
+        Buffer.BlockCopy(replacement, 0, result, start, replacement.Length);
+        Buffer.BlockCopy(source, end, result, start + replacement.Length, source.Length - end);
+        return result;
+    }
+
+    private static string GetLineIndent(byte[] bytes, int position)
+    {
+        var lineStart = position;
+        while (lineStart > 0 && bytes[lineStart - 1] != (byte)'\n')
+            lineStart--;
+        return Encoding.UTF8.GetString(bytes, lineStart, position - lineStart);
+    }
+
+    private static string DetectIndentUnit(byte[] bytes)
+    {
+        for (var index = 0; index < bytes.Length; index++)
+        {
+            if (bytes[index] != (byte)'\n')
+                continue;
+            var start = ++index;
+            while (index < bytes.Length && (bytes[index] == (byte)' ' || bytes[index] == (byte)'\t'))
+                index++;
+            if (index > start && index < bytes.Length && bytes[index] == (byte)'"')
+                return Encoding.UTF8.GetString(bytes, start, index - start);
+        }
+        return "  ";
+    }
+
+    private static bool IsWhitespace(byte value) =>
+        value is (byte)' ' or (byte)'\t' or (byte)'\r' or (byte)'\n';
+
+    private static bool IsCompletedValue(JsonTokenType tokenType) =>
+        tokenType is JsonTokenType.String or
+            JsonTokenType.Number or
+            JsonTokenType.True or
+            JsonTokenType.False or
+            JsonTokenType.Null or
+            JsonTokenType.EndObject or
+            JsonTokenType.EndArray;
+
+    private sealed class JsonLocation
+    {
+        public int RootObjectStart { get; set; } = -1;
+        public int RootObjectEnd { get; set; } = -1;
+        public int RootLastValueEnd { get; set; } = -1;
+        public int SdkObjectStart { get; set; } = -1;
+        public int SdkObjectEnd { get; set; } = -1;
+        public int SdkLastValueEnd { get; set; } = -1;
+        public int WorkloadPropertyStart { get; set; } = -1;
+        public int WorkloadValueStart { get; set; } = -1;
+        public int WorkloadValueEnd { get; set; } = -1;
+        public int LegacyWorkloadObjectStart { get; set; } = -1;
+        public int LegacyWorkloadObjectEnd { get; set; } = -1;
+        public int LegacyWorkloadPropertyStart { get; set; } = -1;
+        public int LegacyWorkloadValueStart { get; set; } = -1;
+        public int LegacyWorkloadValueEnd { get; set; } = -1;
+    }
+}

--- a/src/MauiSherpa.Workloads/Services/IDotnetUpdateResolver.cs
+++ b/src/MauiSherpa.Workloads/Services/IDotnetUpdateResolver.cs
@@ -1,0 +1,29 @@
+using MauiSherpa.Workloads.Models;
+
+namespace MauiSherpa.Workloads.Services;
+
+/// <summary>
+/// Resolves dotnetup's tracked channels against the official .NET release metadata to preview
+/// which tracked channels have a newer version available — without running any install/update.
+/// </summary>
+public interface IDotnetUpdateResolver
+{
+    /// <summary>
+    /// For every tracked install spec in <paramref name="list"/>, resolves the channel to its newest
+    /// available version and compares it against the newest installed version that satisfies it.
+    /// </summary>
+    Task<IReadOnlyList<DotnetUpdatePreview>> GetUpdatePreviewAsync(
+        DotnetUpListResult list,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Resolves a single channel for a component to its newest available version (from the release
+    /// feed) and the newest installed version that satisfies it. Used by both the update preview and
+    /// the global.json project inspector.
+    /// </summary>
+    Task<(string? Available, string? Installed)> ResolveChannelAsync(
+        DotnetUpComponent component,
+        string channel,
+        DotnetUpListResult list,
+        CancellationToken cancellationToken = default);
+}

--- a/src/MauiSherpa.Workloads/Services/IGlobalJsonResolver.cs
+++ b/src/MauiSherpa.Workloads/Services/IGlobalJsonResolver.cs
@@ -1,0 +1,21 @@
+using MauiSherpa.Workloads.Models;
+
+namespace MauiSherpa.Workloads.Services;
+
+/// <summary>
+/// Resolves a folder's <c>global.json</c> context: finds the nearest <c>global.json</c> walking up
+/// from the folder (same algorithm as the <c>dotnet</c> host) and maps its <c>sdk.version</c> +
+/// <c>sdk.rollForward</c> to a dotnetup channel. Purely local — no network or process calls.
+/// </summary>
+public interface IGlobalJsonResolver
+{
+    /// <summary>
+    /// Walks up from <paramref name="folderPath"/> to the filesystem root, parses the first
+    /// <c>global.json</c> found, and derives the channel + pinned-ness. The returned
+    /// <see cref="GlobalJsonResolution"/> has the feed-dependent fields
+    /// (<see cref="GlobalJsonResolution.ResolvedVersion"/>, <see cref="GlobalJsonResolution.InstalledVersion"/>,
+    /// <see cref="GlobalJsonResolution.Satisfied"/>, <see cref="GlobalJsonResolution.AlreadyTracked"/>)
+    /// left unset for a caller to enrich.
+    /// </summary>
+    GlobalJsonResolution Resolve(string folderPath);
+}

--- a/src/MauiSherpa.Workloads/Services/IGlobalJsonService.cs
+++ b/src/MauiSherpa.Workloads/Services/IGlobalJsonService.cs
@@ -10,10 +10,14 @@ public record GlobalJsonInfo(
     string? SdkVersion,
     /// <summary>Roll-forward policy (sdk.rollForward).</summary>
     string? RollForward,
-    /// <summary>Pinned workload set version (workloadSet.version).</summary>
+    /// <summary>Pinned workload set version (sdk.workloadVersion).</summary>
     string? WorkloadSetVersion,
     /// <summary>MSBuild SDK versions (msbuild-sdks).</summary>
-    IReadOnlyDictionary<string, string>? MsBuildSdks
+    IReadOnlyDictionary<string, string>? MsBuildSdks,
+    /// <summary>True when the obsolete workloadSet.version shape supplied the value.</summary>
+    bool UsesLegacyWorkloadSetProperty = false,
+    /// <summary>Optional sdk.workloads-update-mode override.</summary>
+    string? WorkloadsUpdateMode = null
 );
 
 /// <summary>
@@ -46,7 +50,7 @@ public interface IGlobalJsonService
     /// Checks if a workload set version is pinned in global.json.
     /// </summary>
     /// <param name="startDirectory">Directory to start searching from. Defaults to current directory.</param>
-    /// <returns>True if workloadSet.version is specified in global.json.</returns>
+    /// <returns>True if sdk.workloadVersion is specified in global.json.</returns>
     bool IsWorkloadSetPinned(string? startDirectory = null);
 
     /// <summary>

--- a/src/MauiSherpa.Workloads/Services/IGlobalJsonWorkloadPinEditor.cs
+++ b/src/MauiSherpa.Workloads/Services/IGlobalJsonWorkloadPinEditor.cs
@@ -1,0 +1,9 @@
+using MauiSherpa.Workloads.Models;
+
+namespace MauiSherpa.Workloads.Services;
+
+public interface IGlobalJsonWorkloadPinEditor
+{
+    GlobalJsonWorkloadPinPreview Preview(string projectFolder, string? workloadVersion);
+    Task ApplyAsync(GlobalJsonWorkloadPinPreview preview, CancellationToken cancellationToken = default);
+}

--- a/src/MauiSherpa.Workloads/Services/LocalSdkService.cs
+++ b/src/MauiSherpa.Workloads/Services/LocalSdkService.cs
@@ -145,7 +145,7 @@ public class LocalSdkService : ILocalSdkService
         var workloadSet = GetInstalledWorkloadSetCore(featureBand);
         if (workloadSet != null)
         {
-            foreach (var manifestId in workloadSet.Workloads.Keys)
+            foreach (var manifestId in workloadSet.ManifestEntries.Keys)
                 manifestIds.Add(manifestId);
         }
 
@@ -169,7 +169,7 @@ public class LocalSdkService : ILocalSdkService
         try
         {
             var json = await File.ReadAllTextAsync(manifestFile, cancellationToken);
-            return ParseManifest(json);
+            return WorkloadManifestService.ParseManifest(json);
         }
         catch
         {
@@ -483,7 +483,7 @@ public class LocalSdkService : ILocalSdkService
         if (workloadSet == null)
             return null;
 
-        var manifestEntry = workloadSet.Workloads
+        var manifestEntry = workloadSet.ManifestEntries
             .FirstOrDefault(entry => entry.Key.Equals(manifestId, StringComparison.OrdinalIgnoreCase));
 
         if (manifestEntry.Key == null || string.IsNullOrEmpty(manifestEntry.Value.ManifestFeatureBand))
@@ -626,7 +626,7 @@ public class LocalSdkService : ILocalSdkService
             {
                 Version = version,
                 FeatureBand = featureBand,
-                Workloads = entries
+                ManifestEntries = entries
             };
         }
         catch (Exception ex)
@@ -787,7 +787,7 @@ public class LocalSdkService : ILocalSdkService
                 workloadSetInfo = new
                 {
                     version = workloadSet.Version,
-                    workloads = workloadSet.Workloads.ToDictionary(
+                    manifestEntries = workloadSet.ManifestEntries.ToDictionary(
                         w => w.Key,
                         w => new
                         {

--- a/src/MauiSherpa.Workloads/Services/WorkloadGraphResolver.cs
+++ b/src/MauiSherpa.Workloads/Services/WorkloadGraphResolver.cs
@@ -31,20 +31,23 @@ public static class WorkloadGraphResolver
         IReadOnlyDictionary<string, PackDefinition> packs,
         string runtimeIdentifier)
     {
+        var resolvedWorkload = ResolveRedirect(workload, workloads);
         var includes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var packIds = new HashSet<string>(workload.Packs, StringComparer.OrdinalIgnoreCase);
+        if (!string.Equals(workload.Id, resolvedWorkload.Id, StringComparison.OrdinalIgnoreCase))
+            includes.Add(resolvedWorkload.Id);
+        var packIds = new HashSet<string>(resolvedWorkload.Packs, StringComparer.OrdinalIgnoreCase);
         var visiting = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        ResolveIncludes(workload.Id, workloads, includes, packIds, visiting);
+        ResolveIncludes(resolvedWorkload.Id, workloads, includes, packIds, visiting);
         includes.Remove(workload.Id);
 
         return new ResolvedWorkloadDefinition
         {
             Id = workload.Id,
-            Description = workload.Description,
-            IsAbstract = workload.IsAbstract,
-            Kind = workload.Kind,
-            Platforms = workload.Platforms,
-            DirectExtends = workload.Extends,
+            Description = workload.Description ?? resolvedWorkload.Description,
+            IsAbstract = resolvedWorkload.IsAbstract,
+            Kind = resolvedWorkload.Kind,
+            Platforms = resolvedWorkload.Platforms,
+            DirectExtends = resolvedWorkload.Extends,
             TransitiveIncludes = includes.OrderBy(id => id, StringComparer.OrdinalIgnoreCase).ToList(),
             Packs = packIds
                 .Select(id => packs.TryGetValue(id, out var pack)
@@ -65,7 +68,10 @@ public static class WorkloadGraphResolver
     {
         if (!workloads.TryGetValue(id, out var workload))
             return;
-        if (!visiting.Add(id))
+        workload = ResolveRedirect(workload, workloads);
+        if (!string.Equals(id, workload.Id, StringComparison.OrdinalIgnoreCase))
+            includes.Add(workload.Id);
+        if (!visiting.Add(workload.Id))
             throw new InvalidDataException($"Workload manifest contains an extends cycle at '{id}'.");
 
         foreach (var pack in workload.Packs)
@@ -76,7 +82,27 @@ public static class WorkloadGraphResolver
             ResolveIncludes(extended, workloads, includes, packIds, visiting);
         }
 
-        visiting.Remove(id);
+        visiting.Remove(workload.Id);
+    }
+
+    private static WorkloadDefinition ResolveRedirect(
+        WorkloadDefinition workload,
+        IReadOnlyDictionary<string, WorkloadDefinition> workloads)
+    {
+        var visiting = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        while (!string.IsNullOrWhiteSpace(workload.RedirectTo))
+        {
+            if (!visiting.Add(workload.Id))
+                throw new InvalidDataException($"Workload manifest contains a redirect cycle at '{workload.Id}'.");
+            if (!workloads.TryGetValue(workload.RedirectTo, out var target))
+            {
+                throw new InvalidDataException(
+                    $"Workload '{workload.Id}' redirects to missing workload '{workload.RedirectTo}'.");
+            }
+            workload = target;
+        }
+
+        return workload;
     }
 
     private static ResolvedPackDefinition ResolvePack(PackDefinition pack, string runtimeIdentifier)

--- a/src/MauiSherpa.Workloads/Services/WorkloadGraphResolver.cs
+++ b/src/MauiSherpa.Workloads/Services/WorkloadGraphResolver.cs
@@ -1,0 +1,105 @@
+using MauiSherpa.Workloads.Models;
+
+namespace MauiSherpa.Workloads.Services;
+
+public static class WorkloadGraphResolver
+{
+    public static IReadOnlyList<ResolvedWorkloadDefinition> Resolve(
+        IEnumerable<WorkloadManifest> manifests,
+        string runtimeIdentifier)
+    {
+        var workloads = new Dictionary<string, WorkloadDefinition>(StringComparer.OrdinalIgnoreCase);
+        var packs = new Dictionary<string, PackDefinition>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var manifest in manifests)
+        {
+            foreach (var workload in manifest.Workloads)
+                workloads[workload.Key] = workload.Value;
+            foreach (var pack in manifest.Packs)
+                packs[pack.Key] = pack.Value;
+        }
+
+        return workloads.Values
+            .Select(workload => ResolveWorkload(workload, workloads, packs, runtimeIdentifier))
+            .OrderBy(workload => workload.Id, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static ResolvedWorkloadDefinition ResolveWorkload(
+        WorkloadDefinition workload,
+        IReadOnlyDictionary<string, WorkloadDefinition> workloads,
+        IReadOnlyDictionary<string, PackDefinition> packs,
+        string runtimeIdentifier)
+    {
+        var includes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var packIds = new HashSet<string>(workload.Packs, StringComparer.OrdinalIgnoreCase);
+        var visiting = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        ResolveIncludes(workload.Id, workloads, includes, packIds, visiting);
+        includes.Remove(workload.Id);
+
+        return new ResolvedWorkloadDefinition
+        {
+            Id = workload.Id,
+            Description = workload.Description,
+            IsAbstract = workload.IsAbstract,
+            Kind = workload.Kind,
+            Platforms = workload.Platforms,
+            DirectExtends = workload.Extends,
+            TransitiveIncludes = includes.OrderBy(id => id, StringComparer.OrdinalIgnoreCase).ToList(),
+            Packs = packIds
+                .Select(id => packs.TryGetValue(id, out var pack)
+                    ? ResolvePack(pack, runtimeIdentifier)
+                    : new ResolvedPackDefinition { Id = id, Version = string.Empty, Kind = "Unknown" })
+                .OrderBy(pack => pack.Id, StringComparer.OrdinalIgnoreCase)
+                .ToList(),
+            RedirectTarget = workload.RedirectTo
+        };
+    }
+
+    private static void ResolveIncludes(
+        string id,
+        IReadOnlyDictionary<string, WorkloadDefinition> workloads,
+        ISet<string> includes,
+        ISet<string> packIds,
+        ISet<string> visiting)
+    {
+        if (!workloads.TryGetValue(id, out var workload))
+            return;
+        if (!visiting.Add(id))
+            throw new InvalidDataException($"Workload manifest contains an extends cycle at '{id}'.");
+
+        foreach (var pack in workload.Packs)
+            packIds.Add(pack);
+        foreach (var extended in workload.Extends)
+        {
+            includes.Add(extended);
+            ResolveIncludes(extended, workloads, includes, packIds, visiting);
+        }
+
+        visiting.Remove(id);
+    }
+
+    private static ResolvedPackDefinition ResolvePack(PackDefinition pack, string runtimeIdentifier)
+    {
+        string? resolved = null;
+        if (pack.AliasToByPlatform != null)
+        {
+            pack.AliasToByPlatform.TryGetValue(runtimeIdentifier, out resolved);
+            if (resolved == null)
+            {
+                var os = runtimeIdentifier.Split('-', 2)[0];
+                pack.AliasToByPlatform.TryGetValue(os, out resolved);
+            }
+            if (resolved == null)
+                pack.AliasToByPlatform.TryGetValue("any", out resolved);
+        }
+
+        return new ResolvedPackDefinition
+        {
+            Id = pack.Id,
+            Version = pack.Version,
+            Kind = pack.Kind,
+            ResolvedPackageId = resolved ?? pack.AliasTo
+        };
+    }
+}

--- a/src/MauiSherpa.Workloads/Services/WorkloadInstallStateReader.cs
+++ b/src/MauiSherpa.Workloads/Services/WorkloadInstallStateReader.cs
@@ -1,0 +1,105 @@
+using System.Text.Json;
+using MauiSherpa.Workloads.Models;
+
+namespace MauiSherpa.Workloads.Services;
+
+/// <summary>
+/// Reads the same per-feature-band install state used by the .NET SDK workload commands.
+/// </summary>
+public static class WorkloadInstallStateReader
+{
+    public static DotnetWorkloadUpdateMode ReadUpdateMode(DotnetWorkloadTarget target)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+
+        var path = GetPath(target);
+
+        if (!File.Exists(path))
+            return DotnetWorkloadUpdateMode.WorkloadSet;
+
+        using var document = ReadDocument(path);
+
+        if (!document.RootElement.TryGetProperty("useWorkloadSets", out var value) ||
+            value.ValueKind == JsonValueKind.Null)
+            return DotnetWorkloadUpdateMode.WorkloadSet;
+
+        return value.ValueKind switch
+        {
+            JsonValueKind.True => DotnetWorkloadUpdateMode.WorkloadSet,
+            JsonValueKind.False => DotnetWorkloadUpdateMode.Manifests,
+            _ => throw new FormatException(
+                $"The workload install-state value 'useWorkloadSets' in '{path}' is not a boolean.")
+        };
+    }
+
+    public static IReadOnlyList<DotnetManifestVersion> ReadManifestVersions(
+        DotnetWorkloadTarget target)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+
+        var path = GetPath(target);
+        if (!File.Exists(path))
+            return [];
+
+        using var document = ReadDocument(path);
+        if (!document.RootElement.TryGetProperty("manifests", out var manifests) ||
+            manifests.ValueKind == JsonValueKind.Null)
+            return [];
+        if (manifests.ValueKind != JsonValueKind.Object)
+            throw new FormatException($"The workload install-state value 'manifests' in '{path}' is not an object.");
+
+        var versions = new List<DotnetManifestVersion>();
+        foreach (var manifest in manifests.EnumerateObject())
+        {
+            if (manifest.Value.ValueKind != JsonValueKind.String)
+                throw new FormatException(
+                    $"The workload install-state manifest '{manifest.Name}' in '{path}' does not have a string version.");
+
+            var value = manifest.Value.GetString() ?? string.Empty;
+            var parts = value.Split('/');
+            if (parts.Length is < 1 or > 2 || string.IsNullOrWhiteSpace(parts[0]))
+                throw new FormatException(
+                    $"The workload install-state manifest '{manifest.Name}' in '{path}' has invalid version '{value}'.");
+
+            versions.Add(new DotnetManifestVersion
+            {
+                ManifestId = manifest.Name,
+                Version = parts[0],
+                FeatureBand = parts.Length == 2
+                    ? parts[1]
+                    : target.FeatureBand.ToString()
+            });
+        }
+
+        return versions;
+    }
+
+    private static string GetPath(DotnetWorkloadTarget target) =>
+        Path.Combine(
+            target.InstallRoot,
+            "metadata",
+            "workloads",
+            CanonicalArchitecture(target.Architecture),
+            target.FeatureBand.ToString(),
+            "InstallState",
+            "default.json");
+
+    private static JsonDocument ReadDocument(string path) =>
+        JsonDocument.Parse(
+            File.ReadAllText(path),
+            new JsonDocumentOptions
+            {
+                CommentHandling = JsonCommentHandling.Skip,
+                AllowTrailingCommas = true
+            });
+
+    private static string CanonicalArchitecture(string architecture) =>
+        architecture.Trim().ToLowerInvariant() switch
+        {
+            "arm64" => "Arm64",
+            "arm" => "Arm",
+            "x64" => "X64",
+            "x86" => "X86",
+            _ => architecture
+        };
+}

--- a/src/MauiSherpa.Workloads/Services/WorkloadInstallationStateResolver.cs
+++ b/src/MauiSherpa.Workloads/Services/WorkloadInstallationStateResolver.cs
@@ -1,0 +1,94 @@
+using MauiSherpa.Workloads.Models;
+
+namespace MauiSherpa.Workloads.Services;
+
+public static class WorkloadInstallationStateResolver
+{
+    public static DotnetWorkloadInstallationResolution Resolve(
+        IEnumerable<DotnetInstalledWorkload> installedWorkloads,
+        IEnumerable<ResolvedWorkloadDefinition> availableWorkloads)
+    {
+        ArgumentNullException.ThrowIfNull(installedWorkloads);
+        ArgumentNullException.ThrowIfNull(availableWorkloads);
+
+        var definitions = availableWorkloads
+            .Where(workload => !string.IsNullOrWhiteSpace(workload.Id))
+            .GroupBy(workload => workload.Id, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(
+                group => group.Key,
+                group => group.Last(),
+                StringComparer.OrdinalIgnoreCase);
+        var records = installedWorkloads
+            .Where(workload => !string.IsNullOrWhiteSpace(workload.Id))
+            .GroupBy(workload => workload.Id, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(
+                group => group.Key,
+                group => group.First(),
+                StringComparer.OrdinalIgnoreCase);
+        var includedBy = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+        var diagnostics = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var record in records.Values)
+        {
+            if (!definitions.TryGetValue(record.Id, out var definition))
+            {
+                diagnostics.Add(
+                    $"Installed workload '{record.Id}' is not defined by the active workload manifests.");
+                continue;
+            }
+
+            foreach (var includedId in definition.TransitiveIncludes)
+            {
+                if (string.Equals(includedId, record.Id, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                if (!includedBy.TryGetValue(includedId, out var parents))
+                {
+                    parents = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                    includedBy[includedId] = parents;
+                }
+                parents.Add(record.Id);
+
+                if (!definitions.ContainsKey(includedId))
+                {
+                    diagnostics.Add(
+                        $"Workload '{includedId}', included by '{record.Id}', is not defined by the active workload manifests.");
+                }
+            }
+        }
+
+        var stateIds = records.Keys
+            .Concat(includedBy.Keys)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(id => id, StringComparer.OrdinalIgnoreCase);
+        var states = stateIds
+            .Select(id =>
+            {
+                records.TryGetValue(id, out var record);
+                definitions.TryGetValue(id, out var definition);
+                includedBy.TryGetValue(id, out var parents);
+
+                return new DotnetWorkloadInstallationState
+                {
+                    Id = id,
+                    Kind = record == null
+                        ? DotnetWorkloadInstallKind.Included
+                        : DotnetWorkloadInstallKind.Explicit,
+                    InstallationRecord = record,
+                    Definition = definition,
+                    IncludedBy = parents?
+                        .OrderBy(parent => parent, StringComparer.OrdinalIgnoreCase)
+                        .ToList() ?? []
+                };
+            })
+            .ToList();
+
+        return new DotnetWorkloadInstallationResolution
+        {
+            States = states,
+            Diagnostics = diagnostics
+                .OrderBy(message => message, StringComparer.Ordinal)
+                .ToList()
+        };
+    }
+}

--- a/src/MauiSherpa.Workloads/Services/WorkloadManifestService.cs
+++ b/src/MauiSherpa.Workloads/Services/WorkloadManifestService.cs
@@ -179,7 +179,7 @@ public class WorkloadManifestService : IWorkloadManifestService
     private static string GetManifestPackageId(string manifestId, string sdkBand) =>
         $"{manifestId}.Manifest-{sdkBand}";
 
-    private static WorkloadManifest? ParseManifest(string json)
+    public static WorkloadManifest? ParseManifest(string json)
     {
         var manifestJson = JsonSerializer.Deserialize<WorkloadManifestJson>(json, JsonOptions);
         if (manifestJson == null)

--- a/src/MauiSherpa.Workloads/Services/WorkloadRecommendationPolicy.cs
+++ b/src/MauiSherpa.Workloads/Services/WorkloadRecommendationPolicy.cs
@@ -1,0 +1,13 @@
+namespace MauiSherpa.Workloads.Services;
+
+public static class WorkloadRecommendationPolicy
+{
+    private static readonly string[] DesktopWorkloads =
+        ["maui", "ios", "macos", "tvos", "maccatalyst", "android", "wasm-tools"];
+
+    private static readonly string[] LinuxWorkloads =
+        ["maui-android", "android", "wasm-tools"];
+
+    public static IReadOnlyList<string> GetRecommendedWorkloadIds(bool isLinux) =>
+        isLinux ? LinuxWorkloads : DesktopWorkloads;
+}

--- a/src/MauiSherpa.Workloads/Services/WorkloadSetService.cs
+++ b/src/MauiSherpa.Workloads/Services/WorkloadSetService.cs
@@ -119,7 +119,7 @@ public class WorkloadSetService : IWorkloadSetService
         {
             Version = version,
             FeatureBand = featureBand,
-            Workloads = entries
+            ManifestEntries = entries
         };
     }
 }

--- a/src/MauiSherpa/Components/DotnetWorkloadCard.razor
+++ b/src/MauiSherpa/Components/DotnetWorkloadCard.razor
@@ -1,0 +1,464 @@
+@using MauiSherpa.Workloads.Models
+
+<div class="workload-card @(Inline ? "workload-card--inline" : null)">
+    @if (Inline)
+    {
+        <div class="workload-inline-head">
+            <div class="workload-title">
+                <i class="fas fa-puzzle-piece" aria-hidden="true"></i>
+                <strong>Workloads</strong>
+                @if (Loading)
+                {
+                    <span class="workload-summary"><i class="fas fa-spinner fa-spin" aria-hidden="true"></i> Reading state...</span>
+                }
+                else if (Inventories.Count == 0)
+                {
+                    <span class="workload-summary">No feature-band state</span>
+                }
+                else
+                {
+                    @foreach (var summary in VersionSummaries())
+                    {
+                        <span class="workload-version-summary"
+                              title="SDK feature band @summary.FeatureBand, workload version @summary.Version">
+                            <span class="summary-segment summary-sdk mono">@summary.FeatureBand</span>
+                            <span class="summary-segment summary-workload mono @(summary.Version == "unknown" ? "unknown" : "")">
+                                @summary.Version
+                            </span>
+                        </span>
+                    }
+                }
+            </div>
+        </div>
+    }
+    else
+    {
+        <button class="workload-card-head"
+                type="button"
+                @onclick="ToggleExpanded"
+                aria-expanded="@expanded">
+            <div class="workload-title">
+                <i class="fas fa-puzzle-piece" aria-hidden="true"></i>
+                <strong>Workloads</strong>
+                @if (Loading)
+                {
+                    <span class="workload-summary"><i class="fas fa-spinner fa-spin"></i> Reading state...</span>
+                }
+                else if (Inventories.Count == 0)
+                {
+                    <span class="workload-summary">No feature-band state</span>
+                }
+                else
+                {
+                    @foreach (var summary in VersionSummaries())
+                    {
+                        <span class="workload-version-summary"
+                              title="SDK feature band @summary.FeatureBand, workload version @summary.Version">
+                            <span class="summary-segment summary-sdk mono">@summary.FeatureBand</span>
+                            <span class="summary-segment summary-workload mono @(summary.Version == "unknown" ? "unknown" : "")">
+                                @summary.Version
+                            </span>
+                        </span>
+                    }
+                }
+            </div>
+            <i class="fas fa-chevron-right workload-chevron @(expanded ? "expanded" : "")" aria-hidden="true"></i>
+        </button>
+    }
+
+    @if (Inline || expanded)
+    {
+        <div class="workload-card-body">
+            @if (Loading)
+            {
+                <div class="workload-loading"><i class="fas fa-spinner fa-spin"></i> Reading workload state...</div>
+            }
+            else if (Inventories.Count == 0)
+            {
+                <div class="workload-loading">No SDK feature-band targets were found.</div>
+            }
+            else
+            {
+                @foreach (var inventory in Inventories)
+                {
+                    <div class="workload-row">
+                        <div class="workload-target">
+                            <div class="workload-target-line">
+                                <span class="mono feature-band">@inventory.Target.FeatureBand</span>
+                                <span class="badge @(inventory.UpdateMode == DotnetWorkloadUpdateMode.WorkloadSet ? "badge-workload-set" : "badge-warning")">
+                                    @ModeLabel(inventory.UpdateMode)
+                                </span>
+                                @if (inventory.UpdateAvailable)
+                                {
+                                    <span class="badge badge-info">set update</span>
+                                }
+                                @if (inventory.WorkloadUpdates.Count > 0)
+                                {
+                                    <span class="badge badge-info">@inventory.WorkloadUpdates.Count workload update@(inventory.WorkloadUpdates.Count == 1 ? "" : "s")</span>
+                                }
+                                @if (inventory.Diagnostics.Count > 0)
+                                {
+                                    <i class="fas fa-circle-exclamation diagnostic" title="@string.Join(Environment.NewLine, inventory.Diagnostics)"></i>
+                                }
+                            </div>
+                            <div class="workload-meta">
+                                <span>SDK <span class="mono">@inventory.Target.RepresentativeSdkVersion</span></span>
+                                <span class="dot">·</span>
+                                <span class="mono">@inventory.ActiveWorkloadVersion</span>
+                                @if (!string.IsNullOrWhiteSpace(inventory.Target.Architecture))
+                                {
+                                    <span class="dot">·</span>
+                                    <span>@inventory.Target.Architecture</span>
+                                }
+                            </div>
+                            <div class="workload-chips">
+                                @if (inventory.InstalledWorkloads.Count == 0)
+                                {
+                                    <span class="no-workloads">No workload IDs installed</span>
+                                }
+                                else
+                                {
+                                    @foreach (var workload in inventory.InstalledWorkloads.Take(5))
+                                    {
+                                        <span class="workload-chip mono">@workload.Id</span>
+                                    }
+                                    @if (inventory.InstalledWorkloads.Count > 5)
+                                    {
+                                        <span class="workload-chip">+@(inventory.InstalledWorkloads.Count - 5)</span>
+                                    }
+                                }
+                            </div>
+                        </div>
+
+                        <div class="workload-actions">
+                            <button class="btn btn-ghost btn-sm icon-button"
+                                    @onclick="@(() => RepairRequested.InvokeAsync(inventory))"
+                                    disabled="@(Busy || inventory.InstalledWorkloads.Count == 0)"
+                                    title="@(inventory.InstalledWorkloads.Count == 0 ? "No installed workloads to repair" : "Repair installed workloads")">
+                                <i class="fas fa-screwdriver-wrench"></i>
+                            </button>
+                            <button class="btn btn-secondary btn-sm"
+                                    @onclick="@(() => ManageRequested.InvokeAsync(inventory))"
+                                    disabled="@(Busy || (inventory.InstalledWorkloads.Count == 0 && !inventory.AvailableWorkloads.Any(workload => !workload.IsAbstract && workload.RedirectTarget == null)))">
+                                <i class="fas fa-list-check"></i> <span>Workloads</span>
+                            </button>
+                            <button class="btn btn-secondary btn-sm segmented-action"
+                                    @onclick="@(() => ChangeSetRequested.InvokeAsync(inventory))"
+                                    disabled="@(Busy || inventory.AvailableSetVersions.Count == 0)">
+                                <span class="segmented-action-main">
+                                    <i class="fas fa-layer-group"></i>
+                                    <span>Sets</span>
+                                </span>
+                                @if (inventory.UpdateAvailable)
+                                {
+                                    <span class="segmented-action-update"
+                                          title="A workload set update is available"
+                                          aria-label="Update available">
+                                        <i class="fas fa-arrow-up"></i>
+                                    </span>
+                                }
+                            </button>
+                        </div>
+                    </div>
+                }
+            }
+        </div>
+    }
+</div>
+
+<style>
+    .workload-card {
+        margin-top: 0.45rem;
+        margin-bottom: 0.4rem;
+        border-radius: var(--card-radius);
+        background: var(--card-bg);
+        overflow: hidden;
+    }
+
+    .workload-card--inline {
+        margin: 0;
+        border-top: 1px solid var(--border-color);
+        border-radius: 0;
+        background: transparent;
+        overflow: visible;
+    }
+
+    .workload-inline-head {
+        padding: 0.55rem 1rem;
+        border-bottom: 1px solid var(--border-color);
+        background: var(--card-bg);
+    }
+
+    .workload-card-head {
+        width: 100%;
+        border: 0;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+        padding: 0.55rem 0.85rem;
+        background: transparent;
+        color: var(--text-secondary);
+        font-size: 0.75rem;
+        font-family: inherit;
+        text-align: left;
+        cursor: pointer;
+    }
+
+    .workload-card-head:hover {
+        background: var(--bg-tertiary);
+    }
+
+    .workload-title {
+        display: flex;
+        flex: 1;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 0.45rem;
+        color: var(--text-primary);
+        font-size: 0.83rem;
+        min-width: 0;
+    }
+
+    .workload-card-head i {
+        color: var(--text-secondary);
+    }
+
+    .workload-chevron {
+        width: 0.7rem;
+        flex-shrink: 0;
+        font-size: 0.68rem;
+        transition: transform 0.15s ease;
+    }
+
+    .workload-chevron.expanded {
+        transform: rotate(90deg);
+    }
+
+    .workload-summary,
+    .workload-version-summary {
+        color: var(--text-secondary);
+        font-size: 0.7rem;
+        font-weight: 400;
+    }
+
+    .workload-version-summary {
+        display: inline-flex;
+        align-items: center;
+        gap: 0;
+        padding: 0;
+        border: 1px solid var(--border-color);
+        border-radius: 999px;
+        overflow: hidden;
+    }
+
+    .summary-segment {
+        padding: 0.14rem 0.46rem;
+        white-space: nowrap;
+    }
+
+    .summary-sdk {
+        color: var(--status-success-text);
+        background: var(--bg-tertiary);
+        font-weight: 600;
+    }
+
+    .summary-workload {
+        color: var(--text-inverse);
+        background: color-mix(in srgb, var(--accent-purple) 80%, var(--text-primary));
+        border-left: 1px solid var(--border-color);
+        font-weight: 600;
+    }
+
+    .summary-workload.unknown {
+        color: var(--status-warning-text);
+        background: var(--status-warning-bg);
+    }
+
+    .badge-workload-set {
+        color: var(--accent-purple);
+        background: color-mix(in srgb, var(--accent-purple) 12%, var(--card-bg));
+        border: 1px solid color-mix(in srgb, var(--accent-purple) 35%, var(--border-color));
+    }
+
+    .workload-card-body {
+        border-top: 1px solid var(--border-color);
+    }
+
+    .workload-card--inline .workload-card-body {
+        border-top: 0;
+    }
+
+    .workload-card--inline .workload-row {
+        padding: 0.65rem 1rem;
+        background: color-mix(in srgb, var(--bg-tertiary) 35%, var(--card-bg));
+    }
+
+    .workload-card--inline .workload-row + .workload-row {
+        border-top: 1px solid var(--border-color);
+    }
+
+    .workload-row {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+        padding: 0.7rem 0.85rem;
+    }
+
+    .workload-row + .workload-row {
+        border-top: 1px solid var(--border-color);
+    }
+
+    .workload-target {
+        flex: 1;
+        min-width: 0;
+    }
+
+    .workload-target-line,
+    .workload-meta,
+    .workload-chips,
+    .workload-actions {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 0.4rem;
+    }
+
+    .feature-band {
+        color: var(--text-primary);
+        font-size: 0.84rem;
+        font-weight: 600;
+    }
+
+    .workload-meta {
+        margin-top: 0.22rem;
+        color: var(--text-secondary);
+        font-size: 0.72rem;
+    }
+
+    .dot {
+        opacity: 0.55;
+    }
+
+    .workload-chips {
+        margin-top: 0.4rem;
+        gap: 0.3rem;
+    }
+
+    .workload-chip {
+        padding: 0.12rem 0.42rem;
+        border-radius: 999px;
+        background: var(--bg-tertiary);
+        color: var(--text-secondary);
+        font-size: 0.68rem;
+    }
+
+    .no-workloads {
+        color: var(--text-secondary);
+        font-size: 0.74rem;
+        font-style: italic;
+    }
+
+    .workload-actions {
+        justify-content: flex-end;
+        flex-shrink: 0;
+    }
+
+    .segmented-action {
+        gap: 0;
+        padding: 0;
+        overflow: hidden;
+    }
+
+    .segmented-action-main,
+    .segmented-action-update {
+        display: inline-flex;
+        align-items: center;
+        align-self: stretch;
+    }
+
+    .segmented-action-main {
+        gap: 0.35rem;
+        padding: 0.32rem 0.58rem;
+    }
+
+    .segmented-action-update {
+        justify-content: center;
+        padding: 0.32rem 0.48rem;
+        border-left: 1px solid var(--border-color);
+        background: var(--status-info-bg);
+        color: var(--status-info-text);
+    }
+
+    .workload-loading {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.45rem;
+        padding: 1rem;
+        color: var(--text-secondary);
+        font-size: 0.8rem;
+    }
+
+    .diagnostic {
+        color: var(--status-warning-text);
+        cursor: help;
+    }
+
+    .icon-button {
+        width: 2rem;
+        justify-content: center;
+        padding-left: 0;
+        padding-right: 0;
+    }
+
+    .badge {
+        display: inline-flex;
+        align-items: center;
+        padding: 2px 0.5rem;
+        border-radius: 999px;
+        font-size: 0.68rem;
+        font-weight: 500;
+        white-space: nowrap;
+    }
+
+    @@media (max-width: 850px) {
+        .workload-row {
+            align-items: flex-start;
+            flex-direction: column;
+        }
+
+        .workload-actions {
+            justify-content: flex-start;
+        }
+    }
+</style>
+
+@code {
+    [Parameter] public IReadOnlyList<DotnetWorkloadInventory> Inventories { get; set; } = [];
+    [Parameter] public bool Loading { get; set; }
+    [Parameter] public bool Busy { get; set; }
+    [Parameter] public bool Inline { get; set; }
+    [Parameter] public EventCallback<DotnetWorkloadInventory> ManageRequested { get; set; }
+    [Parameter] public EventCallback<DotnetWorkloadInventory> ChangeSetRequested { get; set; }
+    [Parameter] public EventCallback<DotnetWorkloadInventory> RepairRequested { get; set; }
+
+    private bool expanded;
+
+    private void ToggleExpanded() => expanded = !expanded;
+
+    private IReadOnlyList<(string FeatureBand, string Version)> VersionSummaries() =>
+        Inventories
+            .Select(inventory => (
+                inventory.Target.FeatureBand.ToString(),
+                inventory.ActiveWorkloadVersion ?? "unknown"))
+            .Distinct()
+            .ToList();
+
+    private static string ModeLabel(DotnetWorkloadUpdateMode mode) => mode switch
+    {
+        DotnetWorkloadUpdateMode.WorkloadSet => "workload set",
+        DotnetWorkloadUpdateMode.Manifests => "loose manifests",
+        _ => "unknown mode"
+    };
+}

--- a/src/MauiSherpa/Components/DotnetWorkloadCard.razor
+++ b/src/MauiSherpa/Components/DotnetWorkloadCard.razor
@@ -81,6 +81,8 @@
             {
                 @foreach (var inventory in Inventories)
                 {
+                    var effectiveWorkloads = VisibleInstalledWorkloads(inventory);
+                    var includedCount = effectiveWorkloads.Count(workload => !workload.IsExplicit);
                     <div class="workload-row">
                         <div class="workload-target">
                             <div class="workload-target-line">
@@ -112,19 +114,29 @@
                                 }
                             </div>
                             <div class="workload-chips">
-                                @if (inventory.InstalledWorkloads.Count == 0)
+                                @if (effectiveWorkloads.Count == 0)
                                 {
                                     <span class="no-workloads">No workload IDs installed</span>
                                 }
                                 else
                                 {
-                                    @foreach (var workload in inventory.InstalledWorkloads.Take(5))
+                                    <span class="workload-count">
+                                        @inventory.InstalledWorkloads.Count direct
+                                        @if (includedCount > 0)
+                                        {
+                                            <text> · @includedCount included</text>
+                                        }
+                                    </span>
+                                    @foreach (var workload in effectiveWorkloads.Take(5))
                                     {
-                                        <span class="workload-chip mono">@workload.Id</span>
+                                        <span class="workload-chip mono @(!workload.IsExplicit ? "workload-chip--included" : "")"
+                                              title="@WorkloadStateTitle(workload)">
+                                            @workload.Id
+                                        </span>
                                     }
-                                    @if (inventory.InstalledWorkloads.Count > 5)
+                                    @if (effectiveWorkloads.Count > 5)
                                     {
-                                        <span class="workload-chip">+@(inventory.InstalledWorkloads.Count - 5)</span>
+                                        <span class="workload-chip">+@(effectiveWorkloads.Count - 5)</span>
                                     }
                                 }
                             </div>
@@ -139,7 +151,7 @@
                             </button>
                             <button class="btn btn-secondary btn-sm"
                                     @onclick="@(() => ManageRequested.InvokeAsync(inventory))"
-                                    disabled="@(Busy || (inventory.InstalledWorkloads.Count == 0 && !inventory.AvailableWorkloads.Any(workload => !workload.IsAbstract && workload.RedirectTarget == null)))">
+                                    disabled="@(Busy || (effectiveWorkloads.Count == 0 && inventory.InstallableWorkloads.Count == 0))">
                                 <i class="fas fa-list-check"></i> <span>Workloads</span>
                             </button>
                             <button class="btn btn-secondary btn-sm segmented-action"
@@ -353,6 +365,16 @@
         font-size: 0.68rem;
     }
 
+    .workload-chip--included {
+        color: var(--status-info-text);
+        background: var(--status-info-bg);
+    }
+
+    .workload-count {
+        color: var(--text-secondary);
+        font-size: 0.68rem;
+    }
+
     .no-workloads {
         color: var(--text-secondary);
         font-size: 0.74rem;
@@ -454,6 +476,21 @@
                 inventory.ActiveWorkloadVersion ?? "unknown"))
             .Distinct()
             .ToList();
+
+    private static IReadOnlyList<DotnetWorkloadInstallationState> VisibleInstalledWorkloads(
+        DotnetWorkloadInventory inventory) =>
+        inventory.EffectiveInstalledWorkloads
+            .Where(workload => workload.IsUserVisible)
+            .OrderByDescending(workload => workload.IsExplicit)
+            .ThenBy(workload => workload.Id, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+    private static string WorkloadStateTitle(DotnetWorkloadInstallationState workload) =>
+        workload.IsExplicit
+            ? workload.IncludedBy.Count == 0
+                ? "Directly installed"
+                : $"Directly installed; also included by {string.Join(", ", workload.IncludedBy)}"
+            : $"Included by {string.Join(", ", workload.IncludedBy)}";
 
     private static string ModeLabel(DotnetWorkloadUpdateMode mode) => mode switch
     {

--- a/src/MauiSherpa/Components/InstalledDotnetVersionCard.razor
+++ b/src/MauiSherpa/Components/InstalledDotnetVersionCard.razor
@@ -1,0 +1,495 @@
+@using MauiSherpa.Workloads.Models
+
+<div class="installed-dotnet-version-card">
+    <button class="installed-dotnet-version-card__toggle"
+            type="button"
+            @onclick="ToggleExpanded"
+            aria-expanded="@expanded"
+            aria-controls="@bodyId">
+        <div class="installed-dotnet-version-card__summary">
+            <div class="installed-dotnet-version-card__title-row">
+                <span class="installed-dotnet-version-card__title">@DisplayRuntimeLine</span>
+
+                @if (!string.IsNullOrWhiteSpace(NewestSdkVersion))
+                {
+                    <span class="installed-dotnet-version-card__summary-chip installed-dotnet-version-card__summary-chip--sdk"
+                          title="Newest installed SDK patch">
+                        <i class="fas fa-toolbox" aria-hidden="true"></i>
+                        <span class="mono">SDK @NewestSdkVersion</span>
+                    </span>
+                }
+                else
+                {
+                    <span class="installed-dotnet-version-card__summary-chip installed-dotnet-version-card__summary-chip--muted">
+                        <i class="fas fa-gears" aria-hidden="true"></i>
+                        <span>runtime only</span>
+                    </span>
+                }
+
+                @if (InvalidCount > 0)
+                {
+                    <span class="badge badge-warning installed-dotnet-version-card__invalid-badge"
+                          title="@InvalidCount invalid installation@(InvalidCount == 1 ? string.Empty : "s")">
+                        <i class="fas fa-triangle-exclamation" aria-hidden="true"></i>
+                        <span>@InvalidCount invalid</span>
+                    </span>
+                }
+            </div>
+
+            <div class="installed-dotnet-version-card__meta-row">
+                @if (Loading)
+                {
+                    <span class="installed-dotnet-version-card__loading">
+                        <i class="fas fa-spinner fa-spin" aria-hidden="true"></i>
+                        <span>Refreshing…</span>
+                    </span>
+                }
+
+                <span class="installed-dotnet-version-card__count-pill">
+                    <strong>@SdkCount</strong>
+                    <span>SDK@(SdkCount == 1 ? string.Empty : "s")</span>
+                </span>
+                <span class="installed-dotnet-version-card__count-pill">
+                    <strong>@RuntimeCount</strong>
+                    <span>runtime@(RuntimeCount == 1 ? string.Empty : "s")</span>
+                </span>
+                <span class="installed-dotnet-version-card__count-pill">
+                    <strong>@WorkloadBandCount</strong>
+                    <span>workload band@(WorkloadBandCount == 1 ? string.Empty : "s")</span>
+                </span>
+            </div>
+        </div>
+
+        <span class="installed-dotnet-version-card__chevron" aria-hidden="true">
+            <i class="fas fa-chevron-right @(expanded ? "installed-dotnet-version-card__chevron-icon--expanded" : string.Empty)"></i>
+        </span>
+    </button>
+
+    @if (expanded)
+    {
+        <div id="@bodyId" class="installed-dotnet-version-card__body">
+            @if (Loading && Installations.Count == 0)
+            {
+                <div class="installed-dotnet-version-card__state">
+                    <i class="fas fa-spinner fa-spin" aria-hidden="true"></i>
+                    <span>Loading installed components…</span>
+                </div>
+            }
+            else if (Installations.Count == 0)
+            {
+                <div class="installed-dotnet-version-card__state">
+                    <i class="fas fa-box-open" aria-hidden="true"></i>
+                    <span>No installed components for this runtime line.</span>
+                </div>
+            }
+            else
+            {
+                @foreach (var installation in OrderedInstallations)
+                {
+                    <div class="installed-dotnet-version-card__item" @key="ItemKey(installation)">
+                        <div class="installed-dotnet-version-card__item-main">
+                            <div class="installed-dotnet-version-card__item-line">
+                                <span class="badge @ComponentBadgeClass(installation.Component)">@ComponentShort(installation.Component)</span>
+                                <span class="installed-dotnet-version-card__item-version mono">@installation.Version</span>
+                                <span class="installed-dotnet-version-card__item-name">@ComponentDisplay(installation.Component)</span>
+                            </div>
+
+                            @if (!string.IsNullOrWhiteSpace(installation.Architecture) || !installation.IsValid)
+                            {
+                                <div class="installed-dotnet-version-card__item-subline">
+                                    @if (!string.IsNullOrWhiteSpace(installation.Architecture))
+                                    {
+                                        <span>@installation.Architecture</span>
+                                    }
+
+                                    @if (!installation.IsValid)
+                                    {
+                                        <span class="badge badge-warning">
+                                            <i class="fas fa-triangle-exclamation" aria-hidden="true"></i>
+                                            <span>invalid</span>
+                                        </span>
+                                    }
+                                </div>
+                            }
+                        </div>
+
+                        @if (AllowMachineChanges)
+                        {
+                            <div class="installed-dotnet-version-card__item-actions">
+                                <button class="btn btn-danger btn-sm installed-dotnet-version-card__action"
+                                        type="button"
+                                        @onclick="() => UninstallRequested.InvokeAsync(installation)"
+                                        disabled="@Busy"
+                                        title="Uninstall this component"
+                                        aria-label="Uninstall @installation.Version @ComponentDisplay(installation.Component)">
+                                    <i class="fas fa-trash" aria-hidden="true"></i>
+                                </button>
+                            </div>
+                        }
+                    </div>
+                }
+            }
+
+            @if (HasSdk && AllowMachineChanges)
+            {
+                <div class="installed-dotnet-version-card__workloads">
+                    <DotnetWorkloadCard Inventories="@WorkloadInventories"
+                                        Loading="@Loading"
+                                        Busy="@Busy"
+                                        Inline="true"
+                                        ManageRequested="@ManageRequested"
+                                        ChangeSetRequested="@ChangeSetRequested"
+                                        RepairRequested="@RepairRequested" />
+                </div>
+            }
+        </div>
+    }
+</div>
+
+<style>
+    .installed-dotnet-version-card {
+        border: 1px solid var(--border-color);
+        border-radius: var(--card-radius);
+        background: var(--card-bg);
+        overflow: hidden;
+    }
+
+    .installed-dotnet-version-card .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.3rem;
+        padding: 2px 0.5rem;
+        border-radius: 999px;
+        font-size: 0.68rem;
+        font-weight: 600;
+        white-space: nowrap;
+    }
+
+    .installed-dotnet-version-card__toggle {
+        width: 100%;
+        border: 0;
+        background: transparent;
+        color: inherit;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+        padding: 0.9rem 1rem;
+        font: inherit;
+        text-align: left;
+        cursor: pointer;
+    }
+
+    .installed-dotnet-version-card__toggle:hover {
+        background: var(--bg-tertiary);
+    }
+
+    .installed-dotnet-version-card__toggle:focus-visible {
+        outline: 2px solid var(--accent-primary);
+        outline-offset: -2px;
+    }
+
+    .installed-dotnet-version-card__summary {
+        min-width: 0;
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 0.45rem;
+    }
+
+    .installed-dotnet-version-card__title-row,
+    .installed-dotnet-version-card__meta-row {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        min-width: 0;
+    }
+
+    .installed-dotnet-version-card__title {
+        color: var(--text-primary);
+        font-size: 0.96rem;
+        font-weight: 700;
+    }
+
+    .installed-dotnet-version-card__summary-chip,
+    .installed-dotnet-version-card__count-pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        padding: 0.2rem 0.55rem;
+        border-radius: 999px;
+        background: var(--bg-tertiary);
+        color: var(--text-secondary);
+        font-size: 0.72rem;
+        white-space: nowrap;
+    }
+
+    .installed-dotnet-version-card__summary-chip--sdk {
+        color: var(--text-primary);
+    }
+
+    .installed-dotnet-version-card__summary-chip--muted {
+        opacity: 0.85;
+    }
+
+    .installed-dotnet-version-card__count-pill strong {
+        color: var(--text-primary);
+        font-size: 0.78rem;
+    }
+
+    .installed-dotnet-version-card__invalid-badge {
+        margin-left: auto;
+    }
+
+    .installed-dotnet-version-card__loading {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        color: var(--text-secondary);
+        font-size: 0.76rem;
+    }
+
+    .installed-dotnet-version-card__chevron {
+        flex-shrink: 0;
+        color: var(--text-secondary);
+        font-size: 0.76rem;
+    }
+
+    .installed-dotnet-version-card__chevron-icon--expanded {
+        transform: rotate(90deg);
+    }
+
+    .installed-dotnet-version-card__chevron i {
+        transition: transform 0.15s ease;
+    }
+
+    .installed-dotnet-version-card__body {
+        padding: 0;
+        border-top: 1px solid var(--border-color);
+    }
+
+    .installed-dotnet-version-card__state {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.45rem;
+        padding: 1rem 0;
+        color: var(--text-secondary);
+        font-size: 0.8rem;
+    }
+
+    .installed-dotnet-version-card__item {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.75rem;
+        padding: 0.65rem 1rem;
+        background: color-mix(in srgb, var(--bg-tertiary) 35%, var(--card-bg));
+    }
+
+    .installed-dotnet-version-card__item + .installed-dotnet-version-card__item {
+        border-top: 1px solid var(--border-color);
+    }
+
+    .installed-dotnet-version-card__item-main {
+        min-width: 0;
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 0.35rem;
+    }
+
+    .installed-dotnet-version-card__item-line,
+    .installed-dotnet-version-card__item-subline,
+    .installed-dotnet-version-card__item-actions {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 0.45rem;
+    }
+
+    .installed-dotnet-version-card__item-version {
+        color: var(--text-primary);
+        font-weight: 700;
+    }
+
+    .installed-dotnet-version-card__item-name,
+    .installed-dotnet-version-card__item-subline {
+        color: var(--text-secondary);
+        font-size: 0.8rem;
+    }
+
+    .installed-dotnet-version-card__item-actions {
+        flex-shrink: 0;
+        justify-content: flex-end;
+    }
+
+    .installed-dotnet-version-card__action {
+        min-width: 2.25rem;
+        justify-content: center;
+        padding-left: 0;
+        padding-right: 0;
+    }
+
+    .installed-dotnet-version-card__workloads {
+        margin-top: 0;
+    }
+
+    @@media (max-width: 900px) {
+        .installed-dotnet-version-card__toggle {
+            align-items: flex-start;
+        }
+
+        .installed-dotnet-version-card__invalid-badge {
+            margin-left: 0;
+        }
+    }
+
+    @@media (max-width: 700px) {
+        .installed-dotnet-version-card__toggle {
+            padding-left: 0.85rem;
+            padding-right: 0.85rem;
+        }
+
+        .installed-dotnet-version-card__item {
+            flex-direction: column;
+            align-items: stretch;
+        }
+
+        .installed-dotnet-version-card__item-actions {
+            justify-content: flex-start;
+        }
+    }
+</style>
+
+@code {
+    [Parameter] public string? RuntimeLine { get; set; }
+    [Parameter] public IReadOnlyList<DotnetUpInstallation> Installations { get; set; } = [];
+    [Parameter] public IReadOnlyList<DotnetWorkloadInventory> WorkloadInventories { get; set; } = [];
+    [Parameter] public bool Loading { get; set; }
+    [Parameter] public bool Busy { get; set; }
+    [Parameter] public bool InitiallyExpanded { get; set; }
+    [Parameter] public bool AllowMachineChanges { get; set; } = true;
+    [Parameter] public EventCallback<DotnetUpInstallation> UninstallRequested { get; set; }
+    [Parameter] public EventCallback<DotnetWorkloadInventory> ManageRequested { get; set; }
+    [Parameter] public EventCallback<DotnetWorkloadInventory> ChangeSetRequested { get; set; }
+    [Parameter] public EventCallback<DotnetWorkloadInventory> RepairRequested { get; set; }
+
+    private readonly string bodyId = $"installed-dotnet-version-card-{Guid.NewGuid():N}";
+    private bool expanded;
+    private bool capturedInitialExpansion;
+
+    private IEnumerable<DotnetUpInstallation> OrderedInstallations => Installations
+        .OrderBy(installation => ComponentSortOrder(installation.Component))
+        .ThenByDescending(installation => VersionSortKey(installation.Version))
+        .ThenByDescending(installation => installation.Version, StringComparer.OrdinalIgnoreCase);
+
+    private string DisplayRuntimeLine => string.IsNullOrWhiteSpace(RuntimeLine)
+        ? DeriveRuntimeLine()
+        : RuntimeLine!;
+
+    private int SdkCount => Installations.Count(installation => installation.Component == DotnetUpComponent.Sdk);
+
+    private int RuntimeCount => Installations.Count(installation => installation.Component != DotnetUpComponent.Sdk);
+
+    private int WorkloadBandCount => WorkloadInventories
+        .Select(inventory => inventory.Target.FeatureBand.ToString())
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .Count();
+
+    private int InvalidCount => Installations.Count(installation => !installation.IsValid);
+
+    private bool HasSdk => Installations.Any(installation => installation.Component == DotnetUpComponent.Sdk);
+
+    private string? NewestSdkVersion => Installations
+        .Where(installation => installation.Component == DotnetUpComponent.Sdk)
+        .OrderByDescending(installation => VersionSortKey(installation.Version))
+        .Select(installation => installation.Version)
+        .FirstOrDefault();
+
+    protected override void OnParametersSet()
+    {
+        if (capturedInitialExpansion)
+        {
+            return;
+        }
+
+        expanded = InitiallyExpanded;
+        capturedInitialExpansion = true;
+    }
+
+    private void ToggleExpanded() => expanded = !expanded;
+
+    private string DeriveRuntimeLine()
+    {
+        var seedVersion = NewestSdkVersion ?? Installations.FirstOrDefault()?.Version;
+        if (string.IsNullOrWhiteSpace(seedVersion))
+        {
+            return ".NET";
+        }
+
+        var parts = seedVersion.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        return parts.Length >= 2 && int.TryParse(parts[0], out _) && int.TryParse(parts[1], out _)
+            ? $".NET {parts[0]}.{parts[1]}"
+            : seedVersion;
+    }
+
+    private static string ItemKey(DotnetUpInstallation installation) =>
+        $"{installation.Component}|{installation.Version}|{installation.Architecture}|{installation.InstallRoot}";
+
+    private static string ComponentDisplay(DotnetUpComponent component) => component switch
+    {
+        DotnetUpComponent.Sdk => ".NET SDK",
+        DotnetUpComponent.Runtime => ".NET Runtime",
+        DotnetUpComponent.AspNetCore => "ASP.NET Core Runtime",
+        DotnetUpComponent.WindowsDesktop => "Windows Desktop Runtime",
+        _ => "Component"
+    };
+
+    private static string ComponentShort(DotnetUpComponent component) => component switch
+    {
+        DotnetUpComponent.Sdk => "SDK",
+        DotnetUpComponent.Runtime => "Runtime",
+        DotnetUpComponent.AspNetCore => "ASP.NET",
+        DotnetUpComponent.WindowsDesktop => "Desktop",
+        _ => "Other"
+    };
+
+    private static string ComponentBadgeClass(DotnetUpComponent component) => component switch
+    {
+        DotnetUpComponent.Sdk => "badge-success",
+        DotnetUpComponent.Runtime => "badge-info",
+        DotnetUpComponent.AspNetCore => "badge-info",
+        DotnetUpComponent.WindowsDesktop => "badge-info",
+        _ => "badge-secondary"
+    };
+
+    private static int ComponentSortOrder(DotnetUpComponent component) => component switch
+    {
+        DotnetUpComponent.Sdk => 0,
+        DotnetUpComponent.Runtime => 1,
+        DotnetUpComponent.AspNetCore => 2,
+        DotnetUpComponent.WindowsDesktop => 3,
+        _ => 4
+    };
+
+    private static (int ReleaseRank, int Major, int Minor, int Patch, int Revision, string Raw) VersionSortKey(string version)
+    {
+        var raw = version ?? string.Empty;
+        var releaseRank = raw.Contains('-', StringComparison.Ordinal) ? 0 : 1;
+        var numericPortion = raw.Split('-', 2, StringSplitOptions.TrimEntries)[0];
+        var segments = numericPortion.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        return (
+            releaseRank,
+            ParseSegment(segments, 0),
+            ParseSegment(segments, 1),
+            ParseSegment(segments, 2),
+            ParseSegment(segments, 3),
+            raw);
+    }
+
+    private static int ParseSegment(IReadOnlyList<string> segments, int index) =>
+        index < segments.Count && int.TryParse(segments[index], out var value) ? value : -1;
+}

--- a/src/MauiSherpa/Components/MainLayout.razor
+++ b/src/MauiSherpa/Components/MainLayout.razor
@@ -23,6 +23,11 @@
                 <i class="fas fa-home nav-icon"></i>
                 <span>Dashboard</span>
             </NavLink>
+            <div class="nav-section"><i class="fas fa-layer-group nav-section-icon"></i> .NET</div>
+            <NavLink class="nav-item" href="dotnet-sdk">
+                <i class="fas fa-layer-group nav-icon"></i>
+                <span>SDK Manager</span>
+            </NavLink>
             <div class="nav-section"><i class="fab fa-android nav-section-icon"></i> Android</div>
             <NavLink class="nav-item" href="devices">
                 <i class="fas fa-mobile-alt nav-icon"></i>

--- a/src/MauiSherpa/Components/MainLayout.razor
+++ b/src/MauiSherpa/Components/MainLayout.razor
@@ -23,11 +23,6 @@
                 <i class="fas fa-home nav-icon"></i>
                 <span>Dashboard</span>
             </NavLink>
-            <div class="nav-section"><i class="fas fa-layer-group nav-section-icon"></i> .NET</div>
-            <NavLink class="nav-item" href="dotnet-sdk">
-                <i class="fas fa-layer-group nav-icon"></i>
-                <span>SDK Manager</span>
-            </NavLink>
             <div class="nav-section"><i class="fab fa-android nav-section-icon"></i> Android</div>
             <NavLink class="nav-item" href="devices">
                 <i class="fas fa-mobile-alt nav-icon"></i>
@@ -101,6 +96,10 @@
             </NavLink>
 
             <div class="nav-section"><i class="fas fa-toolbox nav-section-icon"></i> Tools</div>
+            <NavLink class="nav-item" href="dotnet-sdk">
+                <i class="fas fa-layer-group nav-icon"></i>
+                <span>.NET SDK Manager</span>
+            </NavLink>
             <NavLink class="nav-item" href="profiling">
                 <i class="fas fa-chart-line nav-icon"></i>
                 <span>Profiling</span>
@@ -588,6 +587,9 @@
 
     .platform-macos .content {
         padding: 15px;
+        /* Reserve a right-hand gutter so content never sits under the
+           floating viewport scrollbar (WKWebView document-level scroll). */
+        padding-right: 23px;
         margin-left: 0;
         background-color: transparent;
         /* Let the document scroll instead of this div so WKWebView

--- a/src/MauiSherpa/Components/ProcessExecutionModal.razor
+++ b/src/MauiSherpa/Components/ProcessExecutionModal.razor
@@ -21,6 +21,13 @@
                     <p class="description">@Request.Description</p>
                 }
 
+                @if (!string.IsNullOrEmpty(Request?.ConfirmationDetails))
+                {
+                    <div class="confirmation-details">
+                        <pre>@Request.ConfirmationDetails</pre>
+                    </div>
+                }
+
                 <div class="command-preview">
                     <label>Command to execute:</label>
                     <div class="command-box">
@@ -32,7 +39,8 @@
                 {
                     <div class="elevation-warning">
                         <i class="fas fa-exclamation-triangle warning-icon"></i>
-                        <span>This command requires administrator privileges. You may be prompted for your password.</span>
+                        <span>@(Request.ElevationPrompt ??
+                            "This command requires administrator privileges. You may be prompted for your password.")</span>
                     </div>
                 }
 
@@ -108,8 +116,26 @@
 
     /* Confirmation View */
     .confirmation-view .description {
-        color: #4a5568;
+        color: var(--text-secondary);
         margin-bottom: 1rem;
+    }
+
+    .confirmation-details {
+        margin-bottom: 1rem;
+        padding: 0.8rem 0.95rem;
+        border: 1px solid var(--border-color);
+        border-radius: var(--card-radius, 1rem);
+        background: var(--bg-tertiary);
+    }
+
+    .confirmation-details pre {
+        margin: 0;
+        color: var(--text-primary);
+        font-family: "SF Mono", Menlo, Monaco, monospace;
+        font-size: 0.76rem;
+        line-height: 1.5;
+        white-space: pre-wrap;
+        word-break: break-word;
     }
 
     .command-preview {
@@ -367,15 +393,21 @@
             // Replay stdout
             if (!string.IsNullOrEmpty(Result.Output))
             {
-                foreach (var line in Result.Output.Split('\n', StringSplitOptions.None))
-                    await JS.InvokeVoidAsync("terminalInterop.write", "process-terminal", line);
+                if (Request?.UsePseudoTerminal == true)
+                    await JS.InvokeVoidAsync("terminalInterop.writeRaw", "process-terminal", Result.Output);
+                else
+                    foreach (var line in Result.Output.Split('\n', StringSplitOptions.None))
+                        await JS.InvokeVoidAsync("terminalInterop.write", "process-terminal", line);
             }
 
             // Replay stderr
             if (!string.IsNullOrEmpty(Result.Error))
             {
-                foreach (var line in Result.Error.Split('\n', StringSplitOptions.None))
-                    await JS.InvokeVoidAsync("terminalInterop.writeError", "process-terminal", line);
+                if (Request?.UsePseudoTerminal == true)
+                    await JS.InvokeVoidAsync("terminalInterop.writeRaw", "process-terminal", Result.Error);
+                else
+                    foreach (var line in Result.Error.Split('\n', StringSplitOptions.None))
+                        await JS.InvokeVoidAsync("terminalInterop.writeError", "process-terminal", line);
             }
 
             // Write final status line
@@ -419,7 +451,9 @@
         {
             if (_terminalInitialized)
             {
-                if (e.IsError)
+                if (e.IsRaw)
+                    await JS.InvokeVoidAsync("terminalInterop.writeRaw", "process-terminal", e.Data);
+                else if (e.IsError)
                     await JS.InvokeVoidAsync("terminalInterop.writeError", "process-terminal", e.Data);
                 else
                     await JS.InvokeVoidAsync("terminalInterop.write", "process-terminal", e.Data);
@@ -522,9 +556,13 @@
         {
             case ModalView.Confirmation:
                 bridge.SetTitle(Request?.Title ?? "Confirm Execution");
+                var executeLabel = Request?.ConfirmationButtonText ?? "Execute";
                 bridge.SetButtons(
                     new ProgressButton("cancel", "Cancel", ProgressButtonStyle.Secondary),
-                    new ProgressButton("execute", Request?.RequiresElevation == true ? "🔐 Execute" : "Execute", ProgressButtonStyle.Primary));
+                    new ProgressButton(
+                        "execute",
+                        Request?.RequiresElevation == true ? $"🔐 {executeLabel}" : executeLabel,
+                        ProgressButtonStyle.Primary));
                 break;
             case ModalView.Running:
                 bridge.SetTitle(Request?.Title ?? "Running Process");

--- a/src/MauiSherpa/Components/TrackedDotnetChannelsCard.razor
+++ b/src/MauiSherpa/Components/TrackedDotnetChannelsCard.razor
@@ -1,0 +1,895 @@
+@using MauiSherpa.Workloads.Models
+@using System.Text.RegularExpressions
+
+<div class="tdc-card">
+    <div class="tdc-header">
+        <button class="tdc-toggle"
+                type="button"
+                id="@headerId"
+                aria-controls="@bodyId"
+                aria-expanded="@expanded"
+                aria-label="@ToggleAriaLabel"
+                @onclick="ToggleExpanded">
+            <div class="tdc-toggle-copy">
+                <div class="tdc-title-line">
+                    <span class="tdc-title">
+                        <i class="fas fa-list-check" aria-hidden="true"></i>
+                        <span>@Title</span>
+                    </span>
+                    <span class="tdc-count">@EffectiveInstallSpecs.Count</span>
+                </div>
+
+                <div class="tdc-meta-line">
+                    @if (HeaderSdkChips.Count > 0)
+                    {
+                        <div class="tdc-sdk-chips" aria-label="Tracked SDK channels">
+                            @foreach (var spec in HeaderSdkChips)
+                            {
+                                <span class="tdc-sdk-chip mono" title="@ChannelHuman(spec.VersionOrChannel)">@spec.VersionOrChannel</span>
+                            }
+                        </div>
+                    }
+
+                    <span class="tdc-status @HeaderStatus.CssClass">
+                        <i class="@HeaderStatus.IconClass" aria-hidden="true"></i>
+                        <span>@HeaderStatus.Text</span>
+                    </span>
+
+                    @if (!string.IsNullOrWhiteSpace(HeaderStatus.Note))
+                    {
+                        <span class="tdc-status-note" title="@HeaderStatus.Note">
+                            <i class="fas fa-circle-info" aria-hidden="true"></i>
+                            <span>@HeaderStatus.Note</span>
+                        </span>
+                    }
+                </div>
+            </div>
+
+            <i class="fas fa-chevron-right tdc-chevron @(expanded ? "expanded" : null)" aria-hidden="true"></i>
+        </button>
+
+        <button class="btn btn-primary btn-sm tdc-add-button"
+                type="button"
+                @onclick="InvokeAddRequested"
+                disabled="@(Busy || !AddRequested.HasDelegate)"
+                title="Track another SDK channel">
+            <i class="fas fa-plus"></i>
+            <span>Add channel</span>
+        </button>
+    </div>
+
+    @if (expanded)
+    {
+        <div class="tdc-body" id="@bodyId" role="region" aria-labelledby="@headerId">
+            @if (CheckingUpdates && UpdatePreviews is null)
+            {
+                <div class="tdc-update-checking">
+                    <i class="fas fa-spinner fa-spin"></i>
+                    <span>Checking installed versions against the current .NET channel releases...</span>
+                </div>
+            }
+
+            @if (!string.IsNullOrWhiteSpace(ErrorMessage))
+            {
+                <div class="tdc-state tdc-state-error">
+                    <i class="fas fa-triangle-exclamation" aria-hidden="true"></i>
+                    <div>
+                        <strong>Unable to load tracked channels</strong>
+                        <p>@ErrorMessage</p>
+                    </div>
+                </div>
+            }
+
+            @if (AvailablePreviews.Count > 0 || UpdatesUnresolved)
+            {
+                <div class="tdc-update-toolbar">
+                    <div class="tdc-preview-head">
+                        @if (AvailablePreviews.Count > 0)
+                        {
+                            <span class="tdc-preview-summary has-updates">
+                                <i class="fas fa-circle-arrow-up" aria-hidden="true"></i>
+                                @AvailablePreviews.Count update@(AvailablePreviews.Count == 1 ? string.Empty : "s") available
+                            </span>
+                        }
+
+                        @if (UpdatesUnresolved)
+                        {
+                            <span class="tdc-preview-note" title="Couldn't reach the .NET release feed for some channels">
+                                <i class="fas fa-triangle-exclamation" aria-hidden="true"></i>
+                                <span>Some channels couldn't be checked</span>
+                            </span>
+                        }
+                    </div>
+
+                    @if (AvailablePreviews.Count > 0)
+                    {
+                        <div class="tdc-preview-actions">
+                            @if (HasSdkUpdates && HasRuntimeUpdates)
+                            {
+                                <button class="btn btn-secondary btn-sm"
+                                        type="button"
+                                        @onclick="InvokeUpdateSdksRequested"
+                                        disabled="@(Busy || !UpdateSdksRequested.HasDelegate)"
+                                        title="Update tracked SDK channels only">
+                                    <i class="fas fa-arrow-up"></i>
+                                    <span>Update SDKs</span>
+                                </button>
+                                <button class="btn btn-secondary btn-sm"
+                                        type="button"
+                                        @onclick="InvokeUpdateRuntimesRequested"
+                                        disabled="@(Busy || !UpdateRuntimesRequested.HasDelegate)"
+                                        title="Update tracked Runtime &amp; ASP.NET Core channels only">
+                                    <i class="fas fa-arrow-up"></i>
+                                    <span>Update runtimes</span>
+                                </button>
+                            }
+                            else if (HasSdkUpdates)
+                            {
+                                <button class="btn btn-secondary btn-sm"
+                                        type="button"
+                                        @onclick="InvokeUpdateSdksRequested"
+                                        disabled="@(Busy || !UpdateSdksRequested.HasDelegate)"
+                                        title="Update tracked SDK channels">
+                                    <i class="fas fa-arrow-up"></i>
+                                    <span>Update SDKs</span>
+                                </button>
+                            }
+                            else if (HasRuntimeUpdates)
+                            {
+                                <button class="btn btn-secondary btn-sm"
+                                        type="button"
+                                        @onclick="InvokeUpdateRuntimesRequested"
+                                        disabled="@(Busy || !UpdateRuntimesRequested.HasDelegate)"
+                                        title="Update tracked Runtime &amp; ASP.NET Core channels">
+                                    <i class="fas fa-arrow-up"></i>
+                                    <span>Update runtimes</span>
+                                </button>
+                            }
+
+                            <button class="btn btn-primary btn-sm"
+                                    type="button"
+                                    @onclick="InvokeUpdateAllRequested"
+                                    disabled="@(Busy || !UpdateAllRequested.HasDelegate)"
+                                    title="Update everything dotnetup tracks">
+                                <i class="fas fa-arrows-rotate"></i>
+                                <span>Update all</span>
+                            </button>
+                        </div>
+                    }
+                </div>
+            }
+
+            @if (EffectiveInstallSpecs.Count > 0)
+            {
+                @foreach (var group in TrackedGroups())
+                {
+                    <div class="tdc-comp-group">
+                        <div class="tdc-comp-group-head">
+                            <i class="@group.Icon" aria-hidden="true"></i>
+                            <span>@group.Key</span>
+                            <span class="tdc-comp-group-count">@group.Items.Count</span>
+                        </div>
+
+                        <div class="tdc-track-list">
+                        @foreach (var spec in group.Items)
+                        {
+                            var preview = PreviewFor(spec);
+                            <div class="tdc-track-item">
+                                <div class="tdc-track-details">
+                                    <div class="tdc-track-line">
+                                        <span class="tdc-track-channel mono">@spec.VersionOrChannel</span>
+                                        <span class="tdc-track-human">@ChannelHuman(spec.VersionOrChannel)</span>
+                                    </div>
+                                </div>
+
+                                <div class="tdc-track-controls">
+                                    @if (preview != null)
+                                    {
+                                        <div class="tdc-track-resolution">
+                                            @if (preview.IsPinned)
+                                            {
+                                                <span class="tdc-prev-ver mono">@(preview.InstalledVersion ?? preview.Channel)</span>
+                                                <span class="tdc-badge badge-secondary" title="Pinned to an exact version">pinned</span>
+                                            }
+                                            else if (preview.UpdateAvailable)
+                                            {
+                                                <span class="tdc-prev-ver mono old">@(preview.InstalledVersion ?? "—")</span>
+                                                <i class="fas fa-arrow-right tdc-prev-arrow" aria-hidden="true"></i>
+                                                <span class="tdc-prev-ver mono new">@preview.AvailableVersion</span>
+                                                <span class="tdc-badge badge-info">update</span>
+                                            }
+                                            else if (preview.AvailableVersion is null)
+                                            {
+                                                <span class="tdc-prev-ver mono">@(preview.InstalledVersion ?? "—")</span>
+                                                <span class="tdc-badge badge-warning" title="Couldn't resolve this channel against the release feed">unknown</span>
+                                            }
+                                            else
+                                            {
+                                                <span class="tdc-prev-ver mono">@preview.AvailableVersion</span>
+                                                <span class="tdc-inline-result is-success">
+                                                    <i class="fas fa-circle-check" aria-hidden="true"></i>
+                                                    <span>up to date</span>
+                                                </span>
+                                            }
+                                        </div>
+                                    }
+
+                                    @if (spec.Source == DotnetUpInstallSource.Explicit)
+                                    {
+                                        <button class="btn btn-danger btn-sm"
+                                                type="button"
+                                                @onclick="() => InvokeUntrackRequested(spec)"
+                                                disabled="@(Busy || !UntrackRequested.HasDelegate)"
+                                                title="Stop tracking and uninstall this channel">
+                                            <i class="fas fa-trash"></i>
+                                            <span>Untrack</span>
+                                        </button>
+                                    }
+                                </div>
+                            </div>
+                        }
+                        </div>
+                    </div>
+                }
+
+            }
+            else if (string.IsNullOrWhiteSpace(ErrorMessage))
+            {
+                <div class="tdc-state tdc-state-empty">
+                    <i class="fas fa-inbox" aria-hidden="true"></i>
+                    <div>
+                        <strong>No channels tracked yet</strong>
+                        <p>Use <strong>Add channel</strong> and dotnetup will install it and keep it updated.</p>
+                    </div>
+                    <button class="btn btn-primary btn-sm"
+                            type="button"
+                            @onclick="InvokeAddRequested"
+                            disabled="@(Busy || !AddRequested.HasDelegate)">
+                        <i class="fas fa-plus"></i>
+                        <span>Add channel</span>
+                    </button>
+                </div>
+            }
+        </div>
+    }
+</div>
+
+<style>
+    .tdc-card {
+        border: 1px solid var(--border-color);
+        border-radius: var(--card-radius);
+        background: var(--card-bg);
+        overflow: hidden;
+    }
+
+    .tdc-header {
+        position: relative;
+        padding: 0.9rem 1rem;
+    }
+
+    .tdc-toggle {
+        width: 100%;
+        min-width: 0;
+        display: flex;
+        align-items: center;
+        gap: 0.9rem;
+        padding: 0 10.75rem 0 0;
+        border: 0;
+        background: transparent;
+        color: inherit;
+        font: inherit;
+        text-align: left;
+        cursor: pointer;
+    }
+
+    .tdc-toggle:hover {
+        color: inherit;
+    }
+
+    .tdc-toggle:focus-visible,
+    .tdc-add-button:focus-visible,
+    .tdc-body button:focus-visible {
+        outline: 2px solid var(--accent-primary);
+        outline-offset: 2px;
+    }
+
+    .tdc-toggle-copy {
+        flex: 1;
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 0.55rem;
+    }
+
+    .tdc-title-line,
+    .tdc-meta-line,
+    .tdc-preview-head,
+    .tdc-preview-actions,
+    .tdc-track-line,
+    .tdc-state {
+        display: flex;
+        align-items: center;
+        gap: 0.55rem;
+        flex-wrap: wrap;
+    }
+
+    .tdc-title-line {
+        gap: 0.65rem;
+    }
+
+    .tdc-title {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        min-width: 0;
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--text-primary);
+    }
+
+    .tdc-title i,
+    .tdc-comp-group-head i {
+        color: var(--text-secondary);
+    }
+
+    .tdc-count,
+    .tdc-comp-group-count {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-width: 1.4rem;
+        padding: 0.05rem 0.5rem;
+        border-radius: 999px;
+        background: var(--bg-tertiary);
+        color: var(--text-secondary);
+        font-size: 0.72rem;
+        font-weight: 600;
+    }
+
+    .tdc-meta-line {
+        justify-content: space-between;
+        row-gap: 0.5rem;
+    }
+
+    .tdc-sdk-chips {
+        display: flex;
+        align-items: center;
+        gap: 0.45rem;
+        flex-wrap: wrap;
+        min-width: 0;
+    }
+
+    .tdc-sdk-chip {
+        display: inline-flex;
+        align-items: center;
+        padding: 0.2rem 0.55rem;
+        border-radius: 999px;
+        background: color-mix(in srgb, var(--accent-primary) 10%, var(--card-bg));
+        border: 1px solid color-mix(in srgb, var(--accent-primary) 25%, var(--border-color));
+        color: var(--text-primary);
+        font-size: 0.76rem;
+        font-weight: 600;
+        white-space: nowrap;
+    }
+
+    .tdc-status,
+    .tdc-status-note {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        font-size: 0.8rem;
+    }
+
+    .tdc-status {
+        font-weight: 600;
+        white-space: nowrap;
+    }
+
+    .tdc-status-note {
+        min-width: 0;
+    }
+
+    .tdc-status.is-checking,
+    .tdc-status.is-neutral {
+        color: var(--text-secondary);
+    }
+
+    .tdc-status.is-info {
+        color: var(--status-info-text);
+    }
+
+    .tdc-status.is-success {
+        color: var(--status-success-text);
+    }
+
+    .tdc-status.is-warning,
+    .tdc-status-note {
+        color: var(--status-warning-text);
+    }
+
+    .tdc-status.is-error {
+        color: var(--status-error-text);
+    }
+
+    .tdc-chevron {
+        position: absolute;
+        right: 1.05rem;
+        top: 50%;
+        transform: translateY(-50%);
+        color: var(--text-secondary);
+        font-size: 0.8rem;
+        transition: transform 0.15s ease;
+    }
+
+    .tdc-chevron.expanded {
+        transform: translateY(-50%) rotate(90deg);
+    }
+
+    .tdc-add-button {
+        position: absolute;
+        right: 3rem;
+        bottom: 0.9rem;
+        z-index: 1;
+    }
+
+    .tdc-body {
+        border-top: 1px solid var(--border-color);
+        padding: 0;
+    }
+
+    .tdc-update-checking {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.65rem 1rem;
+        border-bottom: 1px solid var(--border-color);
+        background: color-mix(in srgb, var(--bg-tertiary) 35%, var(--card-bg));
+        color: var(--text-secondary);
+        font-size: 0.85rem;
+    }
+
+    .tdc-update-toolbar {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        margin: 0;
+        padding: 0.55rem 1rem;
+        border-bottom: 1px solid var(--border-color);
+        background: var(--card-bg);
+    }
+
+    .tdc-preview-head {
+        gap: 0.75rem;
+    }
+
+    .tdc-preview-summary {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.45rem;
+        font-weight: 600;
+        font-size: 0.9rem;
+    }
+
+    .tdc-preview-summary.has-updates {
+        color: var(--status-info-text);
+    }
+
+    .tdc-preview-note {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        font-size: 0.78rem;
+        color: var(--status-warning-text);
+    }
+
+    .tdc-track-list {
+        display: flex;
+        flex-direction: column;
+        gap: 0;
+    }
+
+    .tdc-track-item {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.75rem;
+        padding: 0.65rem 1rem;
+        background: color-mix(in srgb, var(--bg-tertiary) 35%, var(--card-bg));
+    }
+
+    .tdc-track-item + .tdc-track-item {
+        border-top: 1px solid var(--border-color);
+    }
+
+    .tdc-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.25rem;
+        padding: 2px 0.625rem;
+        border-radius: 0.75rem;
+        font-size: 0.75rem;
+        font-weight: 500;
+        white-space: nowrap;
+    }
+
+    .tdc-track-channel,
+    .tdc-prev-ver {
+        font-weight: 600;
+        color: var(--text-primary);
+        font-size: 0.85rem;
+    }
+
+    .tdc-prev-ver.old,
+    .tdc-track-human {
+        color: var(--text-secondary);
+        font-weight: 500;
+    }
+
+    .tdc-prev-ver.new {
+        color: var(--status-success-text);
+    }
+
+    .tdc-inline-result {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        font-size: 0.75rem;
+        font-weight: 600;
+        white-space: nowrap;
+    }
+
+    .tdc-inline-result.is-success {
+        color: var(--status-success-text);
+    }
+
+    .tdc-track-human {
+        font-size: 0.8rem;
+    }
+
+    .tdc-prev-arrow {
+        color: var(--text-secondary);
+        font-size: 0.75rem;
+    }
+
+    .tdc-track-details {
+        flex: 1;
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 0.35rem;
+    }
+
+    .tdc-track-controls,
+    .tdc-track-resolution {
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+    }
+
+    .tdc-track-controls {
+        flex-shrink: 0;
+        gap: 0.75rem;
+    }
+
+    .tdc-preview-actions {
+        gap: 0.5rem;
+    }
+
+    .tdc-comp-group {
+        margin: 0;
+    }
+
+    .tdc-comp-group-head {
+        display: flex;
+        align-items: center;
+        gap: 0.45rem;
+        padding: 0.55rem 1rem;
+        border-bottom: 1px solid var(--border-color);
+        background: var(--card-bg);
+        font-size: 0.85rem;
+        font-weight: 600;
+        color: var(--text-primary);
+    }
+
+    .tdc-comp-group + .tdc-comp-group .tdc-comp-group-head {
+        border-top: 1px solid var(--border-color);
+    }
+
+    .tdc-state {
+        justify-content: space-between;
+        margin: 0;
+        padding: 0.9rem 1rem;
+        border-bottom: 1px solid var(--border-color);
+        background: color-mix(in srgb, var(--bg-tertiary) 35%, var(--card-bg));
+    }
+
+    .tdc-state:last-child {
+        border-bottom: 0;
+    }
+
+    .tdc-state > i {
+        font-size: 1rem;
+        flex-shrink: 0;
+        color: inherit;
+    }
+
+    .tdc-state > div {
+        flex: 1;
+        min-width: 0;
+    }
+
+    .tdc-state strong {
+        display: block;
+        color: var(--text-primary);
+        font-size: 0.92rem;
+    }
+
+    .tdc-state p {
+        margin: 0.2rem 0 0;
+        color: var(--text-secondary);
+        font-size: 0.82rem;
+        line-height: 1.45;
+    }
+
+    .tdc-state-error {
+        color: var(--status-error-text);
+    }
+
+    .tdc-state-empty {
+        color: var(--text-secondary);
+    }
+
+    @@media (max-width: 820px) {
+        .tdc-header,
+        .tdc-toggle,
+        .tdc-track-item,
+        .tdc-state {
+            align-items: flex-start;
+        }
+
+        .tdc-header {
+            display: flex;
+            flex-direction: column;
+            gap: 0.75rem;
+        }
+
+        .tdc-toggle {
+            padding-right: 2rem;
+        }
+
+        .tdc-add-button {
+            position: static;
+            align-self: flex-start;
+        }
+
+        .tdc-chevron {
+            top: 1.35rem;
+            transform: none;
+        }
+
+        .tdc-chevron.expanded {
+            transform: rotate(90deg);
+        }
+
+        .tdc-meta-line,
+        .tdc-preview-head,
+        .tdc-preview-actions {
+            justify-content: flex-start;
+        }
+
+        .tdc-track-item,
+        .tdc-state {
+            flex-direction: column;
+        }
+
+        .tdc-update-toolbar,
+        .tdc-track-controls,
+        .tdc-track-resolution {
+            align-items: flex-start;
+            justify-content: flex-start;
+        }
+
+        .tdc-update-toolbar,
+        .tdc-track-controls {
+            flex-direction: column;
+        }
+    }
+</style>
+
+@code {
+    [Parameter] public string Title { get; set; } = "Tracked SDK channels";
+    [Parameter] public bool InitiallyExpanded { get; set; }
+    [Parameter] public DotnetUpListResult? ListResult { get; set; }
+    [Parameter] public IReadOnlyList<DotnetUpInstallSpec>? InstallSpecs { get; set; }
+    [Parameter] public IReadOnlyList<DotnetUpdatePreview>? UpdatePreviews { get; set; }
+    [Parameter] public bool Busy { get; set; }
+    [Parameter] public bool CheckingUpdates { get; set; }
+    [Parameter] public bool UpdatesUnresolved { get; set; }
+    [Parameter] public string? ErrorMessage { get; set; }
+    [Parameter] public EventCallback AddRequested { get; set; }
+    [Parameter] public EventCallback UpdateSdksRequested { get; set; }
+    [Parameter] public EventCallback UpdateRuntimesRequested { get; set; }
+    [Parameter] public EventCallback UpdateAllRequested { get; set; }
+    [Parameter] public EventCallback<DotnetUpInstallSpec> UntrackRequested { get; set; }
+
+    private readonly string headerId = $"tdc-head-{Guid.NewGuid():N}";
+    private readonly string bodyId = $"tdc-body-{Guid.NewGuid():N}";
+    private bool expanded;
+    private bool expansionInitialized;
+
+    private IReadOnlyList<DotnetUpInstallSpec> EffectiveInstallSpecs =>
+        InstallSpecs ?? ListResult?.InstallSpecs ?? Array.Empty<DotnetUpInstallSpec>();
+
+    private IReadOnlyList<DotnetUpdatePreview> EffectivePreviews =>
+        UpdatePreviews ?? Array.Empty<DotnetUpdatePreview>();
+
+    private IReadOnlyList<DotnetUpdatePreview> AvailablePreviews =>
+        EffectivePreviews.Where(preview => preview.UpdateAvailable).ToList();
+
+    private IReadOnlyList<DotnetUpInstallSpec> HeaderSdkChips =>
+        EffectiveInstallSpecs
+            .Where(spec => spec.Component == DotnetUpComponent.Sdk)
+            .GroupBy(spec => spec.VersionOrChannel, StringComparer.OrdinalIgnoreCase)
+            .Select(group => group.First())
+            .OrderBy(spec => ChipSortKey(spec.VersionOrChannel), StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+    private bool HasSdkUpdates => AvailablePreviews.Any(preview => preview.Component == DotnetUpComponent.Sdk);
+
+    private bool HasRuntimeUpdates => AvailablePreviews.Any(preview => preview.Component is DotnetUpComponent.Runtime or DotnetUpComponent.AspNetCore or DotnetUpComponent.WindowsDesktop);
+
+    private HeaderStatusInfo HeaderStatus => BuildHeaderStatus();
+
+    private string ToggleAriaLabel => expanded ? $"Collapse {Title}" : $"Expand {Title}";
+
+    protected override void OnParametersSet()
+    {
+        if (!expansionInitialized)
+        {
+            expanded = InitiallyExpanded;
+            expansionInitialized = true;
+        }
+    }
+
+    private void ToggleExpanded() => expanded = !expanded;
+
+    private Task InvokeAddRequested() => AddRequested.InvokeAsync();
+
+    private Task InvokeUpdateSdksRequested() => UpdateSdksRequested.InvokeAsync();
+
+    private Task InvokeUpdateRuntimesRequested() => UpdateRuntimesRequested.InvokeAsync();
+
+    private Task InvokeUpdateAllRequested() => UpdateAllRequested.InvokeAsync();
+
+    private Task InvokeUntrackRequested(DotnetUpInstallSpec spec) => UntrackRequested.InvokeAsync(spec);
+
+    private DotnetUpdatePreview? PreviewFor(DotnetUpInstallSpec spec) =>
+        EffectivePreviews.FirstOrDefault(preview =>
+            preview.Component == spec.Component &&
+            string.Equals(
+                preview.Channel,
+                spec.VersionOrChannel,
+                StringComparison.OrdinalIgnoreCase));
+
+    private IEnumerable<TrackGroup> TrackedGroups()
+    {
+        var groups = EffectiveInstallSpecs
+            .GroupBy(spec => spec.Component)
+            .OrderBy(group => ComponentSortOrder(group.Key));
+
+        foreach (var group in groups)
+        {
+            yield return new TrackGroup(
+                ComponentDisplay(group.Key),
+                ComponentIcon(group.Key),
+                group.OrderByDescending(spec => spec.VersionOrChannel, StringComparer.OrdinalIgnoreCase).ToList());
+        }
+    }
+
+    private HeaderStatusInfo BuildHeaderStatus()
+    {
+        if (CheckingUpdates && UpdatePreviews is null)
+            return new("Checking updates…", "fas fa-spinner fa-spin", "is-checking");
+
+        if (!string.IsNullOrWhiteSpace(ErrorMessage))
+            return new("Unable to load tracked channels", "fas fa-circle-exclamation", "is-error");
+
+        if (EffectiveInstallSpecs.Count == 0)
+            return new("No tracked channels", "fas fa-inbox", "is-neutral");
+
+        if (UpdatesUnresolved)
+        {
+            var note = AvailablePreviews.Count > 0
+                ? $"{AvailablePreviews.Count} update{(AvailablePreviews.Count == 1 ? string.Empty : "s")} found"
+                : "Some channels couldn't be checked";
+            return new("Partially unresolved", "fas fa-triangle-exclamation", "is-warning", note);
+        }
+
+        if (AvailablePreviews.Count > 0)
+            return new($"{AvailablePreviews.Count} update{(AvailablePreviews.Count == 1 ? string.Empty : "s")} available", "fas fa-circle-arrow-up", "is-info");
+
+        if (UpdatePreviews != null)
+            return new("Up to date", "fas fa-circle-check", "is-success");
+
+        return new($"{EffectiveInstallSpecs.Count} tracked", "fas fa-list-check", "is-neutral");
+    }
+
+    private static int ComponentSortOrder(DotnetUpComponent component) => component switch
+    {
+        DotnetUpComponent.Sdk => 0,
+        DotnetUpComponent.Runtime => 1,
+        DotnetUpComponent.AspNetCore => 2,
+        DotnetUpComponent.WindowsDesktop => 3,
+        _ => 4
+    };
+
+    private static string ComponentDisplay(DotnetUpComponent component) => component switch
+    {
+        DotnetUpComponent.Sdk => ".NET SDK",
+        DotnetUpComponent.Runtime => ".NET Runtime",
+        DotnetUpComponent.AspNetCore => "ASP.NET Core Runtime",
+        DotnetUpComponent.WindowsDesktop => "Windows Desktop Runtime",
+        _ => "Component"
+    };
+
+    private static string ComponentIcon(DotnetUpComponent component) => component switch
+    {
+        DotnetUpComponent.Sdk => "fas fa-toolbox",
+        DotnetUpComponent.Runtime => "fas fa-gears",
+        DotnetUpComponent.AspNetCore => "fas fa-globe",
+        DotnetUpComponent.WindowsDesktop => "fas fa-desktop",
+        _ => "fas fa-cube"
+    };
+
+    private static string ChannelHuman(string channel)
+    {
+        var value = channel.Trim().ToLowerInvariant();
+        return value switch
+        {
+            "latest" => "Latest stable",
+            "lts" => "Long-Term Support",
+            "preview" => "Latest preview",
+            "daily" => "Daily build",
+            _ => FormatVersionChannel(channel.Trim())
+        };
+    }
+
+    private static string FormatVersionChannel(string channel)
+    {
+        if (Regex.IsMatch(channel, @"^\d+\.\d+$"))
+            return $".NET {channel} · latest patch";
+
+        if (Regex.IsMatch(channel, @"^\d+\.\d+\.\dxx$"))
+        {
+            var band = channel.Split('.').Last();
+            var majorMinor = channel[..channel.LastIndexOf('.')];
+            return $".NET {majorMinor} · feature band {band}";
+        }
+
+        if (Regex.IsMatch(channel, @"^\d+\.\d+\.\d+"))
+            return $"Pinned to {channel}";
+
+        return channel;
+    }
+
+    private static string ChipSortKey(string channel)
+    {
+        var trimmed = channel.Trim();
+        return trimmed.ToLowerInvariant() switch
+        {
+            "latest" => "0000-latest",
+            "lts" => "0001-lts",
+            "preview" => "0002-preview",
+            "daily" => "0003-daily",
+            _ => $"9999-{trimmed}"
+        };
+    }
+
+    private sealed record TrackGroup(string Key, string Icon, IReadOnlyList<DotnetUpInstallSpec> Items);
+
+    private sealed record HeaderStatusInfo(string Text, string IconClass, string CssClass, string? Note = null);
+}

--- a/src/MauiSherpa/MauiProgram.cs
+++ b/src/MauiSherpa/MauiProgram.cs
@@ -158,6 +158,7 @@ public static class MauiProgram
         builder.Services.AddSingleton<MauiSherpa.Core.Interfaces.IAppInspectorClientFactory, MauiSherpa.Core.Services.AppInspectorClientFactory>();
         builder.Services.AddSingleton<IDebugFlagService, DebugFlagService>();
         builder.Services.AddSingleton<IDoctorService, DoctorService>();
+        builder.Services.AddSingleton<IDotnetUpService, DotnetUpService>();
         builder.Services.AddSingleton<IProfilingContextService, ProfilingContextService>();
         builder.Services.AddSingleton<ICopilotToolsService, CopilotToolsService>();
         builder.Services.AddSingleton<ICopilotService, CopilotService>();

--- a/src/MauiSherpa/MauiProgram.cs
+++ b/src/MauiSherpa/MauiProgram.cs
@@ -249,6 +249,12 @@ public static class MauiProgram
         builder.Services.AddSingleton<CopilotViewModel>();
         builder.Services.AddSingleton<SettingsViewModel>();
 
+        // Shiny.Mediator 6.6.x serializes the persistent cache via Shiny.Json, which is strict
+        // (source-gen contexts only) and throws "No JsonTypeInfo registered" for any cached type.
+        // We don't ship [ShinyJsonInclude]/source-gen contexts, so register the reflection-based
+        // resolver to restore plain serialization for all cached request/response types.
+        Shiny.Json.AddResolver(new System.Text.Json.Serialization.Metadata.DefaultJsonTypeInfoResolver());
+
         // Shiny Mediator with caching and offline support
         builder.AddShinyMediator(cfg =>
         {

--- a/src/MauiSherpa/MauiProgram.cs
+++ b/src/MauiSherpa/MauiProgram.cs
@@ -4,6 +4,7 @@ using MauiSherpa.Services;
 using MauiSherpa.Core.ViewModels;
 using MauiSherpa.Core.Interfaces;
 using MauiSherpa.Core.Services;
+using MauiSherpa.Workloads.Services;
 #if LINUXGTK
 // DevFlow GTK usings removed temporarily (package conflict with new Microsoft.Maui.Platforms.Linux.Gtk4)
 using Microsoft.Maui.Platforms.Linux.Gtk4.BlazorWebView;
@@ -159,6 +160,8 @@ public static class MauiProgram
         builder.Services.AddSingleton<IDebugFlagService, DebugFlagService>();
         builder.Services.AddSingleton<IDoctorService, DoctorService>();
         builder.Services.AddSingleton<IDotnetUpService, DotnetUpService>();
+        builder.Services.AddSingleton<IGlobalJsonWorkloadPinEditor, GlobalJsonWorkloadPinEditor>();
+        builder.Services.AddSingleton<IDotnetWorkloadService, DotnetWorkloadService>();
         builder.Services.AddSingleton<IProfilingContextService, ProfilingContextService>();
         builder.Services.AddSingleton<ICopilotToolsService, CopilotToolsService>();
         builder.Services.AddSingleton<ICopilotService, CopilotService>();

--- a/src/MauiSherpa/MauiSherpa.csproj
+++ b/src/MauiSherpa/MauiSherpa.csproj
@@ -51,13 +51,13 @@
     <PackageReference Include="Markdig" Version="0.44.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="10.0.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.31" />
+    <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.60" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
     <PackageReference Include="Microsoft.Maui.DevFlow.Agent" Version="0.1.0-preview.7.26230.1" Condition="'$(Configuration)' == 'Debug'" />
     <PackageReference Include="Microsoft.Maui.DevFlow.Blazor" Version="0.1.0-preview.7.26230.1" Condition="'$(Configuration)' == 'Debug'" />
     <PackageReference Include="Sentry.Maui" Version="6.4.0" />
-    <PackageReference Include="Shiny.Mediator.Caching.MicrosoftMemoryCache" Version="6.1.1" />
-    <PackageReference Include="Shiny.Mediator.Maui" Version="6.1.1" />
+    <PackageReference Include="Shiny.Mediator.Caching.MicrosoftMemoryCache" Version="6.6.2" />
+    <PackageReference Include="Shiny.Mediator.Maui" Version="6.6.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MauiSherpa/Pages/Doctor.razor
+++ b/src/MauiSherpa/Pages/Doctor.razor
@@ -1024,7 +1024,7 @@ else
 
     private async Task RunWorkloadFix(DependencyStatus dep)
     {
-        var targetVersion = report?.AvailableWorkloadSetVersions?.FirstOrDefault();
+        var targetVersion = dep.RecommendedVersion;
         if (string.IsNullOrEmpty(targetVersion))
         {
             await AlertService.ShowAlertAsync("No Workload Versions", "No workload set versions are available to install.");
@@ -1038,16 +1038,23 @@ else
     {
         if (version == report?.InstalledWorkloadSetVersion) return;
 
-        // Build the workload update command using full path (GUI apps may not have dotnet on PATH)
-        var dotnetPath = DoctorService.GetDotNetExecutablePath();
-        var request = new ProcessRequest(
-            Command: dotnetPath,
+        var featureBand = report?.Context.EffectiveFeatureBand;
+        var request = featureBand == null
+            ? null
+            : await DoctorService.GetWorkloadUpdateRequestAsync(
+                featureBand,
+                report!.Context.WorkingDirectory,
+                version,
+                report.Context.DotNetSdkPath,
+                report.Context.DotNetArchitecture,
+                report.Context.ActiveSdkVersion);
+        request ??= new ProcessRequest(
+            Command: DoctorService.GetDotNetExecutablePath(),
             Arguments: new[] { "workload", "update", "--version", version },
             RequiresElevation: true,
             ElevationPrompt: "Install .NET Workloads",
             Title: "Update Workloads",
-            Description: $"Update .NET workloads to version {version}"
-        );
+            Description: $"Update .NET workloads to version {version}");
 
         var result = await ProcessModal.ShowProcessAsync(request);
         

--- a/src/MauiSherpa/Pages/Doctor.razor
+++ b/src/MauiSherpa/Pages/Doctor.razor
@@ -4,6 +4,7 @@
 @using MauiSherpa.Services
 @using Microsoft.Extensions.Logging
 @inject IDoctorService DoctorService
+@inject IDotnetUpService DotnetUp
 @inject IAlertService AlertService
 @inject IDialogService DialogService
 @inject IProcessModalService ProcessModal
@@ -892,6 +893,18 @@ else
                 await RunWorkloadFix(dep);
                 return;
             }
+
+            if (dep.FixAction == "install-dotnetup")
+            {
+                await RunInstallDotnetUp(dep);
+                return;
+            }
+
+            if (dep.FixAction.StartsWith("dotnetup-update-sdk"))
+            {
+                await RunDotnetUpSdkUpdate(dep);
+                return;
+            }
         }
 
         // Build command based on dependency type
@@ -1046,6 +1059,67 @@ else
         else if (result != null && !result.WasCancelled && !result.WasKilled)
         {
             await AlertService.ShowAlertAsync("Update Failed", "Workload update failed. Check the output for details.");
+        }
+    }
+
+    private async Task<bool> EnsureDotnetUpInstalled()
+    {
+        if (DotnetUp.IsInstalled)
+            return true;
+
+        var result = await OperationModal.RunAsync(
+            "Install dotnetup",
+            "Downloading and verifying the dotnetup .NET toolchain manager",
+            async ctx =>
+            {
+                var progress = new Progress<string>(msg =>
+                {
+                    ctx.SetStatus(msg);
+                    ctx.LogInfo(msg);
+                });
+                var ok = await DotnetUp.EnsureInstalledAsync(progress: progress);
+                if (ok) ctx.LogSuccess("dotnetup installed");
+                else ctx.LogError("Failed to install dotnetup");
+                return ok;
+            },
+            canCancel: true);
+
+        return result.Success;
+    }
+
+    private async Task RunInstallDotnetUp(DependencyStatus dep)
+    {
+        var installed = await EnsureDotnetUpInstalled();
+        if (installed)
+        {
+            await AlertService.ShowToastAsync("dotnetup installed");
+            await RunDoctor();
+        }
+    }
+
+    private async Task RunDotnetUpSdkUpdate(DependencyStatus dep)
+    {
+        // dotnetup must be present before we can drive an SDK install.
+        if (!await EnsureDotnetUpInstalled())
+            return;
+
+        // FixAction is "dotnetup-update-sdk:<channel>" — install that channel in Terminal Mode.
+        string? channel = null;
+        var colon = dep.FixAction!.IndexOf(':');
+        if (colon >= 0 && colon < dep.FixAction.Length - 1)
+            channel = dep.FixAction[(colon + 1)..];
+
+        var request = DotnetUp.InstallSdkRequest(channel);
+        var result = await ProcessModal.ShowProcessAsync(request);
+
+        if (result?.Success == true)
+        {
+            await AlertService.ShowToastAsync($"Installed .NET SDK ({channel ?? "latest"})");
+            await RunDoctor();
+        }
+        else if (result != null && !result.WasCancelled && !result.WasKilled)
+        {
+            await AlertService.ShowAlertAsync("Update Failed", "The .NET SDK install failed. Check the output for details.");
         }
     }
 

--- a/src/MauiSherpa/Pages/DotnetSdk.razor
+++ b/src/MauiSherpa/Pages/DotnetSdk.razor
@@ -1,0 +1,552 @@
+@page "/dotnet-sdk"
+@using MauiSherpa.Core.Interfaces
+@using MauiSherpa.Core.Services
+@using MauiSherpa.Services
+@using MauiSherpa.Workloads.Models
+@inject IDotnetUpService DotnetUp
+@inject IProcessModalService ProcessModal
+@inject IOperationModalService OperationModal
+@inject IAlertService AlertService
+@inject IPlatformService PlatformInfo
+@implements IDisposable
+
+<h1><i class="fas fa-layer-group"></i> .NET SDK Manager</h1>
+
+@if (!PlatformInfo.HasNativeToolbar)
+{
+<div class="toolbar">
+    <button class="btn btn-primary" @onclick="Refresh" disabled="@isLoading">
+        @if (isLoading)
+        {
+            <i class="fas fa-spinner fa-spin"></i> <span>Loading...</span>
+        }
+        else
+        {
+            <i class="fas fa-sync-alt"></i> <span>Refresh</span>
+        }
+    </button>
+    @if (DotnetUp.IsInstalled)
+    {
+        <button class="btn btn-success" @onclick="RunUpdateAll" disabled="@isLoading">
+            <i class="fas fa-arrow-up-from-bracket"></i> <span>Update All</span>
+        </button>
+    }
+</div>
+}
+
+@if (!string.IsNullOrEmpty(errorMessage))
+{
+    <div class="error-bar">@errorMessage</div>
+}
+
+<!-- dotnetup status card -->
+<div class="section-card status-card">
+    <div class="status-row">
+        <div class="status-icon @(DotnetUp.IsInstalled ? "ok" : "missing")">
+            <i class="fas @(DotnetUp.IsInstalled ? "fa-circle-check" : "fa-circle-exclamation")"></i>
+        </div>
+        <div class="status-body">
+            @if (DotnetUp.IsInstalled)
+            {
+                <strong>dotnetup is installed</strong>
+                <div class="status-meta mono">
+                    @if (toolInfo != null)
+                    {
+                        <span>v@(toolInfo.Version)</span>
+                        @if (!string.IsNullOrEmpty(toolInfo.Rid))
+                        {
+                            <span class="dot">·</span><span>@toolInfo.Rid</span>
+                        }
+                    }
+                    else
+                    {
+                        <span>@DotnetUp.ExecutablePath</span>
+                    }
+                </div>
+                @if (managedRoots.Count > 0)
+                {
+                    <div class="status-meta">
+                        Managed install root@(managedRoots.Count > 1 ? "s" : ""):
+                        @foreach (var root in managedRoots)
+                        {
+                            <span class="mono root-chip">@root</span>
+                        }
+                    </div>
+                }
+            }
+            else
+            {
+                <strong>dotnetup is not installed</strong>
+                <div class="status-meta">Install the .NET toolchain manager to install and update SDKs &amp; runtimes from here.</div>
+            }
+        </div>
+        <div class="status-actions">
+            @if (DotnetUp.IsInstalled)
+            {
+                <button class="btn btn-secondary btn-sm" @onclick="ReinstallDotnetUp" disabled="@isLoading">
+                    <i class="fas fa-rotate"></i> <span>Reinstall</span>
+                </button>
+            }
+            else
+            {
+                <button class="btn btn-success" @onclick="InstallDotnetUp" disabled="@isLoading">
+                    <i class="fas fa-download"></i> <span>Install dotnetup</span>
+                </button>
+            }
+        </div>
+    </div>
+</div>
+
+@if (DotnetUp.IsInstalled)
+{
+    <!-- Install / update controls -->
+    <div class="section-card">
+        <div class="card-title-row">
+            <h2 class="card-title"><i class="fas fa-download"></i> Install a .NET SDK</h2>
+        </div>
+        <div class="install-row">
+            <select class="channel-select" @bind="selectedChannel" disabled="@isLoading">
+                @foreach (var ch in channelOptions)
+                {
+                    <option value="@ch.Value">@ch.Label</option>
+                }
+                <option value="__custom__">Custom channel…</option>
+            </select>
+            @if (selectedChannel == "__custom__")
+            {
+                <input type="text" class="channel-input" placeholder="e.g. 9.0.1xx or 10.0.103"
+                       @bind="customChannel" @bind:event="oninput" disabled="@isLoading" />
+            }
+            <label class="terminal-toggle" title="Configure PATH and DOTNET_ROOT so the terminal 'dotnet' uses this install">
+                <input type="checkbox" @bind="terminalMode" disabled="@isLoading" />
+                <span>Set as default (Terminal Mode)</span>
+            </label>
+            <button class="btn btn-primary" @onclick="RunInstallSdk" disabled="@(isLoading || !HasInstallChannel)">
+                <i class="fas fa-download"></i> <span>Install SDK</span>
+            </button>
+        </div>
+        <div class="install-row secondary">
+            <button class="btn btn-secondary btn-sm" @onclick="RunUpdateSdks" disabled="@isLoading">
+                <i class="fas fa-arrow-up"></i> <span>Update tracked SDKs</span>
+            </button>
+            <button class="btn btn-secondary btn-sm" @onclick="RunUpdateRuntimes" disabled="@isLoading">
+                <i class="fas fa-arrow-up"></i> <span>Update tracked runtimes</span>
+            </button>
+        </div>
+    </div>
+
+    <!-- Installations -->
+    <div class="section-card">
+        <div class="card-title-row">
+            <h2 class="card-title"><i class="fas fa-cubes"></i> Installed components</h2>
+            @if (list != null)
+            {
+                <span class="badge badge-secondary">@list.Installations.Count</span>
+            }
+        </div>
+
+        @if (list == null)
+        {
+            <div class="empty-state"><i class="fas fa-spinner fa-spin"></i> Loading…</div>
+        }
+        else if (list.Installations.Count == 0)
+        {
+            <div class="empty-state">
+                <i class="fas fa-box-open"></i>
+                <p>No dotnetup-managed .NET components yet. Install an SDK above to get started.</p>
+            </div>
+        }
+        else
+        {
+            @foreach (var group in list.Installations.GroupBy(i => i.InstallRoot))
+            {
+                <div class="install-group">
+                    <div class="install-group-root mono">
+                        <i class="fas fa-folder"></i> @group.Key
+                    </div>
+                    @foreach (var item in group.OrderByDescending(i => i.Version))
+                    {
+                        <div class="install-item">
+                            <span class="badge @ComponentBadgeClass(item.Component)">@item.ComponentRaw</span>
+                            <span class="install-version mono">@item.Version</span>
+                            @if (!string.IsNullOrEmpty(item.FrameworkName))
+                            {
+                                <span class="install-framework mono">@item.FrameworkName</span>
+                            }
+                            @if (!string.IsNullOrEmpty(item.Architecture))
+                            {
+                                <span class="install-arch">@item.Architecture</span>
+                            }
+                            @if (!item.IsValid)
+                            {
+                                <span class="badge badge-warning">invalid</span>
+                            }
+                            <span class="spacer"></span>
+                            <button class="btn btn-danger btn-sm" @onclick="@(() => RunUninstall(item))" disabled="@isLoading"
+                                    title="Uninstall this component">
+                                <i class="fas fa-trash"></i>
+                            </button>
+                        </div>
+                    }
+                </div>
+            }
+        }
+    </div>
+
+    <!-- Tracked channels -->
+    @if (list != null && list.InstallSpecs.Count > 0)
+    {
+        <div class="section-card">
+            <div class="card-title-row">
+                <h2 class="card-title"><i class="fas fa-list-check"></i> Tracked channels</h2>
+                <span class="badge badge-secondary">@list.InstallSpecs.Count</span>
+            </div>
+            @foreach (var spec in list.InstallSpecs)
+            {
+                <div class="install-item">
+                    <span class="badge @ComponentBadgeClass(spec.Component)">@spec.ComponentRaw</span>
+                    <span class="install-version mono">@spec.VersionOrChannel</span>
+                    <span class="badge badge-info">@spec.Source</span>
+                    @if (!string.IsNullOrEmpty(spec.GlobalJsonPath))
+                    {
+                        <span class="install-framework mono" title="@spec.GlobalJsonPath">global.json</span>
+                    }
+                </div>
+            }
+        </div>
+    }
+}
+
+@code {
+    private bool isLoading;
+    private string? errorMessage;
+    private DotnetUpToolInfo? toolInfo;
+    private DotnetUpListResult? list;
+    private List<string> managedRoots = new();
+
+    private string selectedChannel = "latest";
+    private string customChannel = string.Empty;
+    private bool terminalMode = true;
+
+    private record ChannelOption(string Value, string Label);
+
+    private readonly List<ChannelOption> channelOptions = new()
+    {
+        new("latest", "Latest"),
+        new("lts", "LTS (Long-Term Support)"),
+        new("preview", "Preview"),
+        new("10.0.1xx", "10.0 (feature band 1xx)"),
+        new("9.0.1xx", "9.0 (feature band 1xx)"),
+        new("8.0.1xx", "8.0 (feature band 1xx)"),
+        new("daily", "Daily build"),
+    };
+
+    private bool HasInstallChannel =>
+        selectedChannel != "__custom__" || !string.IsNullOrWhiteSpace(customChannel);
+
+    private string? CurrentChannel =>
+        selectedChannel == "__custom__"
+            ? (string.IsNullOrWhiteSpace(customChannel) ? null : customChannel.Trim())
+            : selectedChannel;
+
+    protected override async Task OnInitializedAsync() => await Refresh();
+
+    private async Task Refresh()
+    {
+        isLoading = true;
+        errorMessage = null;
+        StateHasChanged();
+        try
+        {
+            if (DotnetUp.IsInstalled)
+            {
+                toolInfo = await DotnetUp.GetToolInfoAsync();
+                list = await DotnetUp.GetListAsync();
+                managedRoots = list?.InstallRoots.ToList() ?? new();
+            }
+            else
+            {
+                toolInfo = null;
+                list = null;
+                managedRoots = new();
+            }
+        }
+        catch (Exception ex)
+        {
+            errorMessage = $"Failed to query dotnetup: {ex.Message}";
+        }
+        finally
+        {
+            isLoading = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task<bool> EnsureInstalled(bool force = false)
+    {
+        if (DotnetUp.IsInstalled && !force)
+            return true;
+
+        var result = await OperationModal.RunAsync(
+            force ? "Reinstall dotnetup" : "Install dotnetup",
+            "Downloading and verifying the dotnetup .NET toolchain manager",
+            async ctx =>
+            {
+                var progress = new Progress<string>(msg =>
+                {
+                    ctx.SetStatus(msg);
+                    ctx.LogInfo(msg);
+                });
+                var ok = await DotnetUp.EnsureInstalledAsync(force: force, progress: progress);
+                if (ok) ctx.LogSuccess("dotnetup installed");
+                else ctx.LogError("Failed to install dotnetup");
+                return ok;
+            },
+            canCancel: true);
+
+        return result.Success;
+    }
+
+    private async Task InstallDotnetUp()
+    {
+        if (await EnsureInstalled())
+        {
+            await AlertService.ShowToastAsync("dotnetup installed");
+            await Refresh();
+        }
+    }
+
+    private async Task ReinstallDotnetUp()
+    {
+        var confirm = await AlertService.ShowConfirmAsync(
+            "Reinstall dotnetup",
+            "Download and overwrite the dotnetup binary with the latest published build?",
+            "Reinstall", "Cancel");
+        if (!confirm) return;
+
+        if (await EnsureInstalled(force: true))
+        {
+            await AlertService.ShowToastAsync("dotnetup reinstalled");
+            await Refresh();
+        }
+    }
+
+    private async Task RunInstallSdk()
+    {
+        if (!await EnsureInstalled()) return;
+        var channel = CurrentChannel;
+        var request = DotnetUp.InstallSdkRequest(channel, terminalMode);
+        await RunProcessAndRefresh(request, $"Installed .NET SDK ({channel ?? "latest"})", "The .NET SDK install failed.");
+    }
+
+    private async Task RunUpdateAll()
+    {
+        if (!await EnsureInstalled()) return;
+        await RunProcessAndRefresh(DotnetUp.UpdateAllRequest(), "All components updated", "The update failed.");
+    }
+
+    private async Task RunUpdateSdks()
+    {
+        if (!await EnsureInstalled()) return;
+        await RunProcessAndRefresh(DotnetUp.UpdateSdksRequest(), "SDKs updated", "The SDK update failed.");
+    }
+
+    private async Task RunUpdateRuntimes()
+    {
+        if (!await EnsureInstalled()) return;
+        await RunProcessAndRefresh(DotnetUp.UpdateRuntimesRequest(), "Runtimes updated", "The runtime update failed.");
+    }
+
+    private async Task RunUninstall(DotnetUpInstallation item)
+    {
+        var label = $"{item.ComponentRaw} {item.Version}";
+        var confirm = await AlertService.ShowConfirmAsync(
+            "Uninstall component",
+            $"Remove {label} from {item.InstallRoot}?",
+            "Uninstall", "Cancel");
+        if (!confirm) return;
+
+        ProcessRequest request = item.Component == DotnetUpComponent.Sdk
+            ? DotnetUp.UninstallSdkRequest(item.Version)
+            : DotnetUp.UninstallRuntimeRequest($"{RuntimeToken(item)}@{item.Version}");
+
+        await RunProcessAndRefresh(request, $"Uninstalled {label}", "The uninstall failed.");
+    }
+
+    private async Task RunProcessAndRefresh(ProcessRequest request, string successToast, string failureMessage)
+    {
+        var result = await ProcessModal.ShowProcessAsync(request);
+        if (result?.Success == true)
+        {
+            await AlertService.ShowToastAsync(successToast);
+            await Refresh();
+        }
+        else if (result != null && !result.WasCancelled && !result.WasKilled)
+        {
+            await AlertService.ShowAlertAsync("Operation Failed", $"{failureMessage} Check the output for details.");
+        }
+    }
+
+    private static string RuntimeToken(DotnetUpInstallation item) => item.Component switch
+    {
+        DotnetUpComponent.AspNetCore => "aspnetcore",
+        DotnetUpComponent.WindowsDesktop => "windowsdesktop",
+        _ => "runtime"
+    };
+
+    private static string ComponentBadgeClass(DotnetUpComponent component) => component switch
+    {
+        DotnetUpComponent.Sdk => "badge-success",
+        DotnetUpComponent.Runtime => "badge-info",
+        DotnetUpComponent.AspNetCore => "badge-info",
+        DotnetUpComponent.WindowsDesktop => "badge-info",
+        _ => "badge-secondary"
+    };
+
+    public void Dispose() { }
+}
+
+<style>
+    .status-card {
+        padding: 1rem 1.25rem;
+        margin-bottom: 1rem;
+    }
+
+    .status-row {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+    }
+
+    .status-icon {
+        font-size: 1.75rem;
+        flex-shrink: 0;
+    }
+
+    .status-icon.ok {
+        color: var(--status-success-text, #16a34a);
+    }
+
+    .status-icon.missing {
+        color: var(--status-warning-text, #d97706);
+    }
+
+    .status-body {
+        flex: 1;
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+    }
+
+    .status-meta {
+        color: var(--text-secondary);
+        font-size: 0.85rem;
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 0.35rem;
+    }
+
+    .status-meta .dot {
+        opacity: 0.5;
+    }
+
+    .root-chip {
+        background: var(--bg-tertiary);
+        border-radius: 4px;
+        padding: 0.1rem 0.4rem;
+    }
+
+    .status-actions {
+        flex-shrink: 0;
+    }
+
+    .section-card {
+        padding: 1rem 1.25rem;
+        margin-bottom: 1rem;
+    }
+
+    .card-title-row {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        margin-bottom: 0.75rem;
+    }
+
+    .card-title {
+        font-size: 1rem;
+        font-weight: 600;
+        margin: 0;
+        color: var(--text-primary);
+    }
+
+    .install-row {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 0.6rem;
+    }
+
+    .install-row.secondary {
+        margin-top: 0.75rem;
+        padding-top: 0.75rem;
+        border-top: 1px solid var(--border-color);
+    }
+
+    .channel-select,
+    .channel-input {
+        padding: 0.4rem 0.6rem;
+        border: 1px solid var(--input-border);
+        border-radius: 6px;
+        font-size: 0.9rem;
+        min-width: 12rem;
+    }
+
+    .terminal-toggle {
+        display: flex;
+        align-items: center;
+        gap: 0.4rem;
+        font-size: 0.85rem;
+        color: var(--text-secondary);
+        cursor: pointer;
+    }
+
+    .install-group {
+        margin-bottom: 0.75rem;
+    }
+
+    .install-group-root {
+        font-size: 0.8rem;
+        color: var(--text-secondary);
+        margin-bottom: 0.35rem;
+        display: flex;
+        align-items: center;
+        gap: 0.35rem;
+    }
+
+    .install-item {
+        display: flex;
+        align-items: center;
+        gap: 0.6rem;
+        padding: 0.45rem 0.6rem;
+        border-radius: 6px;
+        background: var(--bg-tertiary);
+        margin-bottom: 0.35rem;
+    }
+
+    .install-version {
+        font-weight: 600;
+        color: var(--text-primary);
+    }
+
+    .install-framework,
+    .install-arch {
+        font-size: 0.78rem;
+        color: var(--text-secondary);
+    }
+
+    .spacer {
+        flex: 1;
+    }
+</style>

--- a/src/MauiSherpa/Pages/DotnetSdk.razor
+++ b/src/MauiSherpa/Pages/DotnetSdk.razor
@@ -434,6 +434,20 @@
                 (selection.InstallIds.Count == 0 && selection.UninstallIds.Count == 0))
                 return;
 
+            var explicitIds = inventory.InstalledWorkloads
+                .Select(workload => workload.Id)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            var effectiveIds = inventory.EffectiveInstalledWorkloadIds
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            if (selection.UninstallIds.Any(id => !explicitIds.Contains(id)) ||
+                selection.InstallIds.Any(effectiveIds.Contains))
+            {
+                await AlertService.ShowAlertAsync(
+                    "Workload Selection Changed",
+                    "Only directly installed workload IDs can be removed, and included workloads cannot be installed again. Refresh and retry the selection.");
+                return;
+            }
+
             if (selection.UninstallIds.Count > 0)
             {
                 var uninstall = Workloads.CreateUninstallRequest(

--- a/src/MauiSherpa/Pages/DotnetSdk.razor
+++ b/src/MauiSherpa/Pages/DotnetSdk.razor
@@ -4,9 +4,11 @@
 @using MauiSherpa.Services
 @using MauiSherpa.Pages.Forms
 @using MauiSherpa.Pages.Modals
+@using MauiSherpa.Components
 @using MauiSherpa.Workloads.Models
-@using System.Text.RegularExpressions
+@using MauiSherpa.Workloads.Services
 @inject IDotnetUpService DotnetUp
+@inject IDotnetWorkloadService Workloads
 @inject IProcessModalService ProcessModal
 @inject IOperationModalService OperationModal
 @inject IAlertService AlertService
@@ -15,398 +17,71 @@
 @inject IToolbarService ToolbarService
 @inject IFormModalService FormModal
 @inject HybridFormBridgeHolder BridgeHolder
+@inject ModalParameterService ModalParams
 @implements IDisposable
 
-<h1><i class="fas fa-layer-group"></i> .NET SDK Manager</h1>
+<div class="dotnet-sdk-page-header">
+    <div class="dotnet-sdk-page-heading">
+        <h1><i class="fas fa-layer-group"></i> .NET SDK Manager</h1>
+        <p>Track SDK and runtime channels to keep compatible versions installed and up to date. Sherpa uses dotnetup to install, update, and manage these components.</p>
+    </div>
+    <div class="dotnet-sdk-page-actions">
+        @if (!PlatformInfo.HasNativeToolbar)
+        {
+            <button class="btn btn-primary" @onclick="Refresh" disabled="@isLoading">
+                @if (isLoading)
+                {
+                    <i class="fas fa-spinner fa-spin"></i> <span>Loading...</span>
+                }
+                else
+                {
+                    <i class="fas fa-sync-alt"></i> <span>Refresh</span>
+                }
+            </button>
+            <button class="btn btn-secondary" @onclick="PickProjectFolder" disabled="@isLoading">
+                <i class="fas fa-folder-open"></i> <span>Open project folder</span>
+            </button>
+        }
 
-@if (!PlatformInfo.HasNativeToolbar)
-{
-<div class="toolbar">
-    <button class="btn btn-primary" @onclick="Refresh" disabled="@isLoading">
-        @if (isLoading)
-        {
-            <i class="fas fa-spinner fa-spin"></i> <span>Loading...</span>
-        }
-        else
-        {
-            <i class="fas fa-sync-alt"></i> <span>Refresh</span>
-        }
-    </button>
-    @if (DotnetUp.IsInstalled)
-    {
-        <button class="btn btn-secondary" @onclick="OpenAddDialog" disabled="@isLoading">
-            <i class="fas fa-plus"></i> <span>Add Channel</span>
+        <button type="button"
+                class="dotnetup-indicator @DotnetUpIndicatorClass"
+                @onclick="OpenDotnetUpDetails"
+                disabled="@isLoading"
+                title="@DotnetUpIndicatorTitle"
+                aria-label="@DotnetUpIndicatorTitle">
+            <span>dotnetup</span>
+            <i class="@DotnetUpIndicatorIcon" aria-hidden="true"></i>
+            @if (toolUpdateInfo?.UpdateAvailable == true)
+            {
+                <span class="dotnetup-indicator-update" aria-hidden="true">
+                    <i class="fas fa-arrow-up"></i>
+                </span>
+            }
         </button>
-        @if (list != null && list.InstallSpecs.Count > 0)
-        {
-            <button class="btn btn-secondary" @onclick="CheckForUpdates" disabled="@(isLoading || checkingUpdates)">
-                <i class="fas fa-magnifying-glass"></i> <span>Check for updates</span>
-            </button>
-            <button class="btn btn-success" @onclick="RunUpdateAll" disabled="@isLoading">
-                <i class="fas fa-arrow-up-from-bracket"></i> <span>Update All</span>
-            </button>
-        }
-    }
+    </div>
 </div>
-}
 
 @if (!string.IsNullOrEmpty(errorMessage))
 {
     <div class="error-bar">@errorMessage</div>
 }
 
-<!-- dotnetup status -->
-<div class="dnup-status @(DotnetUp.IsInstalled ? "ok" : "missing")">
-    <div class="dnup-status-icon">
-        <i class="fas @(DotnetUp.IsInstalled ? "fa-circle-check" : "fa-circle-exclamation")"></i>
-    </div>
-    <div class="dnup-status-body">
-        @if (DotnetUp.IsInstalled)
-        {
-            <span class="dnup-status-title">dotnetup</span>
-            @if (toolInfo != null)
-            {
-                <span class="dnup-status-ver mono">v@(toolInfo.Version)</span>
-                @if (!string.IsNullOrEmpty(toolInfo.Rid))
-                {
-                    <span class="dot">·</span><span class="mono dnup-status-rid">@toolInfo.Rid</span>
-                }
-            }
-        }
-        else
-        {
-            <span class="dnup-status-title">dotnetup is not installed</span>
-            <span class="dnup-status-sub">Install the .NET toolchain manager to install &amp; update SDKs and runtimes from here.</span>
-        }
-    </div>
-    <div class="dnup-status-actions">
-        @if (DotnetUp.IsInstalled)
-        {
-            <button class="btn btn-ghost btn-sm" @onclick="ReinstallDotnetUp" disabled="@isLoading" title="Download and overwrite dotnetup with the latest published build">
-                <i class="fas fa-rotate"></i> <span>Reinstall</span>
-            </button>
-        }
-        else
-        {
-            <button class="btn btn-success" @onclick="InstallDotnetUp" disabled="@isLoading">
-                <i class="fas fa-download"></i> <span>Install dotnetup</span>
-            </button>
-        }
-    </div>
-</div>
-
-@if (DotnetUp.IsInstalled && managedRoots.Count > 0)
-{
-    <div class="managed-root-line">
-        <i class="fas fa-folder-tree"></i>
-        <span>Managed install root@(managedRoots.Count > 1 ? "s" : ""):</span>
-        @foreach (var root in managedRoots)
-        {
-            <span class="mono root-chip">@root</span>
-        }
-    </div>
-}
-
 @if (DotnetUp.IsInstalled)
 {
-    <!-- ===== Project context (global.json) ===== -->
     <section class="page-section">
-        <div class="section-head">
-            <div class="section-head-main">
-                <h2><i class="fas fa-folder-open"></i> Project context</h2>
-                <p class="section-desc">
-                    Point Sherpa at a project folder to see which .NET SDK its <code>global.json</code> requires
-                    (Sherpa walks up to the nearest one, just like the <code>dotnet</code> CLI) and whether an
-                    installed SDK satisfies it — then install &amp; track it for that project.
-                </p>
-            </div>
-            <div class="section-actions">
-                <button class="btn btn-primary btn-sm" @onclick="PickProjectFolder" disabled="@(isLoading || inspectingFolder)">
-                    <i class="fas fa-folder-open"></i> <span>@(projectResolution == null ? "Open folder…" : "Choose another…")</span>
-                </button>
-                @if (projectResolution != null || !string.IsNullOrWhiteSpace(selectedFolder))
-                {
-                    <button class="btn btn-secondary btn-sm" @onclick="ClearProject" disabled="@(isLoading || inspectingFolder)" title="Stop inspecting this folder">
-                        <i class="fas fa-xmark"></i> <span>Close</span>
-                    </button>
-                }
-            </div>
-        </div>
-
-        @if (inspectingFolder)
-        {
-            <div class="panel"><span class="empty-state"><i class="fas fa-spinner fa-spin"></i> Inspecting @selectedFolder…</span></div>
-        }
-        else if (projectResolution is { } r)
-        {
-            <div class="panel project-panel">
-                <div class="project-folder">
-                    <i class="fas fa-folder"></i>
-                    <span class="mono" title="@r.FolderPath">@r.FolderPath</span>
-                </div>
-
-                @if (r.Status == GlobalJsonStatus.NoGlobalJson)
-                {
-                    <p class="info-note">
-                        <i class="fas fa-circle-info"></i>
-                        No <code>global.json</code> found walking up from this folder — it'll use your default SDK
-                        (the <strong>latest</strong> tracked channel).
-                    </p>
-                }
-                else if (r.Status == GlobalJsonStatus.NoSdkVersion)
-                {
-                    <p class="info-note">
-                        <i class="fas fa-circle-info"></i>
-                        Found <span class="mono">@r.GlobalJsonPath</span>, but it doesn't pin an
-                        <code>sdk.version</code> — any installed SDK can build this project.
-                    </p>
-                }
-                else
-                {
-                    <div class="project-gj">
-                        <i class="fas fa-file-code"></i>
-                        <span class="mono" title="@r.GlobalJsonPath">@r.GlobalJsonPath</span>
-                    </div>
-
-                    <div class="project-req">
-                        <div class="req-cell">
-                            <span class="req-label">Requested</span>
-                            <span class="mono req-value">@r.RequestedVersion</span>
-                        </div>
-                        <div class="req-cell">
-                            <span class="req-label">Roll-forward</span>
-                            <span class="req-value">
-                                @r.RollForward
-                                @if (r.IsPinned)
-                                {
-                                    <span class="badge badge-secondary" title="Pinned to an exact version — never auto-updates">pinned</span>
-                                }
-                                else
-                                {
-                                    <span class="badge badge-info" title="Rolling channel — dotnetup keeps it updated">rolling</span>
-                                }
-                            </span>
-                        </div>
-                        <div class="req-cell">
-                            <span class="req-label">Channel</span>
-                            <span class="mono req-value">@r.Channel</span>
-                        </div>
-                    </div>
-
-                    <div class="preview-row @(r.Satisfied ? "" : "row-update")">
-                        <span class="badge badge-info">SDK</span>
-                        <span class="track-channel mono">@r.Channel</span>
-                        <span class="spacer"></span>
-                        @if (r.Satisfied)
-                        {
-                            <span class="prev-ver mono new">@r.InstalledVersion</span>
-                            <span class="badge badge-success">installed</span>
-                        }
-                        else if (r.ResolvedVersion != null)
-                        {
-                            <span class="prev-ver mono">@r.ResolvedVersion</span>
-                            <span class="badge badge-warning">not installed</span>
-                        }
-                        else
-                        {
-                            <span class="badge badge-warning" title="Couldn't resolve this channel against the release feed">unknown</span>
-                        }
-                        @if (r.AlreadyTracked)
-                        {
-                            <span class="badge badge-secondary" title="dotnetup already tracks this project's global.json">tracked</span>
-                        }
-                    </div>
-
-                    <div class="project-actions">
-                        @if (r.Satisfied && r.AlreadyTracked)
-                        {
-                            <span class="project-ready"><i class="fas fa-circle-check"></i> Ready — this project's SDK is installed and tracked.</span>
-                        }
-                        else if (r.Satisfied)
-                        {
-                            <span class="project-hint">An installed SDK satisfies this project, but dotnetup isn't tracking its <code>global.json</code> yet.</span>
-                            <button class="btn btn-secondary btn-sm" @onclick="RunInstallForProject" disabled="@isLoading" title="Record this project's global.json so dotnetup keeps the right SDK installed">
-                                <i class="fas fa-thumbtack"></i> <span>Track this project</span>
-                            </button>
-                        }
-                        else
-                        {
-                            <span class="project-hint">No installed SDK satisfies this project yet.</span>
-                            <button class="btn btn-primary btn-sm" @onclick="RunInstallForProject" disabled="@isLoading" title="Install the SDK required by this folder's global.json and track it">
-                                <i class="fas fa-download"></i> <span>Install SDK for this project</span>
-                            </button>
-                        }
-                    </div>
-                }
-            </div>
-        }
+        <TrackedDotnetChannelsCard
+            ListResult="@list"
+            UpdatePreviews="@updatePreviews"
+            Busy="@isLoading"
+            CheckingUpdates="@checkingUpdates"
+            UpdatesUnresolved="@updatesUnresolved"
+            AddRequested="@OpenAddDialog"
+            UpdateSdksRequested="@RunUpdateSdks"
+            UpdateRuntimesRequested="@RunUpdateRuntimes"
+            UpdateAllRequested="@RunUpdateAll"
+            UntrackRequested="@RunUntrack" />
     </section>
 
-    <!-- ===== Tracked channels (manage) ===== -->
-    <section class="page-section">
-        <div class="section-head">
-            <div class="section-head-main">
-                <h2><i class="fas fa-list-check"></i> Tracked channels @if (list != null) { <span class="count">@list.InstallSpecs.Count</span> }</h2>
-                <p class="section-desc">
-                    dotnetup keeps every tracked channel installed and automatically up to date. You can track as many as you like —
-                    for example <strong>Latest</strong> alongside an older feature band like <strong>9.0.1xx</strong>. Updating re-resolves
-                    each channel to its newest matching version.
-                </p>
-            </div>
-            <div class="section-actions">
-                <button class="btn btn-primary btn-sm" @onclick="OpenAddDialog" disabled="@isLoading" title="Track another SDK channel">
-                    <i class="fas fa-plus"></i> <span>Add channel</span>
-                </button>
-            </div>
-        </div>
-
-        @if (updatePreviews != null)
-        {
-            var avail = updatePreviews.Where(p => p.UpdateAvailable).ToList();
-            var anySdk = avail.Any(p => p.Component == DotnetUpComponent.Sdk);
-            var anyRuntime = avail.Any(p => p.Component is DotnetUpComponent.Runtime or DotnetUpComponent.AspNetCore or DotnetUpComponent.WindowsDesktop);
-            <div class="panel preview-panel">
-                <div class="preview-head">
-                    @if (avail.Count > 0)
-                    {
-                        <span class="preview-summary has-updates">
-                            <i class="fas fa-circle-arrow-up"></i>
-                            @avail.Count update@(avail.Count == 1 ? "" : "s") available
-                        </span>
-                    }
-                    else
-                    {
-                        <span class="preview-summary up-to-date">
-                            <i class="fas fa-circle-check"></i> Everything is up to date
-                        </span>
-                    }
-                    <span class="spacer"></span>
-                    @if (updatesUnresolved)
-                    {
-                        <span class="preview-note" title="Couldn't reach the .NET release feed for some channels">
-                            <i class="fas fa-triangle-exclamation"></i> Some channels couldn't be checked
-                        </span>
-                    }
-                    <button class="preview-close" @onclick="DismissPreview" title="Dismiss"><i class="fas fa-xmark"></i></button>
-                </div>
-
-                <div class="preview-rows">
-                    @foreach (var p in updatePreviews)
-                    {
-                        <div class="preview-row @(p.UpdateAvailable ? "row-update" : "")">
-                            <span class="badge @ComponentBadgeClass(p.Component)">@ComponentShort(p.Component)</span>
-                            <span class="track-channel mono">@p.Channel</span>
-                            <span class="spacer"></span>
-                            @if (p.IsPinned)
-                            {
-                                <span class="prev-ver mono">@(p.InstalledVersion ?? p.Channel)</span>
-                                <span class="badge badge-secondary" title="Pinned to an exact version — channels don't apply">pinned</span>
-                            }
-                            else if (p.UpdateAvailable)
-                            {
-                                <span class="prev-ver mono old">@(p.InstalledVersion ?? "—")</span>
-                                <i class="fas fa-arrow-right prev-arrow"></i>
-                                <span class="prev-ver mono new">@p.AvailableVersion</span>
-                                <span class="badge badge-info">update</span>
-                            }
-                            else if (p.AvailableVersion == null)
-                            {
-                                <span class="prev-ver mono">@(p.InstalledVersion ?? "—")</span>
-                                <span class="badge badge-warning" title="Couldn't resolve this channel against the release feed">unknown</span>
-                            }
-                            else
-                            {
-                                <span class="prev-ver mono">@p.AvailableVersion</span>
-                                <span class="badge badge-success">up to date</span>
-                            }
-                        </div>
-                    }
-                </div>
-
-                @if (avail.Count > 0)
-                {
-                    <div class="preview-actions">
-                        <span class="preview-actions-label">Apply:</span>
-                        @if (anySdk && anyRuntime)
-                        {
-                            <button class="btn btn-secondary btn-sm" @onclick="RunUpdateSdks" disabled="@isLoading" title="Update tracked SDK channels only">
-                                <i class="fas fa-arrow-up"></i> <span>Update SDKs</span>
-                            </button>
-                            <button class="btn btn-secondary btn-sm" @onclick="RunUpdateRuntimes" disabled="@isLoading" title="Update tracked Runtime &amp; ASP.NET Core channels only">
-                                <i class="fas fa-arrow-up"></i> <span>Update runtimes</span>
-                            </button>
-                        }
-                        else if (anySdk)
-                        {
-                            <button class="btn btn-secondary btn-sm" @onclick="RunUpdateSdks" disabled="@isLoading" title="Update tracked SDK channels">
-                                <i class="fas fa-arrow-up"></i> <span>Update SDKs</span>
-                            </button>
-                        }
-                        else if (anyRuntime)
-                        {
-                            <button class="btn btn-secondary btn-sm" @onclick="RunUpdateRuntimes" disabled="@isLoading" title="Update tracked Runtime &amp; ASP.NET Core channels">
-                                <i class="fas fa-arrow-up"></i> <span>Update runtimes</span>
-                            </button>
-                        }
-                        <button class="btn btn-primary btn-sm" @onclick="RunUpdateAll" disabled="@isLoading" title="Update everything dotnetup tracks">
-                            <i class="fas fa-arrows-rotate"></i> <span>Update all</span>
-                        </button>
-                    </div>
-                }
-            </div>
-        }
-
-        @if (list != null && list.InstallSpecs.Count > 0)
-        {
-            @foreach (var grp in TrackedGroups())
-            {
-                <div class="comp-group">
-                    <div class="comp-group-head">
-                        <i class="@grp.Icon"></i>
-                        <span>@grp.Key</span>
-                        <span class="comp-group-count">@grp.Items.Count</span>
-                    </div>
-                    @foreach (var spec in grp.Items)
-                    {
-                        var src = SourceInfo(spec.Source);
-                        <div class="track-item">
-                            <span class="track-channel mono">@spec.VersionOrChannel</span>
-                            <span class="track-human">@ChannelHuman(spec.VersionOrChannel)</span>
-                            <span class="spacer"></span>
-                            @if (!string.IsNullOrEmpty(spec.GlobalJsonPath))
-                            {
-                                <span class="badge badge-warning" title="@spec.GlobalJsonPath">global.json</span>
-                            }
-                            <span class="badge @src.Cls" title="@src.Desc">@src.Text</span>
-                            @if (spec.Source == DotnetUpInstallSource.Explicit)
-                            {
-                                <button class="btn btn-danger btn-sm" @onclick="@(() => RunUntrack(spec))" disabled="@isLoading" title="Stop tracking and uninstall this channel">
-                                    <i class="fas fa-trash"></i>
-                                </button>
-                            }
-                        </div>
-                    }
-                </div>
-            }
-
-            <div class="legend">
-                <span class="legend-item"><span class="badge badge-info">explicit</span> You added this channel yourself.</span>
-                <span class="legend-item"><span class="badge badge-warning">global.json</span> Required by a project's global.json.</span>
-            </div>
-        }
-        else if (list != null)
-        {
-            <div class="empty-state">
-                <i class="fas fa-inbox"></i>
-                <p>No channels tracked yet. Use <strong>Add channel</strong> and dotnetup will install it and keep it updated.</p>
-                <button class="btn btn-primary btn-sm" @onclick="OpenAddDialog" disabled="@isLoading">
-                    <i class="fas fa-plus"></i> <span>Add channel</span>
-                </button>
-            </div>
-        }
-    </section>
-
-    <!-- ===== Installed components ===== -->
     <section class="page-section">
         <div class="section-head">
             <div class="section-head-main">
@@ -417,16 +92,6 @@
                     <p class="info-note"><i class="fas fa-lightbulb"></i> Each .NET SDK bundles its own runtime, so a standalone <strong>Runtime</strong> entry only appears when you track a runtime channel separately.</p>
                 }
             </div>
-            @if (list != null && list.Installations.Count > 0)
-            {
-                <div class="group-toggle">
-                    <span class="group-toggle-label">Group by</span>
-                    <div class="seg-group">
-                        <button class="seg @(groupMode == GroupMode.ByVersion ? "active" : "")" @onclick="@(() => groupMode = GroupMode.ByVersion)">Version</button>
-                        <button class="seg @(groupMode == GroupMode.ByType ? "active" : "")" @onclick="@(() => groupMode = GroupMode.ByType)">Type</button>
-                    </div>
-                </div>
-            }
         </div>
 
         @if (list == null)
@@ -442,40 +107,23 @@
         }
         else
         {
-            @foreach (var grp in ComponentGroups())
-            {
-                <div class="comp-group">
-                    <div class="comp-group-head">
-                        @if (!string.IsNullOrEmpty(grp.Icon)) { <i class="@grp.Icon"></i> }
-                        <span>@grp.Key</span>
-                        <span class="comp-group-count">@grp.Items.Count</span>
-                    </div>
-                    @foreach (var item in grp.Items)
-                    {
-                        <div class="comp-item">
-                            <span class="badge @ComponentBadgeClass(item.Component)">@ComponentShort(item.Component)</span>
-                            <span class="comp-version mono">@item.Version</span>
-                            @if (groupMode == GroupMode.ByVersion)
-                            {
-                                <span class="comp-name">@ComponentDisplay(item.Component)</span>
-                            }
-                            @if (!string.IsNullOrEmpty(item.Architecture))
-                            {
-                                <span class="comp-arch">@item.Architecture</span>
-                            }
-                            @if (!item.IsValid)
-                            {
-                                <span class="badge badge-warning">invalid</span>
-                            }
-                            <span class="spacer"></span>
-                            <button class="btn btn-danger btn-sm" @onclick="@(() => RunUninstall(item))" disabled="@isLoading"
-                                    title="Uninstall this component">
-                                <i class="fas fa-trash"></i>
-                            </button>
-                        </div>
-                    }
-                </div>
-            }
+            <div class="installed-version-list">
+                @foreach (var group in DotnetSdkPresentationBuilder.Build(list, workloadInventories, updatePreviews).InstalledGroups)
+                {
+                    <InstalledDotnetVersionCard
+                        @key="group.MajorMinor"
+                        RuntimeLine="@group.DisplayName"
+                        Installations="@group.Installations"
+                        WorkloadInventories="@group.WorkloadInventories"
+                        Loading="@(loadingWorkloads && group.WorkloadInventories.Count == 0)"
+                        Busy="@(isLoading || workloadBusy)"
+                        InitiallyExpanded="false"
+                        UninstallRequested="@RunUninstall"
+                        ManageRequested="@OpenManageWorkloads"
+                        ChangeSetRequested="@OpenChangeWorkloadSet"
+                        RepairRequested="@RepairWorkloads" />
+                }
+            </div>
         }
     </section>
 }
@@ -484,21 +132,17 @@
     private bool isLoading;
     private string? errorMessage;
     private DotnetUpToolInfo? toolInfo;
+    private DotnetUpToolUpdateInfo? toolUpdateInfo;
+    private bool checkingToolUpdate;
     private DotnetUpListResult? list;
     private List<string> managedRoots = new();
+    private IReadOnlyList<DotnetWorkloadInventory> workloadInventories = [];
+    private bool loadingWorkloads;
+    private bool workloadBusy;
 
     private IReadOnlyList<DotnetUpdatePreview>? updatePreviews;
     private bool checkingUpdates;
     private bool updatesUnresolved;
-
-    private string? selectedFolder;
-    private GlobalJsonResolution? projectResolution;
-    private bool inspectingFolder;
-
-    private enum GroupMode { ByVersion, ByType }
-    private GroupMode groupMode = GroupMode.ByVersion;
-
-    private record CompGroup(string Key, string Icon, IReadOnlyList<DotnetUpInstallation> Items);
 
     private async Task OpenAddDialog()
     {
@@ -519,70 +163,6 @@
         await RunProcessAndRefresh(request, $"Installed .NET SDK ({channel})", "The .NET SDK install failed.");
     }
 
-    private IEnumerable<CompGroup> ComponentGroups() =>
-        groupMode == GroupMode.ByVersion ? GroupedByVersion() : GroupedByType();
-
-    private IEnumerable<CompGroup> GroupedByVersion()
-    {
-        if (list == null) yield break;
-        var groups = list.Installations
-            .GroupBy(i => MajorMinor(i.Version))
-            .OrderByDescending(g => Version.TryParse(g.Key, out var v) ? v : new Version(0, 0));
-        foreach (var g in groups)
-        {
-            var items = g
-                .OrderBy(i => ComponentSortOrder(i.Component))
-                .ThenByDescending(i => i.Version, StringComparer.OrdinalIgnoreCase)
-                .ToList();
-            yield return new CompGroup($".NET {g.Key}", "fas fa-cube", items);
-        }
-    }
-
-    private IEnumerable<CompGroup> GroupedByType()
-    {
-        if (list == null) yield break;
-        var groups = list.Installations
-            .GroupBy(i => i.Component)
-            .OrderBy(g => ComponentSortOrder(g.Key));
-        foreach (var g in groups)
-        {
-            var items = g.OrderByDescending(i => i.Version, StringComparer.OrdinalIgnoreCase).ToList();
-            yield return new CompGroup(ComponentDisplay(g.Key), ComponentIcon(g.Key), items);
-        }
-    }
-
-    private record TrackGroup(string Key, string Icon, List<DotnetUpInstallSpec> Items);
-
-    private IEnumerable<TrackGroup> TrackedGroups()
-    {
-        if (list == null) yield break;
-        var groups = list.InstallSpecs
-            .GroupBy(s => s.Component)
-            .OrderBy(g => ComponentSortOrder(g.Key));
-        foreach (var g in groups)
-        {
-            var items = g
-                .OrderByDescending(s => s.VersionOrChannel, StringComparer.OrdinalIgnoreCase)
-                .ToList();
-            yield return new TrackGroup(ComponentDisplay(g.Key), ComponentIcon(g.Key), items);
-        }
-    }
-
-    private static string MajorMinor(string version)
-    {
-        var parts = version.Split('.');
-        return parts.Length >= 2 && int.TryParse(parts[0], out _) ? $"{parts[0]}.{parts[1]}" : version;
-    }
-
-    private static int ComponentSortOrder(DotnetUpComponent c) => c switch
-    {
-        DotnetUpComponent.Sdk => 0,
-        DotnetUpComponent.Runtime => 1,
-        DotnetUpComponent.AspNetCore => 2,
-        DotnetUpComponent.WindowsDesktop => 3,
-        _ => 4
-    };
-
     private static string ComponentDisplay(DotnetUpComponent c) => c switch
     {
         DotnetUpComponent.Sdk => ".NET SDK",
@@ -592,63 +172,6 @@
         _ => "Component"
     };
 
-    private static string ComponentShort(DotnetUpComponent c) => c switch
-    {
-        DotnetUpComponent.Sdk => "SDK",
-        DotnetUpComponent.Runtime => "Runtime",
-        DotnetUpComponent.AspNetCore => "ASP.NET",
-        DotnetUpComponent.WindowsDesktop => "Desktop",
-        _ => "Other"
-    };
-
-    private static string ComponentIcon(DotnetUpComponent c) => c switch
-    {
-        DotnetUpComponent.Sdk => "fas fa-toolbox",
-        DotnetUpComponent.Runtime => "fas fa-gears",
-        DotnetUpComponent.AspNetCore => "fas fa-globe",
-        DotnetUpComponent.WindowsDesktop => "fas fa-desktop",
-        _ => "fas fa-cube"
-    };
-
-    private static string ChannelHuman(string channel)
-    {
-        var v = channel.Trim().ToLowerInvariant();
-        return v switch
-        {
-            "latest" => "Latest stable",
-            "lts" => "Long-Term Support",
-            "preview" => "Latest preview",
-            "daily" => "Daily build",
-            _ => FormatVersionChannel(channel.Trim())
-        };
-    }
-
-    private static string FormatVersionChannel(string ch)
-    {
-        if (Regex.IsMatch(ch, @"^\d+\.\d+$"))
-            return $".NET {ch} · latest patch";
-        if (Regex.IsMatch(ch, @"^\d+\.\d+\.\dxx$"))
-        {
-            var band = ch.Split('.').Last();
-            var mm = ch.Substring(0, ch.LastIndexOf('.'));
-            return $".NET {mm} · feature band {band}";
-        }
-        if (Regex.IsMatch(ch, @"^\d+\.\d+\.\d+"))
-            return $"Pinned to {ch}";
-        return ch;
-    }
-
-    private record SourceBadge(string Text, string Cls, string Desc);
-
-    private static SourceBadge SourceInfo(DotnetUpInstallSource s) => s switch
-    {
-        DotnetUpInstallSource.Explicit => new("explicit", "badge-info", "You added this channel directly with Install."),
-        DotnetUpInstallSource.GlobalJson => new("global.json", "badge-warning", "Required by a project's global.json."),
-        DotnetUpInstallSource.All => new("all", "badge-secondary", "Applies to all components."),
-        _ => new("unknown", "badge-secondary", "Source unknown.")
-    };
-
-
     protected override async Task OnInitializedAsync()
     {
         ToolbarService.ToolbarItemClicked += OnToolbarItemClicked;
@@ -657,24 +180,9 @@
 
     private void UpdateToolbar()
     {
-        if (DotnetUp.IsInstalled)
-        {
-            var items = new List<ToolbarAction>
-            {
-                new("refresh", "Refresh", "arrow.clockwise"),
-                new("add-channel", "Add Channel", "plus"),
-            };
-            if (list != null && list.InstallSpecs.Count > 0)
-            {
-                items.Add(new ToolbarAction("check-updates", "Check for Updates", "magnifyingglass", IsPrimary: false));
-                items.Add(new ToolbarAction("update-all", "Update All", "square.and.arrow.up", IsPrimary: false));
-            }
-            ToolbarService.SetItems(items.ToArray());
-        }
-        else
-        {
-            ToolbarService.SetItems(new ToolbarAction("refresh", "Refresh", "arrow.clockwise"));
-        }
+        ToolbarService.SetItems(
+            new ToolbarAction("refresh", "Refresh", "arrow.clockwise"),
+            new ToolbarAction("open-project", "Open Project Folder", "folder"));
     }
 
     private void OnToolbarItemClicked(string actionId)
@@ -686,14 +194,8 @@
                 case "refresh":
                     await Refresh();
                     break;
-                case "add-channel":
-                    await OpenAddDialog();
-                    break;
-                case "check-updates":
-                    await CheckForUpdates();
-                    break;
-                case "update-all":
-                    await RunUpdateAll();
+                case "open-project":
+                    await PickProjectFolder();
                     break;
             }
             StateHasChanged();
@@ -706,6 +208,9 @@
         errorMessage = null;
         updatePreviews = null;
         updatesUnresolved = false;
+        toolUpdateInfo = null;
+        checkingToolUpdate = DotnetUp.IsInstalled;
+        workloadInventories = [];
         StateHasChanged();
         try
         {
@@ -714,10 +219,12 @@
                 toolInfo = await DotnetUp.GetToolInfoAsync();
                 list = await DotnetUp.GetListAsync();
                 managedRoots = list?.InstallRoots.ToList() ?? new();
+                toolUpdateInfo = await DotnetUp.GetToolUpdateInfoAsync(toolInfo);
             }
             else
             {
                 toolInfo = null;
+                toolUpdateInfo = null;
                 list = null;
                 managedRoots = new();
             }
@@ -728,19 +235,25 @@
         }
         finally
         {
+            checkingToolUpdate = false;
             isLoading = false;
             UpdateToolbar();
             StateHasChanged();
         }
+
+        if (list?.InstallSpecs.Count > 0)
+            await LoadUpdatePreviewAsync(showErrors: false);
+        if (list != null)
+            await LoadWorkloadInventoriesAsync(forceRefresh: true);
     }
 
-    private async Task<bool> EnsureInstalled(bool force = false)
+    private async Task<bool> EnsureInstalled(bool force = false, bool isUpdate = false)
     {
         if (DotnetUp.IsInstalled && !force)
             return true;
 
         var result = await OperationModal.RunAsync(
-            force ? "Reinstall dotnetup" : "Install dotnetup",
+            isUpdate ? "Update dotnetup" : force ? "Reinstall dotnetup" : "Install dotnetup",
             "Downloading and verifying the dotnetup .NET toolchain manager",
             async ctx =>
             {
@@ -768,22 +281,94 @@
         }
     }
 
-    private async Task ReinstallDotnetUp()
+    private Task UpdateDotnetUp() => ReplaceDotnetUp(isUpdate: true);
+
+    private Task ReinstallDotnetUp() => ReplaceDotnetUp(isUpdate: false);
+
+    private async Task ReplaceDotnetUp(bool isUpdate)
     {
+        var action = isUpdate ? "Update" : "Reinstall";
+        var detail = isUpdate
+            ? $"Update dotnetup from v{toolUpdateInfo!.InstalledVersion} to v{toolUpdateInfo.AvailableVersion}?"
+            : "Download and overwrite the dotnetup binary with the latest published build?";
         var confirm = await AlertService.ShowConfirmAsync(
-            "Reinstall dotnetup",
-            "Download and overwrite the dotnetup binary with the latest published build?",
-            "Reinstall", "Cancel");
+            $"{action} dotnetup",
+            detail,
+            action, "Cancel");
         if (!confirm) return;
 
-        if (await EnsureInstalled(force: true))
+        if (await EnsureInstalled(force: true, isUpdate: isUpdate))
         {
-            await AlertService.ShowToastAsync("dotnetup reinstalled");
+            await AlertService.ShowToastAsync(isUpdate ? "dotnetup updated" : "dotnetup reinstalled");
             await Refresh();
         }
     }
 
-    private async Task CheckForUpdates()
+    private async Task OpenDotnetUpDetails()
+    {
+        var page = new DotnetUpDetailsPage(
+            ModalParams,
+            DotnetUp.IsInstalled,
+            toolInfo,
+            toolUpdateInfo,
+            managedRoots,
+            DotnetUp.ExecutablePath,
+            DotnetUp.ToolDirectory);
+
+        await FormModal.ShowViewAsync(page, page.WaitForCloseAsync);
+
+        switch (page.SelectedAction)
+        {
+            case DotnetUpDetailsAction.Install:
+                await InstallDotnetUp();
+                break;
+            case DotnetUpDetailsAction.Update:
+                await UpdateDotnetUp();
+                break;
+            case DotnetUpDetailsAction.Reinstall:
+                await ReinstallDotnetUp();
+                break;
+        }
+    }
+
+    private Task CheckForUpdates() => LoadUpdatePreviewAsync(showErrors: true);
+
+    private string DotnetUpIndicatorClass
+    {
+        get
+        {
+            if (isLoading || checkingToolUpdate)
+                return "checking";
+            if (!DotnetUp.IsInstalled)
+                return "missing";
+            if (toolUpdateInfo?.UpdateAvailable == true)
+                return "update-available";
+            return "installed";
+        }
+    }
+
+    private string DotnetUpIndicatorIcon =>
+        isLoading || checkingToolUpdate
+            ? "fas fa-spinner fa-spin"
+            : DotnetUp.IsInstalled
+                ? "fa-regular fa-circle-check"
+                : "fa-regular fa-circle-xmark";
+
+    private string DotnetUpIndicatorTitle
+    {
+        get
+        {
+            if (isLoading || checkingToolUpdate)
+                return "dotnetup: checking status";
+            if (!DotnetUp.IsInstalled)
+                return "dotnetup is not installed. Open details.";
+            if (toolUpdateInfo?.UpdateAvailable == true)
+                return "A dotnetup update is available. Open details.";
+            return "dotnetup is ready. Open details.";
+        }
+    }
+
+    private async Task LoadUpdatePreviewAsync(bool showErrors)
     {
         if (list == null) return;
         checkingUpdates = true;
@@ -797,8 +382,10 @@
         }
         catch (Exception ex)
         {
-            errorMessage = $"Couldn't check for updates: {ex.Message}";
+            if (showErrors)
+                errorMessage = $"Couldn't check for updates: {ex.Message}";
             updatePreviews = null;
+            updatesUnresolved = true;
         }
         finally
         {
@@ -807,68 +394,177 @@
         }
     }
 
-    private void DismissPreview()
-    {
-        updatePreviews = null;
-        updatesUnresolved = false;
-    }
-
     private async Task PickProjectFolder()
     {
         var folder = await Dialog.PickFolderAsync("Choose a project folder");
         if (string.IsNullOrWhiteSpace(folder)) return;
-        selectedFolder = folder;
-        await InspectSelectedFolder();
-    }
-
-    private void ClearProject()
-    {
-        projectResolution = null;
-        selectedFolder = null;
-        StateHasChanged();
-    }
-
-    private async Task InspectSelectedFolder()
-    {
-        if (string.IsNullOrWhiteSpace(selectedFolder) || list == null) return;
-        inspectingFolder = true;
-        errorMessage = null;
-        StateHasChanged();
-        try
-        {
-            projectResolution = await DotnetUp.InspectProjectFolderAsync(selectedFolder, list);
-        }
-        catch (Exception ex)
-        {
-            errorMessage = $"Couldn't inspect the folder: {ex.Message}";
-            projectResolution = null;
-        }
-        finally
-        {
-            inspectingFolder = false;
-            StateHasChanged();
-        }
-    }
-
-    private async Task RunInstallForProject()
-    {
-        if (!await EnsureInstalled() || string.IsNullOrWhiteSpace(selectedFolder)) return;
-        var request = DotnetUp.InstallForProjectRequest(selectedFolder);
-        var result = await ProcessModal.ShowProcessAsync(request);
-        if (result?.Success == true)
-        {
-            await AlertService.ShowToastAsync("Project SDK installed");
+        var page = new ProjectDotnetContextPage(ModalParams, folder);
+        await FormModal.ShowViewAsync(page, page.WaitForCloseAsync);
+        if (page.HasChanges)
             await Refresh();
-            await InspectSelectedFolder();
-        }
-        else if (result != null && !result.WasCancelled && !result.WasKilled)
-        {
-            await AlertService.ShowAlertAsync("Operation Failed", "The project SDK install failed. Check the output for details.");
-        }
     }
 
+    private async Task LoadWorkloadInventoriesAsync(bool forceRefresh)
+        {
+            if (list == null)
+                return;
+            loadingWorkloads = true;
+            StateHasChanged();
+            try
+            {
+                workloadInventories = await Workloads.GetInventoriesAsync(list, forceRefresh);
+            }
+            catch (Exception ex)
+            {
+                errorMessage = $"Couldn't read .NET workload state: {ex.Message}";
+                workloadInventories = [];
+            }
+            finally
+            {
+                loadingWorkloads = false;
+                StateHasChanged();
+            }
+        }
+
+    private async Task OpenManageWorkloads(DotnetWorkloadInventory inventory)
+        {
+            var selection = await FormModal.ShowAsync<WorkloadSelectionResult?>(
+                new WorkloadSelectionPage(BridgeHolder, inventory));
+            if (selection == null ||
+                (selection.InstallIds.Count == 0 && selection.UninstallIds.Count == 0))
+                return;
+
+            if (selection.UninstallIds.Count > 0)
+            {
+                var uninstall = Workloads.CreateUninstallRequest(
+                    inventory.Target,
+                    selection.UninstallIds);
+                if (!await RunWorkloadProcess(
+                        uninstall,
+                        inventory.Target,
+                        "Selected workloads uninstalled",
+                        "The workload uninstall failed."))
+                    return;
+            }
+
+            if (selection.InstallIds.Count > 0)
+            {
+                var install = Workloads.CreateInstallRequest(
+                    inventory.Target,
+                    selection.InstallIds);
+                await RunWorkloadProcess(
+                    install,
+                    inventory.Target,
+                    "Selected workloads installed",
+                    "The workload install failed.");
+            }
+        }
+
+    private Task OpenChangeWorkloadSet(DotnetWorkloadInventory inventory) =>
+        OpenWorkloadSetPicker(inventory);
+
+    private async Task OpenWorkloadSetPicker(
+        DotnetWorkloadInventory inventory,
+        string? initialVersion = null)
+        {
+            var version = await FormModal.ShowAsync<string?>(
+                new WorkloadSetPage(BridgeHolder, inventory, initialVersion));
+            if (string.IsNullOrWhiteSpace(version))
+                return;
+            await ApplyWorkloadSet(inventory, version);
+        }
+
+        private async Task ApplyWorkloadSet(
+            DotnetWorkloadInventory inventory,
+            string version)
+        {
+            workloadBusy = true;
+            StateHasChanged();
+            try
+            {
+                var preview = await Workloads.GetWorkloadSetPreviewAsync(inventory.Target, version);
+                var request = Workloads.CreateUpdateSetRequest(inventory.Target, version);
+                request = request with
+                {
+                    ConfirmationDetails = BuildWorkloadSetConfirmationDetails(preview, inventory.UpdateMode)
+                };
+
+                await RunWorkloadProcess(
+                    request,
+                    inventory.Target,
+                    $"Workload set changed to {version}",
+                    "The workload-set update failed.");
+            }
+            catch (Exception ex)
+            {
+                await AlertService.ShowAlertAsync("Workload Preview Failed", ex.Message);
+            }
+            finally
+            {
+                workloadBusy = false;
+                StateHasChanged();
+            }
+        }
+
+    private async Task RepairWorkloads(DotnetWorkloadInventory inventory)
+        {
+            var request = Workloads.CreateRepairRequest(inventory.Target) with
+            {
+                ConfirmationDetails =
+                    $"SDK feature band: {inventory.Target.FeatureBand}\n" +
+                    $"Recorded workload IDs: {inventory.InstalledWorkloads.Count}\n" +
+                    "The .NET SDK will reinstall packs referenced by these workloads."
+            };
+            await RunWorkloadProcess(
+                request,
+                inventory.Target,
+                "Workloads repaired",
+                "The workload repair failed.");
+        }
+
+    private async Task<bool> RunWorkloadProcess(
+        ProcessRequest request,
+        DotnetWorkloadTarget target,
+        string successToast,
+        string failureMessage)
+        {
+            workloadBusy = true;
+            StateHasChanged();
+            try
+            {
+                var result = await ProcessModal.ShowProcessAsync(request);
+                if (result?.Success == true)
+                {
+                    Workloads.Invalidate(target.InstallRoot);
+                    await AlertService.ShowToastAsync(successToast);
+                    await LoadWorkloadInventoriesAsync(forceRefresh: true);
+                    return true;
+                }
+                else if (result != null && !result.WasCancelled && !result.WasKilled)
+                {
+                    await AlertService.ShowAlertAsync("Operation Failed", $"{failureMessage} Check the output for details.");
+                }
+                return false;
+            }
+            finally
+            {
+                workloadBusy = false;
+                StateHasChanged();
+            }
+        }
     private async Task RunUpdateAll()
     {
+        if (checkingUpdates) return;
+        if (updatePreviews == null)
+        {
+            await CheckForUpdates();
+            return;
+        }
+        if (!updatePreviews.Any(p => p.UpdateAvailable))
+        {
+            await AlertService.ShowToastAsync("Everything is already up to date");
+            return;
+        }
         if (!await EnsureInstalled()) return;
         await RunProcessAndRefresh(DotnetUp.UpdateAllRequest(), "All components updated", "The update failed.");
     }
@@ -888,32 +584,61 @@
     private async Task RunUninstall(DotnetUpInstallation item)
     {
         var label = $"{item.ComponentRaw} {item.Version}";
-        var confirm = await AlertService.ShowConfirmAsync(
-            "Uninstall component",
-            $"Remove {label} from {item.InstallRoot}?",
-            "Uninstall", "Cancel");
-        if (!confirm) return;
-
         ProcessRequest request = item.Component == DotnetUpComponent.Sdk
             ? DotnetUp.UninstallSdkRequest(item.Version)
             : DotnetUp.UninstallRuntimeRequest($"{RuntimeToken(item)}@{item.Version}");
+        request = request with
+        {
+            Description = $"Remove {label} from {item.InstallRoot}.",
+            ConfirmationButtonText = "Uninstall"
+        };
 
         await RunProcessAndRefresh(request, $"Uninstalled {label}", "The uninstall failed.");
     }
 
     private async Task RunUntrack(DotnetUpInstallSpec spec)
     {
-        var confirm = await AlertService.ShowConfirmAsync(
-            "Stop tracking channel",
-            $"Stop tracking {spec.VersionOrChannel} ({ComponentDisplay(spec.Component)}) and uninstall the version it resolved to?",
-            "Untrack", "Cancel");
-        if (!confirm) return;
-
         ProcessRequest request = spec.Component == DotnetUpComponent.Sdk
             ? DotnetUp.UninstallSdkRequest(spec.VersionOrChannel, spec.Source)
             : DotnetUp.UninstallRuntimeRequest($"{RuntimeTokenForComponent(spec.Component)}@{spec.VersionOrChannel}");
+        request = request with
+        {
+            Description =
+                $"Stop tracking {spec.VersionOrChannel} ({ComponentDisplay(spec.Component)}) and uninstall the version it resolved to.",
+            ConfirmationButtonText = "Untrack"
+        };
 
         await RunProcessAndRefresh(request, $"Stopped tracking {spec.VersionOrChannel}", "The untrack failed.");
+    }
+
+    private static string BuildWorkloadSetConfirmationDetails(
+        DotnetWorkloadSetPreview preview,
+        DotnetWorkloadUpdateMode currentMode)
+    {
+        var lines = new List<string>
+        {
+            $"SDK feature band: {preview.Target.FeatureBand}",
+            $"Current workload set: {preview.CurrentVersion ?? "not installed"}",
+            $"New workload set: {preview.TargetVersion}",
+            $"Installed workload IDs affected: {preview.InstalledWorkloadIds.Count}",
+            $"Manifest changes: {preview.ManifestChanges.Count}"
+        };
+
+        if (currentMode == DotnetWorkloadUpdateMode.Manifests)
+            lines.Insert(1, "Update mode: Loose manifests -> Workload set");
+
+        if (preview.ManifestChanges.Count > 0)
+        {
+            lines.Add("");
+            lines.Add("Manifest changes");
+            lines.AddRange(preview.ManifestChanges.Take(8).Select(
+                change =>
+                    $"{change.ManifestId}: {change.CurrentVersion ?? "not installed"} -> {change.TargetVersion ?? "removed"}"));
+            if (preview.ManifestChanges.Count > 8)
+                lines.Add($"+ {preview.ManifestChanges.Count - 8} more");
+        }
+
+        return string.Join(Environment.NewLine, lines);
     }
 
     private static string RuntimeTokenForComponent(DotnetUpComponent c) => c switch
@@ -944,15 +669,6 @@
         _ => "runtime"
     };
 
-    private static string ComponentBadgeClass(DotnetUpComponent component) => component switch
-    {
-        DotnetUpComponent.Sdk => "badge-success",
-        DotnetUpComponent.Runtime => "badge-info",
-        DotnetUpComponent.AspNetCore => "badge-info",
-        DotnetUpComponent.WindowsDesktop => "badge-info",
-        _ => "badge-secondary"
-    };
-
     public void Dispose()
     {
         ToolbarService.ToolbarItemClicked -= OnToolbarItemClicked;
@@ -960,130 +676,96 @@
 }
 
 <style>
-    /* ===== badge base shape (global CSS only supplies colors) ===== */
-    .badge {
-        display: inline-flex;
-        align-items: center;
-        padding: 2px 0.625rem;
-        border-radius: 0.75rem;
-        font-size: 0.75rem;
-        font-weight: 500;
-        white-space: nowrap;
-    }
-
-    /* ===== dotnetup status (flat) ===== */
-    .dnup-status {
+    .dotnet-sdk-page-header {
         display: flex;
         align-items: center;
-        gap: 0.6rem;
-        padding: 0.55rem 0.8rem;
-        border-radius: var(--card-radius);
-        background: var(--card-bg);
-        border-left: 3px solid var(--border-color);
-        margin-top: 1.25rem;
-        margin-bottom: 0.6rem;
+        justify-content: space-between;
+        flex-wrap: wrap;
+        gap: 0.75rem 1rem;
+        margin-bottom: 1.25rem;
     }
 
-    .dnup-status.ok {
-        border-left-color: var(--status-success-text, #16a34a);
+    .dotnet-sdk-page-header h1 {
+        margin: 0;
     }
 
-    .dnup-status.missing {
-        border-left-color: var(--status-warning-text, #d97706);
-    }
-
-    .dnup-status-icon {
-        font-size: 1.05rem;
-        flex-shrink: 0;
-        display: flex;
-    }
-
-    .dnup-status.ok .dnup-status-icon {
-        color: var(--status-success-text, #16a34a);
-    }
-
-    .dnup-status.missing .dnup-status-icon {
-        color: var(--status-warning-text, #d97706);
-    }
-
-    .dnup-status-body {
-        flex: 1;
+    .dotnet-sdk-page-heading {
         min-width: 0;
         display: flex;
-        align-items: baseline;
+        flex: 1;
+        flex-direction: column;
+        gap: 0.3rem;
+    }
+
+    .dotnet-sdk-page-heading p {
+        max-width: 52rem;
+        margin: 0;
+        color: var(--text-secondary);
+        font-size: 0.85rem;
+        line-height: 1.4;
+    }
+
+    .dotnet-sdk-page-actions {
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
         flex-wrap: wrap;
+        gap: 0.55rem;
+    }
+
+    .dotnetup-indicator {
+        display: inline-flex;
+        align-items: center;
         gap: 0.4rem;
-    }
-
-    .dnup-status-title {
-        font-weight: 600;
-        color: var(--text-primary);
-        font-size: 0.9rem;
-    }
-
-    .dnup-status-ver,
-    .dnup-status-rid {
-        color: var(--text-secondary);
-        font-size: 0.8rem;
-    }
-
-    .dnup-status-sub {
-        color: var(--text-secondary);
-        font-size: 0.82rem;
-        font-weight: 400;
-    }
-
-    .dnup-status-actions {
-        flex-shrink: 0;
-    }
-
-    .btn-ghost {
+        min-height: 2rem;
+        padding: 0.3rem 0.5rem;
+        border: 0;
+        border-radius: 0.4rem;
         background: transparent;
-        border: 1px solid transparent;
         color: var(--text-secondary);
+        font: inherit;
+        font-size: 0.78rem;
+        font-weight: 500;
+        cursor: pointer;
+        transition: background-color 0.15s ease, color 0.15s ease;
     }
 
-    .btn-ghost:hover {
+    .dotnetup-indicator:hover:not(:disabled) {
         background: var(--bg-tertiary);
         color: var(--text-primary);
     }
 
-    .status-meta {
-        color: var(--text-secondary);
-        font-size: 0.82rem;
-        display: flex;
-        flex-wrap: wrap;
-        align-items: center;
-        gap: 0.35rem;
+    .dotnetup-indicator:focus-visible {
+        outline: 2px solid var(--accent-primary);
+        outline-offset: 2px;
     }
 
-    .status-meta .dot,
-    .dnup-status-body .dot {
-        opacity: 0.5;
-    }
-
-    .managed-root-line {
-        display: flex;
-        flex-wrap: wrap;
-        align-items: center;
-        gap: 0.4rem;
-        color: var(--text-secondary);
-        font-size: 0.8rem;
-        margin-bottom: 1.5rem;
-        padding-left: 0.15rem;
-    }
-
-    .managed-root-line i {
+    .dotnetup-indicator:disabled {
+        cursor: default;
         opacity: 0.7;
     }
 
-    .root-chip {
-        background: var(--bg-tertiary);
-        border-radius: 0.375rem;
-        padding: 0.1rem 0.4rem;
+    .dotnetup-indicator.installed > i,
+    .dotnetup-indicator.update-available > i {
+        color: color-mix(in srgb, var(--status-success-text) 72%, var(--text-secondary));
     }
 
-    /* ===== flat sections ===== */
+    .dotnetup-indicator.missing > i {
+        color: color-mix(in srgb, var(--status-warning-text) 72%, var(--text-secondary));
+    }
+
+    .dotnetup-indicator-update {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 1rem;
+        height: 1rem;
+        border-radius: 999px;
+        background: var(--status-info-bg);
+        color: var(--status-info-text);
+        font-size: 0.58rem;
+    }
+
     .page-section {
         margin-bottom: 1.75rem;
     }
@@ -1105,365 +787,60 @@
     }
 
     .section-head h2 {
-        font-size: 1.05rem;
-        font-weight: 600;
-        margin: 0;
-        color: var(--text-primary);
         display: flex;
         align-items: center;
         gap: 0.5rem;
+        margin: 0;
+        color: var(--text-primary);
+        font-size: 1.05rem;
+        font-weight: 600;
     }
 
-    .section-head h2 i {
+    .section-head h2 i,
+    .info-note i {
         color: var(--text-secondary);
     }
 
     .section-desc {
         margin: 0.25rem 0 0;
-        font-size: 0.85rem;
         color: var(--text-secondary);
+        font-size: 0.85rem;
         line-height: 1.4;
     }
 
     .count {
-        font-size: 0.72rem;
-        font-weight: 600;
+        padding: 0.05rem 0.5rem;
+        border-radius: 999px;
         background: var(--bg-tertiary);
         color: var(--text-secondary);
-        border-radius: 999px;
-        padding: 0.05rem 0.5rem;
-    }
-
-    /* grey item-card panels */
-    .panel {
-        background: var(--card-bg);
-        border-radius: var(--card-radius);
-        padding: 1rem 1.1rem;
-        margin-bottom: 0.75rem;
-    }
-
-    /* ===== add-channel ===== */
-    .section-actions {
-        display: flex;
-        gap: 0.5rem;
-        flex-wrap: wrap;
-        flex-shrink: 0;
-    }
-
-    /* ===== group toggle ===== */
-    .group-toggle {
-        display: flex;
-        align-items: center;
-        gap: 0.5rem;
-        flex-shrink: 0;
-    }
-
-    .group-toggle-label {
-        font-size: 0.78rem;
-        color: var(--text-secondary);
-    }
-
-    .seg-group {
-        display: inline-flex;
-        border: 1px solid var(--border-color);
-        border-radius: 0.5rem;
-        overflow: hidden;
-    }
-
-    .seg {
-        background: var(--card-bg);
-        border: none;
-        color: var(--text-secondary);
-        font-size: 0.8rem;
-        padding: 0.3rem 0.7rem;
-        cursor: pointer;
-    }
-
-    .seg + .seg {
-        border-left: 1px solid var(--border-color);
-    }
-
-    .seg.active {
-        background: var(--accent-primary, #4299e1);
-        color: #fff;
+        font-size: 0.72rem;
+        font-weight: 600;
     }
 
     .info-note {
-        font-size: 0.8rem;
-        color: var(--text-secondary);
         margin: 0.4rem 0 0;
+        color: var(--text-secondary);
+        font-size: 0.8rem;
         line-height: 1.4;
     }
 
     .info-note i {
         margin-right: 0.4rem;
-        color: var(--text-secondary);
     }
 
-    /* ===== component groups ===== */
-    .comp-group {
-        margin-bottom: 1rem;
-    }
-
-    .comp-group-head {
-        display: flex;
-        align-items: center;
-        gap: 0.45rem;
-        font-size: 0.85rem;
-        font-weight: 600;
-        color: var(--text-primary);
-        margin-bottom: 0.4rem;
-    }
-
-    .comp-group-head i {
-        color: var(--text-secondary);
-    }
-
-    .comp-group-count {
-        font-size: 0.7rem;
-        font-weight: 600;
-        color: var(--text-secondary);
-        background: var(--bg-tertiary);
-        border-radius: 999px;
-        padding: 0.02rem 0.45rem;
-    }
-
-    .comp-item,
-    .track-item {
-        display: flex;
-        align-items: center;
-        gap: 0.6rem;
-        padding: 0.55rem 0.85rem;
-        border-radius: var(--card-radius);
-        background: var(--card-bg);
-        margin-bottom: 0.4rem;
-    }
-
-    .comp-version,
-    .track-channel {
-        font-weight: 600;
-        color: var(--text-primary);
-    }
-
-    .comp-name,
-    .comp-arch,
-    .track-human {
-        font-size: 0.8rem;
-        color: var(--text-secondary);
-    }
-
-    /* ===== tracked channels ===== */
-    .legend {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.25rem 1.25rem;
-        margin-top: 0.6rem;
-        font-size: 0.78rem;
-        color: var(--text-secondary);
-    }
-
-    .legend-item {
-        display: flex;
-        align-items: center;
-        gap: 0.4rem;
-    }
-
-    .spacer {
-        flex: 1;
-    }
-
-    /* ===== update preview ===== */
-    .preview-panel {
-        border: 1px solid var(--border-color);
-    }
-
-    .preview-head {
-        display: flex;
-        align-items: center;
-        gap: 0.6rem;
-        margin-bottom: 0.75rem;
-    }
-
-    .preview-summary {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.45rem;
-        font-weight: 600;
-        font-size: 0.9rem;
-    }
-
-    .preview-summary.has-updates {
-        color: var(--status-info-text, #2563eb);
-    }
-
-    .preview-summary.up-to-date {
-        color: var(--status-success-text, #16a34a);
-    }
-
-    .preview-note {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.35rem;
-        font-size: 0.78rem;
-        color: var(--status-warning-text, #d97706);
-    }
-
-    .preview-close {
-        background: none;
-        border: none;
-        color: var(--text-secondary);
-        cursor: pointer;
-        padding: 0.15rem 0.35rem;
-        border-radius: 6px;
-        font-size: 0.9rem;
-    }
-
-    .preview-close:hover {
-        background: var(--bg-tertiary);
-        color: var(--text-primary);
-    }
-
-    .preview-rows {
-        display: flex;
-        flex-direction: column;
-        gap: 0.4rem;
-    }
-
-    .preview-row {
-        display: flex;
-        align-items: center;
-        gap: 0.6rem;
-        padding: 0.5rem 0.75rem;
-        border-radius: var(--card-radius);
-        background: var(--bg-tertiary);
-    }
-
-    .prev-ver {
-        font-weight: 600;
-        color: var(--text-primary);
-        font-size: 0.85rem;
-    }
-
-    .prev-ver.old {
-        color: var(--text-secondary);
-        font-weight: 500;
-    }
-
-    .prev-ver.new {
-        color: var(--status-success-text, #16a34a);
-    }
-
-    .prev-arrow {
-        color: var(--text-secondary);
-        font-size: 0.75rem;
-    }
-
-    .preview-actions {
-        display: flex;
-        align-items: center;
-        gap: 0.5rem;
-        flex-wrap: wrap;
-        margin-top: 0.85rem;
-        padding-top: 0.85rem;
-        border-top: 1px solid var(--border-color);
-    }
-
-    .preview-actions-label {
-        font-size: 0.82rem;
-        font-weight: 600;
-        color: var(--text-secondary);
-        margin-right: 0.15rem;
-    }
-
-    /* ===== project context (global.json) ===== */
-    .project-panel {
-        display: flex;
-        flex-direction: column;
+    .installed-version-list {
+        display: grid;
         gap: 0.75rem;
     }
 
-    .project-folder,
-    .project-gj {
-        display: flex;
-        align-items: center;
-        gap: 0.5rem;
-        font-size: 0.85rem;
-        color: var(--text-secondary);
-        min-width: 0;
-    }
+    @@media (max-width: 700px) {
+        .dotnet-sdk-page-header,
+        .dotnet-sdk-page-actions {
+            align-items: flex-start;
+        }
 
-    .project-folder i,
-    .project-gj i {
-        flex-shrink: 0;
-        color: var(--text-secondary);
-    }
-
-    .project-folder .mono,
-    .project-gj .mono {
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-        color: var(--text-primary);
-    }
-
-    .project-req {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 1.25rem;
-        padding: 0.65rem 0.85rem;
-        background: var(--bg-tertiary);
-        border-radius: var(--card-radius);
-    }
-
-    .req-cell {
-        display: flex;
-        flex-direction: column;
-        gap: 0.2rem;
-    }
-
-    .req-label {
-        font-size: 0.72rem;
-        font-weight: 600;
-        text-transform: uppercase;
-        letter-spacing: 0.04em;
-        color: var(--text-secondary);
-    }
-
-    .req-value {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.4rem;
-        font-size: 0.88rem;
-        font-weight: 600;
-        color: var(--text-primary);
-    }
-
-    .preview-row.row-update {
-        background: var(--bg-tertiary);
-    }
-
-    .project-actions {
-        display: flex;
-        align-items: center;
-        gap: 0.75rem;
-        flex-wrap: wrap;
-        padding-top: 0.75rem;
-        border-top: 1px solid var(--border-color);
-    }
-
-    .project-hint {
-        font-size: 0.85rem;
-        color: var(--text-secondary);
-        flex: 1 1 auto;
-        min-width: 12rem;
-    }
-
-    .project-ready {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.45rem;
-        font-size: 0.88rem;
-        font-weight: 600;
-        color: var(--status-success-text, #16a34a);
+        .dotnet-sdk-page-actions {
+            justify-content: flex-start;
+        }
     }
 </style>

--- a/src/MauiSherpa/Pages/DotnetSdk.razor
+++ b/src/MauiSherpa/Pages/DotnetSdk.razor
@@ -2,12 +2,19 @@
 @using MauiSherpa.Core.Interfaces
 @using MauiSherpa.Core.Services
 @using MauiSherpa.Services
+@using MauiSherpa.Pages.Forms
+@using MauiSherpa.Pages.Modals
 @using MauiSherpa.Workloads.Models
+@using System.Text.RegularExpressions
 @inject IDotnetUpService DotnetUp
 @inject IProcessModalService ProcessModal
 @inject IOperationModalService OperationModal
 @inject IAlertService AlertService
+@inject IDialogService Dialog
 @inject IPlatformService PlatformInfo
+@inject IToolbarService ToolbarService
+@inject IFormModalService FormModal
+@inject HybridFormBridgeHolder BridgeHolder
 @implements IDisposable
 
 <h1><i class="fas fa-layer-group"></i> .NET SDK Manager</h1>
@@ -27,9 +34,18 @@
     </button>
     @if (DotnetUp.IsInstalled)
     {
-        <button class="btn btn-success" @onclick="RunUpdateAll" disabled="@isLoading">
-            <i class="fas fa-arrow-up-from-bracket"></i> <span>Update All</span>
+        <button class="btn btn-secondary" @onclick="OpenAddDialog" disabled="@isLoading">
+            <i class="fas fa-plus"></i> <span>Add Channel</span>
         </button>
+        @if (list != null && list.InstallSpecs.Count > 0)
+        {
+            <button class="btn btn-secondary" @onclick="CheckForUpdates" disabled="@(isLoading || checkingUpdates)">
+                <i class="fas fa-magnifying-glass"></i> <span>Check for updates</span>
+            </button>
+            <button class="btn btn-success" @onclick="RunUpdateAll" disabled="@isLoading">
+                <i class="fas fa-arrow-up-from-bracket"></i> <span>Update All</span>
+            </button>
+        }
     }
 </div>
 }
@@ -39,109 +55,377 @@
     <div class="error-bar">@errorMessage</div>
 }
 
-<!-- dotnetup status card -->
-<div class="section-card status-card">
-    <div class="status-row">
-        <div class="status-icon @(DotnetUp.IsInstalled ? "ok" : "missing")">
-            <i class="fas @(DotnetUp.IsInstalled ? "fa-circle-check" : "fa-circle-exclamation")"></i>
-        </div>
-        <div class="status-body">
-            @if (DotnetUp.IsInstalled)
+<!-- dotnetup status -->
+<div class="dnup-status @(DotnetUp.IsInstalled ? "ok" : "missing")">
+    <div class="dnup-status-icon">
+        <i class="fas @(DotnetUp.IsInstalled ? "fa-circle-check" : "fa-circle-exclamation")"></i>
+    </div>
+    <div class="dnup-status-body">
+        @if (DotnetUp.IsInstalled)
+        {
+            <span class="dnup-status-title">dotnetup</span>
+            @if (toolInfo != null)
             {
-                <strong>dotnetup is installed</strong>
-                <div class="status-meta mono">
-                    @if (toolInfo != null)
-                    {
-                        <span>v@(toolInfo.Version)</span>
-                        @if (!string.IsNullOrEmpty(toolInfo.Rid))
-                        {
-                            <span class="dot">·</span><span>@toolInfo.Rid</span>
-                        }
-                    }
-                    else
-                    {
-                        <span>@DotnetUp.ExecutablePath</span>
-                    }
-                </div>
-                @if (managedRoots.Count > 0)
+                <span class="dnup-status-ver mono">v@(toolInfo.Version)</span>
+                @if (!string.IsNullOrEmpty(toolInfo.Rid))
                 {
-                    <div class="status-meta">
-                        Managed install root@(managedRoots.Count > 1 ? "s" : ""):
-                        @foreach (var root in managedRoots)
-                        {
-                            <span class="mono root-chip">@root</span>
-                        }
-                    </div>
+                    <span class="dot">·</span><span class="mono dnup-status-rid">@toolInfo.Rid</span>
                 }
             }
-            else
-            {
-                <strong>dotnetup is not installed</strong>
-                <div class="status-meta">Install the .NET toolchain manager to install and update SDKs &amp; runtimes from here.</div>
-            }
-        </div>
-        <div class="status-actions">
-            @if (DotnetUp.IsInstalled)
-            {
-                <button class="btn btn-secondary btn-sm" @onclick="ReinstallDotnetUp" disabled="@isLoading">
-                    <i class="fas fa-rotate"></i> <span>Reinstall</span>
-                </button>
-            }
-            else
-            {
-                <button class="btn btn-success" @onclick="InstallDotnetUp" disabled="@isLoading">
-                    <i class="fas fa-download"></i> <span>Install dotnetup</span>
-                </button>
-            }
-        </div>
+        }
+        else
+        {
+            <span class="dnup-status-title">dotnetup is not installed</span>
+            <span class="dnup-status-sub">Install the .NET toolchain manager to install &amp; update SDKs and runtimes from here.</span>
+        }
+    </div>
+    <div class="dnup-status-actions">
+        @if (DotnetUp.IsInstalled)
+        {
+            <button class="btn btn-ghost btn-sm" @onclick="ReinstallDotnetUp" disabled="@isLoading" title="Download and overwrite dotnetup with the latest published build">
+                <i class="fas fa-rotate"></i> <span>Reinstall</span>
+            </button>
+        }
+        else
+        {
+            <button class="btn btn-success" @onclick="InstallDotnetUp" disabled="@isLoading">
+                <i class="fas fa-download"></i> <span>Install dotnetup</span>
+            </button>
+        }
     </div>
 </div>
 
+@if (DotnetUp.IsInstalled && managedRoots.Count > 0)
+{
+    <div class="managed-root-line">
+        <i class="fas fa-folder-tree"></i>
+        <span>Managed install root@(managedRoots.Count > 1 ? "s" : ""):</span>
+        @foreach (var root in managedRoots)
+        {
+            <span class="mono root-chip">@root</span>
+        }
+    </div>
+}
+
 @if (DotnetUp.IsInstalled)
 {
-    <!-- Install / update controls -->
-    <div class="section-card">
-        <div class="card-title-row">
-            <h2 class="card-title"><i class="fas fa-download"></i> Install a .NET SDK</h2>
-        </div>
-        <div class="install-row">
-            <select class="channel-select" @bind="selectedChannel" disabled="@isLoading">
-                @foreach (var ch in channelOptions)
+    <!-- ===== Project context (global.json) ===== -->
+    <section class="page-section">
+        <div class="section-head">
+            <div class="section-head-main">
+                <h2><i class="fas fa-folder-open"></i> Project context</h2>
+                <p class="section-desc">
+                    Point Sherpa at a project folder to see which .NET SDK its <code>global.json</code> requires
+                    (Sherpa walks up to the nearest one, just like the <code>dotnet</code> CLI) and whether an
+                    installed SDK satisfies it — then install &amp; track it for that project.
+                </p>
+            </div>
+            <div class="section-actions">
+                <button class="btn btn-primary btn-sm" @onclick="PickProjectFolder" disabled="@(isLoading || inspectingFolder)">
+                    <i class="fas fa-folder-open"></i> <span>@(projectResolution == null ? "Open folder…" : "Choose another…")</span>
+                </button>
+                @if (projectResolution != null || !string.IsNullOrWhiteSpace(selectedFolder))
                 {
-                    <option value="@ch.Value">@ch.Label</option>
+                    <button class="btn btn-secondary btn-sm" @onclick="ClearProject" disabled="@(isLoading || inspectingFolder)" title="Stop inspecting this folder">
+                        <i class="fas fa-xmark"></i> <span>Close</span>
+                    </button>
                 }
-                <option value="__custom__">Custom channel…</option>
-            </select>
-            @if (selectedChannel == "__custom__")
-            {
-                <input type="text" class="channel-input" placeholder="e.g. 9.0.1xx or 10.0.103"
-                       @bind="customChannel" @bind:event="oninput" disabled="@isLoading" />
-            }
-            <label class="terminal-toggle" title="Configure PATH and DOTNET_ROOT so the terminal 'dotnet' uses this install">
-                <input type="checkbox" @bind="terminalMode" disabled="@isLoading" />
-                <span>Set as default (Terminal Mode)</span>
-            </label>
-            <button class="btn btn-primary" @onclick="RunInstallSdk" disabled="@(isLoading || !HasInstallChannel)">
-                <i class="fas fa-download"></i> <span>Install SDK</span>
-            </button>
+            </div>
         </div>
-        <div class="install-row secondary">
-            <button class="btn btn-secondary btn-sm" @onclick="RunUpdateSdks" disabled="@isLoading">
-                <i class="fas fa-arrow-up"></i> <span>Update tracked SDKs</span>
-            </button>
-            <button class="btn btn-secondary btn-sm" @onclick="RunUpdateRuntimes" disabled="@isLoading">
-                <i class="fas fa-arrow-up"></i> <span>Update tracked runtimes</span>
-            </button>
-        </div>
-    </div>
 
-    <!-- Installations -->
-    <div class="section-card">
-        <div class="card-title-row">
-            <h2 class="card-title"><i class="fas fa-cubes"></i> Installed components</h2>
-            @if (list != null)
+        @if (inspectingFolder)
+        {
+            <div class="panel"><span class="empty-state"><i class="fas fa-spinner fa-spin"></i> Inspecting @selectedFolder…</span></div>
+        }
+        else if (projectResolution is { } r)
+        {
+            <div class="panel project-panel">
+                <div class="project-folder">
+                    <i class="fas fa-folder"></i>
+                    <span class="mono" title="@r.FolderPath">@r.FolderPath</span>
+                </div>
+
+                @if (r.Status == GlobalJsonStatus.NoGlobalJson)
+                {
+                    <p class="info-note">
+                        <i class="fas fa-circle-info"></i>
+                        No <code>global.json</code> found walking up from this folder — it'll use your default SDK
+                        (the <strong>latest</strong> tracked channel).
+                    </p>
+                }
+                else if (r.Status == GlobalJsonStatus.NoSdkVersion)
+                {
+                    <p class="info-note">
+                        <i class="fas fa-circle-info"></i>
+                        Found <span class="mono">@r.GlobalJsonPath</span>, but it doesn't pin an
+                        <code>sdk.version</code> — any installed SDK can build this project.
+                    </p>
+                }
+                else
+                {
+                    <div class="project-gj">
+                        <i class="fas fa-file-code"></i>
+                        <span class="mono" title="@r.GlobalJsonPath">@r.GlobalJsonPath</span>
+                    </div>
+
+                    <div class="project-req">
+                        <div class="req-cell">
+                            <span class="req-label">Requested</span>
+                            <span class="mono req-value">@r.RequestedVersion</span>
+                        </div>
+                        <div class="req-cell">
+                            <span class="req-label">Roll-forward</span>
+                            <span class="req-value">
+                                @r.RollForward
+                                @if (r.IsPinned)
+                                {
+                                    <span class="badge badge-secondary" title="Pinned to an exact version — never auto-updates">pinned</span>
+                                }
+                                else
+                                {
+                                    <span class="badge badge-info" title="Rolling channel — dotnetup keeps it updated">rolling</span>
+                                }
+                            </span>
+                        </div>
+                        <div class="req-cell">
+                            <span class="req-label">Channel</span>
+                            <span class="mono req-value">@r.Channel</span>
+                        </div>
+                    </div>
+
+                    <div class="preview-row @(r.Satisfied ? "" : "row-update")">
+                        <span class="badge badge-info">SDK</span>
+                        <span class="track-channel mono">@r.Channel</span>
+                        <span class="spacer"></span>
+                        @if (r.Satisfied)
+                        {
+                            <span class="prev-ver mono new">@r.InstalledVersion</span>
+                            <span class="badge badge-success">installed</span>
+                        }
+                        else if (r.ResolvedVersion != null)
+                        {
+                            <span class="prev-ver mono">@r.ResolvedVersion</span>
+                            <span class="badge badge-warning">not installed</span>
+                        }
+                        else
+                        {
+                            <span class="badge badge-warning" title="Couldn't resolve this channel against the release feed">unknown</span>
+                        }
+                        @if (r.AlreadyTracked)
+                        {
+                            <span class="badge badge-secondary" title="dotnetup already tracks this project's global.json">tracked</span>
+                        }
+                    </div>
+
+                    <div class="project-actions">
+                        @if (r.Satisfied && r.AlreadyTracked)
+                        {
+                            <span class="project-ready"><i class="fas fa-circle-check"></i> Ready — this project's SDK is installed and tracked.</span>
+                        }
+                        else if (r.Satisfied)
+                        {
+                            <span class="project-hint">An installed SDK satisfies this project, but dotnetup isn't tracking its <code>global.json</code> yet.</span>
+                            <button class="btn btn-secondary btn-sm" @onclick="RunInstallForProject" disabled="@isLoading" title="Record this project's global.json so dotnetup keeps the right SDK installed">
+                                <i class="fas fa-thumbtack"></i> <span>Track this project</span>
+                            </button>
+                        }
+                        else
+                        {
+                            <span class="project-hint">No installed SDK satisfies this project yet.</span>
+                            <button class="btn btn-primary btn-sm" @onclick="RunInstallForProject" disabled="@isLoading" title="Install the SDK required by this folder's global.json and track it">
+                                <i class="fas fa-download"></i> <span>Install SDK for this project</span>
+                            </button>
+                        }
+                    </div>
+                }
+            </div>
+        }
+    </section>
+
+    <!-- ===== Tracked channels (manage) ===== -->
+    <section class="page-section">
+        <div class="section-head">
+            <div class="section-head-main">
+                <h2><i class="fas fa-list-check"></i> Tracked channels @if (list != null) { <span class="count">@list.InstallSpecs.Count</span> }</h2>
+                <p class="section-desc">
+                    dotnetup keeps every tracked channel installed and automatically up to date. You can track as many as you like —
+                    for example <strong>Latest</strong> alongside an older feature band like <strong>9.0.1xx</strong>. Updating re-resolves
+                    each channel to its newest matching version.
+                </p>
+            </div>
+            <div class="section-actions">
+                <button class="btn btn-primary btn-sm" @onclick="OpenAddDialog" disabled="@isLoading" title="Track another SDK channel">
+                    <i class="fas fa-plus"></i> <span>Add channel</span>
+                </button>
+            </div>
+        </div>
+
+        @if (updatePreviews != null)
+        {
+            var avail = updatePreviews.Where(p => p.UpdateAvailable).ToList();
+            var anySdk = avail.Any(p => p.Component == DotnetUpComponent.Sdk);
+            var anyRuntime = avail.Any(p => p.Component is DotnetUpComponent.Runtime or DotnetUpComponent.AspNetCore or DotnetUpComponent.WindowsDesktop);
+            <div class="panel preview-panel">
+                <div class="preview-head">
+                    @if (avail.Count > 0)
+                    {
+                        <span class="preview-summary has-updates">
+                            <i class="fas fa-circle-arrow-up"></i>
+                            @avail.Count update@(avail.Count == 1 ? "" : "s") available
+                        </span>
+                    }
+                    else
+                    {
+                        <span class="preview-summary up-to-date">
+                            <i class="fas fa-circle-check"></i> Everything is up to date
+                        </span>
+                    }
+                    <span class="spacer"></span>
+                    @if (updatesUnresolved)
+                    {
+                        <span class="preview-note" title="Couldn't reach the .NET release feed for some channels">
+                            <i class="fas fa-triangle-exclamation"></i> Some channels couldn't be checked
+                        </span>
+                    }
+                    <button class="preview-close" @onclick="DismissPreview" title="Dismiss"><i class="fas fa-xmark"></i></button>
+                </div>
+
+                <div class="preview-rows">
+                    @foreach (var p in updatePreviews)
+                    {
+                        <div class="preview-row @(p.UpdateAvailable ? "row-update" : "")">
+                            <span class="badge @ComponentBadgeClass(p.Component)">@ComponentShort(p.Component)</span>
+                            <span class="track-channel mono">@p.Channel</span>
+                            <span class="spacer"></span>
+                            @if (p.IsPinned)
+                            {
+                                <span class="prev-ver mono">@(p.InstalledVersion ?? p.Channel)</span>
+                                <span class="badge badge-secondary" title="Pinned to an exact version — channels don't apply">pinned</span>
+                            }
+                            else if (p.UpdateAvailable)
+                            {
+                                <span class="prev-ver mono old">@(p.InstalledVersion ?? "—")</span>
+                                <i class="fas fa-arrow-right prev-arrow"></i>
+                                <span class="prev-ver mono new">@p.AvailableVersion</span>
+                                <span class="badge badge-info">update</span>
+                            }
+                            else if (p.AvailableVersion == null)
+                            {
+                                <span class="prev-ver mono">@(p.InstalledVersion ?? "—")</span>
+                                <span class="badge badge-warning" title="Couldn't resolve this channel against the release feed">unknown</span>
+                            }
+                            else
+                            {
+                                <span class="prev-ver mono">@p.AvailableVersion</span>
+                                <span class="badge badge-success">up to date</span>
+                            }
+                        </div>
+                    }
+                </div>
+
+                @if (avail.Count > 0)
+                {
+                    <div class="preview-actions">
+                        <span class="preview-actions-label">Apply:</span>
+                        @if (anySdk && anyRuntime)
+                        {
+                            <button class="btn btn-secondary btn-sm" @onclick="RunUpdateSdks" disabled="@isLoading" title="Update tracked SDK channels only">
+                                <i class="fas fa-arrow-up"></i> <span>Update SDKs</span>
+                            </button>
+                            <button class="btn btn-secondary btn-sm" @onclick="RunUpdateRuntimes" disabled="@isLoading" title="Update tracked Runtime &amp; ASP.NET Core channels only">
+                                <i class="fas fa-arrow-up"></i> <span>Update runtimes</span>
+                            </button>
+                        }
+                        else if (anySdk)
+                        {
+                            <button class="btn btn-secondary btn-sm" @onclick="RunUpdateSdks" disabled="@isLoading" title="Update tracked SDK channels">
+                                <i class="fas fa-arrow-up"></i> <span>Update SDKs</span>
+                            </button>
+                        }
+                        else if (anyRuntime)
+                        {
+                            <button class="btn btn-secondary btn-sm" @onclick="RunUpdateRuntimes" disabled="@isLoading" title="Update tracked Runtime &amp; ASP.NET Core channels">
+                                <i class="fas fa-arrow-up"></i> <span>Update runtimes</span>
+                            </button>
+                        }
+                        <button class="btn btn-primary btn-sm" @onclick="RunUpdateAll" disabled="@isLoading" title="Update everything dotnetup tracks">
+                            <i class="fas fa-arrows-rotate"></i> <span>Update all</span>
+                        </button>
+                    </div>
+                }
+            </div>
+        }
+
+        @if (list != null && list.InstallSpecs.Count > 0)
+        {
+            @foreach (var grp in TrackedGroups())
             {
-                <span class="badge badge-secondary">@list.Installations.Count</span>
+                <div class="comp-group">
+                    <div class="comp-group-head">
+                        <i class="@grp.Icon"></i>
+                        <span>@grp.Key</span>
+                        <span class="comp-group-count">@grp.Items.Count</span>
+                    </div>
+                    @foreach (var spec in grp.Items)
+                    {
+                        var src = SourceInfo(spec.Source);
+                        <div class="track-item">
+                            <span class="track-channel mono">@spec.VersionOrChannel</span>
+                            <span class="track-human">@ChannelHuman(spec.VersionOrChannel)</span>
+                            <span class="spacer"></span>
+                            @if (!string.IsNullOrEmpty(spec.GlobalJsonPath))
+                            {
+                                <span class="badge badge-warning" title="@spec.GlobalJsonPath">global.json</span>
+                            }
+                            <span class="badge @src.Cls" title="@src.Desc">@src.Text</span>
+                            @if (spec.Source == DotnetUpInstallSource.Explicit)
+                            {
+                                <button class="btn btn-danger btn-sm" @onclick="@(() => RunUntrack(spec))" disabled="@isLoading" title="Stop tracking and uninstall this channel">
+                                    <i class="fas fa-trash"></i>
+                                </button>
+                            }
+                        </div>
+                    }
+                </div>
+            }
+
+            <div class="legend">
+                <span class="legend-item"><span class="badge badge-info">explicit</span> You added this channel yourself.</span>
+                <span class="legend-item"><span class="badge badge-warning">global.json</span> Required by a project's global.json.</span>
+            </div>
+        }
+        else if (list != null)
+        {
+            <div class="empty-state">
+                <i class="fas fa-inbox"></i>
+                <p>No channels tracked yet. Use <strong>Add channel</strong> and dotnetup will install it and keep it updated.</p>
+                <button class="btn btn-primary btn-sm" @onclick="OpenAddDialog" disabled="@isLoading">
+                    <i class="fas fa-plus"></i> <span>Add channel</span>
+                </button>
+            </div>
+        }
+    </section>
+
+    <!-- ===== Installed components ===== -->
+    <section class="page-section">
+        <div class="section-head">
+            <div class="section-head-main">
+                <h2><i class="fas fa-cubes"></i> Installed components @if (list != null) { <span class="count">@list.Installations.Count</span> }</h2>
+                <p class="section-desc">.NET SDKs, runtimes, and ASP.NET Core runtimes dotnetup has installed on this machine.</p>
+                @if (list != null && list.Installations.Count > 0)
+                {
+                    <p class="info-note"><i class="fas fa-lightbulb"></i> Each .NET SDK bundles its own runtime, so a standalone <strong>Runtime</strong> entry only appears when you track a runtime channel separately.</p>
+                }
+            </div>
+            @if (list != null && list.Installations.Count > 0)
+            {
+                <div class="group-toggle">
+                    <span class="group-toggle-label">Group by</span>
+                    <div class="seg-group">
+                        <button class="seg @(groupMode == GroupMode.ByVersion ? "active" : "")" @onclick="@(() => groupMode = GroupMode.ByVersion)">Version</button>
+                        <button class="seg @(groupMode == GroupMode.ByType ? "active" : "")" @onclick="@(() => groupMode = GroupMode.ByType)">Type</button>
+                    </div>
+                </div>
             }
         </div>
 
@@ -153,29 +437,31 @@
         {
             <div class="empty-state">
                 <i class="fas fa-box-open"></i>
-                <p>No dotnetup-managed .NET components yet. Install an SDK above to get started.</p>
+                <p>No dotnetup-managed .NET components yet. Add a channel above to install your first SDK.</p>
             </div>
         }
         else
         {
-            @foreach (var group in list.Installations.GroupBy(i => i.InstallRoot))
+            @foreach (var grp in ComponentGroups())
             {
-                <div class="install-group">
-                    <div class="install-group-root mono">
-                        <i class="fas fa-folder"></i> @group.Key
+                <div class="comp-group">
+                    <div class="comp-group-head">
+                        @if (!string.IsNullOrEmpty(grp.Icon)) { <i class="@grp.Icon"></i> }
+                        <span>@grp.Key</span>
+                        <span class="comp-group-count">@grp.Items.Count</span>
                     </div>
-                    @foreach (var item in group.OrderByDescending(i => i.Version))
+                    @foreach (var item in grp.Items)
                     {
-                        <div class="install-item">
-                            <span class="badge @ComponentBadgeClass(item.Component)">@item.ComponentRaw</span>
-                            <span class="install-version mono">@item.Version</span>
-                            @if (!string.IsNullOrEmpty(item.FrameworkName))
+                        <div class="comp-item">
+                            <span class="badge @ComponentBadgeClass(item.Component)">@ComponentShort(item.Component)</span>
+                            <span class="comp-version mono">@item.Version</span>
+                            @if (groupMode == GroupMode.ByVersion)
                             {
-                                <span class="install-framework mono">@item.FrameworkName</span>
+                                <span class="comp-name">@ComponentDisplay(item.Component)</span>
                             }
                             @if (!string.IsNullOrEmpty(item.Architecture))
                             {
-                                <span class="install-arch">@item.Architecture</span>
+                                <span class="comp-arch">@item.Architecture</span>
                             }
                             @if (!item.IsValid)
                             {
@@ -191,30 +477,7 @@
                 </div>
             }
         }
-    </div>
-
-    <!-- Tracked channels -->
-    @if (list != null && list.InstallSpecs.Count > 0)
-    {
-        <div class="section-card">
-            <div class="card-title-row">
-                <h2 class="card-title"><i class="fas fa-list-check"></i> Tracked channels</h2>
-                <span class="badge badge-secondary">@list.InstallSpecs.Count</span>
-            </div>
-            @foreach (var spec in list.InstallSpecs)
-            {
-                <div class="install-item">
-                    <span class="badge @ComponentBadgeClass(spec.Component)">@spec.ComponentRaw</span>
-                    <span class="install-version mono">@spec.VersionOrChannel</span>
-                    <span class="badge badge-info">@spec.Source</span>
-                    @if (!string.IsNullOrEmpty(spec.GlobalJsonPath))
-                    {
-                        <span class="install-framework mono" title="@spec.GlobalJsonPath">global.json</span>
-                    }
-                </div>
-            }
-        </div>
-    }
+    </section>
 }
 
 @code {
@@ -224,37 +487,225 @@
     private DotnetUpListResult? list;
     private List<string> managedRoots = new();
 
-    private string selectedChannel = "latest";
-    private string customChannel = string.Empty;
-    private bool terminalMode = true;
+    private IReadOnlyList<DotnetUpdatePreview>? updatePreviews;
+    private bool checkingUpdates;
+    private bool updatesUnresolved;
 
-    private record ChannelOption(string Value, string Label);
+    private string? selectedFolder;
+    private GlobalJsonResolution? projectResolution;
+    private bool inspectingFolder;
 
-    private readonly List<ChannelOption> channelOptions = new()
+    private enum GroupMode { ByVersion, ByType }
+    private GroupMode groupMode = GroupMode.ByVersion;
+
+    private record CompGroup(string Key, string Icon, IReadOnlyList<DotnetUpInstallation> Items);
+
+    private async Task OpenAddDialog()
     {
-        new("latest", "Latest"),
-        new("lts", "LTS (Long-Term Support)"),
-        new("preview", "Preview"),
-        new("10.0.1xx", "10.0 (feature band 1xx)"),
-        new("9.0.1xx", "9.0 (feature band 1xx)"),
-        new("8.0.1xx", "8.0 (feature band 1xx)"),
-        new("daily", "Daily build"),
+        if (!await EnsureInstalled()) return;
+
+        var tracked = list?.InstallSpecs
+            .Where(s => s.Component == DotnetUpComponent.Sdk)
+            .Select(s => s.VersionOrChannel)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList() ?? new List<string>();
+
+        var channel = await FormModal.ShowAsync<string?>(new AddChannelPage(BridgeHolder, tracked));
+        if (string.IsNullOrWhiteSpace(channel)) return;
+
+        // Tracked-channel installs never change the global default ("Terminal mode" is a one-time
+        // global choice made by `dotnetup init`, not a per-channel setting), so terminalMode: false.
+        var request = DotnetUp.InstallSdkRequest(channel, terminalMode: false);
+        await RunProcessAndRefresh(request, $"Installed .NET SDK ({channel})", "The .NET SDK install failed.");
+    }
+
+    private IEnumerable<CompGroup> ComponentGroups() =>
+        groupMode == GroupMode.ByVersion ? GroupedByVersion() : GroupedByType();
+
+    private IEnumerable<CompGroup> GroupedByVersion()
+    {
+        if (list == null) yield break;
+        var groups = list.Installations
+            .GroupBy(i => MajorMinor(i.Version))
+            .OrderByDescending(g => Version.TryParse(g.Key, out var v) ? v : new Version(0, 0));
+        foreach (var g in groups)
+        {
+            var items = g
+                .OrderBy(i => ComponentSortOrder(i.Component))
+                .ThenByDescending(i => i.Version, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            yield return new CompGroup($".NET {g.Key}", "fas fa-cube", items);
+        }
+    }
+
+    private IEnumerable<CompGroup> GroupedByType()
+    {
+        if (list == null) yield break;
+        var groups = list.Installations
+            .GroupBy(i => i.Component)
+            .OrderBy(g => ComponentSortOrder(g.Key));
+        foreach (var g in groups)
+        {
+            var items = g.OrderByDescending(i => i.Version, StringComparer.OrdinalIgnoreCase).ToList();
+            yield return new CompGroup(ComponentDisplay(g.Key), ComponentIcon(g.Key), items);
+        }
+    }
+
+    private record TrackGroup(string Key, string Icon, List<DotnetUpInstallSpec> Items);
+
+    private IEnumerable<TrackGroup> TrackedGroups()
+    {
+        if (list == null) yield break;
+        var groups = list.InstallSpecs
+            .GroupBy(s => s.Component)
+            .OrderBy(g => ComponentSortOrder(g.Key));
+        foreach (var g in groups)
+        {
+            var items = g
+                .OrderByDescending(s => s.VersionOrChannel, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            yield return new TrackGroup(ComponentDisplay(g.Key), ComponentIcon(g.Key), items);
+        }
+    }
+
+    private static string MajorMinor(string version)
+    {
+        var parts = version.Split('.');
+        return parts.Length >= 2 && int.TryParse(parts[0], out _) ? $"{parts[0]}.{parts[1]}" : version;
+    }
+
+    private static int ComponentSortOrder(DotnetUpComponent c) => c switch
+    {
+        DotnetUpComponent.Sdk => 0,
+        DotnetUpComponent.Runtime => 1,
+        DotnetUpComponent.AspNetCore => 2,
+        DotnetUpComponent.WindowsDesktop => 3,
+        _ => 4
     };
 
-    private bool HasInstallChannel =>
-        selectedChannel != "__custom__" || !string.IsNullOrWhiteSpace(customChannel);
+    private static string ComponentDisplay(DotnetUpComponent c) => c switch
+    {
+        DotnetUpComponent.Sdk => ".NET SDK",
+        DotnetUpComponent.Runtime => ".NET Runtime",
+        DotnetUpComponent.AspNetCore => "ASP.NET Core Runtime",
+        DotnetUpComponent.WindowsDesktop => "Windows Desktop Runtime",
+        _ => "Component"
+    };
 
-    private string? CurrentChannel =>
-        selectedChannel == "__custom__"
-            ? (string.IsNullOrWhiteSpace(customChannel) ? null : customChannel.Trim())
-            : selectedChannel;
+    private static string ComponentShort(DotnetUpComponent c) => c switch
+    {
+        DotnetUpComponent.Sdk => "SDK",
+        DotnetUpComponent.Runtime => "Runtime",
+        DotnetUpComponent.AspNetCore => "ASP.NET",
+        DotnetUpComponent.WindowsDesktop => "Desktop",
+        _ => "Other"
+    };
 
-    protected override async Task OnInitializedAsync() => await Refresh();
+    private static string ComponentIcon(DotnetUpComponent c) => c switch
+    {
+        DotnetUpComponent.Sdk => "fas fa-toolbox",
+        DotnetUpComponent.Runtime => "fas fa-gears",
+        DotnetUpComponent.AspNetCore => "fas fa-globe",
+        DotnetUpComponent.WindowsDesktop => "fas fa-desktop",
+        _ => "fas fa-cube"
+    };
+
+    private static string ChannelHuman(string channel)
+    {
+        var v = channel.Trim().ToLowerInvariant();
+        return v switch
+        {
+            "latest" => "Latest stable",
+            "lts" => "Long-Term Support",
+            "preview" => "Latest preview",
+            "daily" => "Daily build",
+            _ => FormatVersionChannel(channel.Trim())
+        };
+    }
+
+    private static string FormatVersionChannel(string ch)
+    {
+        if (Regex.IsMatch(ch, @"^\d+\.\d+$"))
+            return $".NET {ch} · latest patch";
+        if (Regex.IsMatch(ch, @"^\d+\.\d+\.\dxx$"))
+        {
+            var band = ch.Split('.').Last();
+            var mm = ch.Substring(0, ch.LastIndexOf('.'));
+            return $".NET {mm} · feature band {band}";
+        }
+        if (Regex.IsMatch(ch, @"^\d+\.\d+\.\d+"))
+            return $"Pinned to {ch}";
+        return ch;
+    }
+
+    private record SourceBadge(string Text, string Cls, string Desc);
+
+    private static SourceBadge SourceInfo(DotnetUpInstallSource s) => s switch
+    {
+        DotnetUpInstallSource.Explicit => new("explicit", "badge-info", "You added this channel directly with Install."),
+        DotnetUpInstallSource.GlobalJson => new("global.json", "badge-warning", "Required by a project's global.json."),
+        DotnetUpInstallSource.All => new("all", "badge-secondary", "Applies to all components."),
+        _ => new("unknown", "badge-secondary", "Source unknown.")
+    };
+
+
+    protected override async Task OnInitializedAsync()
+    {
+        ToolbarService.ToolbarItemClicked += OnToolbarItemClicked;
+        await Refresh();
+    }
+
+    private void UpdateToolbar()
+    {
+        if (DotnetUp.IsInstalled)
+        {
+            var items = new List<ToolbarAction>
+            {
+                new("refresh", "Refresh", "arrow.clockwise"),
+                new("add-channel", "Add Channel", "plus"),
+            };
+            if (list != null && list.InstallSpecs.Count > 0)
+            {
+                items.Add(new ToolbarAction("check-updates", "Check for Updates", "magnifyingglass", IsPrimary: false));
+                items.Add(new ToolbarAction("update-all", "Update All", "square.and.arrow.up", IsPrimary: false));
+            }
+            ToolbarService.SetItems(items.ToArray());
+        }
+        else
+        {
+            ToolbarService.SetItems(new ToolbarAction("refresh", "Refresh", "arrow.clockwise"));
+        }
+    }
+
+    private void OnToolbarItemClicked(string actionId)
+    {
+        InvokeAsync(async () =>
+        {
+            switch (actionId)
+            {
+                case "refresh":
+                    await Refresh();
+                    break;
+                case "add-channel":
+                    await OpenAddDialog();
+                    break;
+                case "check-updates":
+                    await CheckForUpdates();
+                    break;
+                case "update-all":
+                    await RunUpdateAll();
+                    break;
+            }
+            StateHasChanged();
+        });
+    }
 
     private async Task Refresh()
     {
         isLoading = true;
         errorMessage = null;
+        updatePreviews = null;
+        updatesUnresolved = false;
         StateHasChanged();
         try
         {
@@ -278,6 +729,7 @@
         finally
         {
             isLoading = false;
+            UpdateToolbar();
             StateHasChanged();
         }
     }
@@ -331,12 +783,88 @@
         }
     }
 
-    private async Task RunInstallSdk()
+    private async Task CheckForUpdates()
     {
-        if (!await EnsureInstalled()) return;
-        var channel = CurrentChannel;
-        var request = DotnetUp.InstallSdkRequest(channel, terminalMode);
-        await RunProcessAndRefresh(request, $"Installed .NET SDK ({channel ?? "latest"})", "The .NET SDK install failed.");
+        if (list == null) return;
+        checkingUpdates = true;
+        errorMessage = null;
+        StateHasChanged();
+        try
+        {
+            var previews = await DotnetUp.GetUpdatePreviewAsync(list);
+            updatePreviews = previews;
+            updatesUnresolved = previews.Any(p => !p.IsPinned && p.AvailableVersion == null);
+        }
+        catch (Exception ex)
+        {
+            errorMessage = $"Couldn't check for updates: {ex.Message}";
+            updatePreviews = null;
+        }
+        finally
+        {
+            checkingUpdates = false;
+            StateHasChanged();
+        }
+    }
+
+    private void DismissPreview()
+    {
+        updatePreviews = null;
+        updatesUnresolved = false;
+    }
+
+    private async Task PickProjectFolder()
+    {
+        var folder = await Dialog.PickFolderAsync("Choose a project folder");
+        if (string.IsNullOrWhiteSpace(folder)) return;
+        selectedFolder = folder;
+        await InspectSelectedFolder();
+    }
+
+    private void ClearProject()
+    {
+        projectResolution = null;
+        selectedFolder = null;
+        StateHasChanged();
+    }
+
+    private async Task InspectSelectedFolder()
+    {
+        if (string.IsNullOrWhiteSpace(selectedFolder) || list == null) return;
+        inspectingFolder = true;
+        errorMessage = null;
+        StateHasChanged();
+        try
+        {
+            projectResolution = await DotnetUp.InspectProjectFolderAsync(selectedFolder, list);
+        }
+        catch (Exception ex)
+        {
+            errorMessage = $"Couldn't inspect the folder: {ex.Message}";
+            projectResolution = null;
+        }
+        finally
+        {
+            inspectingFolder = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task RunInstallForProject()
+    {
+        if (!await EnsureInstalled() || string.IsNullOrWhiteSpace(selectedFolder)) return;
+        var request = DotnetUp.InstallForProjectRequest(selectedFolder);
+        var result = await ProcessModal.ShowProcessAsync(request);
+        if (result?.Success == true)
+        {
+            await AlertService.ShowToastAsync("Project SDK installed");
+            await Refresh();
+            await InspectSelectedFolder();
+        }
+        else if (result != null && !result.WasCancelled && !result.WasKilled)
+        {
+            await AlertService.ShowAlertAsync("Operation Failed", "The project SDK install failed. Check the output for details.");
+        }
     }
 
     private async Task RunUpdateAll()
@@ -373,6 +901,28 @@
         await RunProcessAndRefresh(request, $"Uninstalled {label}", "The uninstall failed.");
     }
 
+    private async Task RunUntrack(DotnetUpInstallSpec spec)
+    {
+        var confirm = await AlertService.ShowConfirmAsync(
+            "Stop tracking channel",
+            $"Stop tracking {spec.VersionOrChannel} ({ComponentDisplay(spec.Component)}) and uninstall the version it resolved to?",
+            "Untrack", "Cancel");
+        if (!confirm) return;
+
+        ProcessRequest request = spec.Component == DotnetUpComponent.Sdk
+            ? DotnetUp.UninstallSdkRequest(spec.VersionOrChannel, spec.Source)
+            : DotnetUp.UninstallRuntimeRequest($"{RuntimeTokenForComponent(spec.Component)}@{spec.VersionOrChannel}");
+
+        await RunProcessAndRefresh(request, $"Stopped tracking {spec.VersionOrChannel}", "The untrack failed.");
+    }
+
+    private static string RuntimeTokenForComponent(DotnetUpComponent c) => c switch
+    {
+        DotnetUpComponent.AspNetCore => "aspnetcore",
+        DotnetUpComponent.WindowsDesktop => "windowsdesktop",
+        _ => "runtime"
+    };
+
     private async Task RunProcessAndRefresh(ProcessRequest request, string successToast, string failureMessage)
     {
         var result = await ProcessModal.ShowProcessAsync(request);
@@ -403,150 +953,517 @@
         _ => "badge-secondary"
     };
 
-    public void Dispose() { }
+    public void Dispose()
+    {
+        ToolbarService.ToolbarItemClicked -= OnToolbarItemClicked;
+    }
 }
 
 <style>
-    .status-card {
-        padding: 1rem 1.25rem;
-        margin-bottom: 1rem;
+    /* ===== badge base shape (global CSS only supplies colors) ===== */
+    .badge {
+        display: inline-flex;
+        align-items: center;
+        padding: 2px 0.625rem;
+        border-radius: 0.75rem;
+        font-size: 0.75rem;
+        font-weight: 500;
+        white-space: nowrap;
     }
 
-    .status-row {
+    /* ===== dotnetup status (flat) ===== */
+    .dnup-status {
         display: flex;
         align-items: center;
-        gap: 1rem;
+        gap: 0.6rem;
+        padding: 0.55rem 0.8rem;
+        border-radius: var(--card-radius);
+        background: var(--card-bg);
+        border-left: 3px solid var(--border-color);
+        margin-top: 1.25rem;
+        margin-bottom: 0.6rem;
     }
 
-    .status-icon {
-        font-size: 1.75rem;
+    .dnup-status.ok {
+        border-left-color: var(--status-success-text, #16a34a);
+    }
+
+    .dnup-status.missing {
+        border-left-color: var(--status-warning-text, #d97706);
+    }
+
+    .dnup-status-icon {
+        font-size: 1.05rem;
         flex-shrink: 0;
+        display: flex;
     }
 
-    .status-icon.ok {
+    .dnup-status.ok .dnup-status-icon {
         color: var(--status-success-text, #16a34a);
     }
 
-    .status-icon.missing {
+    .dnup-status.missing .dnup-status-icon {
         color: var(--status-warning-text, #d97706);
     }
 
-    .status-body {
+    .dnup-status-body {
         flex: 1;
         min-width: 0;
         display: flex;
-        flex-direction: column;
-        gap: 0.25rem;
+        align-items: baseline;
+        flex-wrap: wrap;
+        gap: 0.4rem;
+    }
+
+    .dnup-status-title {
+        font-weight: 600;
+        color: var(--text-primary);
+        font-size: 0.9rem;
+    }
+
+    .dnup-status-ver,
+    .dnup-status-rid {
+        color: var(--text-secondary);
+        font-size: 0.8rem;
+    }
+
+    .dnup-status-sub {
+        color: var(--text-secondary);
+        font-size: 0.82rem;
+        font-weight: 400;
+    }
+
+    .dnup-status-actions {
+        flex-shrink: 0;
+    }
+
+    .btn-ghost {
+        background: transparent;
+        border: 1px solid transparent;
+        color: var(--text-secondary);
+    }
+
+    .btn-ghost:hover {
+        background: var(--bg-tertiary);
+        color: var(--text-primary);
     }
 
     .status-meta {
         color: var(--text-secondary);
-        font-size: 0.85rem;
+        font-size: 0.82rem;
         display: flex;
         flex-wrap: wrap;
         align-items: center;
         gap: 0.35rem;
     }
 
-    .status-meta .dot {
+    .status-meta .dot,
+    .dnup-status-body .dot {
         opacity: 0.5;
+    }
+
+    .managed-root-line {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 0.4rem;
+        color: var(--text-secondary);
+        font-size: 0.8rem;
+        margin-bottom: 1.5rem;
+        padding-left: 0.15rem;
+    }
+
+    .managed-root-line i {
+        opacity: 0.7;
     }
 
     .root-chip {
         background: var(--bg-tertiary);
-        border-radius: 4px;
+        border-radius: 0.375rem;
         padding: 0.1rem 0.4rem;
     }
 
-    .status-actions {
-        flex-shrink: 0;
+    /* ===== flat sections ===== */
+    .page-section {
+        margin-bottom: 1.75rem;
     }
 
-    .section-card {
-        padding: 1rem 1.25rem;
-        margin-bottom: 1rem;
+    .page-section + .page-section {
+        margin-top: 1rem;
     }
 
-    .card-title-row {
+    .section-head {
         display: flex;
-        align-items: center;
-        gap: 0.5rem;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 1rem;
         margin-bottom: 0.75rem;
     }
 
-    .card-title {
-        font-size: 1rem;
+    .section-head-main {
+        min-width: 0;
+    }
+
+    .section-head h2 {
+        font-size: 1.05rem;
         font-weight: 600;
         margin: 0;
         color: var(--text-primary);
-    }
-
-    .install-row {
         display: flex;
         align-items: center;
-        flex-wrap: wrap;
-        gap: 0.6rem;
+        gap: 0.5rem;
     }
 
-    .install-row.secondary {
-        margin-top: 0.75rem;
-        padding-top: 0.75rem;
-        border-top: 1px solid var(--border-color);
+    .section-head h2 i {
+        color: var(--text-secondary);
     }
 
-    .channel-select,
-    .channel-input {
-        padding: 0.4rem 0.6rem;
-        border: 1px solid var(--input-border);
-        border-radius: 6px;
-        font-size: 0.9rem;
-        min-width: 12rem;
-    }
-
-    .terminal-toggle {
-        display: flex;
-        align-items: center;
-        gap: 0.4rem;
+    .section-desc {
+        margin: 0.25rem 0 0;
         font-size: 0.85rem;
         color: var(--text-secondary);
-        cursor: pointer;
+        line-height: 1.4;
     }
 
-    .install-group {
+    .count {
+        font-size: 0.72rem;
+        font-weight: 600;
+        background: var(--bg-tertiary);
+        color: var(--text-secondary);
+        border-radius: 999px;
+        padding: 0.05rem 0.5rem;
+    }
+
+    /* grey item-card panels */
+    .panel {
+        background: var(--card-bg);
+        border-radius: var(--card-radius);
+        padding: 1rem 1.1rem;
         margin-bottom: 0.75rem;
     }
 
-    .install-group-root {
-        font-size: 0.8rem;
-        color: var(--text-secondary);
-        margin-bottom: 0.35rem;
+    /* ===== add-channel ===== */
+    .section-actions {
+        display: flex;
+        gap: 0.5rem;
+        flex-wrap: wrap;
+        flex-shrink: 0;
+    }
+
+    /* ===== group toggle ===== */
+    .group-toggle {
         display: flex;
         align-items: center;
-        gap: 0.35rem;
+        gap: 0.5rem;
+        flex-shrink: 0;
     }
 
-    .install-item {
-        display: flex;
-        align-items: center;
-        gap: 0.6rem;
-        padding: 0.45rem 0.6rem;
-        border-radius: 6px;
-        background: var(--bg-tertiary);
-        margin-bottom: 0.35rem;
-    }
-
-    .install-version {
-        font-weight: 600;
-        color: var(--text-primary);
-    }
-
-    .install-framework,
-    .install-arch {
+    .group-toggle-label {
         font-size: 0.78rem;
         color: var(--text-secondary);
     }
 
+    .seg-group {
+        display: inline-flex;
+        border: 1px solid var(--border-color);
+        border-radius: 0.5rem;
+        overflow: hidden;
+    }
+
+    .seg {
+        background: var(--card-bg);
+        border: none;
+        color: var(--text-secondary);
+        font-size: 0.8rem;
+        padding: 0.3rem 0.7rem;
+        cursor: pointer;
+    }
+
+    .seg + .seg {
+        border-left: 1px solid var(--border-color);
+    }
+
+    .seg.active {
+        background: var(--accent-primary, #4299e1);
+        color: #fff;
+    }
+
+    .info-note {
+        font-size: 0.8rem;
+        color: var(--text-secondary);
+        margin: 0.4rem 0 0;
+        line-height: 1.4;
+    }
+
+    .info-note i {
+        margin-right: 0.4rem;
+        color: var(--text-secondary);
+    }
+
+    /* ===== component groups ===== */
+    .comp-group {
+        margin-bottom: 1rem;
+    }
+
+    .comp-group-head {
+        display: flex;
+        align-items: center;
+        gap: 0.45rem;
+        font-size: 0.85rem;
+        font-weight: 600;
+        color: var(--text-primary);
+        margin-bottom: 0.4rem;
+    }
+
+    .comp-group-head i {
+        color: var(--text-secondary);
+    }
+
+    .comp-group-count {
+        font-size: 0.7rem;
+        font-weight: 600;
+        color: var(--text-secondary);
+        background: var(--bg-tertiary);
+        border-radius: 999px;
+        padding: 0.02rem 0.45rem;
+    }
+
+    .comp-item,
+    .track-item {
+        display: flex;
+        align-items: center;
+        gap: 0.6rem;
+        padding: 0.55rem 0.85rem;
+        border-radius: var(--card-radius);
+        background: var(--card-bg);
+        margin-bottom: 0.4rem;
+    }
+
+    .comp-version,
+    .track-channel {
+        font-weight: 600;
+        color: var(--text-primary);
+    }
+
+    .comp-name,
+    .comp-arch,
+    .track-human {
+        font-size: 0.8rem;
+        color: var(--text-secondary);
+    }
+
+    /* ===== tracked channels ===== */
+    .legend {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.25rem 1.25rem;
+        margin-top: 0.6rem;
+        font-size: 0.78rem;
+        color: var(--text-secondary);
+    }
+
+    .legend-item {
+        display: flex;
+        align-items: center;
+        gap: 0.4rem;
+    }
+
     .spacer {
         flex: 1;
+    }
+
+    /* ===== update preview ===== */
+    .preview-panel {
+        border: 1px solid var(--border-color);
+    }
+
+    .preview-head {
+        display: flex;
+        align-items: center;
+        gap: 0.6rem;
+        margin-bottom: 0.75rem;
+    }
+
+    .preview-summary {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.45rem;
+        font-weight: 600;
+        font-size: 0.9rem;
+    }
+
+    .preview-summary.has-updates {
+        color: var(--status-info-text, #2563eb);
+    }
+
+    .preview-summary.up-to-date {
+        color: var(--status-success-text, #16a34a);
+    }
+
+    .preview-note {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        font-size: 0.78rem;
+        color: var(--status-warning-text, #d97706);
+    }
+
+    .preview-close {
+        background: none;
+        border: none;
+        color: var(--text-secondary);
+        cursor: pointer;
+        padding: 0.15rem 0.35rem;
+        border-radius: 6px;
+        font-size: 0.9rem;
+    }
+
+    .preview-close:hover {
+        background: var(--bg-tertiary);
+        color: var(--text-primary);
+    }
+
+    .preview-rows {
+        display: flex;
+        flex-direction: column;
+        gap: 0.4rem;
+    }
+
+    .preview-row {
+        display: flex;
+        align-items: center;
+        gap: 0.6rem;
+        padding: 0.5rem 0.75rem;
+        border-radius: var(--card-radius);
+        background: var(--bg-tertiary);
+    }
+
+    .prev-ver {
+        font-weight: 600;
+        color: var(--text-primary);
+        font-size: 0.85rem;
+    }
+
+    .prev-ver.old {
+        color: var(--text-secondary);
+        font-weight: 500;
+    }
+
+    .prev-ver.new {
+        color: var(--status-success-text, #16a34a);
+    }
+
+    .prev-arrow {
+        color: var(--text-secondary);
+        font-size: 0.75rem;
+    }
+
+    .preview-actions {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        flex-wrap: wrap;
+        margin-top: 0.85rem;
+        padding-top: 0.85rem;
+        border-top: 1px solid var(--border-color);
+    }
+
+    .preview-actions-label {
+        font-size: 0.82rem;
+        font-weight: 600;
+        color: var(--text-secondary);
+        margin-right: 0.15rem;
+    }
+
+    /* ===== project context (global.json) ===== */
+    .project-panel {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+    }
+
+    .project-folder,
+    .project-gj {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        font-size: 0.85rem;
+        color: var(--text-secondary);
+        min-width: 0;
+    }
+
+    .project-folder i,
+    .project-gj i {
+        flex-shrink: 0;
+        color: var(--text-secondary);
+    }
+
+    .project-folder .mono,
+    .project-gj .mono {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        color: var(--text-primary);
+    }
+
+    .project-req {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1.25rem;
+        padding: 0.65rem 0.85rem;
+        background: var(--bg-tertiary);
+        border-radius: var(--card-radius);
+    }
+
+    .req-cell {
+        display: flex;
+        flex-direction: column;
+        gap: 0.2rem;
+    }
+
+    .req-label {
+        font-size: 0.72rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: var(--text-secondary);
+    }
+
+    .req-value {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        font-size: 0.88rem;
+        font-weight: 600;
+        color: var(--text-primary);
+    }
+
+    .preview-row.row-update {
+        background: var(--bg-tertiary);
+    }
+
+    .project-actions {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+        padding-top: 0.75rem;
+        border-top: 1px solid var(--border-color);
+    }
+
+    .project-hint {
+        font-size: 0.85rem;
+        color: var(--text-secondary);
+        flex: 1 1 auto;
+        min-width: 12rem;
+    }
+
+    .project-ready {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.45rem;
+        font-size: 0.88rem;
+        font-weight: 600;
+        color: var(--status-success-text, #16a34a);
     }
 </style>

--- a/src/MauiSherpa/Pages/Forms/HybridViewPage.cs
+++ b/src/MauiSherpa/Pages/Forms/HybridViewPage.cs
@@ -48,6 +48,8 @@ public abstract class HybridViewPage : ContentPage
 
     public Task WaitForCloseAsync() => _tcs.Task;
 
+    protected void CompleteClose() => _tcs.TrySetResult();
+
     private void BuildPage()
     {
         var titleLabel = new Label
@@ -149,7 +151,7 @@ public abstract class HybridViewPage : ContentPage
 
     private void OnCloseClicked(object? sender, EventArgs e)
     {
-        _tcs.TrySetResult();
+        CompleteClose();
     }
 
     private void OnBlazorReady(double contentHeight)

--- a/src/MauiSherpa/Pages/Modals/AddChannelModal.razor
+++ b/src/MauiSherpa/Pages/Modals/AddChannelModal.razor
@@ -1,0 +1,291 @@
+@page "/modal/add-channel"
+@using MauiSherpa.Core.Interfaces
+@using MauiSherpa.Pages.Forms
+@inject HybridFormBridgeHolder BridgeHolder
+@implements IDisposable
+
+@{
+    var bridge = BridgeHolder.Current;
+}
+
+@if (bridge != null)
+{
+    <div class="add-channel-dialog">
+        <p class="intro">
+            Pick a channel to install and track. dotnetup keeps it installed and up to date.
+            You can track several at once (e.g. <strong>Latest</strong> plus an older band like <strong>9.0.1xx</strong>).
+        </p>
+
+        <div class="selection-list">
+            @foreach (var ch in channelOptions)
+            {
+                var tracked = IsTracked(ch.Value);
+                <label class="channel-item @(selectedChannel == ch.Value ? "selected" : "")"
+                       @onclick="@(() => SelectChannel(ch.Value))">
+                    <div class="channel-content">
+                        <div class="channel-title">
+                            @ch.Label
+                            @if (tracked)
+                            {
+                                <span class="badge badge-secondary"><i class="fas fa-thumbtack"></i> tracking</span>
+                            }
+                        </div>
+                        <div class="channel-desc">@ch.Description</div>
+                    </div>
+                    @if (selectedChannel == ch.Value)
+                    {
+                        <i class="fas fa-check selected-mark"></i>
+                    }
+                </label>
+            }
+
+            <label class="channel-item @(selectedChannel == CustomValue ? "selected" : "")"
+                   @onclick="@(() => SelectChannel(CustomValue))">
+                <div class="channel-content">
+                    <div class="channel-title">Custom…</div>
+                    <div class="channel-desc">Enter an exact version or feature band (e.g. 10.0.203, 9.0.2xx).</div>
+                    @if (selectedChannel == CustomValue)
+                    {
+                        <input type="text" class="channel-input" placeholder="e.g. 9.0.1xx or 10.0.103"
+                               @bind="customChannel" @bind:event="oninput" @bind:after="UpdateBridge"
+                               @onclick:stopPropagation="true" />
+                    }
+                </div>
+                @if (selectedChannel == CustomValue)
+                {
+                    <i class="fas fa-check selected-mark"></i>
+                }
+            </label>
+        </div>
+
+        <p class="note">
+            <i class="fas fa-circle-info"></i>
+            <span>
+                This won't change your default <code>dotnet</code>. How <code>dotnet</code> resolves on your
+                <code>PATH</code> (Terminal vs Isolation mode) is a one-time global choice made by
+                <code>dotnetup init</code>, not a per-channel setting.
+            </span>
+        </p>
+    </div>
+}
+
+<style>
+    .add-channel-dialog {
+        display: flex;
+        flex-direction: column;
+        gap: 0.875rem;
+        padding: 1rem 1.25rem;
+    }
+
+    .add-channel-dialog .intro {
+        margin: 0;
+        font-size: 0.875rem;
+        color: var(--text-secondary);
+        line-height: 1.45;
+    }
+
+    .add-channel-dialog .selection-list {
+        display: flex;
+        flex-direction: column;
+        gap: 0;
+        border: 1px solid var(--border-color);
+        border-radius: 0.875rem;
+        background: var(--card-bg);
+        overflow: hidden;
+    }
+
+    .channel-item {
+        display: flex;
+        align-items: flex-start;
+        gap: 0.875rem;
+        padding: 0.75rem 1rem;
+        cursor: pointer;
+        transition: background 0.15s, box-shadow 0.15s;
+    }
+
+    .channel-item + .channel-item {
+        border-top: 1px solid var(--border-color);
+    }
+
+    .channel-item:hover {
+        background: var(--bg-tertiary);
+    }
+
+    .channel-item.selected {
+        background: var(--accent-bg, rgba(139, 92, 246, 0.08));
+        box-shadow: inset 0 0 0 1px var(--accent-primary);
+    }
+
+    .channel-content {
+        flex: 1;
+        min-width: 0;
+    }
+
+    .channel-title {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 0.5rem;
+        font-weight: 600;
+        font-size: 0.9rem;
+        color: var(--text-primary);
+        margin-bottom: 0.2rem;
+    }
+
+    .channel-desc {
+        font-size: 0.8125rem;
+        color: var(--text-secondary);
+        line-height: 1.4;
+    }
+
+    .channel-input {
+        margin-top: 0.5rem;
+        width: 100%;
+        box-sizing: border-box;
+        padding: 0.5rem 0.7rem;
+        border: 1px solid var(--input-border, var(--border-color));
+        border-radius: 0.5rem;
+        background: var(--input-bg);
+        color: var(--text-primary);
+        font-size: 0.875rem;
+        outline: none;
+    }
+
+    .channel-input:focus {
+        border-color: var(--accent-primary, #7c3aed);
+    }
+
+    .selected-mark {
+        color: var(--accent-primary);
+        margin-top: 0.2rem;
+        flex-shrink: 0;
+    }
+
+    .add-channel-dialog .note {
+        margin: 0;
+        display: flex;
+        gap: 0.5rem;
+        font-size: 0.8rem;
+        color: var(--text-secondary);
+        line-height: 1.45;
+        padding: 0.65rem 0.75rem;
+        background: var(--bg-tertiary);
+        border-radius: 0.625rem;
+    }
+
+    .add-channel-dialog .note i {
+        margin-top: 0.15rem;
+        opacity: 0.8;
+        flex-shrink: 0;
+    }
+
+    .add-channel-dialog code {
+        font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+        font-size: 0.78rem;
+        background: var(--card-bg);
+        border-radius: 0.3rem;
+        padding: 0.05rem 0.3rem;
+    }
+
+    /* badge base shape (global CSS supplies colors) */
+    .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.25rem;
+        padding: 2px 0.55rem;
+        border-radius: 0.75rem;
+        font-size: 0.7rem;
+        font-weight: 500;
+        white-space: nowrap;
+    }
+</style>
+
+@code {
+    private const string CustomValue = "__custom__";
+
+    private string selectedChannel = "latest";
+    private string customChannel = string.Empty;
+    private HashSet<string> trackedChannels = new(StringComparer.OrdinalIgnoreCase);
+
+    private record ChannelOption(string Value, string Label, string Description);
+
+    private readonly List<ChannelOption> channelOptions = new()
+    {
+        new("latest", "Latest", "Newest stable .NET SDK. Tracks each new GA release as it ships."),
+        new("lts", "LTS · Long-Term Support", "Stays on the current Long-Term Support line and takes its patches."),
+        new("preview", "Preview", "Latest preview / RC build. Tracks newer previews until GA."),
+        new("10.0.1xx", "10.0 · feature band 1xx", "Latest SDK in the .NET 10.0 first feature band (10.0.1xx)."),
+        new("9.0.1xx", "9.0 · feature band 1xx", "Latest SDK in the .NET 9.0 first feature band (9.0.1xx)."),
+        new("8.0.1xx", "8.0 · feature band 1xx", "Latest SDK in the .NET 8.0 first feature band (8.0.1xx)."),
+        new("daily", "Daily build", "Latest nightly build from the VMR. Pinned — never auto-updates."),
+    };
+
+    protected override void OnInitialized()
+    {
+        var bridge = BridgeHolder.Current;
+        if (bridge == null)
+            return;
+
+        if (bridge.Parameters.TryGetValue("TrackedChannels", out var trackedValue) &&
+            trackedValue is IReadOnlyList<string> trackedList)
+        {
+            trackedChannels = new HashSet<string>(trackedList, StringComparer.OrdinalIgnoreCase);
+        }
+
+        bridge.SubmitRequested += OnSubmit;
+        bridge.CancelRequested += OnCancel;
+
+        // Pre-select "Latest" for convenience.
+        UpdateBridge();
+    }
+
+    private bool IsTracked(string value) => trackedChannels.Contains(value);
+
+    private void SelectChannel(string value)
+    {
+        selectedChannel = value;
+        UpdateBridge();
+    }
+
+    private string? EffectiveChannel =>
+        selectedChannel == CustomValue
+            ? (string.IsNullOrWhiteSpace(customChannel) ? null : customChannel.Trim())
+            : selectedChannel;
+
+    private void UpdateBridge()
+    {
+        var bridge = BridgeHolder.Current;
+        if (bridge == null)
+            return;
+
+        var channel = EffectiveChannel;
+        bridge.Result = channel;
+        bridge.SetValid(!string.IsNullOrWhiteSpace(channel));
+        StateHasChanged();
+    }
+
+    private Task OnSubmit()
+    {
+        var bridge = BridgeHolder.Current;
+        if (bridge != null)
+            bridge.Result = EffectiveChannel;
+        return Task.CompletedTask;
+    }
+
+    private void OnCancel()
+    {
+        var bridge = BridgeHolder.Current;
+        if (bridge != null)
+            bridge.Result = null;
+    }
+
+    public void Dispose()
+    {
+        var bridge = BridgeHolder.Current;
+        if (bridge != null)
+        {
+            bridge.SubmitRequested -= OnSubmit;
+            bridge.CancelRequested -= OnCancel;
+        }
+    }
+}

--- a/src/MauiSherpa/Pages/Modals/AddChannelPage.cs
+++ b/src/MauiSherpa/Pages/Modals/AddChannelPage.cs
@@ -1,0 +1,35 @@
+using MauiSherpa.Pages.Forms;
+#if MACOSAPP
+using Microsoft.Maui.Platforms.MacOS.Platform;
+#endif
+#if LINUXGTK
+using Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
+#endif
+
+namespace MauiSherpa.Pages.Modals;
+
+/// <summary>
+/// Native hybrid modal for tracking a new .NET SDK channel with dotnetup.
+/// Returns the selected channel string (e.g. "latest", "9.0.1xx", "10.0.203"),
+/// or null when cancelled.
+/// </summary>
+public class AddChannelPage : HybridFormPage<string?>
+{
+    protected override string FormTitle => "Track an SDK channel";
+    protected override string SubmitButtonText => "Install & track";
+    protected override string BlazorRoute => "/modal/add-channel";
+
+    public AddChannelPage(HybridFormBridgeHolder bridgeHolder, IReadOnlyList<string> trackedChannels)
+        : base(bridgeHolder)
+    {
+        Bridge.Parameters["TrackedChannels"] = trackedChannels;
+
+#if MACOSAPP
+        MacOSPage.SetModalSheetSizesToContent(this, true);
+        MacOSPage.SetModalSheetMinWidth(this, 560);
+#elif LINUXGTK
+        GtkPage.SetModalSizesToContent(this, true);
+        GtkPage.SetModalMinWidth(this, 560);
+#endif
+    }
+}

--- a/src/MauiSherpa/Pages/Modals/DotnetUpDetailsModal.razor
+++ b/src/MauiSherpa/Pages/Modals/DotnetUpDetailsModal.razor
@@ -1,0 +1,302 @@
+@page "/modal/dotnetup-details"
+@using MauiSherpa.Pages.Forms
+@using MauiSherpa.Workloads.Models
+@inject ModalParameterService ModalParams
+
+@if (session is null)
+{
+    <div class="dotnetup-details-state">
+        <i class="fas fa-triangle-exclamation" aria-hidden="true"></i>
+        <span>dotnetup details are unavailable.</span>
+    </div>
+}
+else
+{
+    <div class="dotnetup-details">
+        <div class="dotnetup-details-summary @(session.IsInstalled ? "installed" : "missing")">
+            <i class="fa-regular @(session.IsInstalled ? "fa-circle-check" : "fa-circle-xmark")"
+               aria-hidden="true"></i>
+            <div>
+                <strong>@StatusTitle</strong>
+                <span>@StatusDescription</span>
+            </div>
+        </div>
+
+        <dl class="dotnetup-details-facts">
+            <div class="dotnetup-details-fact">
+                <dt>Installed version</dt>
+                <dd class="mono">@ValueOrFallback(session.ToolInfo?.Version)</dd>
+            </div>
+            @if (UpdateAvailable)
+            {
+                <div class="dotnetup-details-fact">
+                    <dt>Available version</dt>
+                    <dd class="mono update-version">@session.ToolUpdateInfo!.AvailableVersion</dd>
+                </div>
+            }
+            <div class="dotnetup-details-fact">
+                <dt>RID</dt>
+                <dd class="mono">@ValueOrFallback(session.ToolInfo?.Rid)</dd>
+            </div>
+            <div class="dotnetup-details-fact">
+                <dt>Architecture</dt>
+                <dd>@ValueOrFallback(session.ToolInfo?.Architecture)</dd>
+            </div>
+            @if (!string.IsNullOrWhiteSpace(session.ExecutablePath))
+            {
+                <div class="dotnetup-details-fact full-width">
+                    <dt>Binary path</dt>
+                    <dd class="mono path-value" title="@session.ExecutablePath">@session.ExecutablePath</dd>
+                </div>
+            }
+            @if (!string.IsNullOrWhiteSpace(session.ToolDirectory))
+            {
+                <div class="dotnetup-details-fact full-width">
+                    <dt>Tool directory</dt>
+                    <dd class="mono path-value" title="@session.ToolDirectory">@session.ToolDirectory</dd>
+                </div>
+            }
+        </dl>
+
+        @if (ManagedRoots.Count > 0)
+        {
+            <section class="dotnetup-details-roots">
+                <h2>Managed roots</h2>
+                <div class="dotnetup-details-root-list">
+                    @foreach (var root in ManagedRoots)
+                    {
+                        <code title="@root">@root</code>
+                    }
+                </div>
+            </section>
+        }
+
+        <div class="dotnetup-details-actions">
+            @if (!session.IsInstalled)
+            {
+                <button type="button"
+                        class="btn btn-primary"
+                        @onclick="() => SelectAction(DotnetUpDetailsAction.Install)">
+                    <i class="fas fa-download" aria-hidden="true"></i>
+                    <span>Install dotnetup</span>
+                </button>
+            }
+            else
+            {
+                @if (UpdateAvailable)
+                {
+                    <button type="button"
+                            class="btn btn-primary"
+                            @onclick="() => SelectAction(DotnetUpDetailsAction.Update)">
+                        <i class="fas fa-arrow-up" aria-hidden="true"></i>
+                        <span>Update</span>
+                    </button>
+                }
+                <button type="button"
+                        class="btn btn-secondary"
+                        @onclick="() => SelectAction(DotnetUpDetailsAction.Reinstall)">
+                    <i class="fas fa-rotate" aria-hidden="true"></i>
+                    <span>Reinstall</span>
+                </button>
+            }
+        </div>
+    </div>
+}
+
+<style>
+    .dotnetup-details {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+        padding: 1.1rem 1.25rem;
+        color: var(--text-primary);
+    }
+
+    .dotnetup-details-summary,
+    .dotnetup-details-state {
+        display: flex;
+        align-items: flex-start;
+        gap: 0.7rem;
+    }
+
+    .dotnetup-details-summary {
+        padding: 0.75rem 0.85rem;
+        border: 1px solid var(--border-color);
+        border-radius: var(--card-radius);
+        background: var(--card-bg);
+    }
+
+    .dotnetup-details-summary > i {
+        margin-top: 0.08rem;
+        font-size: 1.05rem;
+    }
+
+    .dotnetup-details-summary.installed > i {
+        color: color-mix(in srgb, var(--status-success-text) 72%, var(--text-secondary));
+    }
+
+    .dotnetup-details-summary.missing > i,
+    .dotnetup-details-state {
+        color: var(--status-warning-text);
+    }
+
+    .dotnetup-details-summary > div {
+        display: flex;
+        flex-direction: column;
+        gap: 0.2rem;
+    }
+
+    .dotnetup-details-summary strong {
+        font-size: 0.94rem;
+    }
+
+    .dotnetup-details-summary span {
+        color: var(--text-secondary);
+        font-size: 0.82rem;
+        line-height: 1.4;
+    }
+
+    .dotnetup-details-facts {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 0;
+        margin: 0;
+        border-top: 1px solid var(--border-color);
+        border-bottom: 1px solid var(--border-color);
+    }
+
+    .dotnetup-details-fact {
+        min-width: 0;
+        padding: 0.65rem 0.75rem;
+        background: color-mix(in srgb, var(--bg-tertiary) 35%, var(--card-bg));
+    }
+
+    .dotnetup-details-fact:nth-child(even) {
+        border-left: 1px solid var(--border-color);
+    }
+
+    .dotnetup-details-fact:nth-child(n + 3),
+    .dotnetup-details-fact.full-width {
+        border-top: 1px solid var(--border-color);
+    }
+
+    .dotnetup-details-fact.full-width {
+        grid-column: 1 / -1;
+        border-left: 0;
+    }
+
+    .dotnetup-details-fact dt {
+        margin-bottom: 0.22rem;
+        color: var(--text-secondary);
+        font-size: 0.68rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+    }
+
+    .dotnetup-details-fact dd {
+        margin: 0;
+        font-size: 0.82rem;
+    }
+
+    .update-version {
+        color: var(--status-info-text);
+        font-weight: 600;
+    }
+
+    .path-value {
+        overflow-wrap: anywhere;
+        color: var(--text-secondary);
+    }
+
+    .dotnetup-details-roots h2 {
+        margin: 0 0 0.45rem;
+        font-size: 0.82rem;
+        font-weight: 600;
+    }
+
+    .dotnetup-details-root-list {
+        display: flex;
+        flex-direction: column;
+        gap: 0.35rem;
+    }
+
+    .dotnetup-details-root-list code {
+        padding: 0.4rem 0.55rem;
+        border: 1px solid var(--border-color);
+        border-radius: 0.35rem;
+        background: var(--bg-tertiary);
+        color: var(--text-secondary);
+        overflow-wrap: anywhere;
+        user-select: text;
+    }
+
+    .dotnetup-details-actions {
+        display: flex;
+        justify-content: flex-end;
+        flex-wrap: wrap;
+        gap: 0.55rem;
+        padding-top: 0.15rem;
+    }
+
+    .dotnetup-details-state {
+        padding: 1.25rem;
+    }
+
+    @@media (max-width: 600px) {
+        .dotnetup-details-facts {
+            grid-template-columns: 1fr;
+        }
+
+        .dotnetup-details-fact:nth-child(even) {
+            border-left: 0;
+        }
+
+        .dotnetup-details-fact + .dotnetup-details-fact {
+            border-top: 1px solid var(--border-color);
+        }
+    }
+</style>
+
+@code {
+    private DotnetUpDetailsSession? session;
+
+    private bool UpdateAvailable =>
+        session?.IsInstalled == true &&
+        session.ToolUpdateInfo?.UpdateAvailable == true;
+
+    private string StatusTitle => session?.IsInstalled == true
+        ? UpdateAvailable ? "Update available" : "Ready"
+        : "Not installed";
+
+    private string StatusDescription
+    {
+        get
+        {
+            if (session?.IsInstalled != true)
+                return "Install dotnetup to manage .NET SDKs and runtimes from Sherpa.";
+
+            if (UpdateAvailable)
+                return $"Version {session.ToolUpdateInfo!.AvailableVersion} is available. You currently have {session.ToolInfo?.Version ?? session.ToolUpdateInfo.InstalledVersion}.";
+
+            return "dotnetup is available for SDK, runtime, and tracked-channel operations.";
+        }
+    }
+
+    private IReadOnlyList<string> ManagedRoots =>
+        session?.ManagedRoots
+            .Where(root => !string.IsNullOrWhiteSpace(root))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray() ?? [];
+
+    protected override void OnInitialized()
+    {
+        session = ModalParams.Get<DotnetUpDetailsSession>("Session");
+    }
+
+    private void SelectAction(DotnetUpDetailsAction action) =>
+        session?.RequestAction(action);
+
+    private static string ValueOrFallback(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? "Unknown" : value;
+}

--- a/src/MauiSherpa/Pages/Modals/DotnetUpDetailsPage.cs
+++ b/src/MauiSherpa/Pages/Modals/DotnetUpDetailsPage.cs
@@ -1,0 +1,78 @@
+using MauiSherpa.Pages.Forms;
+using MauiSherpa.Workloads.Models;
+#if MACOSAPP
+using Microsoft.Maui.Platforms.MacOS.Platform;
+#endif
+#if LINUXGTK
+using Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
+#endif
+
+namespace MauiSherpa.Pages.Modals;
+
+public enum DotnetUpDetailsAction
+{
+    None,
+    Install,
+    Update,
+    Reinstall
+}
+
+public sealed class DotnetUpDetailsSession
+{
+    public required bool IsInstalled { get; init; }
+    public DotnetUpToolInfo? ToolInfo { get; init; }
+    public DotnetUpToolUpdateInfo? ToolUpdateInfo { get; init; }
+    public IReadOnlyList<string> ManagedRoots { get; init; } = [];
+    public string? ExecutablePath { get; init; }
+    public string? ToolDirectory { get; init; }
+    public required Action<DotnetUpDetailsAction> RequestAction { get; init; }
+}
+
+public sealed class DotnetUpDetailsPage : HybridViewPage
+{
+    protected override string FormTitle => "dotnetup";
+    protected override string BlazorRoute => "/modal/dotnetup-details";
+
+    public DotnetUpDetailsAction SelectedAction { get; private set; }
+
+    public DotnetUpDetailsPage(
+        ModalParameterService modalParams,
+        bool isInstalled,
+        DotnetUpToolInfo? toolInfo,
+        DotnetUpToolUpdateInfo? toolUpdateInfo,
+        IReadOnlyList<string> managedRoots,
+        string? executablePath,
+        string? toolDirectory)
+    {
+        var session = new DotnetUpDetailsSession
+        {
+            IsInstalled = isInstalled,
+            ToolInfo = toolInfo,
+            ToolUpdateInfo = toolUpdateInfo,
+            ManagedRoots = managedRoots,
+            ExecutablePath = executablePath,
+            ToolDirectory = toolDirectory,
+            RequestAction = SelectAction
+        };
+
+        modalParams.Clear();
+        modalParams.Set("Session", session);
+
+#if MACOSAPP
+        MacOSPage.SetModalSheetWidth(this, 720);
+        MacOSPage.SetModalSheetHeight(this, 620);
+#elif LINUXGTK
+        GtkPage.SetModalWidth(this, 720);
+        GtkPage.SetModalHeight(this, 620);
+#endif
+    }
+
+    private void SelectAction(DotnetUpDetailsAction action)
+    {
+        if (action == DotnetUpDetailsAction.None)
+            return;
+
+        SelectedAction = action;
+        Dispatcher.Dispatch(CompleteClose);
+    }
+}

--- a/src/MauiSherpa/Pages/Modals/ProjectDotnetContextModal.razor
+++ b/src/MauiSherpa/Pages/Modals/ProjectDotnetContextModal.razor
@@ -239,8 +239,12 @@
                             <strong class="mono">@ValueOrDash(inventory.ActiveWorkloadVersion)</strong>
                         </div>
                         <div>
-                            <span class="eyebrow">Installed workload IDs</span>
-                            <strong>@inventory.InstalledWorkloads.Count</strong>
+                            <span class="eyebrow">Installed workloads</span>
+                            <strong>@inventory.EffectiveInstalledWorkloads.Count(workload => workload.IsUserVisible)</strong>
+                            <span class="fact-detail">
+                                @inventory.InstalledWorkloads.Count direct ·
+                                @inventory.EffectiveInstalledWorkloads.Count(workload => workload.IsUserVisible && !workload.IsExplicit) included
+                            </span>
                         </div>
                         <div>
                             <span class="eyebrow">Architecture</span>
@@ -427,6 +431,13 @@
         margin-top: 0.2rem;
         overflow-wrap: anywhere;
         font-size: 0.83rem;
+    }
+
+    .fact-detail {
+        display: block;
+        margin-top: 0.18rem;
+        color: var(--text-secondary);
+        font-size: 0.72rem;
     }
 
     .facts-grid--workloads {

--- a/src/MauiSherpa/Pages/Modals/ProjectDotnetContextModal.razor
+++ b/src/MauiSherpa/Pages/Modals/ProjectDotnetContextModal.razor
@@ -1,0 +1,765 @@
+@page "/modal/project-dotnet-context"
+@using MauiSherpa.Core.Interfaces
+@using MauiSherpa.Pages.Forms
+@using MauiSherpa.Workloads.Models
+@using MauiSherpa.Workloads.Services
+@inject IDotnetUpService DotnetUp
+@inject IDotnetWorkloadService Workloads
+@inject IProcessModalService ProcessModal
+@inject IFormModalService FormModal
+@inject IAlertService AlertService
+@inject HybridFormBridgeHolder BridgeHolder
+@inject ModalParameterService ModalParams
+
+<div class="project-context-modal">
+    @if (isLoading)
+    {
+        <div class="state-panel">
+            <i class="fas fa-spinner fa-spin" aria-hidden="true"></i>
+            <div>
+                <strong>Inspecting project .NET context</strong>
+                <span class="mono">@FolderPath</span>
+            </div>
+        </div>
+    }
+    else if (!string.IsNullOrWhiteSpace(errorMessage))
+    {
+        <div class="state-panel state-panel--error">
+            <i class="fas fa-triangle-exclamation" aria-hidden="true"></i>
+            <div>
+                <strong>Project inspection failed</strong>
+                <span>@errorMessage</span>
+            </div>
+            <button type="button" class="btn btn-secondary btn-sm" @onclick="ReloadAsync">
+                <i class="fas fa-rotate" aria-hidden="true"></i> Retry
+            </button>
+        </div>
+    }
+    else if (resolution is { } project)
+    {
+        <section class="context-card context-card--identity">
+            <div class="identity-row">
+                <i class="fas fa-folder-open" aria-hidden="true"></i>
+                <div>
+                    <span class="eyebrow">Project folder</span>
+                    <strong class="mono" title="@project.FolderPath">@project.FolderPath</strong>
+                </div>
+            </div>
+
+            @if (!string.IsNullOrWhiteSpace(project.GlobalJsonPath))
+            {
+                <div class="identity-row">
+                    <i class="fas fa-file-code" aria-hidden="true"></i>
+                    <div>
+                        <span class="eyebrow">Effective global.json</span>
+                        <strong class="mono" title="@project.GlobalJsonPath">@project.GlobalJsonPath</strong>
+                    </div>
+                </div>
+            }
+        </section>
+
+        @if (project.Status == GlobalJsonStatus.NoGlobalJson)
+        {
+            <div class="state-panel">
+                <i class="fas fa-circle-info" aria-hidden="true"></i>
+                <div>
+                    <strong>No global.json found</strong>
+                    <span>The project uses the machine's default SDK. Sherpa walked up from this folder just like the <code>dotnet</code> host.</span>
+                </div>
+            </div>
+        }
+        else if (project.Status == GlobalJsonStatus.NoSdkVersion)
+        {
+            <div class="state-panel">
+                <i class="fas fa-circle-info" aria-hidden="true"></i>
+                <div>
+                    <strong>No SDK version requested</strong>
+                    <span>This <code>global.json</code> does not define <code>sdk.version</code>, so it does not resolve to a project SDK.</span>
+                </div>
+            </div>
+        }
+        else
+        {
+            <section class="context-card">
+                <div class="section-heading">
+                    <div>
+                        <span class="eyebrow">SDK requirement</span>
+                        <h2>Project resolution</h2>
+                    </div>
+                    <div class="status-badges">
+                        <span class="badge @(!project.Satisfied || project.UpdateAvailable ? "badge-warning" : "badge-success")">
+                            @(project.UpdateAvailable ? "update available" : project.Satisfied ? "installed" : "not installed")
+                        </span>
+                        <span class="badge @(project.AlreadyTracked ? "badge-info" : "badge-secondary")">
+                            @(project.AlreadyTracked ? "tracked" : "not tracked")
+                        </span>
+                    </div>
+                </div>
+
+                <div class="facts-grid">
+                    <div>
+                        <span class="eyebrow">Requested SDK</span>
+                        <strong class="mono">@ValueOrDash(project.RequestedVersion)</strong>
+                    </div>
+                    <div>
+                        <span class="eyebrow">Roll-forward</span>
+                        <strong>@ValueOrDash(project.RollForward)</strong>
+                    </div>
+                    <div>
+                        <span class="eyebrow">Channel</span>
+                        <strong class="mono">@ValueOrDash(project.Channel)</strong>
+                    </div>
+                    <div>
+                        <span class="eyebrow">SDK policy</span>
+                        <strong>@(project.IsPinned ? "Pinned exact version" : "Rolling channel")</strong>
+                    </div>
+                    <div>
+                        <span class="eyebrow">Resolved SDK</span>
+                        <strong class="mono">@ValueOrDash(project.ResolvedVersion)</strong>
+                    </div>
+                    <div>
+                        <span class="eyebrow">Workload pin</span>
+                        <strong class="mono">@ValueOrDash(project.WorkloadVersion)</strong>
+                    </div>
+                </div>
+
+                @if (project.UsesLegacyWorkloadSetProperty)
+                {
+                    <p class="inline-note">
+                        <i class="fas fa-triangle-exclamation" aria-hidden="true"></i>
+                        This file uses the legacy workload-set shape. Sherpa writes the supported <code>sdk.workloadVersion</code> property.
+                    </p>
+                }
+
+                <div class="project-action-row">
+                    @if (!DotnetUp.IsInstalled)
+                    {
+                        <span class="action-hint">
+                            dotnetup is not installed. Close this dialog and install it from the .NET SDK page before changing project SDK tracking.
+                        </span>
+                    }
+                    else if (project.UpdateAvailable)
+                    {
+                        <span class="action-hint">
+                            Update this project from <span class="mono">@project.InstalledVersion</span>
+                            to <span class="mono">@project.ResolvedVersion</span>.
+                        </span>
+                        <button type="button"
+                                class="btn btn-primary btn-sm"
+                                disabled="@isBusy"
+                                @onclick="InstallOrTrackProjectAsync">
+                            <i class="fas fa-circle-arrow-up" aria-hidden="true"></i>
+                            Update project SDK
+                        </button>
+                    }
+                    else if (project.Satisfied && project.AlreadyTracked)
+                    {
+                        <span class="ready-message">
+                            <i class="fas fa-circle-check" aria-hidden="true"></i>
+                            Ready — this project's SDK is installed and tracked.
+                        </span>
+                    }
+                    else
+                    {
+                        <span class="action-hint">
+                            @(project.Satisfied
+                                ? "Track this global.json so dotnetup keeps a compatible SDK installed."
+                                : "Install the SDK resolved for this global.json and track the project.")
+                        </span>
+                        <button type="button"
+                                class="btn @(project.Satisfied ? "btn-secondary" : "btn-primary") btn-sm"
+                                disabled="@isBusy"
+                                @onclick="InstallOrTrackProjectAsync">
+                            <i class="fas @(project.Satisfied ? "fa-thumbtack" : "fa-download")" aria-hidden="true"></i>
+                            @(project.Satisfied ? "Track this project" : "Install SDK for this project")
+                        </button>
+                    }
+                </div>
+            </section>
+
+            @if (resolvedGroup is { } group)
+            {
+                <section class="resolved-section">
+                    <div class="section-heading">
+                        <div>
+                            <span class="eyebrow">Project-resolved installation</span>
+                            <h2>@group.DisplayName</h2>
+                        </div>
+                    </div>
+                    <InstalledDotnetVersionCard RuntimeLine="@group.DisplayName"
+                                                   Installations="@group.Installations"
+                                                   WorkloadInventories="@group.WorkloadInventories"
+                                                   Loading="@isBusy"
+                                                   Busy="@isBusy"
+                                                   InitiallyExpanded="true"
+                                                   AllowMachineChanges="false" />
+                </section>
+            }
+            else if (!project.Satisfied)
+            {
+                <div class="state-panel">
+                    <i class="fas fa-box-open" aria-hidden="true"></i>
+                    <div>
+                        <strong>No matching SDK installation</strong>
+                        <span>Install the project SDK to see its resolved version and workload context.</span>
+                    </div>
+                </div>
+            }
+            else
+            {
+                <div class="state-panel">
+                    <i class="fas fa-triangle-exclamation" aria-hidden="true"></i>
+                    <div>
+                        <strong>Installation target is ambiguous</strong>
+                        <span>The SDK exists in more than one root or architecture, so Sherpa cannot safely choose one project's component details.</span>
+                    </div>
+                </div>
+            }
+
+            @if (projectWorkloads is { } inventory)
+            {
+                <section class="context-card">
+                    <div class="section-heading">
+                        <div>
+                            <span class="eyebrow">Exact project target</span>
+                            <h2>Project workloads</h2>
+                        </div>
+                        <span class="badge @(inventory.VersionSource == DotnetWorkloadVersionSource.GlobalJson ? "badge-info" : "badge-secondary")">
+                            @(inventory.VersionSource == DotnetWorkloadVersionSource.GlobalJson ? "project pin" : "machine default")
+                        </span>
+                    </div>
+
+                    <div class="facts-grid facts-grid--workloads">
+                        <div>
+                            <span class="eyebrow">SDK feature band</span>
+                            <strong class="mono">@inventory.Target.FeatureBand</strong>
+                        </div>
+                        <div>
+                            <span class="eyebrow">Active workload set</span>
+                            <strong class="mono">@ValueOrDash(inventory.ActiveWorkloadVersion)</strong>
+                        </div>
+                        <div>
+                            <span class="eyebrow">Installed workload IDs</span>
+                            <strong>@inventory.InstalledWorkloads.Count</strong>
+                        </div>
+                        <div>
+                            <span class="eyebrow">Architecture</span>
+                            <strong class="mono">@inventory.Target.Architecture</strong>
+                        </div>
+                    </div>
+
+                    <div class="workload-actions">
+                        <button type="button" class="btn btn-secondary btn-sm" disabled="@isBusy" @onclick="ChangeProjectWorkloadPinAsync">
+                            <i class="fas fa-thumbtack" aria-hidden="true"></i>
+                            @(string.IsNullOrWhiteSpace(project.WorkloadVersion) ? "Pin & restore" : "Change pin & restore")
+                        </button>
+                        @if (!string.IsNullOrWhiteSpace(project.WorkloadVersion))
+                        {
+                            <button type="button" class="btn btn-secondary btn-sm" disabled="@isBusy" @onclick="RemoveProjectWorkloadPinAsync">
+                                <i class="fas fa-link-slash" aria-hidden="true"></i> Use machine default
+                            </button>
+                        }
+                        <button type="button" class="btn btn-secondary btn-sm" disabled="@isBusy" @onclick="RestoreProjectWorkloadsAsync">
+                            <i class="fas fa-rotate" aria-hidden="true"></i> Restore workloads
+                        </button>
+                    </div>
+                </section>
+            }
+            else if (project.Satisfied)
+            {
+                <div class="state-panel">
+                    <i class="fas fa-puzzle-piece" aria-hidden="true"></i>
+                    <div>
+                        <strong>Workload target unavailable</strong>
+                        <span>No exact workload inventory matched the resolved SDK feature band, install root, and architecture.</span>
+                    </div>
+                </div>
+            }
+        }
+    }
+    else
+    {
+        <div class="state-panel state-panel--error">
+            <i class="fas fa-triangle-exclamation" aria-hidden="true"></i>
+            <div>
+                <strong>Missing project context</strong>
+                <span>Close this window and open the project context again.</span>
+            </div>
+        </div>
+    }
+</div>
+
+<style>
+    .project-context-modal {
+        height: 100%;
+        box-sizing: border-box;
+        overflow-y: auto;
+        padding: 1.1rem 1.25rem 1.5rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+        color: var(--text-primary);
+    }
+
+    .context-card,
+    .resolved-section,
+    .state-panel {
+        border: 1px solid var(--border-color);
+        border-radius: 0.8rem;
+        background: var(--card-bg);
+    }
+
+    .context-card {
+        padding: 1rem;
+    }
+
+    .context-card--identity {
+        display: flex;
+        flex-direction: column;
+        gap: 0.8rem;
+    }
+
+    .identity-row,
+    .state-panel {
+        display: flex;
+        align-items: flex-start;
+        gap: 0.75rem;
+    }
+
+    .identity-row > i,
+    .state-panel > i {
+        width: 1.1rem;
+        margin-top: 0.15rem;
+        color: var(--accent-primary);
+        text-align: center;
+    }
+
+    .identity-row > div,
+    .state-panel > div {
+        min-width: 0;
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 0.2rem;
+    }
+
+    .identity-row strong {
+        overflow-wrap: anywhere;
+        font-size: 0.82rem;
+    }
+
+    .state-panel {
+        align-items: center;
+        padding: 1rem;
+        color: var(--text-secondary);
+    }
+
+    .state-panel strong {
+        color: var(--text-primary);
+    }
+
+    .state-panel--error {
+        border-color: color-mix(in srgb, var(--accent-danger) 45%, var(--border-color));
+    }
+
+    .state-panel--error > i {
+        color: var(--accent-danger);
+    }
+
+    .section-heading,
+    .project-action-row,
+    .workload-actions {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+    }
+
+    .section-heading {
+        margin-bottom: 0.85rem;
+    }
+
+    .section-heading h2 {
+        margin: 0.1rem 0 0;
+        font-size: 1rem;
+    }
+
+    .eyebrow {
+        display: block;
+        color: var(--text-secondary);
+        font-size: 0.67rem;
+        font-weight: 700;
+        letter-spacing: 0.045em;
+        text-transform: uppercase;
+    }
+
+    .status-badges {
+        display: flex;
+        gap: 0.4rem;
+    }
+
+    .badge {
+        display: inline-flex;
+        align-items: center;
+        padding: 2px 0.5rem;
+        border-radius: 999px;
+        font-size: 0.68rem;
+        font-weight: 600;
+        white-space: nowrap;
+    }
+
+    .facts-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 0.65rem;
+    }
+
+    .facts-grid > div {
+        min-width: 0;
+        padding: 0.65rem 0.75rem;
+        border-radius: 0.6rem;
+        background: var(--bg-tertiary);
+    }
+
+    .facts-grid strong {
+        display: block;
+        margin-top: 0.2rem;
+        overflow-wrap: anywhere;
+        font-size: 0.83rem;
+    }
+
+    .facts-grid--workloads {
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
+
+    .inline-note {
+        margin: 0.75rem 0 0;
+        padding: 0.65rem 0.75rem;
+        border-radius: 0.6rem;
+        background: var(--bg-tertiary);
+        color: var(--text-secondary);
+        font-size: 0.78rem;
+    }
+
+    .inline-note i {
+        margin-right: 0.35rem;
+        color: var(--accent-warning);
+    }
+
+    .project-action-row,
+    .workload-actions {
+        margin-top: 0.9rem;
+    }
+
+    .ready-message {
+        color: var(--accent-success);
+        font-size: 0.82rem;
+        font-weight: 600;
+    }
+
+    .action-hint {
+        flex: 1;
+        color: var(--text-secondary);
+        font-size: 0.8rem;
+    }
+
+    .resolved-section {
+        padding: 1rem;
+    }
+
+    @@media (max-width: 800px) {
+        .facts-grid,
+        .facts-grid--workloads {
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+    }
+
+    @@media (max-width: 540px) {
+        .facts-grid,
+        .facts-grid--workloads {
+            grid-template-columns: 1fr;
+        }
+
+        .project-context-modal {
+            padding-left: 0.85rem;
+            padding-right: 0.85rem;
+        }
+    }
+</style>
+
+@code {
+    private ProjectDotnetContextSession? session;
+    private GlobalJsonResolution? resolution;
+    private DotnetUpListResult? list;
+    private DotnetMajorMinorGroupSummary? resolvedGroup;
+    private DotnetWorkloadInventory? projectWorkloads;
+    private bool isLoading = true;
+    private bool isBusy;
+    private string? errorMessage;
+
+    private string FolderPath => session?.FolderPath ?? string.Empty;
+
+    protected override async Task OnInitializedAsync()
+    {
+        session = ModalParams.Get<ProjectDotnetContextSession>("Session");
+        if (session == null)
+        {
+            errorMessage = "The project session was not provided.";
+            isLoading = false;
+            return;
+        }
+
+        await ReloadAsync();
+    }
+
+    private async Task ReloadAsync()
+    {
+        if (session == null)
+            return;
+
+        isLoading = true;
+        errorMessage = null;
+        resolvedGroup = null;
+        projectWorkloads = null;
+        StateHasChanged();
+
+        try
+        {
+            list = DotnetUp.IsInstalled
+                ? await DotnetUp.GetListAsync()
+                : null;
+            var safeList = list ?? new DotnetUpListResult();
+            var projectResolution = await DotnetUp.InspectProjectFolderAsync(FolderPath, safeList);
+            resolution = projectResolution;
+
+            IReadOnlyList<DotnetWorkloadInventory> inventories = [];
+            if (list != null)
+                inventories = await Workloads.GetInventoriesAsync(list, forceRefresh: true);
+            var displayInventories = inventories;
+
+            var summary = DotnetSdkPresentationBuilder.Build(
+                safeList,
+                inventories,
+                projectResolution: projectResolution);
+            var target = summary.ProjectWorkloads?.SelectedInventory?.Target;
+            if (target != null)
+            {
+                var projectInventory = await Workloads.GetInventoryAsync(
+                    target,
+                    FolderPath,
+                    forceRefresh: true);
+                projectWorkloads = projectInventory;
+
+                var projectInventories = inventories
+                    .Where(inventory => !string.Equals(
+                        inventory.Target.Key,
+                        target.Key,
+                        StringComparison.OrdinalIgnoreCase))
+                    .Append(projectInventory)
+                    .ToList();
+                displayInventories = projectInventories;
+
+                summary = DotnetSdkPresentationBuilder.Build(
+                    safeList,
+                    projectInventories,
+                    projectResolution: projectResolution);
+            }
+
+            resolvedGroup = DotnetSdkPresentationBuilder.BuildProjectInstalledGroup(
+                projectResolution,
+                safeList.Installations,
+                displayInventories);
+        }
+        catch (Exception ex)
+        {
+            errorMessage = ex.Message;
+        }
+        finally
+        {
+            isLoading = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task InstallOrTrackProjectAsync()
+    {
+        if (session == null || isBusy)
+            return;
+
+        isBusy = true;
+        try
+        {
+            var wasUpdate = resolution?.UpdateAvailable == true;
+            var wasAlreadyInstalled = resolution?.Satisfied == true;
+            var result = await ProcessModal.ShowProcessAsync(
+                DotnetUp.InstallForProjectRequest(FolderPath));
+            if (result?.Success == true)
+            {
+                session.HasChanges = true;
+                await AlertService.ShowToastAsync(
+                    wasUpdate
+                        ? "Project SDK updated"
+                        : wasAlreadyInstalled
+                            ? "Project SDK tracked"
+                            : "Project SDK installed and tracked");
+                await ReloadAsync();
+            }
+            else
+            {
+                await ShowProcessFailureAsync(result, "The project SDK install failed.");
+            }
+        }
+        finally
+        {
+            isBusy = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task ChangeProjectWorkloadPinAsync()
+    {
+        if (session == null || projectWorkloads == null || isBusy)
+            return;
+
+        var version = await FormModal.ShowAsync<string?>(
+            new WorkloadSetPage(
+                BridgeHolder,
+                projectWorkloads,
+                resolution?.WorkloadVersion));
+        if (string.IsNullOrWhiteSpace(version))
+            return;
+
+        GlobalJsonWorkloadPinPreview preview;
+        try
+        {
+            preview = Workloads.PreviewProjectWorkloadPin(FolderPath, version);
+        }
+        catch (Exception ex)
+        {
+            await AlertService.ShowAlertAsync("Workload Pin Preview Failed", ex.Message);
+            return;
+        }
+
+        var confirmed = await AlertService.ShowConfirmAsync(
+            "Pin project workload set",
+            BuildJsoncConfirmation(preview, "Sherpa will preserve comments and unrelated settings, apply this JSONC change, then restore workloads from the project folder."),
+            "Pin & restore",
+            "Cancel");
+        if (!confirmed)
+            return;
+
+        isBusy = true;
+        try
+        {
+            await Workloads.ApplyProjectWorkloadPinAsync(preview);
+            session.HasChanges = true;
+            await ReloadAsync();
+            await RestoreProjectWorkloadsCoreAsync();
+        }
+        catch (Exception ex)
+        {
+            await AlertService.ShowAlertAsync("Workload Pin Failed", ex.Message);
+        }
+        finally
+        {
+            isBusy = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task RemoveProjectWorkloadPinAsync()
+    {
+        if (session == null || projectWorkloads == null || isBusy)
+            return;
+
+        GlobalJsonWorkloadPinPreview preview;
+        try
+        {
+            preview = Workloads.PreviewProjectWorkloadPin(FolderPath, null);
+        }
+        catch (Exception ex)
+        {
+            await AlertService.ShowAlertAsync("Workload Pin Preview Failed", ex.Message);
+            return;
+        }
+
+        var confirmed = await AlertService.ShowConfirmAsync(
+            "Use machine workload set",
+            BuildJsoncConfirmation(preview, "Remove the project override and use the machine default workload set for this SDK feature band?"),
+            "Remove pin",
+            "Cancel");
+        if (!confirmed)
+            return;
+
+        isBusy = true;
+        try
+        {
+            await Workloads.ApplyProjectWorkloadPinAsync(preview);
+            session.HasChanges = true;
+            await AlertService.ShowToastAsync("Project workload pin removed");
+            await ReloadAsync();
+        }
+        catch (Exception ex)
+        {
+            await AlertService.ShowAlertAsync("Workload Pin Removal Failed", ex.Message);
+        }
+        finally
+        {
+            isBusy = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task RestoreProjectWorkloadsAsync()
+    {
+        if (session == null || projectWorkloads == null || isBusy)
+            return;
+
+        isBusy = true;
+        try
+        {
+            await RestoreProjectWorkloadsCoreAsync();
+        }
+        finally
+        {
+            isBusy = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task<bool> RestoreProjectWorkloadsCoreAsync()
+    {
+        if (session == null || projectWorkloads == null)
+            return false;
+
+        var target = projectWorkloads.Target;
+        var result = await ProcessModal.ShowProcessAsync(
+            Workloads.CreateRestoreRequest(target, FolderPath));
+        if (result?.Success == true)
+        {
+            session.HasChanges = true;
+            Workloads.Invalidate(target.InstallRoot);
+            await AlertService.ShowToastAsync("Project workloads restored");
+            await ReloadAsync();
+            return true;
+        }
+
+        await ShowProcessFailureAsync(result, "The project workload restore failed.");
+        return false;
+    }
+
+    private async Task ShowProcessFailureAsync(ProcessResult? result, string message)
+    {
+        if (result != null && !result.WasCancelled && !result.WasKilled)
+            await AlertService.ShowAlertAsync("Operation Failed", $"{message} Check the output for details.");
+    }
+
+    private static string BuildJsoncConfirmation(
+        GlobalJsonWorkloadPinPreview preview,
+        string explanation) =>
+        $"{preview.Diff}\n\n{explanation}\n\nUpdated global.json preview:\n{preview.UpdatedContent}";
+
+    private static string ValueOrDash(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? "—" : value;
+}

--- a/src/MauiSherpa/Pages/Modals/ProjectDotnetContextPage.cs
+++ b/src/MauiSherpa/Pages/Modals/ProjectDotnetContextPage.cs
@@ -1,0 +1,49 @@
+using MauiSherpa.Pages.Forms;
+#if MACOSAPP
+using Microsoft.Maui.Platforms.MacOS.Platform;
+#endif
+#if LINUXGTK
+using Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
+#endif
+
+namespace MauiSherpa.Pages.Modals;
+
+public sealed class ProjectDotnetContextSession
+{
+    public required string FolderPath { get; init; }
+    public bool HasChanges { get; set; }
+}
+
+public sealed class ProjectDotnetContextPage : HybridViewPage
+{
+    protected override string FormTitle => "Project .NET Context";
+    protected override string BlazorRoute => "/modal/project-dotnet-context";
+
+    public ProjectDotnetContextSession Session { get; }
+    public bool HasChanges => Session.HasChanges;
+
+    public ProjectDotnetContextPage(ModalParameterService modalParams, string folderPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(folderPath);
+
+        Session = new ProjectDotnetContextSession
+        {
+            FolderPath = Path.GetFullPath(folderPath)
+        };
+
+        modalParams.Clear();
+        modalParams.Set("Session", Session);
+
+        var window = Application.Current?.Windows.FirstOrDefault();
+        var width = (int)Math.Clamp(Math.Round((window?.Width ?? 1200) * 0.9), 820, 1400);
+        var height = (int)Math.Clamp(Math.Round((window?.Height ?? 800) * 0.9), 620, 1000);
+
+#if MACOSAPP
+        MacOSPage.SetModalSheetWidth(this, width);
+        MacOSPage.SetModalSheetHeight(this, height);
+#elif LINUXGTK
+        GtkPage.SetModalWidth(this, width);
+        GtkPage.SetModalHeight(this, height);
+#endif
+    }
+}

--- a/src/MauiSherpa/Pages/Modals/WorkloadSelectionModal.razor
+++ b/src/MauiSherpa/Pages/Modals/WorkloadSelectionModal.razor
@@ -17,8 +17,8 @@
         </div>
 
         <p class="intro">
-            Uncheck installed workloads to remove them, or select available workloads to install. Aggregate workloads
-            show what they include, and Sherpa removes redundant child selections.
+            Uncheck directly installed workloads to remove them, or select available workloads to install. Workloads
+            included by an aggregate remain checked and are managed through that aggregate.
         </p>
 
         <div class="search-box">
@@ -41,23 +41,33 @@
                 <div class="workload-list">
                     @foreach (var workload in FilteredInstalledWorkloads())
                     {
-                        <label class="workload-item remove @(selectedUninstall.Contains(workload.Id) ? "selected" : "")">
+                        <label class="workload-item remove @(!workload.CanUninstall ? "included" : "") @(selectedUninstall.Contains(workload.Id) ? "selected" : "")">
                             <input type="checkbox"
-                                   aria-label="Keep @workload.Id installed"
+                                   aria-label="@InstalledAriaLabel(workload)"
                                    checked="@(!selectedUninstall.Contains(workload.Id))"
-                                   @onchange="@(_ => ToggleUninstall(workload.Id))" />
+                                   disabled="@(!workload.CanUninstall)"
+                                   @onchange="@(_ => ToggleUninstall(workload))" />
                             <div class="workload-main">
                                 <div class="workload-title">
                                     <span class="mono">@workload.Id</span>
-                                    <span class="badge badge-success"><i class="fas fa-check"></i> installed</span>
+                                    @if (workload.IsExplicit)
+                                    {
+                                        <span class="badge badge-success"><i class="fas fa-check"></i> installed</span>
+                                    }
+                                    @if (workload.IncludedBy.Count > 0)
+                                    {
+                                        <span class="badge badge-info">
+                                            @(workload.IsExplicit ? "also included by" : "included by") @ParentLabel(workload.IncludedBy)
+                                        </span>
+                                    }
                                     @if (selectedUninstall.Contains(workload.Id))
                                     {
                                         <span class="badge badge-error">remove</span>
                                     }
                                 </div>
-                                @if (!string.IsNullOrWhiteSpace(workload.Description))
+                                @if (!string.IsNullOrWhiteSpace(workload.Definition?.Description))
                                 {
-                                    <div class="workload-description">@workload.Description</div>
+                                    <div class="workload-description">@workload.Definition.Description</div>
                                 }
                             </div>
                         </label>
@@ -338,6 +348,11 @@
         opacity: 0.72;
     }
 
+    .workload-item.included:hover {
+        border-color: var(--border-color);
+        box-shadow: none;
+    }
+
     .workload-item input {
         margin-top: 0.2rem;
         accent-color: var(--accent-primary);
@@ -450,17 +465,13 @@
         UpdateBridge();
     }
 
-    private IReadOnlyList<ResolvedWorkloadDefinition> InstalledWorkloads()
+    private IReadOnlyList<DotnetWorkloadInstallationState> InstalledWorkloads()
     {
         if (inventory == null)
             return [];
 
-        var definitions = inventory.AvailableWorkloads.ToDictionary(
-            workload => workload.Id,
-            StringComparer.OrdinalIgnoreCase);
-        return inventory.InstalledWorkloads
-            .Select(installed => definitions.GetValueOrDefault(installed.Id) ??
-                new ResolvedWorkloadDefinition { Id = installed.Id })
+        return inventory.EffectiveInstalledWorkloads
+            .Where(workload => workload.IsUserVisible)
             .OrderBy(workload => workload.Id, StringComparer.OrdinalIgnoreCase)
             .ToList();
     }
@@ -470,9 +481,6 @@
         if (inventory == null)
             return [];
 
-        var installed = inventory.InstalledWorkloads
-            .Select(workload => workload.Id)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
         var recommended = WorkloadRecommendationPolicy.GetRecommendedWorkloadIds(
             OperatingSystem.IsLinux());
         var recommendedSet = recommended.ToHashSet(StringComparer.OrdinalIgnoreCase);
@@ -480,18 +488,15 @@
             .Select((id, index) => (id, index))
             .ToDictionary(item => item.id, item => item.index, StringComparer.OrdinalIgnoreCase);
 
-        return inventory.AvailableWorkloads
+        return inventory.InstallableWorkloads
             .Where(workload =>
-                !workload.IsAbstract &&
-                workload.RedirectTarget == null &&
-                !installed.Contains(workload.Id) &&
                 (showAll || recommendedSet.Contains(workload.Id)))
             .OrderBy(workload => order.GetValueOrDefault(workload.Id, int.MaxValue))
             .ThenBy(workload => workload.Id, StringComparer.OrdinalIgnoreCase)
             .ToList();
     }
 
-    private IEnumerable<ResolvedWorkloadDefinition> FilteredInstalledWorkloads() =>
+    private IEnumerable<DotnetWorkloadInstallationState> FilteredInstalledWorkloads() =>
         InstalledWorkloads().Where(MatchesSearch);
 
     private IEnumerable<ResolvedWorkloadDefinition> FilteredAvailableWorkloads() =>
@@ -501,6 +506,12 @@
         string.IsNullOrWhiteSpace(search) ||
         workload.Id.Contains(search, StringComparison.OrdinalIgnoreCase) ||
         (workload.Description?.Contains(search, StringComparison.OrdinalIgnoreCase) ?? false);
+
+    private bool MatchesSearch(DotnetWorkloadInstallationState workload) =>
+        string.IsNullOrWhiteSpace(search) ||
+        workload.Id.Contains(search, StringComparison.OrdinalIgnoreCase) ||
+        (workload.Definition?.Description?.Contains(search, StringComparison.OrdinalIgnoreCase) ?? false) ||
+        workload.IncludedBy.Any(parent => parent.Contains(search, StringComparison.OrdinalIgnoreCase));
 
     private void ToggleInstall(ResolvedWorkloadDefinition workload)
     {
@@ -512,10 +523,12 @@
         UpdateBridge();
     }
 
-    private void ToggleUninstall(string id)
+    private void ToggleUninstall(DotnetWorkloadInstallationState workload)
     {
-        if (!selectedUninstall.Add(id))
-            selectedUninstall.Remove(id);
+        if (!workload.CanUninstall)
+            return;
+        if (!selectedUninstall.Add(workload.Id))
+            selectedUninstall.Remove(workload.Id);
         UpdateBridge();
     }
 
@@ -525,6 +538,14 @@
                 selectedInstall.Contains(workload.Id) &&
                 workload.TransitiveIncludes.Contains(id, StringComparer.OrdinalIgnoreCase))
             ?.Id;
+
+    private static string ParentLabel(IReadOnlyList<string> parents) =>
+        string.Join(", ", parents);
+
+    private static string InstalledAriaLabel(DotnetWorkloadInstallationState workload) =>
+        workload.CanUninstall
+            ? $"Keep {workload.Id} installed"
+            : $"{workload.Id} is included by {ParentLabel(workload.IncludedBy)}";
 
     private void UpdateBridge()
     {

--- a/src/MauiSherpa/Pages/Modals/WorkloadSelectionModal.razor
+++ b/src/MauiSherpa/Pages/Modals/WorkloadSelectionModal.razor
@@ -1,0 +1,562 @@
+@page "/modal/manage-workloads"
+@using MauiSherpa.Pages.Forms
+@using MauiSherpa.Workloads.Models
+@using MauiSherpa.Workloads.Services
+@inject HybridFormBridgeHolder BridgeHolder
+@implements IDisposable
+
+@if (inventory != null)
+{
+    <div class="workload-dialog">
+        <div class="target-summary">
+            <div>
+                <strong>.NET @inventory.Target.RuntimeVersion</strong>
+                <span class="mono">@inventory.Target.FeatureBand</span>
+            </div>
+            <span class="target-set mono">@inventory.ActiveWorkloadVersion</span>
+        </div>
+
+        <p class="intro">
+            Uncheck installed workloads to remove them, or select available workloads to install. Aggregate workloads
+            show what they include, and Sherpa removes redundant child selections.
+        </p>
+
+        <div class="search-box">
+            <i class="fas fa-magnifying-glass"></i>
+            <input type="search" placeholder="Filter workloads" @bind="search" @bind:event="oninput" />
+        </div>
+
+        <div class="workload-groups">
+            <section class="workload-group remove-group">
+                <div class="group-heading">
+                    <div>
+                        <i class="fas fa-box-archive"></i>
+                        <div>
+                            <strong>Installed</strong>
+                            <span>Uncheck to uninstall</span>
+                        </div>
+                    </div>
+                    <span class="count-badge">@InstalledWorkloads().Count</span>
+                </div>
+                <div class="workload-list">
+                    @foreach (var workload in FilteredInstalledWorkloads())
+                    {
+                        <label class="workload-item remove @(selectedUninstall.Contains(workload.Id) ? "selected" : "")">
+                            <input type="checkbox"
+                                   aria-label="Keep @workload.Id installed"
+                                   checked="@(!selectedUninstall.Contains(workload.Id))"
+                                   @onchange="@(_ => ToggleUninstall(workload.Id))" />
+                            <div class="workload-main">
+                                <div class="workload-title">
+                                    <span class="mono">@workload.Id</span>
+                                    <span class="badge badge-success"><i class="fas fa-check"></i> installed</span>
+                                    @if (selectedUninstall.Contains(workload.Id))
+                                    {
+                                        <span class="badge badge-error">remove</span>
+                                    }
+                                </div>
+                                @if (!string.IsNullOrWhiteSpace(workload.Description))
+                                {
+                                    <div class="workload-description">@workload.Description</div>
+                                }
+                            </div>
+                        </label>
+                    }
+                    @if (!FilteredInstalledWorkloads().Any())
+                    {
+                        <div class="empty">
+                            @(InstalledWorkloads().Count == 0
+                                ? "No workload IDs are currently installed."
+                                : "No installed workloads match this filter.")
+                        </div>
+                    }
+                </div>
+            </section>
+
+            <section class="workload-group install-group">
+                <div class="group-heading">
+                    <div>
+                        <i class="fas fa-circle-plus"></i>
+                        <div>
+                            <strong>Available</strong>
+                            <span>Select to install</span>
+                        </div>
+                    </div>
+                    <div class="available-controls">
+                        <label class="show-all-toggle">
+                            <input type="checkbox" @bind="showAll" />
+                            Show all
+                        </label>
+                        <span class="count-badge">@AvailableWorkloads().Count</span>
+                    </div>
+                </div>
+                <div class="workload-list">
+                    @foreach (var workload in FilteredAvailableWorkloads())
+                    {
+                        var includedBy = IncludedBySelectedInstall(workload.Id);
+                        var disabled = includedBy != null && !selectedInstall.Contains(workload.Id);
+                        <label class="workload-item install @(selectedInstall.Contains(workload.Id) ? "selected" : "") @(disabled ? "included" : "")">
+                            <input type="checkbox"
+                                   aria-label="Select @workload.Id for installation"
+                                   checked="@(selectedInstall.Contains(workload.Id) || includedBy != null)"
+                                   disabled="@disabled"
+                                   @onchange="@(_ => ToggleInstall(workload))" />
+                            <div class="workload-main">
+                                <div class="workload-title">
+                                    <span class="mono">@workload.Id</span>
+                                    @if (workload.TransitiveIncludes.Count > 0)
+                                    {
+                                        <span class="badge badge-info">includes @workload.TransitiveIncludes.Count</span>
+                                    }
+                                    @if (workload.Packs.Count > 0)
+                                    {
+                                        <span class="badge badge-secondary">@workload.Packs.Count packs</span>
+                                    }
+                                    @if (includedBy != null)
+                                    {
+                                        <span class="badge badge-success">included by @includedBy</span>
+                                    }
+                                </div>
+                                @if (!string.IsNullOrWhiteSpace(workload.Description))
+                                {
+                                    <div class="workload-description">@workload.Description</div>
+                                }
+                                @if (workload.TransitiveIncludes.Count > 0)
+                                {
+                                    <details>
+                                        <summary>Included workloads</summary>
+                                        <div class="include-chips">
+                                            @foreach (var included in workload.TransitiveIncludes)
+                                            {
+                                                <span class="include-chip mono">@included</span>
+                                            }
+                                        </div>
+                                    </details>
+                                }
+                            </div>
+                        </label>
+                    }
+                    @if (!FilteredAvailableWorkloads().Any())
+                    {
+                        <div class="empty">
+                            @(AvailableWorkloads().Count == 0 && !showAll
+                                ? "No recommended workloads are available. Turn on Show all to see every workload."
+                                : "No available workloads match this filter.")
+                        </div>
+                    }
+                </div>
+            </section>
+        </div>
+
+        <div class="selection-summary">
+            <i class="fas fa-code-compare"></i>
+            <span>@selectedInstall.Count to install · @selectedUninstall.Count to uninstall</span>
+        </div>
+    </div>
+}
+
+<style>
+    .workload-dialog {
+        display: flex;
+        flex-direction: column;
+        gap: 0.8rem;
+        height: 100%;
+        min-height: 0;
+        padding: 1rem 1.25rem;
+    }
+
+    .target-summary {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+        padding: 0.65rem 0.8rem;
+        border-radius: 0.625rem;
+        background: var(--bg-tertiary);
+        color: var(--text-primary);
+        font-size: 0.85rem;
+    }
+
+    .target-summary > div {
+        display: flex;
+        align-items: center;
+        gap: 0.55rem;
+    }
+
+    .target-set {
+        color: var(--text-secondary);
+        font-size: 0.78rem;
+    }
+
+    .intro {
+        margin: 0;
+        color: var(--text-secondary);
+        font-size: 0.85rem;
+        line-height: 1.45;
+    }
+
+    .search-box {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.5rem 0.7rem;
+        border: 1px solid var(--input-border, var(--border-color));
+        border-radius: 0.5rem;
+        background: var(--input-bg);
+        color: var(--text-secondary);
+    }
+
+    .search-box input {
+        flex: 1;
+        min-width: 0;
+        border: 0;
+        outline: 0;
+        background: transparent;
+        color: var(--text-primary);
+        font-size: 0.875rem;
+    }
+
+    .workload-groups {
+        display: grid;
+        grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+        gap: 0.9rem;
+        flex: 1;
+        min-height: 0;
+    }
+
+    .workload-group {
+        display: flex;
+        flex-direction: column;
+        min-width: 0;
+        min-height: 0;
+        border: 1px solid var(--border-color);
+        border-radius: 0.75rem;
+        overflow: hidden;
+        background: var(--bg-tertiary);
+    }
+
+    .group-heading {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.75rem;
+        padding: 0.7rem 0.8rem;
+        border-bottom: 1px solid var(--border-color);
+        background: var(--card-bg);
+        color: var(--text-primary);
+        font-size: 0.82rem;
+    }
+
+    .group-heading > div:first-child {
+        display: flex;
+        align-items: center;
+        gap: 0.55rem;
+    }
+
+    .group-heading > div:first-child > i {
+        color: var(--text-secondary);
+    }
+
+    .group-heading > div:first-child > div {
+        display: flex;
+        flex-direction: column;
+        gap: 0.05rem;
+    }
+
+    .group-heading > div:first-child span {
+        color: var(--text-secondary);
+        font-size: 0.68rem;
+        font-weight: 400;
+    }
+
+    .available-controls,
+    .show-all-toggle {
+        display: flex;
+        align-items: center;
+    }
+
+    .available-controls {
+        gap: 0.55rem;
+    }
+
+    .show-all-toggle {
+        gap: 0.3rem;
+        color: var(--text-secondary);
+        font-size: 0.72rem;
+        white-space: nowrap;
+    }
+
+    .count-badge {
+        min-width: 1.65rem;
+        padding: 0.1rem 0.4rem;
+        border-radius: 999px;
+        background: var(--bg-tertiary);
+        color: var(--text-secondary);
+        font-size: 0.7rem;
+        text-align: center;
+    }
+
+    .workload-list {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        flex: 1;
+        min-height: 0;
+        padding: 0.55rem;
+        overflow-y: auto;
+    }
+
+    .workload-item {
+        display: flex;
+        align-items: flex-start;
+        gap: 0.75rem;
+        padding: 0.7rem 0.75rem;
+        border: 1px solid var(--border-color);
+        border-radius: 0.625rem;
+        background: var(--card-bg);
+        cursor: pointer;
+        transition: border-color 0.15s ease, background 0.15s ease, box-shadow 0.15s ease;
+    }
+
+    .workload-item:hover {
+        border-color: var(--accent-primary);
+        box-shadow: var(--card-shadow);
+    }
+
+    .workload-item.install.selected {
+        border-color: var(--status-success-text);
+        background: var(--status-success-bg);
+    }
+
+    .workload-item.remove.selected {
+        border-color: var(--status-error-text);
+        background: var(--status-error-bg);
+    }
+
+    .workload-item.included {
+        cursor: default;
+        opacity: 0.72;
+    }
+
+    .workload-item input {
+        margin-top: 0.2rem;
+        accent-color: var(--accent-primary);
+    }
+
+    .workload-item.remove input {
+        accent-color: var(--status-success-text);
+    }
+
+    .workload-main {
+        flex: 1;
+        min-width: 0;
+    }
+
+    .workload-title {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 0.4rem;
+        color: var(--text-primary);
+        font-weight: 600;
+        font-size: 0.86rem;
+    }
+
+    .workload-description {
+        margin-top: 0.2rem;
+        color: var(--text-secondary);
+        font-size: 0.8rem;
+        line-height: 1.35;
+    }
+
+    details {
+        margin-top: 0.45rem;
+        color: var(--text-secondary);
+        font-size: 0.75rem;
+    }
+
+    summary {
+        cursor: pointer;
+    }
+
+    .include-chips {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.3rem;
+        margin-top: 0.4rem;
+    }
+
+    .include-chip {
+        padding: 0.15rem 0.4rem;
+        border-radius: 999px;
+        background: var(--bg-secondary);
+        color: var(--text-secondary);
+        font-size: 0.7rem;
+    }
+
+    .selection-summary {
+        display: flex;
+        align-items: center;
+        gap: 0.45rem;
+        color: var(--text-secondary);
+        font-size: 0.8rem;
+    }
+
+    .empty {
+        padding: 1.25rem;
+        text-align: center;
+        color: var(--text-secondary);
+        font-size: 0.85rem;
+    }
+
+    .badge {
+        display: inline-flex;
+        align-items: center;
+        padding: 2px 0.5rem;
+        border-radius: 999px;
+        font-size: 0.68rem;
+        font-weight: 500;
+        white-space: nowrap;
+    }
+
+    .badge-error {
+        color: var(--status-error-text);
+        background: var(--status-error-bg);
+    }
+
+    @@media (max-width: 720px) {
+        .workload-groups {
+            grid-template-columns: 1fr;
+        }
+    }
+</style>
+
+@code {
+    private DotnetWorkloadInventory? inventory;
+    private string search = string.Empty;
+    private bool showAll;
+    private readonly HashSet<string> selectedInstall = new(StringComparer.OrdinalIgnoreCase);
+    private readonly HashSet<string> selectedUninstall = new(StringComparer.OrdinalIgnoreCase);
+
+    protected override void OnInitialized()
+    {
+        var bridge = BridgeHolder.Current;
+        if (bridge == null)
+            return;
+
+        inventory = bridge.Parameters.GetValueOrDefault("Inventory") as DotnetWorkloadInventory;
+        bridge.SubmitRequested += OnSubmit;
+        bridge.CancelRequested += OnCancel;
+        UpdateBridge();
+    }
+
+    private IReadOnlyList<ResolvedWorkloadDefinition> InstalledWorkloads()
+    {
+        if (inventory == null)
+            return [];
+
+        var definitions = inventory.AvailableWorkloads.ToDictionary(
+            workload => workload.Id,
+            StringComparer.OrdinalIgnoreCase);
+        return inventory.InstalledWorkloads
+            .Select(installed => definitions.GetValueOrDefault(installed.Id) ??
+                new ResolvedWorkloadDefinition { Id = installed.Id })
+            .OrderBy(workload => workload.Id, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private IReadOnlyList<ResolvedWorkloadDefinition> AvailableWorkloads()
+    {
+        if (inventory == null)
+            return [];
+
+        var installed = inventory.InstalledWorkloads
+            .Select(workload => workload.Id)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var recommended = WorkloadRecommendationPolicy.GetRecommendedWorkloadIds(
+            OperatingSystem.IsLinux());
+        var recommendedSet = recommended.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var order = recommended
+            .Select((id, index) => (id, index))
+            .ToDictionary(item => item.id, item => item.index, StringComparer.OrdinalIgnoreCase);
+
+        return inventory.AvailableWorkloads
+            .Where(workload =>
+                !workload.IsAbstract &&
+                workload.RedirectTarget == null &&
+                !installed.Contains(workload.Id) &&
+                (showAll || recommendedSet.Contains(workload.Id)))
+            .OrderBy(workload => order.GetValueOrDefault(workload.Id, int.MaxValue))
+            .ThenBy(workload => workload.Id, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private IEnumerable<ResolvedWorkloadDefinition> FilteredInstalledWorkloads() =>
+        InstalledWorkloads().Where(MatchesSearch);
+
+    private IEnumerable<ResolvedWorkloadDefinition> FilteredAvailableWorkloads() =>
+        AvailableWorkloads().Where(MatchesSearch);
+
+    private bool MatchesSearch(ResolvedWorkloadDefinition workload) =>
+        string.IsNullOrWhiteSpace(search) ||
+        workload.Id.Contains(search, StringComparison.OrdinalIgnoreCase) ||
+        (workload.Description?.Contains(search, StringComparison.OrdinalIgnoreCase) ?? false);
+
+    private void ToggleInstall(ResolvedWorkloadDefinition workload)
+    {
+        if (!selectedInstall.Add(workload.Id))
+            selectedInstall.Remove(workload.Id);
+        else
+            foreach (var included in workload.TransitiveIncludes)
+                selectedInstall.Remove(included);
+        UpdateBridge();
+    }
+
+    private void ToggleUninstall(string id)
+    {
+        if (!selectedUninstall.Add(id))
+            selectedUninstall.Remove(id);
+        UpdateBridge();
+    }
+
+    private string? IncludedBySelectedInstall(string id) =>
+        AvailableWorkloads()
+            .FirstOrDefault(workload =>
+                selectedInstall.Contains(workload.Id) &&
+                workload.TransitiveIncludes.Contains(id, StringComparer.OrdinalIgnoreCase))
+            ?.Id;
+
+    private void UpdateBridge()
+    {
+        var bridge = BridgeHolder.Current;
+        if (bridge == null)
+            return;
+        bridge.Result = new WorkloadSelectionResult(
+            selectedInstall.OrderBy(id => id, StringComparer.OrdinalIgnoreCase).ToList(),
+            selectedUninstall.OrderBy(id => id, StringComparer.OrdinalIgnoreCase).ToList());
+        bridge.SetValid(selectedInstall.Count > 0 || selectedUninstall.Count > 0);
+        StateHasChanged();
+    }
+
+    private Task OnSubmit()
+    {
+        UpdateBridge();
+        return Task.CompletedTask;
+    }
+
+    private void OnCancel()
+    {
+        var bridge = BridgeHolder.Current;
+        if (bridge != null)
+            bridge.Result = null;
+    }
+
+    public void Dispose()
+    {
+        var bridge = BridgeHolder.Current;
+        if (bridge == null)
+            return;
+        bridge.SubmitRequested -= OnSubmit;
+        bridge.CancelRequested -= OnCancel;
+    }
+}

--- a/src/MauiSherpa/Pages/Modals/WorkloadSelectionPage.cs
+++ b/src/MauiSherpa/Pages/Modals/WorkloadSelectionPage.cs
@@ -1,0 +1,36 @@
+using MauiSherpa.Pages.Forms;
+using MauiSherpa.Workloads.Models;
+#if MACOSAPP
+using Microsoft.Maui.Platforms.MacOS.Platform;
+#endif
+#if LINUXGTK
+using Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
+#endif
+
+namespace MauiSherpa.Pages.Modals;
+
+public sealed class WorkloadSelectionPage : HybridFormPage<WorkloadSelectionResult?>
+{
+    protected override string FormTitle => "Manage .NET workloads";
+    protected override string SubmitButtonText => "Review & apply changes";
+
+    protected override string BlazorRoute => "/modal/manage-workloads";
+
+    public WorkloadSelectionPage(
+        HybridFormBridgeHolder bridgeHolder,
+        DotnetWorkloadInventory inventory)
+        : base(bridgeHolder)
+    {
+        Bridge.Parameters["Inventory"] = inventory;
+
+#if MACOSAPP
+        MacOSPage.SetModalSheetSizesToContent(this, false);
+        MacOSPage.SetModalSheetWidth(this, 820);
+        MacOSPage.SetModalSheetHeight(this, 700);
+#elif LINUXGTK
+        GtkPage.SetModalSizesToContent(this, false);
+        GtkPage.SetModalWidth(this, 820);
+        GtkPage.SetModalHeight(this, 700);
+#endif
+    }
+}

--- a/src/MauiSherpa/Pages/Modals/WorkloadSetModal.razor
+++ b/src/MauiSherpa/Pages/Modals/WorkloadSetModal.razor
@@ -1,0 +1,337 @@
+@page "/modal/workload-set"
+@using MauiSherpa.Pages.Forms
+@using MauiSherpa.Workloads.Models
+@inject HybridFormBridgeHolder BridgeHolder
+@implements IDisposable
+
+@if (inventory != null)
+{
+    <div class="set-dialog">
+        <div class="current-set">
+            <div>
+                <span class="label">Feature band</span>
+                <strong class="mono">@inventory.Target.FeatureBand</strong>
+            </div>
+            <div>
+                <span class="label">Current</span>
+                <strong class="mono">@inventory.ActiveWorkloadVersion</strong>
+            </div>
+            <div>
+                <span class="label">Mode</span>
+                <strong>@ModeLabel(inventory.UpdateMode)</strong>
+            </div>
+        </div>
+
+        <div class="set-toolbar">
+            <p>
+                @if (inventory.UpdateMode == DotnetWorkloadUpdateMode.Manifests)
+                {
+                    <span>Select a compatible workload set to replace loose manifest updates with coordinated workload-set updates.</span>
+                }
+                else
+                {
+                    <span>Select a compatible workload set. The next step previews every manifest change before running the SDK command.</span>
+                }
+            </p>
+            @if (inventory.AvailableSetVersions.Any(version => version.IsPrerelease))
+            {
+                <label class="preview-toggle">
+                    <input type="checkbox" @bind="showPreviews" />
+                    Include previews
+                </label>
+            }
+        </div>
+
+        @if (inventory.UpdateMode == DotnetWorkloadUpdateMode.Manifests)
+        {
+            <div class="mode-change-note">
+                <i class="fas fa-code-compare"></i>
+                <div>
+                    <strong>Switch to workload-set mode</strong>
+                    <span>Sherpa uses workload sets for coordinated manifest updates. Applying a version changes this feature band from loose manifests to workload-set mode.</span>
+                </div>
+            </div>
+        }
+
+        <div class="set-list">
+            @foreach (var version in VisibleVersions())
+            {
+                var isCurrent = string.Equals(
+                    version.Version,
+                    inventory.ActiveWorkloadVersion,
+                    StringComparison.OrdinalIgnoreCase) &&
+                    inventory.UpdateMode == DotnetWorkloadUpdateMode.WorkloadSet;
+                <label class="set-item @(selectedVersion == version.Version ? "selected" : "") @(isCurrent ? "current" : "")">
+                    <input type="radio"
+                           name="workload-set"
+                           value="@version.Version"
+                           checked="@(selectedVersion == version.Version)"
+                           @onchange="@(_ => Select(version.Version))" />
+                    <span class="mono set-version">@version.Version</span>
+                    @if (version == VisibleVersions().FirstOrDefault())
+                    {
+                        <span class="badge badge-success">latest</span>
+                    }
+                    @if (version.IsPrerelease)
+                    {
+                        <span class="badge badge-warning">preview</span>
+                    }
+                    @if (isCurrent)
+                    {
+                        <span class="badge badge-info">current</span>
+                    }
+                    @if (string.Equals(version.Version, inventory.Target.RepresentativeSdkVersion, StringComparison.OrdinalIgnoreCase))
+                    {
+                        <span class="badge badge-secondary">matches SDK</span>
+                    }
+                </label>
+            }
+        </div>
+
+        <p class="set-note">
+            <i class="fas fa-circle-info"></i>
+            Changing the set updates manifests together and updates packs for workloads already installed in this feature band.
+        </p>
+    </div>
+}
+
+<style>
+    .set-dialog {
+        display: flex;
+        flex-direction: column;
+        gap: 0.85rem;
+        padding: 1rem 1.25rem;
+    }
+
+    .current-set {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 0.75rem;
+        padding: 0.7rem 0.85rem;
+        border-radius: 0.625rem;
+        background: var(--bg-tertiary);
+    }
+
+    .current-set > div {
+        display: flex;
+        flex-direction: column;
+        gap: 0.2rem;
+        min-width: 0;
+    }
+
+    .label {
+        color: var(--text-secondary);
+        font-size: 0.68rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+    }
+
+    .current-set strong {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        color: var(--text-primary);
+        font-size: 0.83rem;
+    }
+
+    .set-toolbar {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+    }
+
+    .set-toolbar p {
+        margin: 0;
+        color: var(--text-secondary);
+        font-size: 0.84rem;
+        line-height: 1.4;
+    }
+
+    .preview-toggle {
+        display: flex;
+        align-items: center;
+        gap: 0.4rem;
+        color: var(--text-secondary);
+        font-size: 0.78rem;
+        white-space: nowrap;
+    }
+
+    .set-list {
+        max-height: 48vh;
+        overflow-y: auto;
+        border: 1px solid var(--border-color);
+        border-radius: 0.75rem;
+        background: var(--card-bg);
+    }
+
+    .mode-change-note {
+        display: flex;
+        align-items: flex-start;
+        gap: 0.55rem;
+        padding: 0.65rem 0.75rem;
+        border: 1px solid color-mix(in srgb, var(--accent-purple) 35%, var(--border-color));
+        border-radius: 0.625rem;
+        background: color-mix(in srgb, var(--accent-purple) 12%, transparent);
+        color: var(--text-secondary);
+        font-size: 0.78rem;
+        line-height: 1.4;
+    }
+
+    .mode-change-note i {
+        margin-top: 0.15rem;
+        color: var(--accent-purple);
+    }
+
+    .mode-change-note div {
+        display: flex;
+        flex-direction: column;
+        gap: 0.1rem;
+    }
+
+    .mode-change-note strong {
+        color: var(--text-primary);
+    }
+
+    .set-item {
+        display: flex;
+        align-items: center;
+        gap: 0.55rem;
+        padding: 0.65rem 0.85rem;
+        cursor: pointer;
+    }
+
+    .set-item + .set-item {
+        border-top: 1px solid var(--border-color);
+    }
+
+    .set-item:hover,
+    .set-item.selected {
+        background: var(--bg-tertiary);
+    }
+
+    .set-version {
+        flex: 1;
+        color: var(--text-primary);
+        font-size: 0.84rem;
+        font-weight: 600;
+    }
+
+    .set-note {
+        display: flex;
+        gap: 0.45rem;
+        margin: 0;
+        padding: 0.65rem 0.75rem;
+        border-radius: 0.625rem;
+        background: var(--bg-tertiary);
+        color: var(--text-secondary);
+        font-size: 0.78rem;
+        line-height: 1.4;
+    }
+
+    .badge {
+        display: inline-flex;
+        align-items: center;
+        padding: 2px 0.5rem;
+        border-radius: 999px;
+        font-size: 0.68rem;
+        font-weight: 500;
+        white-space: nowrap;
+    }
+
+    @@media (max-width: 620px) {
+        .current-set {
+            grid-template-columns: 1fr;
+        }
+    }
+</style>
+
+@code {
+    private DotnetWorkloadInventory? inventory;
+    private string? selectedVersion;
+    private bool showPreviews;
+
+    protected override void OnInitialized()
+    {
+        var bridge = BridgeHolder.Current;
+        if (bridge == null)
+            return;
+        inventory = bridge.Parameters.GetValueOrDefault("Inventory") as DotnetWorkloadInventory;
+        selectedVersion = bridge.Parameters.GetValueOrDefault("InitialVersion") as string;
+        if (string.IsNullOrWhiteSpace(selectedVersion) &&
+            inventory?.UpdateMode == DotnetWorkloadUpdateMode.WorkloadSet)
+        {
+            selectedVersion = inventory.ActiveWorkloadVersion;
+        }
+        showPreviews =
+            inventory?.Target.FeatureBand.IsPrerelease == true ||
+            inventory?.AvailableSetVersions.Any(version =>
+                version.IsPrerelease &&
+                string.Equals(version.Version, selectedVersion, StringComparison.OrdinalIgnoreCase)) == true;
+        if (!VisibleVersions().Any(version =>
+                string.Equals(version.Version, selectedVersion, StringComparison.OrdinalIgnoreCase)))
+            selectedVersion = null;
+        bridge.SubmitRequested += OnSubmit;
+        bridge.CancelRequested += OnCancel;
+        UpdateBridge();
+    }
+
+    private IReadOnlyList<DotnetWorkloadSetVersion> VisibleVersions() =>
+        inventory?.AvailableSetVersions
+            .Where(version => showPreviews || !version.IsPrerelease)
+            .ToList() ?? [];
+
+    private void Select(string version)
+    {
+        selectedVersion = version;
+        UpdateBridge();
+    }
+
+    private void UpdateBridge()
+    {
+        var bridge = BridgeHolder.Current;
+        if (bridge == null)
+            return;
+        bridge.Result = selectedVersion;
+        bridge.SetValid(
+            !string.IsNullOrWhiteSpace(selectedVersion) &&
+            !IsCurrentVersion(selectedVersion));
+        StateHasChanged();
+    }
+
+    private bool IsCurrentVersion(string? version) =>
+        inventory?.UpdateMode == DotnetWorkloadUpdateMode.WorkloadSet &&
+        string.Equals(
+            version,
+            inventory.ActiveWorkloadVersion,
+            StringComparison.OrdinalIgnoreCase);
+
+    private Task OnSubmit()
+    {
+        UpdateBridge();
+        return Task.CompletedTask;
+    }
+
+    private void OnCancel()
+    {
+        var bridge = BridgeHolder.Current;
+        if (bridge != null)
+            bridge.Result = null;
+    }
+
+    private static string ModeLabel(DotnetWorkloadUpdateMode mode) => mode switch
+    {
+        DotnetWorkloadUpdateMode.WorkloadSet => "Workload set",
+        DotnetWorkloadUpdateMode.Manifests => "Loose manifests",
+        _ => "Unknown"
+    };
+
+    public void Dispose()
+    {
+        var bridge = BridgeHolder.Current;
+        if (bridge == null)
+            return;
+        bridge.SubmitRequested -= OnSubmit;
+        bridge.CancelRequested -= OnCancel;
+    }
+}

--- a/src/MauiSherpa/Pages/Modals/WorkloadSetPage.cs
+++ b/src/MauiSherpa/Pages/Modals/WorkloadSetPage.cs
@@ -1,0 +1,35 @@
+using MauiSherpa.Pages.Forms;
+using MauiSherpa.Workloads.Models;
+#if MACOSAPP
+using Microsoft.Maui.Platforms.MacOS.Platform;
+#endif
+#if LINUXGTK
+using Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
+#endif
+
+namespace MauiSherpa.Pages.Modals;
+
+public sealed class WorkloadSetPage : HybridFormPage<string?>
+{
+    protected override string FormTitle => "Change workload set";
+    protected override string SubmitButtonText => "Review change";
+    protected override string BlazorRoute => "/modal/workload-set";
+
+    public WorkloadSetPage(
+        HybridFormBridgeHolder bridgeHolder,
+        DotnetWorkloadInventory inventory,
+        string? initialVersion = null)
+        : base(bridgeHolder)
+    {
+        Bridge.Parameters["Inventory"] = inventory;
+        Bridge.Parameters["InitialVersion"] = initialVersion;
+
+#if MACOSAPP
+        MacOSPage.SetModalSheetSizesToContent(this, true);
+        MacOSPage.SetModalSheetMinWidth(this, 700);
+#elif LINUXGTK
+        GtkPage.SetModalSizesToContent(this, true);
+        GtkPage.SetModalMinWidth(this, 700);
+#endif
+    }
+}

--- a/src/MauiSherpa/Services/DialogService.cs
+++ b/src/MauiSherpa/Services/DialogService.cs
@@ -159,6 +159,30 @@ public class DialogService : IDialogService
         });
 
         return await tcs.Task;
+#elif MACOSAPP
+        var tcs = new TaskCompletionSource<string?>();
+
+        await Dispatcher.DispatchAsync(() =>
+        {
+            var panel = new NSOpenPanel
+            {
+                Title = title,
+                CanChooseDirectories = true,
+                CanChooseFiles = false,
+                AllowsMultipleSelection = false,
+                CanCreateDirectories = true,
+                DirectoryUrl = NSUrl.FromFilename(
+                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)),
+            };
+
+            var result = panel.RunModal();
+            if (result == 1 && panel.Url?.Path is string path)
+                tcs.TrySetResult(path);
+            else
+                tcs.TrySetResult(null);
+        });
+
+        return await tcs.Task;
 #elif WINDOWS
         return await Dispatcher.DispatchAsync(async () =>
         {

--- a/src/MauiSherpa/Services/ProcessExecutionService.cs
+++ b/src/MauiSherpa/Services/ProcessExecutionService.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
 using MauiSherpa.Core.Interfaces;
+using MauiSherpa.Core.Services;
 
 namespace MauiSherpa.Services;
 
@@ -66,6 +67,20 @@ public class ProcessExecutionService : IProcessExecutionService
             if (request.RequiresElevation && (_platform.IsMacCatalyst || _platform.IsMacOS))
             {
                 return await ExecuteElevatedMacAsync(request, _linkedCts.Token);
+            }
+            if (request.RequiresElevation && _platform.IsWindows)
+            {
+                return await ExecuteElevatedWindowsAsync(request, _linkedCts.Token);
+            }
+            if (request.RequiresElevation)
+            {
+                throw new PlatformNotSupportedException(
+                    "Administrator process execution is not supported on this platform.");
+            }
+
+            if (request.UsePseudoTerminal && (_platform.IsMacCatalyst || _platform.IsMacOS))
+            {
+                return await ExecutePseudoTerminalMacAsync(request, _linkedCts.Token);
             }
             
             return await ExecuteNormalAsync(request, _linkedCts.Token);
@@ -148,6 +163,70 @@ public class ProcessExecutionService : IProcessExecutionService
 
         return CreateResult();
     }
+
+    private async Task<ProcessResult> ExecutePseudoTerminalMacAsync(
+        ProcessRequest request,
+        CancellationToken cancellationToken)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "/usr/bin/script",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            RedirectStandardInput = true,
+            CreateNoWindow = true,
+            WorkingDirectory = request.WorkingDirectory ?? Environment.CurrentDirectory
+        };
+        startInfo.ArgumentList.Add("-q");
+        startInfo.ArgumentList.Add("/dev/null");
+        startInfo.ArgumentList.Add(request.Command);
+        foreach (var arg in request.Arguments)
+            startInfo.ArgumentList.Add(arg);
+
+        startInfo.Environment["TERM"] = "xterm-256color";
+        if (request.Environment != null)
+        {
+            foreach (var kvp in request.Environment)
+                startInfo.Environment[kvp.Key] = kvp.Value;
+        }
+
+        _currentProcess = new Process { StartInfo = startInfo };
+        _currentProcess.Start();
+
+        var stdoutTask = ReadRawOutputAsync(
+            _currentProcess.StandardOutput, isError: false, cancellationToken);
+        var stderrTask = ReadRawOutputAsync(
+            _currentProcess.StandardError, isError: true, cancellationToken);
+
+        try
+        {
+            await _currentProcess.WaitForExitAsync(cancellationToken);
+            await Task.WhenAll(stdoutTask, stderrTask);
+        }
+        catch (OperationCanceledException)
+        {
+            // Cancellation state and process termination are managed by CancelAsync/KillAsync.
+        }
+
+        return CreateResult();
+    }
+
+    private async Task ReadRawOutputAsync(
+        TextReader reader,
+        bool isError,
+        CancellationToken cancellationToken)
+    {
+        var buffer = new char[4096];
+        while (true)
+        {
+            var read = await reader.ReadAsync(buffer.AsMemory(), cancellationToken);
+            if (read == 0)
+                break;
+
+            OnOutput(new string(buffer, 0, read), isError, isRaw: true);
+        }
+    }
     
     private async Task<ProcessResult> ExecuteElevatedMacAsync(ProcessRequest request, CancellationToken cancellationToken)
     {
@@ -159,19 +238,7 @@ public class ProcessExecutionService : IProcessExecutionService
         
         try
         {
-            // Build the command with proper escaping
-            var cmdArgs = string.Join(" ", request.Arguments.Select(EscapeForShell));
-            var fullCommand = $"{request.Command} {cmdArgs}";
-            
-            // Create script that runs command and streams to output file
-            // Using unbuffered output with script command for real-time streaming
-            var scriptContent = $@"#!/bin/bash
-exec > >(tee -a ""{_tempOutputFile}"") 2>&1
-{fullCommand}
-EXIT_CODE=$?
-echo ""__EXIT_CODE__:$EXIT_CODE"" >> ""{_tempOutputFile}""
-exit $EXIT_CODE
-";
+            var scriptContent = MacElevatedProcessScriptBuilder.Build(request, _tempOutputFile);
             await File.WriteAllTextAsync(tempScript, scriptContent, cancellationToken);
             
             // Make script executable
@@ -189,13 +256,16 @@ exit $EXIT_CODE
             
             // Start tailing the output file
             _tailCts = new CancellationTokenSource();
-            var tailTask = TailOutputFileAsync(_tempOutputFile, _tailCts.Token);
+            var tailTask = TailOutputFileAsync(
+                _tempOutputFile,
+                request.UsePseudoTerminal,
+                _tailCts.Token);
             
             // Build osascript command
             var escapedScript = tempScript.Replace("\\", "\\\\").Replace("\"", "\\\"");
             var osascriptCmd = $"do shell script \"\\\"{escapedScript}\\\"\" with administrator privileges";
             
-            _logger.LogInformation($"Running elevated: {fullCommand}");
+            _logger.LogInformation($"Running elevated: {request.CommandLine}");
             OnOutput("🔐 Requesting administrator privileges...", isError: false);
             
             var startInfo = new ProcessStartInfo
@@ -250,6 +320,7 @@ exit $EXIT_CODE
                         exitCode = parsedCode;
                     }
                 }
+
             }
             
             // Determine final state
@@ -278,8 +349,97 @@ exit $EXIT_CODE
             try { if (File.Exists(tempScript)) File.Delete(tempScript); } catch { }
         }
     }
+
+    private async Task<ProcessResult> ExecuteElevatedWindowsAsync(
+        ProcessRequest request,
+        CancellationToken cancellationToken)
+    {
+        _tempOutputFile = Path.Combine(
+            Path.GetTempPath(),
+            $"mauisherpa_output_{Guid.NewGuid():N}.log");
+        var tempScript = Path.Combine(
+            Path.GetTempPath(),
+            $"mauisherpa_cmd_{Guid.NewGuid():N}.ps1");
+
+        try
+        {
+            await File.WriteAllTextAsync(
+                tempScript,
+                WindowsElevatedProcessScriptBuilder.Build(request, _tempOutputFile),
+                cancellationToken);
+            await File.WriteAllTextAsync(_tempOutputFile, string.Empty, cancellationToken);
+
+            _tailCts = new CancellationTokenSource();
+            var tailTask = TailOutputFileAsync(
+                _tempOutputFile,
+                request.UsePseudoTerminal,
+                _tailCts.Token);
+
+            _logger.LogInformation($"Running elevated: {request.CommandLine}");
+            OnOutput("Requesting administrator privileges...", isError: false);
+
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = "powershell.exe",
+                Arguments = $"-NoProfile -ExecutionPolicy Bypass -File \"{tempScript}\"",
+                UseShellExecute = true,
+                Verb = "runas",
+                WorkingDirectory = request.WorkingDirectory ?? Environment.CurrentDirectory
+            };
+
+            _currentProcess = new Process { StartInfo = startInfo };
+            _currentProcess.Start();
+
+            try
+            {
+                await _currentProcess.WaitForExitAsync(cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                // Cancellation state and process termination are managed by CancelAsync/KillAsync.
+            }
+
+            _tailCts.Cancel();
+            try { await tailTask; } catch (OperationCanceledException) { }
+
+            var exitCode = _currentProcess.HasExited ? _currentProcess.ExitCode : -1;
+            if (File.Exists(_tempOutputFile))
+            {
+                var content = await File.ReadAllTextAsync(_tempOutputFile, cancellationToken);
+                var exitMarker = "__EXIT_CODE__:";
+                var markerIndex = content.LastIndexOf(exitMarker, StringComparison.Ordinal);
+                if (markerIndex >= 0)
+                {
+                    var exitCodeText = content[(markerIndex + exitMarker.Length)..]
+                        .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
+                        .FirstOrDefault();
+                    if (int.TryParse(exitCodeText, out var parsedCode))
+                        exitCode = parsedCode;
+                }
+            }
+
+            var finalState = CurrentState;
+            if (finalState == ProcessState.Running)
+                finalState = exitCode == 0 ? ProcessState.Completed : ProcessState.Failed;
+            CurrentState = finalState;
+
+            return new ProcessResult(
+                exitCode,
+                _outputBuilder.ToString(),
+                _errorBuilder.ToString(),
+                DateTime.Now - _startTime,
+                finalState);
+        }
+        finally
+        {
+            try { if (File.Exists(tempScript)) File.Delete(tempScript); } catch { }
+        }
+    }
     
-    private async Task TailOutputFileAsync(string filePath, CancellationToken cancellationToken)
+    private async Task TailOutputFileAsync(
+        string filePath,
+        bool rawOutput,
+        CancellationToken cancellationToken)
     {
         long lastPosition = 0;
         var lastContent = "";
@@ -300,13 +460,22 @@ exit $EXIT_CODE
                         
                         if (!string.IsNullOrEmpty(newContent))
                         {
-                            // Split by lines and output each (skip exit code marker)
-                            var lines = newContent.Split('\n');
-                            foreach (var line in lines)
+                            if (rawOutput)
                             {
-                                if (!string.IsNullOrEmpty(line) && !line.StartsWith("__EXIT_CODE__:"))
+                                var markerIndex = newContent.IndexOf("__EXIT_CODE__:", StringComparison.Ordinal);
+                                var visibleContent = markerIndex >= 0
+                                    ? newContent[..markerIndex].TrimEnd('\r', '\n')
+                                    : newContent;
+                                if (!string.IsNullOrEmpty(visibleContent))
+                                    OnOutput(visibleContent, isError: false, isRaw: true);
+                            }
+                            else
+                            {
+                                var lines = newContent.Split('\n');
+                                foreach (var line in lines)
                                 {
-                                    OnOutput(line.TrimEnd('\r'), isError: false);
+                                    if (!string.IsNullOrEmpty(line) && !line.StartsWith("__EXIT_CODE__:", StringComparison.Ordinal))
+                                        OnOutput(line.TrimEnd('\r'), isError: false);
                                 }
                             }
                         }
@@ -359,19 +528,6 @@ exit $EXIT_CODE
             try { if (File.Exists(_tempOutputFile)) File.Delete(_tempOutputFile); } catch { }
             _tempOutputFile = null;
         }
-    }
-
-    private string EscapeForShell(string arg)
-    {
-        if (string.IsNullOrEmpty(arg)) return "''";
-        if (!arg.Contains(' ') && !arg.Contains('\'') && !arg.Contains('"'))
-            return arg;
-        return $"'{arg.Replace("'", "'\\''")}'";
-    }
-
-    private string EscapeForAppleScript(string command)
-    {
-        return command.Replace("\\", "\\\\").Replace("\"", "\\\"");
     }
 
     public void Cancel()
@@ -448,14 +604,24 @@ exit $EXIT_CODE
         return _outputBuilder.ToString();
     }
 
-    private void OnOutput(string data, bool isError)
+    private void OnOutput(string data, bool isError, bool isRaw = false)
     {
         if (isError)
-            _errorBuilder.AppendLine(data);
+        {
+            if (isRaw)
+                _errorBuilder.Append(data);
+            else
+                _errorBuilder.AppendLine(data);
+        }
         else
-            _outputBuilder.AppendLine(data);
+        {
+            if (isRaw)
+                _outputBuilder.Append(data);
+            else
+                _outputBuilder.AppendLine(data);
+        }
 
-        OutputReceived?.Invoke(this, new ProcessOutputEventArgs(data, isError));
+        OutputReceived?.Invoke(this, new ProcessOutputEventArgs(data, isError, isRaw));
     }
 
     // P/Invoke for sending signals on Unix

--- a/src/MauiSherpa/Services/ProcessModalService.cs
+++ b/src/MauiSherpa/Services/ProcessModalService.cs
@@ -9,6 +9,10 @@ namespace MauiSherpa.Services;
 /// </summary>
 public class ProcessModalService : IProcessModalService
 {
+    private const int MinimumModalWidth = 700;
+    private const int DefaultModalWidth = 1000;
+    private const int MaximumModalWidth = 1600;
+
     private readonly IProcessExecutionService _processService;
     private readonly ProgressBridgeHolder _bridgeHolder;
     private TaskCompletionSource<ProcessResult?>? _completionSource;
@@ -52,7 +56,13 @@ public class ProcessModalService : IProcessModalService
         INavigation? activeNav = nav;
         if (nav != null)
         {
-            var page = new HybridProgressPage(_bridgeHolder, "/modal/process", request.Title ?? "Process Execution", 700, 500);
+            var modalWidth = GetModalWidth(Application.Current?.Windows.FirstOrDefault());
+            var page = new HybridProgressPage(
+                _bridgeHolder,
+                "/modal/process",
+                request.Title ?? "Process Execution",
+                modalWidth,
+                500);
             await nav.PushModalAsync(page, animated: true);
         }
 
@@ -69,6 +79,18 @@ public class ProcessModalService : IProcessModalService
         OnModalClosed?.Invoke();
 
         return result;
+    }
+
+    private static int GetModalWidth(Window? parentWindow)
+    {
+        var parentWidth = parentWindow?.Width ?? 0;
+        if (!double.IsFinite(parentWidth) || parentWidth <= 0)
+            return DefaultModalWidth;
+
+        return (int)Math.Clamp(
+            Math.Round(parentWidth * 0.9),
+            MinimumModalWidth,
+            MaximumModalWidth);
     }
 
     /// <summary>

--- a/src/MauiSherpa/wwwroot/js/terminal.js
+++ b/src/MauiSherpa/wwwroot/js/terminal.js
@@ -99,6 +99,20 @@ window.terminalInterop = {
     },
 
     /**
+     * Write a raw terminal chunk, preserving ANSI cursor movement and carriage returns.
+     */
+    writeRaw: function (containerId, text) {
+        const t = this.terminals[containerId];
+        if (!t) return;
+
+        t.terminal.write(text);
+
+        if (t.autoScroll) {
+            t.terminal.scrollToBottom();
+        }
+    },
+
+    /**
      * Write error text (in red) to the terminal
      */
     writeError: function (containerId, text) {

--- a/tests/MauiSherpa.Core.Tests/Services/DoctorDotnetUpTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/DoctorDotnetUpTests.cs
@@ -1,0 +1,140 @@
+using FluentAssertions;
+using MauiSherpa.Core.Interfaces;
+using MauiSherpa.Core.Services;
+using MauiSherpa.Workloads.Models;
+using MauiSherpa.Workloads.Services;
+using Xunit;
+
+namespace MauiSherpa.Core.Tests.Services;
+
+/// <summary>
+/// Tests for the dotnetup-aware behavior added to Doctor: context fields, the dotnetup
+/// presence dependency status, the fixable .NET SDK status, and managed-SDK reconciliation.
+/// </summary>
+public class DoctorDotnetUpTests
+{
+    [Fact]
+    public void DoctorContext_DotnetUpFields_DefaultToNotInstalled()
+    {
+        var context = new DoctorContext(
+            "/test", "/dotnet", null, null, null, "10.0.100");
+
+        context.DotnetUpInstalled.Should().BeFalse();
+        context.DotnetUpVersion.Should().BeNull();
+        context.DotnetUpManagedInstallRoot.Should().BeNull();
+    }
+
+    [Fact]
+    public void DoctorContext_DotnetUpFields_RoundTrip()
+    {
+        var context = new DoctorContext(
+            "/test", "/dotnet", null, null, null, "10.0.100",
+            DotnetUpInstalled: true,
+            DotnetUpVersion: "0.1.4-preview.6.26323.4",
+            DotnetUpManagedInstallRoot: "/Users/x/Library/Application Support/dotnet");
+
+        context.DotnetUpInstalled.Should().BeTrue();
+        context.DotnetUpVersion.Should().Be("0.1.4-preview.6.26323.4");
+        context.DotnetUpManagedInstallRoot.Should().Be("/Users/x/Library/Application Support/dotnet");
+    }
+
+    [Fact]
+    public void DotnetUpPresenceStatus_WhenInstalled_IsInfoAndCountsOk()
+    {
+        var dep = new DependencyStatus(
+            "dotnetup", DependencyCategory.DotNetSdk,
+            null, null, "0.1.4-preview.6.26323.4",
+            DependencyStatusType.Info,
+            "Installed (0.1.4-preview.6.26323.4) — manages .NET SDKs & runtimes",
+            IsFixable: false);
+
+        var report = MakeReport(dep);
+
+        report.OkCount.Should().Be(1);
+        report.WarningCount.Should().Be(0);
+        report.HasWarnings.Should().BeFalse();
+    }
+
+    [Fact]
+    public void DotnetUpPresenceStatus_WhenMissing_IsFixableInstallAction()
+    {
+        var dep = new DependencyStatus(
+            "dotnetup", DependencyCategory.DotNetSdk,
+            null, null, null,
+            DependencyStatusType.Info,
+            "Not installed — install to manage .NET SDKs & runtimes",
+            IsFixable: true,
+            FixAction: "install-dotnetup");
+
+        dep.IsFixable.Should().BeTrue();
+        dep.FixAction.Should().Be("install-dotnetup");
+
+        // Info status keeps the install action out of the warning/error counts.
+        var report = MakeReport(dep);
+        report.HasWarnings.Should().BeFalse();
+        report.HasErrors.Should().BeFalse();
+    }
+
+    [Fact]
+    public void OutOfDateSdkStatus_WithDotnetUp_EncodesChannelInFixAction()
+    {
+        var dep = new DependencyStatus(
+            ".NET SDK", DependencyCategory.DotNetSdk,
+            null, "10.0.103", "9.0.305",
+            DependencyStatusType.Warning,
+            "Update available: 10.0.103",
+            IsFixable: true,
+            FixAction: "dotnetup-update-sdk:10.0.103");
+
+        dep.IsFixable.Should().BeTrue();
+        dep.FixAction.Should().StartWith("dotnetup-update-sdk:");
+
+        var channel = dep.FixAction!["dotnetup-update-sdk:".Length..];
+        channel.Should().Be("10.0.103");
+    }
+
+    [Fact]
+    public void MergeManagedSdks_AddsDotnetUpVersionsAndSortsDescending()
+    {
+        var local = new List<SdkVersion>
+        {
+            SdkVersion.Parse("9.0.305")
+        };
+
+        var dotnetUpList = DotnetUpParser.ParseList("""
+        { "installations": [
+          { "component": "SDK", "version": "10.0.300", "installRoot": "/u/dotnet", "architecture": "arm64", "isValid": true },
+          { "component": "SDK", "version": "9.0.305", "installRoot": "/u/dotnet", "architecture": "arm64", "isValid": true },
+          { "component": "Runtime", "version": "10.0.8", "installRoot": "/u/dotnet", "architecture": "arm64", "isValid": true }
+        ] }
+        """);
+
+        var merged = DoctorService.MergeManagedSdks(local, dotnetUpList);
+
+        merged.Select(s => s.Version).Should().ContainInOrder("10.0.300", "9.0.305");
+        merged.Should().HaveCount(2, "the duplicate 9.0.305 is de-duplicated and runtimes are excluded");
+        merged[0].Version.Should().Be("10.0.300", "newest SDK should sort first");
+    }
+
+    [Fact]
+    public void MergeManagedSdks_IgnoresInvalidManaged_AndEmptyList()
+    {
+        var local = new List<SdkVersion> { SdkVersion.Parse("10.0.103") };
+        var empty = new DotnetUpListResult();
+
+        var merged = DoctorService.MergeManagedSdks(local, empty);
+
+        merged.Should().ContainSingle().Which.Version.Should().Be("10.0.103");
+    }
+
+    private static DoctorReport MakeReport(params DependencyStatus[] deps) =>
+        new(
+            new DoctorContext("/test", "/dotnet", null, null, null, "10.0.100"),
+            InstalledSdks: [],
+            AvailableSdkVersions: null,
+            InstalledWorkloadSetVersion: null,
+            AvailableWorkloadSetVersions: null,
+            Manifests: [],
+            Dependencies: deps,
+            DateTime.UtcNow);
+}

--- a/tests/MauiSherpa.Core.Tests/Services/DotnetUpServiceTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/DotnetUpServiceTests.cs
@@ -1,0 +1,62 @@
+using FluentAssertions;
+using MauiSherpa.Core.Services;
+using MauiSherpa.Workloads.Models;
+
+namespace MauiSherpa.Core.Tests.Services;
+
+public class DotnetUpServiceTests
+{
+    [Fact]
+    public void SelectInstalledSdkTargetRejectsAmbiguousRoots()
+    {
+        var installations = new[]
+        {
+            SdkInstallation(@"C:\dotnet-a", "x64"),
+            SdkInstallation(@"D:\dotnet-b", "x64")
+        };
+
+        var result = DotnetUpService.SelectInstalledSdkTarget(
+            installations,
+            "10.0.302",
+            matchingSpec: null);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void SelectInstalledSdkTargetUsesExactSpecRootAndArchitecture()
+    {
+        var expected = SdkInstallation(@"C:\dotnet", "arm64");
+        var installations = new[]
+        {
+            SdkInstallation(@"C:\dotnet", "x64"),
+            expected,
+            SdkInstallation(@"D:\dotnet", "arm64")
+        };
+        var spec = new DotnetUpInstallSpec
+        {
+            Component = DotnetUpComponent.Sdk,
+            ComponentRaw = "SDK",
+            VersionOrChannel = "10.0.3xx",
+            InstallRoot = @"C:\dotnet",
+            Architecture = "arm64"
+        };
+
+        var result = DotnetUpService.SelectInstalledSdkTarget(
+            installations,
+            "10.0.302",
+            spec);
+
+        result.Should().BeSameAs(expected);
+    }
+
+    private static DotnetUpInstallation SdkInstallation(string root, string architecture) =>
+        new()
+        {
+            Component = DotnetUpComponent.Sdk,
+            ComponentRaw = "SDK",
+            Version = "10.0.302",
+            InstallRoot = root,
+            Architecture = architecture
+        };
+}

--- a/tests/MauiSherpa.Core.Tests/Services/DotnetWorkloadServiceTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/DotnetWorkloadServiceTests.cs
@@ -1,0 +1,153 @@
+using System.Text.Json;
+using FluentAssertions;
+using MauiSherpa.Core.Interfaces;
+using MauiSherpa.Core.Services;
+using MauiSherpa.Workloads.Models;
+using Moq;
+
+namespace MauiSherpa.Core.Tests.Services;
+
+public class DotnetWorkloadServiceTests
+{
+    private readonly DotnetWorkloadService _service = new(
+        Mock.Of<IDotnetUpService>(),
+        Mock.Of<ILoggingService>());
+
+    [Fact]
+    public async Task TargetsAreGroupedByRootArchitectureAndSdkFeatureBand()
+    {
+        var list = new DotnetUpListResult
+        {
+            Installations =
+            [
+                Sdk("10.0.301"),
+                Sdk("10.0.302"),
+                Sdk("11.0.100-preview.5.26302.115"),
+                Sdk("11.0.100-preview.6.26359.118")
+            ]
+        };
+
+        var result = await _service.GetTargetsAsync(list);
+
+        result.Should().HaveCount(3);
+        result.Single(target => target.FeatureBand.ToString() == "10.0.300")
+            .RepresentativeSdkVersion.Should().Be("10.0.302");
+        result.Select(target => target.FeatureBand.ToString())
+            .Should().Contain(["11.0.100-preview.5", "11.0.100-preview.6"]);
+    }
+
+    [Fact]
+    public void InstallRequestPinsExactSdkContextAndRootEnvironment()
+    {
+        var target = Target("10.0.302");
+
+        var request = _service.CreateInstallRequest(target, ["maui", "android"], "10.0.302");
+
+        request.Command.Should().Be(target.DotnetPath);
+        request.Arguments.Should().Equal(
+            "workload", "install", "maui", "android", "--version", "10.0.302");
+        request.Environment!["DOTNET_ROOT"].Should().Be(target.InstallRoot);
+        request.Environment["DOTNET_MULTILEVEL_LOOKUP"].Should().Be("0");
+        request.Environment["DOTNET_CLI_USE_MSBUILD_SERVER"].Should().Be("0");
+        request.Environment["MSBUILDDISABLENODEREUSE"].Should().Be("1");
+        request.RequiresElevation.Should().BeFalse();
+        request.WorkingDirectory.Should().NotBeNull();
+
+        using var document = JsonDocument.Parse(
+            File.ReadAllText(Path.Combine(request.WorkingDirectory!, "global.json")));
+        document.RootElement.GetProperty("sdk").GetProperty("version").GetString()
+            .Should().Be("10.0.302");
+        document.RootElement.GetProperty("sdk").GetProperty("rollForward").GetString()
+            .Should().Be("disable");
+    }
+
+    [Fact]
+    public void UpdateAndUninstallRequestsUseSupportedCliCommands()
+    {
+        var target = Target("10.0.302");
+
+        _service.CreateUpdateSetRequest(target, "10.0.301.1").Arguments
+            .Should().Equal("workload", "update", "--version", "10.0.301.1");
+        _service.CreateLatestSetUpdateRequest(target).Arguments
+            .Should().Equal("workload", "update");
+        _service.CreateLatestSetUpdateRequest(Target("11.0.100-preview.6.26359.118")).Arguments
+            .Should().Equal("workload", "update", "--include-previews");
+        _service.CreateUninstallRequest(target, ["maui"]).Arguments
+            .Should().Equal("workload", "uninstall", "maui");
+        _service.CreateRepairRequest(target).Arguments
+            .Should().Equal("workload", "repair");
+    }
+
+    [Fact]
+    public void MutationRequestElevatesWhenWorkloadStateIsNotWritable()
+    {
+        var target = Target("10.0.302") with { CanWrite = false };
+
+        var request = _service.CreateUpdateSetRequest(target, "10.0.300.2");
+
+        request.RequiresElevation.Should().BeTrue();
+        request.ElevationPrompt.Should().Contain(target.InstallRoot);
+        request.UsePseudoTerminal.Should().BeTrue();
+        request.ConfirmationButtonText.Should().Be("Change set");
+    }
+
+    [Fact]
+    public void RestoreRequestUsesProjectContextAndExactRoot()
+    {
+        var target = Target("10.0.302");
+        var project = Path.Combine(Path.GetTempPath(), $"sherpa-project-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(project);
+        try
+        {
+            var request = _service.CreateRestoreRequest(target, project);
+
+            request.Arguments.Should().Equal("workload", "restore");
+            request.WorkingDirectory.Should().Be(Path.GetFullPath(project));
+            request.Environment!["DOTNET_ROOT"].Should().Be(target.InstallRoot);
+            request.Environment["DOTNET_MULTILEVEL_LOOKUP"].Should().Be("0");
+        }
+        finally
+        {
+            Directory.Delete(project);
+        }
+    }
+
+    [Fact]
+    public void StableTargetDoesNotOfferPreviewSetAsAutomaticUpdate()
+    {
+        var inventory = new DotnetWorkloadInventory
+        {
+            Target = Target("10.0.302"),
+            UpdateMode = DotnetWorkloadUpdateMode.WorkloadSet,
+            ActiveWorkloadVersion = "10.0.300.1",
+            AvailableSetVersions =
+            [
+                new DotnetWorkloadSetVersion { Version = "11.0.100-preview.1", IsPrerelease = true },
+                new DotnetWorkloadSetVersion { Version = "10.0.300.2" }
+            ]
+        };
+
+        inventory.LatestAvailableSetVersion.Should().Be("10.0.300.2");
+        inventory.UpdateAvailable.Should().BeTrue();
+    }
+
+    private static DotnetUpInstallation Sdk(string version) => new()
+    {
+        Component = DotnetUpComponent.Sdk,
+        ComponentRaw = "SDK",
+        Version = version,
+        InstallRoot = "/tmp/dotnet",
+        Architecture = "arm64"
+    };
+
+    private static DotnetWorkloadTarget Target(string version) => new()
+    {
+        InstallRoot = "/tmp/dotnet",
+        DotnetPath = "/tmp/dotnet/dotnet",
+        Architecture = "arm64",
+        FeatureBand = new SdkFeatureBand(version),
+        RepresentativeSdkVersion = version,
+        IsManagedByDotnetUp = true,
+        CanWrite = true
+    };
+}

--- a/tests/MauiSherpa.Core.Tests/Services/MacElevatedProcessScriptBuilderTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/MacElevatedProcessScriptBuilderTests.cs
@@ -1,0 +1,61 @@
+using FluentAssertions;
+using MauiSherpa.Core.Interfaces;
+using MauiSherpa.Core.Services;
+
+namespace MauiSherpa.Core.Tests.Services;
+
+public class MacElevatedProcessScriptBuilderTests
+{
+    [Fact]
+    public void Build_QuotesCommandAndPreservesExecutionContext()
+    {
+        var request = new ProcessRequest(
+            Command: "/Users/test/Library/Application Support/dotnet/dotnet",
+            Arguments: ["workload", "update", "--version", "10.0.300.1"],
+            WorkingDirectory: "/tmp/context with spaces",
+            Environment: new Dictionary<string, string>
+            {
+                ["DOTNET_ROOT"] = "/Users/test/Library/Application Support/dotnet",
+                ["DOTNET_MULTILEVEL_LOOKUP"] = "0"
+            },
+            UsePseudoTerminal: true);
+
+        var script = MacElevatedProcessScriptBuilder.Build(
+            request,
+            "/tmp/output with spaces.log");
+
+        script.Should().Contain("cd '/tmp/context with spaces' || exit 1");
+        script.Should().Contain(
+            "export DOTNET_ROOT='/Users/test/Library/Application Support/dotnet'");
+        script.Should().Contain("export DOTNET_MULTILEVEL_LOOKUP='0'");
+        script.Should().Contain(
+            "/usr/bin/script -q /dev/null '/Users/test/Library/Application Support/dotnet/dotnet' 'workload' 'update' '--version' '10.0.300.1'");
+        script.Should().Contain("tee -a '/tmp/output with spaces.log'");
+    }
+
+    [Fact]
+    public void Build_ShellQuotesArguments()
+    {
+        var request = new ProcessRequest(
+            "/usr/bin/printf",
+            ["%s", "it's safe; echo not-run"]);
+
+        var script = MacElevatedProcessScriptBuilder.Build(request, "/tmp/output");
+
+        script.Should().Contain("'/usr/bin/printf' '%s' 'it'\\''s safe; echo not-run'");
+    }
+
+    [Fact]
+    public void Build_RejectsInvalidEnvironmentVariableNames()
+    {
+        var request = new ProcessRequest(
+            "/usr/bin/true",
+            [],
+            Environment: new Dictionary<string, string> { ["BAD-NAME"] = "value" });
+
+        var action = () => MacElevatedProcessScriptBuilder.Build(request, "/tmp/output");
+
+        action.Should().Throw<ArgumentException>()
+            .WithMessage("*BAD-NAME*");
+    }
+}

--- a/tests/MauiSherpa.Core.Tests/Services/WindowsElevatedProcessScriptBuilderTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/WindowsElevatedProcessScriptBuilderTests.cs
@@ -1,0 +1,34 @@
+using FluentAssertions;
+using MauiSherpa.Core.Interfaces;
+using MauiSherpa.Core.Services;
+
+namespace MauiSherpa.Core.Tests.Services;
+
+public class WindowsElevatedProcessScriptBuilderTests
+{
+    [Fact]
+    public void BuildPreservesCommandContextAndEscapesPowerShellValues()
+    {
+        var request = new ProcessRequest(
+            Command: @"C:\Program Files\dotnet\dotnet.exe",
+            Arguments: ["workload", "install", "maui", "--version", "10.0.300.1"],
+            WorkingDirectory: @"C:\Users\Test User\project",
+            Environment: new Dictionary<string, string>
+            {
+                ["DOTNET_ROOT"] = @"C:\Program Files\dotnet",
+                ["SPECIAL"] = "it's valid"
+            },
+            UsePseudoTerminal: true);
+
+        var script = WindowsElevatedProcessScriptBuilder.Build(
+            request,
+            @"C:\Users\Test User\AppData\Local\Temp\output.log");
+
+        script.Should().Contain("Set-Location -LiteralPath 'C:\\Users\\Test User\\project'");
+        script.Should().Contain("Set-Item -LiteralPath 'Env:DOTNET_ROOT' -Value 'C:\\Program Files\\dotnet'");
+        script.Should().Contain("Set-Item -LiteralPath 'Env:SPECIAL' -Value 'it''s valid'");
+        script.Should().Contain("& 'C:\\Program Files\\dotnet\\dotnet.exe' 'workload' 'install' 'maui'");
+        script.Should().Contain("Tee-Object -FilePath 'C:\\Users\\Test User\\AppData\\Local\\Temp\\output.log'");
+        script.Should().Contain("__EXIT_CODE__:$exitCode");
+    }
+}

--- a/tests/MauiSherpa.Workloads.Tests/MauiSherpa.Workloads.Tests.csproj
+++ b/tests/MauiSherpa.Workloads.Tests/MauiSherpa.Workloads.Tests.csproj
@@ -22,6 +22,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="Services/DotnetUpFixtures/*.*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
     <Using Include="Xunit" />
   </ItemGroup>
 

--- a/tests/MauiSherpa.Workloads.Tests/Models/SdkFeatureBandTests.cs
+++ b/tests/MauiSherpa.Workloads.Tests/Models/SdkFeatureBandTests.cs
@@ -1,0 +1,27 @@
+using FluentAssertions;
+using MauiSherpa.Workloads.Models;
+
+namespace MauiSherpa.Workloads.Tests.Models;
+
+public class SdkFeatureBandTests
+{
+    [Theory]
+    [InlineData("6.0.100", "6.0.100")]
+    [InlineData("10.0.512", "10.0.500")]
+    [InlineData("11.0.100-preview.6.26359.118", "11.0.100-preview.6")]
+    [InlineData("6.0.100-rc.2.21505.57", "6.0.100-rc.2")]
+    [InlineData("7.0.100-alpha.1.21558.2", "7.0.100-alpha.1")]
+    [InlineData("7.0.100-dev", "7.0.100")]
+    [InlineData("7.0.100-ci", "7.0.100")]
+    public void ParsesSdkFeatureBandsLikeTheSdk(string version, string expected)
+    {
+        new SdkFeatureBand(version).ToString().Should().Be(expected);
+    }
+
+    [Fact]
+    public void SdkVersionUsesPrereleaseFeatureBand()
+    {
+        SdkVersion.Parse("11.0.100-preview.6.26359.118").FeatureBand
+            .Should().Be("11.0.100-preview.6");
+    }
+}

--- a/tests/MauiSherpa.Workloads.Tests/Models/WorkloadSetTests.cs
+++ b/tests/MauiSherpa.Workloads.Tests/Models/WorkloadSetTests.cs
@@ -13,7 +13,7 @@ public class WorkloadSetTests
         {
             Version = "10.0.100",
             FeatureBand = "10.0.100",
-            Workloads = new Dictionary<string, WorkloadSetEntry>
+            ManifestEntries = new Dictionary<string, WorkloadSetEntry>
             {
                 ["microsoft.net.sdk.maui"] = new WorkloadSetEntry
                 {
@@ -27,7 +27,7 @@ public class WorkloadSetTests
         // Assert
         workloadSet.Version.Should().Be("10.0.100");
         workloadSet.FeatureBand.Should().Be("10.0.100");
-        workloadSet.Workloads.Should().ContainKey("microsoft.net.sdk.maui");
+        workloadSet.ManifestEntries.Should().ContainKey("microsoft.net.sdk.maui");
     }
 
     [Fact]

--- a/tests/MauiSherpa.Workloads.Tests/Services/DotnetSdkPresentationBuilderTests.cs
+++ b/tests/MauiSherpa.Workloads.Tests/Services/DotnetSdkPresentationBuilderTests.cs
@@ -1,0 +1,279 @@
+using FluentAssertions;
+using MauiSherpa.Workloads.Models;
+using MauiSherpa.Workloads.Services;
+
+namespace MauiSherpa.Workloads.Tests.Services;
+
+public class DotnetSdkPresentationBuilderTests
+{
+    [Fact]
+    public void Build_GroupsInstalledComponentsByMajorMinorDescending()
+    {
+        var list = new DotnetUpListResult
+        {
+            Installations =
+            [
+                Installation(DotnetUpComponent.Runtime, "10.0.8", isValid: false),
+                Installation(DotnetUpComponent.Sdk, "10.0.302"),
+                Installation(DotnetUpComponent.Sdk, "10.0.203"),
+                Installation(DotnetUpComponent.AspNetCore, "10.0.8"),
+                Installation(DotnetUpComponent.Sdk, "9.0.305"),
+                Installation(DotnetUpComponent.Runtime, "9.0.9")
+            ]
+        };
+
+        var summary = DotnetSdkPresentationBuilder.Build(list, workloadInventories:
+        [
+            Inventory("10.0.302", "/dotnet", "arm64"),
+            Inventory("10.0.203", "/dotnet", "arm64"),
+            Inventory("10.0.301", "/alt-dotnet", "x64"),
+            Inventory("9.0.305", "/dotnet", "arm64")
+        ]);
+
+        summary.InstalledGroups.Select(group => group.MajorMinor)
+            .Should().Equal("10.0", "9.0");
+
+        var tenGroup = summary.InstalledGroups[0];
+        tenGroup.NewestSdkVersion.Should().Be("10.0.302");
+        tenGroup.Counts.Should().BeEquivalentTo(new DotnetInstalledComponentCounts
+        {
+            Total = 4,
+            Sdk = 2,
+            Runtime = 1,
+            AspNetCore = 1
+        });
+        tenGroup.HasInvalidComponents.Should().BeTrue();
+        tenGroup.WorkloadFeatureBandCount.Should().Be(2);
+        tenGroup.WorkloadInventories
+            .Select(inventory => inventory.Target.FeatureBand.ToString())
+            .Should().Equal("10.0.300", "10.0.300", "10.0.200");
+        tenGroup.Installations
+            .Select(installation => (installation.Component, installation.Version))
+            .Should().Equal(
+                (DotnetUpComponent.Sdk, "10.0.302"),
+                (DotnetUpComponent.Sdk, "10.0.203"),
+                (DotnetUpComponent.Runtime, "10.0.8"),
+                (DotnetUpComponent.AspNetCore, "10.0.8"));
+    }
+
+    [Fact]
+    public void Build_SplitsTrackedSdkChannelsFromNonSdkSpecs()
+    {
+        var list = new DotnetUpListResult
+        {
+            InstallSpecs =
+            [
+                Spec(DotnetUpComponent.Runtime, "10.0"),
+                Spec(DotnetUpComponent.Sdk, "preview"),
+                Spec(DotnetUpComponent.Sdk, "10.0.103"),
+                Spec(DotnetUpComponent.AspNetCore, "9.0")
+            ]
+        };
+
+        var summary = DotnetSdkPresentationBuilder.Build(list);
+
+        summary.TrackedSdkChannels.Select(channel => (channel.Channel, channel.IsPinned))
+            .Should().Equal(("preview", false), ("10.0.103", true));
+
+        summary.TrackedNonSdkSpecs.Select(spec => (spec.Component, spec.VersionOrChannel))
+            .Should().Equal(
+                (DotnetUpComponent.Runtime, "10.0"),
+                (DotnetUpComponent.AspNetCore, "9.0"));
+    }
+
+    [Fact]
+    public void Build_ComputesAggregateUpdateStateIncludingUnresolvedChannels()
+    {
+        var summary = DotnetSdkPresentationBuilder.Build(
+            list: new DotnetUpListResult(),
+            updatePreviews:
+            [
+                new DotnetUpdatePreview
+                {
+                    Component = DotnetUpComponent.Sdk,
+                    Channel = "10.0.1xx",
+                    InstalledVersion = "10.0.100",
+                    AvailableVersion = "10.0.103",
+                    UpdateAvailable = true,
+                    IsPinned = false
+                },
+                new DotnetUpdatePreview
+                {
+                    Component = DotnetUpComponent.Runtime,
+                    Channel = "9.0",
+                    InstalledVersion = "9.0.9",
+                    AvailableVersion = null,
+                    UpdateAvailable = false,
+                    IsPinned = false
+                },
+                new DotnetUpdatePreview
+                {
+                    Component = DotnetUpComponent.Sdk,
+                    Channel = "10.0.103",
+                    InstalledVersion = "10.0.103",
+                    AvailableVersion = "10.0.103",
+                    UpdateAvailable = false,
+                    IsPinned = true
+                },
+                new DotnetUpdatePreview
+                {
+                    Component = DotnetUpComponent.AspNetCore,
+                    Channel = "10.0",
+                    InstalledVersion = "10.0.8",
+                    AvailableVersion = "10.0.8",
+                    UpdateAvailable = false,
+                    IsPinned = false
+                }
+            ]);
+
+        summary.Updates.Should().BeEquivalentTo(new
+        {
+            IsChecked = true,
+            PreviewCount = 4,
+            AvailableUpdateCount = 1,
+            SdkUpdateCount = 1,
+            RuntimeUpdateCount = 0,
+            UnresolvedCount = 1,
+            HasUpdates = true,
+            HasUnresolvedNonPinnedChannels = true
+        });
+    }
+
+    [Fact]
+    public void FilterProjectWorkloadInventories_UsesInstalledVersionRootArchitectureAndFeatureBand()
+    {
+        var inventories = new[]
+        {
+            Inventory("10.0.302", "/dotnet", "arm64"),
+            Inventory("10.0.302", "/dotnet", "x64"),
+            Inventory("10.0.302", "/other", "arm64"),
+            Inventory("10.0.203", "/dotnet", "arm64"),
+        };
+        var resolution = new GlobalJsonResolution
+        {
+            FolderPath = "/repo",
+            Status = GlobalJsonStatus.Resolved,
+            InstalledVersion = "10.0.302",
+            InstalledSdkInstallRoot = "/dotnet",
+            InstalledSdkArchitecture = "arm64"
+        };
+
+        var matches = DotnetSdkPresentationBuilder.FilterProjectWorkloadInventories(resolution, inventories);
+        var summary = DotnetSdkPresentationBuilder.Build(new DotnetUpListResult(), inventories, projectResolution: resolution);
+
+        matches.Should().ContainSingle();
+        matches[0].Target.FeatureBand.Should().Be(new SdkFeatureBand("10.0.302"));
+        summary.ProjectWorkloads.Should().NotBeNull();
+        summary.ProjectWorkloads!.FeatureBand.Should().Be(new SdkFeatureBand("10.0.302"));
+        summary.ProjectWorkloads.MatchingInventories.Should().ContainSingle();
+        summary.ProjectWorkloads.SelectedInventory.Should().BeSameAs(matches[0]);
+    }
+
+    [Fact]
+    public void BuildProjectInstalledGroup_UsesExactSdkAndRelatedRuntimeLineFromResolvedTarget()
+    {
+        var installations = new[]
+        {
+            Installation(DotnetUpComponent.Sdk, "10.0.302"),
+            Installation(DotnetUpComponent.Sdk, "10.0.301"),
+            Installation(DotnetUpComponent.Runtime, "10.0.8"),
+            Installation(DotnetUpComponent.AspNetCore, "10.0.8"),
+            Installation(DotnetUpComponent.Runtime, "9.0.9"),
+            Installation(DotnetUpComponent.Runtime, "10.0.8", installRoot: "/other")
+        };
+        var inventories = new[]
+        {
+            Inventory("10.0.302", "/dotnet", "arm64"),
+            Inventory("10.0.302", "/other", "arm64")
+        };
+        var resolution = new GlobalJsonResolution
+        {
+            FolderPath = "/repo",
+            Status = GlobalJsonStatus.Resolved,
+            InstalledVersion = "10.0.302",
+            InstalledSdkInstallRoot = "/dotnet",
+            InstalledSdkArchitecture = "arm64"
+        };
+
+        var group = DotnetSdkPresentationBuilder.BuildProjectInstalledGroup(
+            resolution,
+            installations,
+            inventories);
+
+        group.Should().NotBeNull();
+        group!.DisplayName.Should().Be(".NET 10.0");
+        group.Installations.Select(installation => (installation.Component, installation.Version))
+            .Should().Equal(
+                (DotnetUpComponent.Sdk, "10.0.302"),
+                (DotnetUpComponent.Runtime, "10.0.8"),
+                (DotnetUpComponent.AspNetCore, "10.0.8"));
+        group.WorkloadInventories.Should().ContainSingle();
+        group.WorkloadInventories[0].Target.InstallRoot.Should().Be("/dotnet");
+    }
+
+    [Fact]
+    public void BuildProjectInstalledGroup_ReturnsNullForAmbiguousSdkTargets()
+    {
+        var installations = new[]
+        {
+            Installation(DotnetUpComponent.Sdk, "10.0.302"),
+            Installation(DotnetUpComponent.Sdk, "10.0.302", installRoot: "/other")
+        };
+        var resolution = new GlobalJsonResolution
+        {
+            FolderPath = "/repo",
+            Status = GlobalJsonStatus.Resolved,
+            InstalledVersion = "10.0.302"
+        };
+
+        DotnetSdkPresentationBuilder.BuildProjectInstalledGroup(
+                resolution,
+                installations,
+                workloadInventories: null)
+            .Should().BeNull();
+    }
+
+    private static DotnetUpInstallation Installation(
+        DotnetUpComponent component,
+        string version,
+        bool isValid = true,
+        string installRoot = "/dotnet",
+        string architecture = "arm64") => new()
+        {
+            Component = component,
+            ComponentRaw = component.ToString(),
+            Version = version,
+            InstallRoot = installRoot,
+            Architecture = architecture,
+            IsValid = isValid
+        };
+
+    private static DotnetUpInstallSpec Spec(
+        DotnetUpComponent component,
+        string versionOrChannel,
+        string installRoot = "/dotnet",
+        string architecture = "arm64") => new()
+        {
+            Component = component,
+            ComponentRaw = component.ToString(),
+            VersionOrChannel = versionOrChannel,
+            Source = DotnetUpInstallSource.Explicit,
+            InstallRoot = installRoot,
+            Architecture = architecture
+        };
+
+    private static DotnetWorkloadInventory Inventory(
+        string sdkVersion,
+        string installRoot,
+        string architecture) => new()
+        {
+            Target = new DotnetWorkloadTarget
+            {
+                InstallRoot = installRoot,
+                DotnetPath = Path.Combine(installRoot, "dotnet"),
+                Architecture = architecture,
+                FeatureBand = new SdkFeatureBand(sdkVersion),
+                RepresentativeSdkVersion = sdkVersion
+            }
+        };
+}

--- a/tests/MauiSherpa.Workloads.Tests/Services/DotnetUpArgumentsTests.cs
+++ b/tests/MauiSherpa.Workloads.Tests/Services/DotnetUpArgumentsTests.cs
@@ -1,0 +1,115 @@
+using FluentAssertions;
+using MauiSherpa.Workloads.Models;
+using MauiSherpa.Workloads.Services;
+
+namespace MauiSherpa.Workloads.Tests.Services;
+
+public class DotnetUpArgumentsTests
+{
+    [Fact]
+    public void List_UsesFormatJson_NotJsonFlag()
+    {
+        var args = DotnetUpArguments.List();
+
+        args.Should().Equal("list", "--format", "Json");
+        args.Should().NotContain("--json");
+    }
+
+    [Fact]
+    public void List_NoVerify_AppendsFlag()
+    {
+        DotnetUpArguments.List(noVerify: true)
+            .Should().Equal("list", "--format", "Json", "--no-verify");
+    }
+
+    [Fact]
+    public void Info_IsInfoFlag()
+    {
+        DotnetUpArguments.Info().Should().Equal("--info");
+    }
+
+    [Fact]
+    public void SdkInstall_TerminalMode_SetsDefaultInstallAndNoProgress()
+    {
+        var args = DotnetUpArguments.SdkInstall("lts", setDefaultInstall: true);
+
+        args.Should().Equal("sdk", "install", "lts", "--set-default-install", "--no-progress");
+    }
+
+    [Fact]
+    public void SdkInstall_NoChannel_OmitsChannelToken()
+    {
+        var args = DotnetUpArguments.SdkInstall(channel: null, setDefaultInstall: false);
+
+        args.Should().Equal("sdk", "install", "--no-progress");
+    }
+
+    [Fact]
+    public void SdkInstall_UpdateGlobalJson_AddsFlag()
+    {
+        var args = DotnetUpArguments.SdkInstall("9.0.3xx", setDefaultInstall: true, updateGlobalJson: true);
+
+        args.Should().Equal(
+            "sdk", "install", "9.0.3xx", "--set-default-install", "--update-global-json", "--no-progress");
+    }
+
+    [Fact]
+    public void SdkUpdate_DefaultsToNoProgress()
+    {
+        DotnetUpArguments.SdkUpdate().Should().Equal("sdk", "update", "--no-progress");
+    }
+
+    [Fact]
+    public void SdkUninstall_WithSource_AddsSourceFlag()
+    {
+        DotnetUpArguments.SdkUninstall("9.0.3xx", DotnetUpInstallSource.Explicit)
+            .Should().Equal("sdk", "uninstall", "9.0.3xx", "--source", "Explicit");
+    }
+
+    [Fact]
+    public void SdkUninstall_UnknownSource_OmitsSourceFlag()
+    {
+        DotnetUpArguments.SdkUninstall("9.0.3xx", DotnetUpInstallSource.Unknown)
+            .Should().Equal("sdk", "uninstall", "9.0.3xx");
+    }
+
+    [Fact]
+    public void SdkUninstall_EmptyChannel_Throws()
+    {
+        var act = () => DotnetUpArguments.SdkUninstall("");
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void RuntimeInstall_WithSpec_AddsSpec()
+    {
+        DotnetUpArguments.RuntimeInstall("aspnetcore@9.0")
+            .Should().Equal("runtime", "install", "aspnetcore@9.0", "--no-progress");
+    }
+
+    [Fact]
+    public void RuntimeUpdate_DefaultsToNoProgress()
+    {
+        DotnetUpArguments.RuntimeUpdate().Should().Equal("runtime", "update", "--no-progress");
+    }
+
+    [Fact]
+    public void RuntimeUninstall_AddsSpec()
+    {
+        DotnetUpArguments.RuntimeUninstall("runtime@9.0")
+            .Should().Equal("runtime", "uninstall", "runtime@9.0");
+    }
+
+    [Fact]
+    public void UpdateAll_DefaultsToNoProgress()
+    {
+        DotnetUpArguments.UpdateAll().Should().Equal("update", "--no-progress");
+    }
+
+    [Fact]
+    public void PrintEnvScript_AddsShell()
+    {
+        DotnetUpArguments.PrintEnvScript("zsh")
+            .Should().Equal("print-env-script", "--shell", "zsh");
+    }
+}

--- a/tests/MauiSherpa.Workloads.Tests/Services/DotnetUpDownloaderTests.cs
+++ b/tests/MauiSherpa.Workloads.Tests/Services/DotnetUpDownloaderTests.cs
@@ -1,0 +1,136 @@
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using FluentAssertions;
+using MauiSherpa.Workloads.Services;
+
+namespace MauiSherpa.Workloads.Tests.Services;
+
+public class DotnetUpDownloaderTests
+{
+    [Theory]
+    [InlineData("abc123", "abc123")]
+    [InlineData("ABC123\n", "ABC123")]
+    [InlineData("abc123  dotnetup-osx-arm64", "abc123")]
+    [InlineData("  abc123\t name\n", "abc123")]
+    public void NormalizeChecksum_ExtractsFirstToken(string raw, string expected)
+    {
+        DotnetUpDownloader.NormalizeChecksum(raw).Should().Be(expected);
+    }
+
+    [Fact]
+    public void HashesEqual_IsCaseInsensitive()
+    {
+        DotnetUpDownloader.HashesEqual("ABCDEF", "abcdef").Should().BeTrue();
+        DotnetUpDownloader.HashesEqual("abc", "abd").Should().BeFalse();
+        DotnetUpDownloader.HashesEqual("", "abc").Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ComputeSha512Async_MatchesKnownDigest()
+    {
+        var bytes = Encoding.UTF8.GetBytes("hello dotnetup");
+        var expected = Convert.ToHexString(SHA512.HashData(bytes)).ToLowerInvariant();
+
+        using var stream = new MemoryStream(bytes);
+        var actual = await DotnetUpDownloader.ComputeSha512Async(stream);
+
+        actual.Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task DownloadAndVerifyAsync_ValidChecksum_WritesExecutable()
+    {
+        var payload = Encoding.UTF8.GetBytes("fake-dotnetup-binary");
+        var checksum = Convert.ToHexString(SHA512.HashData(payload)).ToLowerInvariant();
+        var handler = new FakeHandler(payload, checksum + "  dotnetup-osx-arm64");
+        using var client = new HttpClient(handler);
+        var downloader = new DotnetUpDownloader(client);
+
+        var dest = Path.Combine(Path.GetTempPath(), $"dotnetup-test-{Guid.NewGuid():N}", "dotnetup");
+        try
+        {
+            await downloader.DownloadAndVerifyAsync("osx-arm64", dest);
+
+            File.Exists(dest).Should().BeTrue();
+            File.ReadAllBytes(dest).Should().Equal(payload);
+        }
+        finally
+        {
+            var dir = Path.GetDirectoryName(dest);
+            if (dir != null && Directory.Exists(dir))
+                Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task DownloadAndVerifyAsync_BadChecksum_ThrowsAndLeavesNoFile()
+    {
+        var payload = Encoding.UTF8.GetBytes("fake-dotnetup-binary");
+        var handler = new FakeHandler(payload, new string('0', 128));
+        using var client = new HttpClient(handler);
+        var downloader = new DotnetUpDownloader(client);
+
+        var dest = Path.Combine(Path.GetTempPath(), $"dotnetup-test-{Guid.NewGuid():N}", "dotnetup");
+        try
+        {
+            var act = async () => await downloader.DownloadAndVerifyAsync("osx-arm64", dest);
+
+            await act.Should().ThrowAsync<InvalidOperationException>()
+                .WithMessage("*checksum*");
+            File.Exists(dest).Should().BeFalse();
+        }
+        finally
+        {
+            var dir = Path.GetDirectoryName(dest);
+            if (dir != null && Directory.Exists(dir))
+                Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task DownloadAndVerifyAsync_UnsupportedRid_Throws()
+    {
+        using var client = new HttpClient(new FakeHandler(Array.Empty<byte>(), "00"));
+        var downloader = new DotnetUpDownloader(client);
+
+        var act = async () => await downloader.DownloadAndVerifyAsync(
+            "freebsd-x64", Path.Combine(Path.GetTempPath(), "x"));
+
+        await act.Should().ThrowAsync<PlatformNotSupportedException>();
+    }
+
+    private sealed class FakeHandler : HttpMessageHandler
+    {
+        private readonly byte[] _binary;
+        private readonly string _checksumBody;
+
+        public FakeHandler(byte[] binary, string checksumBody)
+        {
+            _binary = binary;
+            _checksumBody = checksumBody;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var url = request.RequestUri!.ToString();
+            HttpResponseMessage response;
+            if (url.EndsWith(".sha512", StringComparison.OrdinalIgnoreCase))
+            {
+                response = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(_checksumBody)
+                };
+            }
+            else
+            {
+                response = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new ByteArrayContent(_binary)
+                };
+            }
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/tests/MauiSherpa.Workloads.Tests/Services/DotnetUpDownloaderTests.cs
+++ b/tests/MauiSherpa.Workloads.Tests/Services/DotnetUpDownloaderTests.cs
@@ -100,15 +100,43 @@ public class DotnetUpDownloaderTests
         await act.Should().ThrowAsync<PlatformNotSupportedException>();
     }
 
+    [Theory]
+    [InlineData(
+        "https://ci.dot.net/public/dotnetup/0.1.4-preview.6.26358.1/dotnetup-osx-arm64.sha512",
+        "0.1.4-preview.6.26358.1")]
+    [InlineData("https://example.test/file", null)]
+    public void ExtractPublishedVersion_UsesParentPathSegment(string url, string? expected)
+    {
+        DotnetUpDownloader.ExtractPublishedVersion(new Uri(url)).Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task GetPublishedArtifactAsync_ReturnsVersionAndChecksum()
+    {
+        var checksum = new string('a', 128);
+        var effectiveUri = new Uri(
+            "https://ci.dot.net/public/dotnetup/0.1.4-preview.6.26358.1/dotnetup-osx-arm64.sha512");
+        var handler = new FakeHandler(Array.Empty<byte>(), checksum, effectiveUri);
+        using var client = new HttpClient(handler);
+        var downloader = new DotnetUpDownloader(client);
+
+        var artifact = await downloader.GetPublishedArtifactAsync("osx-arm64");
+
+        artifact.Version.Should().Be("0.1.4-preview.6.26358.1");
+        artifact.Sha512.Should().Be(checksum);
+    }
+
     private sealed class FakeHandler : HttpMessageHandler
     {
         private readonly byte[] _binary;
         private readonly string _checksumBody;
+        private readonly Uri? _effectiveChecksumUri;
 
-        public FakeHandler(byte[] binary, string checksumBody)
+        public FakeHandler(byte[] binary, string checksumBody, Uri? effectiveChecksumUri = null)
         {
             _binary = binary;
             _checksumBody = checksumBody;
+            _effectiveChecksumUri = effectiveChecksumUri;
         }
 
         protected override Task<HttpResponseMessage> SendAsync(
@@ -122,6 +150,8 @@ public class DotnetUpDownloaderTests
                 {
                     Content = new StringContent(_checksumBody)
                 };
+                if (_effectiveChecksumUri is not null)
+                    response.RequestMessage = new HttpRequestMessage(HttpMethod.Get, _effectiveChecksumUri);
             }
             else
             {

--- a/tests/MauiSherpa.Workloads.Tests/Services/DotnetUpFixtures/info.txt
+++ b/tests/MauiSherpa.Workloads.Tests/Services/DotnetUpFixtures/info.txt
@@ -1,0 +1,33 @@
+dotnetup Information:
+ Version:      0.1.4-preview.6.26323.4
+ Commit:       f555e30                
+ Architecture: arm64                  
+ RID:          osx-arm64              
+
+Installations (managed by dotnetup):
+
+  /Users/redth/Library/Application Support/dotnet
+
+    Tracked channels:
+      .NET SDK 10.0.1xx      (source: explicit)
+      .NET SDK 10.0.2xx      (source: explicit)
+      .NET SDK 10.0.3xx      (source: explicit)
+      .NET SDK 9.0.3xx       (source: explicit)
+      .NET SDK preview       (source: explicit)
+      dotnet (runtime) 10.0  (source: explicit)
+      dotnet (runtime) 9.0   (source: explicit)
+      aspnet (runtime) 10.0  (source: explicit)
+      aspnet (runtime) 9.0   (source: explicit)
+
+    Installed versions:
+      .NET SDK 10.0.103                      (arm64)
+      .NET SDK 10.0.203                      (arm64)
+      .NET SDK 10.0.300                      (arm64)
+      .NET SDK 11.0.100-preview.5.26302.115  (arm64)
+      .NET SDK 9.0.305                       (arm64)
+      dotnet (runtime) 10.0.8                (arm64)
+      dotnet (runtime) 9.0.9                 (arm64)
+      aspnet (runtime) 10.0.8                (arm64)
+      aspnet (runtime) 9.0.9                 (arm64)
+
+Total: 9

--- a/tests/MauiSherpa.Workloads.Tests/Services/DotnetUpFixtures/list.json
+++ b/tests/MauiSherpa.Workloads.Tests/Services/DotnetUpFixtures/list.json
@@ -1,0 +1,150 @@
+{
+  "installSpecs": [
+    {
+      "component": "SDK",
+      "versionOrChannel": "preview",
+      "source": "Explicit",
+      "globalJsonPath": null,
+      "installRoot": "/Users/redth/Library/Application Support/dotnet",
+      "architecture": "arm64"
+    },
+    {
+      "component": "SDK",
+      "versionOrChannel": "10.0.1xx",
+      "source": "Explicit",
+      "globalJsonPath": null,
+      "installRoot": "/Users/redth/Library/Application Support/dotnet",
+      "architecture": "arm64"
+    },
+    {
+      "component": "SDK",
+      "versionOrChannel": "10.0.2xx",
+      "source": "Explicit",
+      "globalJsonPath": null,
+      "installRoot": "/Users/redth/Library/Application Support/dotnet",
+      "architecture": "arm64"
+    },
+    {
+      "component": "SDK",
+      "versionOrChannel": "9.0.3xx",
+      "source": "Explicit",
+      "globalJsonPath": null,
+      "installRoot": "/Users/redth/Library/Application Support/dotnet",
+      "architecture": "arm64"
+    },
+    {
+      "component": "SDK",
+      "versionOrChannel": "10.0.3xx",
+      "source": "Explicit",
+      "globalJsonPath": null,
+      "installRoot": "/Users/redth/Library/Application Support/dotnet",
+      "architecture": "arm64"
+    },
+    {
+      "component": "Runtime",
+      "versionOrChannel": "10.0",
+      "source": "Explicit",
+      "globalJsonPath": null,
+      "installRoot": "/Users/redth/Library/Application Support/dotnet",
+      "architecture": "arm64"
+    },
+    {
+      "component": "ASPNETCore",
+      "versionOrChannel": "10.0",
+      "source": "Explicit",
+      "globalJsonPath": null,
+      "installRoot": "/Users/redth/Library/Application Support/dotnet",
+      "architecture": "arm64"
+    },
+    {
+      "component": "Runtime",
+      "versionOrChannel": "9.0",
+      "source": "Explicit",
+      "globalJsonPath": null,
+      "installRoot": "/Users/redth/Library/Application Support/dotnet",
+      "architecture": "arm64"
+    },
+    {
+      "component": "ASPNETCore",
+      "versionOrChannel": "9.0",
+      "source": "Explicit",
+      "globalJsonPath": null,
+      "installRoot": "/Users/redth/Library/Application Support/dotnet",
+      "architecture": "arm64"
+    }
+  ],
+  "installations": [
+    {
+      "component": "SDK",
+      "version": "11.0.100-preview.5.26302.115",
+      "installRoot": "/Users/redth/Library/Application Support/dotnet",
+      "architecture": "arm64",
+      "isValid": true,
+      "frameworkName": ".NET SDK"
+    },
+    {
+      "component": "SDK",
+      "version": "10.0.103",
+      "installRoot": "/Users/redth/Library/Application Support/dotnet",
+      "architecture": "arm64",
+      "isValid": true,
+      "frameworkName": ".NET SDK"
+    },
+    {
+      "component": "SDK",
+      "version": "10.0.203",
+      "installRoot": "/Users/redth/Library/Application Support/dotnet",
+      "architecture": "arm64",
+      "isValid": true,
+      "frameworkName": ".NET SDK"
+    },
+    {
+      "component": "SDK",
+      "version": "9.0.305",
+      "installRoot": "/Users/redth/Library/Application Support/dotnet",
+      "architecture": "arm64",
+      "isValid": true,
+      "frameworkName": ".NET SDK"
+    },
+    {
+      "component": "SDK",
+      "version": "10.0.300",
+      "installRoot": "/Users/redth/Library/Application Support/dotnet",
+      "architecture": "arm64",
+      "isValid": true,
+      "frameworkName": ".NET SDK"
+    },
+    {
+      "component": "Runtime",
+      "version": "10.0.8",
+      "installRoot": "/Users/redth/Library/Application Support/dotnet",
+      "architecture": "arm64",
+      "isValid": true,
+      "frameworkName": "Microsoft.NETCore.App"
+    },
+    {
+      "component": "ASPNETCore",
+      "version": "10.0.8",
+      "installRoot": "/Users/redth/Library/Application Support/dotnet",
+      "architecture": "arm64",
+      "isValid": true,
+      "frameworkName": "Microsoft.AspNetCore.App"
+    },
+    {
+      "component": "Runtime",
+      "version": "9.0.9",
+      "installRoot": "/Users/redth/Library/Application Support/dotnet",
+      "architecture": "arm64",
+      "isValid": true,
+      "frameworkName": "Microsoft.NETCore.App"
+    },
+    {
+      "component": "ASPNETCore",
+      "version": "9.0.9",
+      "installRoot": "/Users/redth/Library/Application Support/dotnet",
+      "architecture": "arm64",
+      "isValid": true,
+      "frameworkName": "Microsoft.AspNetCore.App"
+    }
+  ]
+}

--- a/tests/MauiSherpa.Workloads.Tests/Services/DotnetUpParserTests.cs
+++ b/tests/MauiSherpa.Workloads.Tests/Services/DotnetUpParserTests.cs
@@ -1,0 +1,147 @@
+using FluentAssertions;
+using MauiSherpa.Workloads.Models;
+using MauiSherpa.Workloads.Services;
+
+namespace MauiSherpa.Workloads.Tests.Services;
+
+public class DotnetUpParserTests
+{
+    private static string FixturePath(string name) =>
+        Path.Combine(AppContext.BaseDirectory, "Services", "DotnetUpFixtures", name);
+
+    private static string ReadFixture(string name) => File.ReadAllText(FixturePath(name));
+
+    [Fact]
+    public void ParseList_RealFixture_ParsesInstallSpecsAndInstallations()
+    {
+        var json = ReadFixture("list.json");
+
+        var result = DotnetUpParser.ParseList(json);
+
+        result.InstallSpecs.Should().HaveCount(9);
+        result.Installations.Should().HaveCount(9);
+    }
+
+    [Fact]
+    public void ParseList_MapsComponentsAndSources()
+    {
+        var json = ReadFixture("list.json");
+
+        var result = DotnetUpParser.ParseList(json);
+
+        result.InstallSpecs.Should().Contain(s =>
+            s.Component == DotnetUpComponent.Sdk &&
+            s.VersionOrChannel == "10.0.1xx" &&
+            s.Source == DotnetUpInstallSource.Explicit);
+
+        result.InstallSpecs.Should().Contain(s =>
+            s.Component == DotnetUpComponent.AspNetCore &&
+            s.VersionOrChannel == "10.0");
+
+        result.InstallSpecs.Should().Contain(s =>
+            s.Component == DotnetUpComponent.Runtime &&
+            s.VersionOrChannel == "9.0");
+    }
+
+    [Fact]
+    public void ParseList_MapsInstallationFields()
+    {
+        var json = ReadFixture("list.json");
+
+        var result = DotnetUpParser.ParseList(json);
+
+        var preview = result.Installations.Single(i => i.Version == "11.0.100-preview.5.26302.115");
+        preview.Component.Should().Be(DotnetUpComponent.Sdk);
+        preview.ComponentRaw.Should().Be("SDK");
+        preview.InstallRoot.Should().Be("/Users/redth/Library/Application Support/dotnet");
+        preview.Architecture.Should().Be("arm64");
+        preview.IsValid.Should().BeTrue();
+        preview.FrameworkName.Should().Be(".NET SDK");
+
+        var runtime = result.Installations.Single(i =>
+            i.Component == DotnetUpComponent.Runtime && i.Version == "10.0.8");
+        runtime.FrameworkName.Should().Be("Microsoft.NETCore.App");
+    }
+
+    [Fact]
+    public void ParseList_InstallRoots_Deduplicates()
+    {
+        var json = ReadFixture("list.json");
+
+        var result = DotnetUpParser.ParseList(json);
+
+        result.InstallRoots.Should().ContainSingle()
+            .Which.Should().Be("/Users/redth/Library/Application Support/dotnet");
+    }
+
+    [Fact]
+    public void GetManagedSdkVersions_ReturnsOnlySdks()
+    {
+        var json = ReadFixture("list.json");
+        var result = DotnetUpParser.ParseList(json);
+
+        var versions = DotnetUpParser.GetManagedSdkVersions(result);
+
+        versions.Should().BeEquivalentTo(new[]
+        {
+            "11.0.100-preview.5.26302.115",
+            "10.0.103",
+            "10.0.203",
+            "9.0.305",
+            "10.0.300"
+        });
+    }
+
+    [Fact]
+    public void ParseList_EmptyOrWhitespace_ReturnsEmpty()
+    {
+        DotnetUpParser.ParseList("").InstallSpecs.Should().BeEmpty();
+        DotnetUpParser.ParseList("   ").Installations.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ParseList_MissingArrays_DoesNotThrow()
+    {
+        var result = DotnetUpParser.ParseList("{}");
+
+        result.InstallSpecs.Should().BeEmpty();
+        result.Installations.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ParseList_UnknownComponent_MapsToUnknownButKeepsRaw()
+    {
+        var json = """
+        { "installations": [
+          { "component": "Mystery", "version": "1.2.3", "installRoot": "/tmp", "architecture": "arm64", "isValid": true }
+        ] }
+        """;
+
+        var result = DotnetUpParser.ParseList(json);
+
+        var only = result.Installations.Single();
+        only.Component.Should().Be(DotnetUpComponent.Unknown);
+        only.ComponentRaw.Should().Be("Mystery");
+    }
+
+    [Fact]
+    public void ParseInfo_RealFixture_ExtractsToolDetails()
+    {
+        var text = ReadFixture("info.txt");
+
+        var info = DotnetUpParser.ParseInfo(text);
+
+        info.Should().NotBeNull();
+        info!.Version.Should().Be("0.1.4-preview.6.26323.4");
+        info.Commit.Should().Be("f555e30");
+        info.Architecture.Should().Be("arm64");
+        info.Rid.Should().Be("osx-arm64");
+    }
+
+    [Fact]
+    public void ParseInfo_EmptyOrUnrecognized_ReturnsNull()
+    {
+        DotnetUpParser.ParseInfo("").Should().BeNull();
+        DotnetUpParser.ParseInfo("no version here").Should().BeNull();
+    }
+}

--- a/tests/MauiSherpa.Workloads.Tests/Services/DotnetUpRuntimeIdentifierTests.cs
+++ b/tests/MauiSherpa.Workloads.Tests/Services/DotnetUpRuntimeIdentifierTests.cs
@@ -1,0 +1,61 @@
+using FluentAssertions;
+using MauiSherpa.Workloads.Services;
+
+namespace MauiSherpa.Workloads.Tests.Services;
+
+public class DotnetUpRuntimeIdentifierTests
+{
+    [Theory]
+    [InlineData("win-x64", "dotnetup-win-x64.exe", "dotnetup.exe")]
+    [InlineData("win-arm64", "dotnetup-win-arm64.exe", "dotnetup.exe")]
+    [InlineData("osx-arm64", "dotnetup-osx-arm64", "dotnetup")]
+    [InlineData("osx-x64", "dotnetup-osx-x64", "dotnetup")]
+    [InlineData("linux-x64", "dotnetup-linux-x64", "dotnetup")]
+    [InlineData("linux-musl-arm64", "dotnetup-linux-musl-arm64", "dotnetup")]
+    public void FileNames_AreRidAndOsSpecific(string rid, string downloadName, string exeName)
+    {
+        DotnetUpRuntimeIdentifier.GetDownloadFileName(rid).Should().Be(downloadName);
+        DotnetUpRuntimeIdentifier.GetExecutableFileName(rid).Should().Be(exeName);
+    }
+
+    [Fact]
+    public void GetDownloadUrl_DefaultsToDailyQuality()
+    {
+        DotnetUpRuntimeIdentifier.GetDownloadUrl("osx-arm64")
+            .Should().Be("https://aka.ms/dotnet/dotnetup/daily/dotnetup-osx-arm64");
+    }
+
+    [Fact]
+    public void GetDownloadUrl_HonorsCustomQuality()
+    {
+        DotnetUpRuntimeIdentifier.GetDownloadUrl("win-x64", "ga")
+            .Should().Be("https://aka.ms/dotnet/dotnetup/ga/dotnetup-win-x64.exe");
+    }
+
+    [Fact]
+    public void GetChecksumUrl_AppendsSha512()
+    {
+        DotnetUpRuntimeIdentifier.GetChecksumUrl("osx-arm64")
+            .Should().Be("https://aka.ms/dotnet/dotnetup/daily/dotnetup-osx-arm64.sha512");
+    }
+
+    [Theory]
+    [InlineData("osx-arm64", true)]
+    [InlineData("win-x64", true)]
+    [InlineData("linux-musl-x64", true)]
+    [InlineData("freebsd-x64", false)]
+    [InlineData("osx-x86", false)]
+    public void IsSupportedRid_MatchesPublishedList(string rid, bool expected)
+    {
+        DotnetUpRuntimeIdentifier.IsSupportedRid(rid).Should().Be(expected);
+    }
+
+    [Fact]
+    public void DetectCurrent_ReturnsSupportedRid()
+    {
+        var rid = DotnetUpRuntimeIdentifier.DetectCurrent();
+
+        DotnetUpRuntimeIdentifier.IsSupportedRid(rid).Should().BeTrue(
+            because: $"detected RID '{rid}' should be one dotnetup publishes");
+    }
+}

--- a/tests/MauiSherpa.Workloads.Tests/Services/DotnetUpdateResolverTests.cs
+++ b/tests/MauiSherpa.Workloads.Tests/Services/DotnetUpdateResolverTests.cs
@@ -1,0 +1,33 @@
+using FluentAssertions;
+using MauiSherpa.Workloads.Models;
+using MauiSherpa.Workloads.Services;
+
+namespace MauiSherpa.Workloads.Tests.Services;
+
+public class DotnetUpdateResolverTests
+{
+    [Fact]
+    public async Task ResolveChannelAsync_ExactVersionReportsMissingWhenNotInstalled()
+    {
+        var result = await new DotnetUpdateResolver().ResolveChannelAsync(
+            DotnetUpComponent.Sdk,
+            "10.0.302",
+            new DotnetUpListResult());
+
+        result.Available.Should().Be("10.0.302");
+        result.Installed.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("10.0.303", "10.0.302", true)]
+    [InlineData("10.0.302", "10.0.302", false)]
+    [InlineData("10.0.301", "10.0.302", false)]
+    [InlineData("11.0.100-preview.6.26359.118", "11.0.100-preview.5.26302.115", true)]
+    public void IsUpdateAvailable_UsesSemanticVersionOrdering(
+        string available,
+        string installed,
+        bool expected)
+    {
+        DotnetUpdateResolver.IsUpdateAvailable(available, installed).Should().Be(expected);
+    }
+}

--- a/tests/MauiSherpa.Workloads.Tests/Services/DotnetWorkloadParserTests.cs
+++ b/tests/MauiSherpa.Workloads.Tests/Services/DotnetWorkloadParserTests.cs
@@ -1,0 +1,95 @@
+using FluentAssertions;
+using MauiSherpa.Workloads.Models;
+using MauiSherpa.Workloads.Services;
+
+namespace MauiSherpa.Workloads.Tests.Services;
+
+public class DotnetWorkloadParserTests
+{
+    [Fact]
+    public void ParsesMachineReadableListWithPreamble()
+    {
+        const string output = """
+        Skipping NuGet package signature verification.
+        {"installed":["wasm-tools","android"],"updateAvailable":[{"existingManifestVersion":"36.1.53","availableUpdateManifestVersion":"36.1.69","description":"Android workload","workloadId":"android"}]}
+        """;
+
+        var result = DotnetWorkloadParser.ParseMachineReadableList(output);
+
+        result.UsedMachineReadableOutput.Should().BeTrue();
+        result.Installed.Select(item => item.Id).Should().Equal("android", "wasm-tools");
+        result.Updates.Should().ContainSingle()
+            .Which.AvailableManifestVersion.Should().Be("36.1.69");
+    }
+
+    [Fact]
+    public void ParsesPlainListFallback()
+    {
+        const string output = """
+
+        Workload version: 10.0.300.1
+
+        Installed Workload Id      Manifest Version       Installation Source
+        ---------------------------------------------------------------------
+        android                    36.1.53/10.0.100       SDK 10.0.300
+        wasm-tools                 10.0.108/10.0.100      SDK 10.0.300
+
+        Use `dotnet workload search` to find additional workloads to install.
+        """;
+
+        var result = DotnetWorkloadParser.ParsePlainList(output);
+
+        result.UsedMachineReadableOutput.Should().BeFalse();
+        result.Installed.Should().HaveCount(2);
+        result.Installed[0].ManifestVersion.Should().Be("36.1.53/10.0.100");
+        result.Installed[1].InstallationSource.Should().Be("SDK 10.0.300");
+    }
+
+    [Fact]
+    public void ParsesAvailableSetVersionsInSemanticOrder()
+    {
+        const string output = """
+        [{"workloadVersion":"10.0.300.3"},{"workloadVersion":"10.0.302"},{"workloadVersion":"10.0.301.1"}]
+        """;
+
+        DotnetWorkloadParser.ParseAvailableSetVersions(output)
+            .Select(item => item.Version)
+            .Should().Equal("10.0.302", "10.0.301.1", "10.0.300.3");
+    }
+
+    [Fact]
+    public void ParsesWorkloadSetManifestMap()
+    {
+        const string output = """
+        {
+          "manifestVersions": {
+            "microsoft.net.sdk.android": "36.1.53/10.0.100",
+            "microsoft.net.sdk.maui": "10.0.20/10.0.100"
+          }
+        }
+        """;
+
+        var result = DotnetWorkloadParser.ParseManifestVersions(output);
+
+        result.Should().HaveCount(2);
+        result[0].ManifestId.Should().Be("microsoft.net.sdk.android");
+        result[0].Version.Should().Be("36.1.53");
+        result[0].FeatureBand.Should().Be("10.0.100");
+    }
+
+    [Theory]
+    [InlineData("10.0.300.1", DotnetWorkloadUpdateMode.WorkloadSet)]
+    [InlineData("11.0.100-manifests.d0c9cb64", DotnetWorkloadUpdateMode.Unknown)]
+    public void InfersModeFromResolvedVersion(string version, DotnetWorkloadUpdateMode expected)
+    {
+        DotnetWorkloadParser.InferUpdateMode(version).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("The workload update mode is workload-set.", DotnetWorkloadUpdateMode.WorkloadSet)]
+    [InlineData("manifests", DotnetWorkloadUpdateMode.Manifests)]
+    public void ParsesConfiguredUpdateMode(string output, DotnetWorkloadUpdateMode expected)
+    {
+        DotnetWorkloadParser.ParseConfiguredUpdateMode(output).Should().Be(expected);
+    }
+}

--- a/tests/MauiSherpa.Workloads.Tests/Services/GlobalJsonResolverTests.cs
+++ b/tests/MauiSherpa.Workloads.Tests/Services/GlobalJsonResolverTests.cs
@@ -112,6 +112,26 @@ public class GlobalJsonResolverTests
     }
 
     [Fact]
+    public void Resolve_ParsesOfficialWorkloadVersionWithJsonComments()
+    {
+        using var temp = new TempDir();
+        temp.WriteGlobalJson("""
+        {
+          // Project toolchain
+          "sdk": {
+            "version": "10.0.302",
+            "workloadVersion": "10.0.300.1",
+          },
+        }
+        """);
+
+        var result = new GlobalJsonResolver().Resolve(temp.Path);
+
+        result.WorkloadVersion.Should().Be("10.0.300.1");
+        result.UsesLegacyWorkloadSetProperty.Should().BeFalse();
+    }
+
+    [Fact]
     public void Resolve_WalksUpToNearestGlobalJson()
     {
         using var temp = new TempDir();

--- a/tests/MauiSherpa.Workloads.Tests/Services/GlobalJsonResolverTests.cs
+++ b/tests/MauiSherpa.Workloads.Tests/Services/GlobalJsonResolverTests.cs
@@ -1,0 +1,177 @@
+using FluentAssertions;
+using MauiSherpa.Workloads.Models;
+using MauiSherpa.Workloads.Services;
+
+namespace MauiSherpa.Workloads.Tests.Services;
+
+public class GlobalJsonResolverTests
+{
+    // ===== DeriveChannel: rollForward -> channel mapping =====
+
+    [Theory]
+    [InlineData("10.0.100", null, "10.0.1xx", false)]            // default = latestPatch
+    [InlineData("10.0.100", "latestPatch", "10.0.1xx", false)]
+    [InlineData("10.0.203", "latestPatch", "10.0.2xx", false)]   // band = hundreds digit of patch
+    [InlineData("9.0.305", "latestPatch", "9.0.3xx", false)]
+    [InlineData("10.0.100", "latestFeature", "10.0", false)]
+    [InlineData("10.0.100", "latestMinor", "10", false)]
+    [InlineData("10.0.100", "latestMajor", "latest", false)]
+    public void DeriveChannel_RollingPolicies_MapToRollingChannel(
+        string version, string? rollForward, string expectedChannel, bool expectedPinned)
+    {
+        var (channel, pinned) = GlobalJsonResolver.DeriveChannel(version, rollForward);
+
+        channel.Should().Be(expectedChannel);
+        pinned.Should().Be(expectedPinned);
+    }
+
+    [Theory]
+    [InlineData("disable")]
+    [InlineData("patch")]
+    [InlineData("feature")]
+    [InlineData("minor")]
+    [InlineData("major")]
+    public void DeriveChannel_PinnedPolicies_ReturnExactVersionPinned(string rollForward)
+    {
+        var (channel, pinned) = GlobalJsonResolver.DeriveChannel("10.0.203", rollForward);
+
+        channel.Should().Be("10.0.203");
+        pinned.Should().BeTrue();
+    }
+
+    [Fact]
+    public void DeriveChannel_IsCaseInsensitive()
+    {
+        GlobalJsonResolver.DeriveChannel("10.0.100", "LATESTFEATURE").Channel.Should().Be("10.0");
+        GlobalJsonResolver.DeriveChannel("10.0.100", "Disable").IsPinned.Should().BeTrue();
+    }
+
+    // ===== Resolve: discovery + parsing =====
+
+    [Fact]
+    public void Resolve_NoGlobalJson_ReturnsNoGlobalJsonStatus()
+    {
+        using var temp = new TempDir();
+
+        var result = new GlobalJsonResolver().Resolve(temp.Path);
+
+        result.Status.Should().Be(GlobalJsonStatus.NoGlobalJson);
+        result.GlobalJsonPath.Should().BeNull();
+        result.Channel.Should().BeNull();
+    }
+
+    [Fact]
+    public void Resolve_GlobalJsonWithoutSdkVersion_ReturnsNoSdkVersion()
+    {
+        using var temp = new TempDir();
+        temp.WriteGlobalJson("""{ "sdk": { "rollForward": "latestFeature" } }""");
+
+        var result = new GlobalJsonResolver().Resolve(temp.Path);
+
+        result.Status.Should().Be(GlobalJsonStatus.NoSdkVersion);
+        result.GlobalJsonPath.Should().NotBeNull();
+        result.RollForward.Should().Be("latestFeature");
+    }
+
+    [Fact]
+    public void Resolve_GlobalJsonWithVersion_DerivesChannelAndDefaultsRollForward()
+    {
+        using var temp = new TempDir();
+        temp.WriteGlobalJson("""{ "sdk": { "version": "9.0.305" } }""");
+
+        var result = new GlobalJsonResolver().Resolve(temp.Path);
+
+        result.Status.Should().Be(GlobalJsonStatus.Resolved);
+        result.RequestedVersion.Should().Be("9.0.305");
+        result.RollForward.Should().Be("latestPatch"); // defaulted when omitted
+        result.Channel.Should().Be("9.0.3xx");
+        result.IsPinned.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Resolve_PinnedRollForward_MarksPinned()
+    {
+        using var temp = new TempDir();
+        temp.WriteGlobalJson("""{ "sdk": { "version": "10.0.204", "rollForward": "disable" } }""");
+
+        var result = new GlobalJsonResolver().Resolve(temp.Path);
+
+        result.Channel.Should().Be("10.0.204");
+        result.IsPinned.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Resolve_ParsesAllowPrerelease()
+    {
+        using var temp = new TempDir();
+        temp.WriteGlobalJson("""{ "sdk": { "version": "10.0.100", "allowPrerelease": false } }""");
+
+        var result = new GlobalJsonResolver().Resolve(temp.Path);
+
+        result.AllowPrerelease.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Resolve_WalksUpToNearestGlobalJson()
+    {
+        using var temp = new TempDir();
+        // global.json at the root of the temp dir
+        temp.WriteGlobalJson("""{ "sdk": { "version": "8.0.400" } }""");
+        var nested = Directory.CreateDirectory(Path.Combine(temp.Path, "src", "project"));
+
+        var result = new GlobalJsonResolver().Resolve(nested.FullName);
+
+        result.Status.Should().Be(GlobalJsonStatus.Resolved);
+        result.GlobalJsonPath.Should().Be(Path.Combine(temp.Path, "global.json"));
+        result.Channel.Should().Be("8.0.4xx");
+    }
+
+    [Fact]
+    public void Resolve_NearestGlobalJsonWins()
+    {
+        using var temp = new TempDir();
+        temp.WriteGlobalJson("""{ "sdk": { "version": "8.0.400" } }""");
+        var nested = Directory.CreateDirectory(Path.Combine(temp.Path, "src"));
+        File.WriteAllText(Path.Combine(nested.FullName, "global.json"),
+            """{ "sdk": { "version": "9.0.100" } }""");
+
+        var result = new GlobalJsonResolver().Resolve(nested.FullName);
+
+        result.GlobalJsonPath.Should().Be(Path.Combine(nested.FullName, "global.json"));
+        result.Channel.Should().Be("9.0.1xx");
+    }
+
+    [Fact]
+    public void Resolve_MalformedGlobalJson_TreatedAsNoSdkVersion()
+    {
+        using var temp = new TempDir();
+        temp.WriteGlobalJson("{ this is not valid json");
+
+        var result = new GlobalJsonResolver().Resolve(temp.Path);
+
+        result.Status.Should().Be(GlobalJsonStatus.NoSdkVersion);
+        result.GlobalJsonPath.Should().NotBeNull();
+    }
+
+    private sealed class TempDir : IDisposable
+    {
+        public string Path { get; }
+
+        public TempDir()
+        {
+            Path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                "gjr-test-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path);
+        }
+
+        public void WriteGlobalJson(string content) =>
+            File.WriteAllText(System.IO.Path.Combine(Path, "global.json"), content);
+
+        public void Dispose()
+        {
+            try { Directory.Delete(Path, recursive: true); }
+            catch { /* best effort */ }
+        }
+    }
+}

--- a/tests/MauiSherpa.Workloads.Tests/Services/GlobalJsonServiceTests.cs
+++ b/tests/MauiSherpa.Workloads.Tests/Services/GlobalJsonServiceTests.cs
@@ -1,0 +1,35 @@
+using FluentAssertions;
+using MauiSherpa.Workloads.Services;
+
+namespace MauiSherpa.Workloads.Tests.Services;
+
+public class GlobalJsonServiceTests
+{
+    [Fact]
+    public void ParseGlobalJson_ReadsWorkloadsUpdateMode()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"global-{Guid.NewGuid():N}.json");
+        try
+        {
+            File.WriteAllText(path, """
+            {
+              "sdk": {
+                "version": "10.0.302",
+                "workloadVersion": "10.0.300.1",
+                "workloads-update-mode": "workload-set"
+              }
+            }
+            """);
+
+            var result = new GlobalJsonService().ParseGlobalJson(path);
+
+            result.Should().NotBeNull();
+            result!.WorkloadSetVersion.Should().Be("10.0.300.1");
+            result.WorkloadsUpdateMode.Should().Be("workload-set");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/tests/MauiSherpa.Workloads.Tests/Services/GlobalJsonWorkloadPinEditorTests.cs
+++ b/tests/MauiSherpa.Workloads.Tests/Services/GlobalJsonWorkloadPinEditorTests.cs
@@ -1,0 +1,228 @@
+using System.Text.Json;
+using FluentAssertions;
+using MauiSherpa.Workloads.Services;
+
+namespace MauiSherpa.Workloads.Tests.Services;
+
+public sealed class GlobalJsonWorkloadPinEditorTests : IDisposable
+{
+    private readonly string _directory = Path.Combine(
+        Path.GetTempPath(),
+        $"mauisherpa-globaljson-{Guid.NewGuid():N}");
+
+    public GlobalJsonWorkloadPinEditorTests() => Directory.CreateDirectory(_directory);
+
+    [Fact]
+    public async Task AddsOfficialPinWithoutRewritingCommentsOrUnknownProperties()
+    {
+        var path = Path.Combine(_directory, "global.json");
+        var original = """
+        {
+          // Keep this project note.
+          "sdk": {
+            "version": "10.0.302",
+          },
+          "custom": true,
+        }
+        """;
+        await File.WriteAllTextAsync(path, original);
+        var editor = new GlobalJsonWorkloadPinEditor();
+
+        var preview = editor.Preview(_directory, "10.0.302");
+        await editor.ApplyAsync(preview);
+        var updated = await File.ReadAllTextAsync(path);
+
+        updated.Should().Contain("// Keep this project note.");
+        updated.Should().Contain("\"custom\": true");
+        updated.Should().Contain("\"workloadVersion\": \"10.0.302\"");
+        new GlobalJsonService().ParseGlobalJson(path)!.WorkloadSetVersion.Should().Be("10.0.302");
+    }
+
+    [Fact]
+    public async Task RemovesOnlyOfficialPin()
+    {
+        var path = Path.Combine(_directory, "global.json");
+        await File.WriteAllTextAsync(path, """
+        {
+          "sdk": {
+            "version": "10.0.302",
+            "workloadVersion": "10.0.300.1",
+            "rollForward": "latestPatch"
+          }
+        }
+        """);
+        var editor = new GlobalJsonWorkloadPinEditor();
+
+        await editor.ApplyAsync(editor.Preview(_directory, null));
+        var updated = await File.ReadAllTextAsync(path);
+
+        updated.Should().NotContain("workloadVersion");
+        using var document = JsonDocument.Parse(updated);
+        document.RootElement.GetProperty("sdk").GetProperty("version").GetString().Should().Be("10.0.302");
+        document.RootElement.GetProperty("sdk").GetProperty("rollForward").GetString().Should().Be("latestPatch");
+    }
+
+    [Fact]
+    public async Task CreatesGlobalJsonWhenProjectHasNone()
+    {
+        var editor = new GlobalJsonWorkloadPinEditor();
+
+        await editor.ApplyAsync(editor.Preview(_directory, "11.0.100-preview.6.26359.118"));
+
+        new GlobalJsonService().ParseGlobalJson(Path.Combine(_directory, "global.json"))!
+            .WorkloadSetVersion.Should().Be("11.0.100-preview.6.26359.118");
+    }
+
+    [Fact]
+    public async Task RemovesLegacyPinWithoutRewritingOtherLegacyProperties()
+    {
+        var path = Path.Combine(_directory, "global.json");
+        await File.WriteAllTextAsync(path, """
+        {
+          // Older Sherpa shape.
+          "sdk": {
+            "version": "10.0.302"
+          },
+          "workloadSet": {
+            "version": "10.0.300.1",
+            "custom": true,
+          }
+        }
+        """);
+        var editor = new GlobalJsonWorkloadPinEditor();
+
+        await editor.ApplyAsync(editor.Preview(_directory, null));
+        var updated = await File.ReadAllTextAsync(path);
+
+        updated.Should().Contain("// Older Sherpa shape.");
+        updated.Should().NotContain("\"version\": \"10.0.300.1\"");
+        updated.Should().Contain("\"custom\": true");
+        new GlobalJsonService().ParseGlobalJson(path)!.WorkloadSetVersion.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task AddsPinAfterPropertyWithTrailingLineComment()
+    {
+        var path = Path.Combine(_directory, "global.json");
+        await File.WriteAllTextAsync(path, """
+        {
+          "sdk": {
+            "version": "10.0.302" // Keep the SDK explanation.
+          }
+        }
+        """);
+        var editor = new GlobalJsonWorkloadPinEditor();
+
+        await editor.ApplyAsync(editor.Preview(_directory, "10.0.300.1"));
+        var updated = await File.ReadAllTextAsync(path);
+
+        updated.Should().Contain("\"version\": \"10.0.302\", // Keep the SDK explanation.");
+        updated.Should().Contain("\"workloadVersion\": \"10.0.300.1\"");
+        ParseJsonc(updated).RootElement.GetProperty("sdk").GetProperty("workloadVersion")
+            .GetString().Should().Be("10.0.300.1");
+    }
+
+    [Fact]
+    public async Task RemovesLastPinWithoutRemovingPreviousPropertyComment()
+    {
+        var path = Path.Combine(_directory, "global.json");
+        await File.WriteAllTextAsync(path, """
+        {
+          "sdk": {
+            "version": "10.0.302", // Keep the SDK explanation.
+            "workloadVersion": "10.0.300.1"
+          }
+        }
+        """);
+        var editor = new GlobalJsonWorkloadPinEditor();
+
+        await editor.ApplyAsync(editor.Preview(_directory, null));
+        var updated = await File.ReadAllTextAsync(path);
+
+        updated.Should().Contain("// Keep the SDK explanation.");
+        updated.Should().NotContain("workloadVersion");
+        ParseJsonc(updated).RootElement.GetProperty("sdk").GetProperty("version")
+            .GetString().Should().Be("10.0.302");
+    }
+
+    [Fact]
+    public async Task RemovesPinWithBlockCommentBeforeFollowingComma()
+    {
+        var path = Path.Combine(_directory, "global.json");
+        await File.WriteAllTextAsync(path, """
+        {
+          "sdk": {
+            "version": "10.0.302",
+            "workloadVersion": "10.0.300.1" /* old pin */,
+            "rollForward": "latestPatch"
+          }
+        }
+        """);
+        var editor = new GlobalJsonWorkloadPinEditor();
+
+        await editor.ApplyAsync(editor.Preview(_directory, null));
+        var updated = await File.ReadAllTextAsync(path);
+
+        updated.Should().NotContain("workloadVersion");
+        ParseJsonc(updated).RootElement.GetProperty("sdk").GetProperty("rollForward")
+            .GetString().Should().Be("latestPatch");
+    }
+
+    [Fact]
+    public async Task IgnoresNestedPropertiesAfterSdkObject()
+    {
+        var path = Path.Combine(_directory, "global.json");
+        await File.WriteAllTextAsync(path, """
+        {
+          "sdk": {
+            "version": "10.0.302"
+          },
+          "msbuild-sdks": {
+            "Custom.Sdk": {
+              "workloadVersion": "leave-me-alone"
+            }
+          }
+        }
+        """);
+        var editor = new GlobalJsonWorkloadPinEditor();
+
+        await editor.ApplyAsync(editor.Preview(_directory, "10.0.300.1"));
+        var updated = await File.ReadAllTextAsync(path);
+
+        ParseJsonc(updated).RootElement
+            .GetProperty("sdk")
+            .GetProperty("workloadVersion")
+            .GetString()
+            .Should().Be("10.0.300.1");
+        updated.Should().Contain("\"workloadVersion\": \"leave-me-alone\"");
+    }
+
+    [Fact]
+    public async Task RejectsApplyWhenGlobalJsonChangedAfterPreview()
+    {
+        var path = Path.Combine(_directory, "global.json");
+        await File.WriteAllTextAsync(path, """{"sdk":{"version":"10.0.302"}}""");
+        var editor = new GlobalJsonWorkloadPinEditor();
+        var preview = editor.Preview(_directory, "10.0.300.1");
+        await File.WriteAllTextAsync(path, """{"sdk":{"version":"10.0.303"}}""");
+
+        var action = () => editor.ApplyAsync(preview);
+
+        await action.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*changed after the workload pin preview*");
+        (await File.ReadAllTextAsync(path)).Should().Contain("10.0.303");
+    }
+
+    private static JsonDocument ParseJsonc(string content) =>
+        JsonDocument.Parse(content, new JsonDocumentOptions
+        {
+            AllowTrailingCommas = true,
+            CommentHandling = JsonCommentHandling.Skip
+        });
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_directory))
+            Directory.Delete(_directory, recursive: true);
+    }
+}

--- a/tests/MauiSherpa.Workloads.Tests/Services/LocalSdkServiceTests.cs
+++ b/tests/MauiSherpa.Workloads.Tests/Services/LocalSdkServiceTests.cs
@@ -139,10 +139,10 @@ public class LocalSdkServiceTests
         foreach (var sdk in sdks)
         {
             var workloadSet = await _service.GetInstalledWorkloadSetAsync(sdk.FeatureBand);
-            if (workloadSet == null || workloadSet.Workloads.Count == 0)
+            if (workloadSet == null || workloadSet.ManifestEntries.Count == 0)
                 continue;
 
-            var remappedEntry = workloadSet.Workloads
+            var remappedEntry = workloadSet.ManifestEntries
                 .FirstOrDefault(w => !string.IsNullOrEmpty(w.Value.ManifestFeatureBand)
                     && !string.Equals(w.Value.ManifestFeatureBand, sdk.FeatureBand, StringComparison.OrdinalIgnoreCase));
 
@@ -163,10 +163,10 @@ public class LocalSdkServiceTests
         foreach (var sdk in sdks)
         {
             var workloadSet = await _service.GetInstalledWorkloadSetAsync(sdk.FeatureBand);
-            if (workloadSet == null || workloadSet.Workloads.Count == 0)
+            if (workloadSet == null || workloadSet.ManifestEntries.Count == 0)
                 continue;
 
-            var remappedEntry = workloadSet.Workloads
+            var remappedEntry = workloadSet.ManifestEntries
                 .FirstOrDefault(w => !string.IsNullOrEmpty(w.Value.ManifestFeatureBand)
                     && !string.Equals(w.Value.ManifestFeatureBand, sdk.FeatureBand, StringComparison.OrdinalIgnoreCase));
 
@@ -189,10 +189,10 @@ public class LocalSdkServiceTests
         foreach (var sdk in sdks)
         {
             var workloadSet = await _service.GetInstalledWorkloadSetAsync(sdk.FeatureBand);
-            if (workloadSet == null || workloadSet.Workloads.Count == 0)
+            if (workloadSet == null || workloadSet.ManifestEntries.Count == 0)
                 continue;
 
-            var remappedEntries = workloadSet.Workloads
+            var remappedEntries = workloadSet.ManifestEntries
                 .Where(w => !string.IsNullOrEmpty(w.Value.ManifestFeatureBand)
                     && !string.Equals(w.Value.ManifestFeatureBand, sdk.FeatureBand, StringComparison.OrdinalIgnoreCase))
                 .OrderByDescending(w => w.Key.Contains("android", StringComparison.OrdinalIgnoreCase))

--- a/tests/MauiSherpa.Workloads.Tests/Services/WorkloadGraphResolverTests.cs
+++ b/tests/MauiSherpa.Workloads.Tests/Services/WorkloadGraphResolverTests.cs
@@ -1,0 +1,58 @@
+using FluentAssertions;
+using MauiSherpa.Workloads.Models;
+using MauiSherpa.Workloads.Services;
+
+namespace MauiSherpa.Workloads.Tests.Services;
+
+public class WorkloadGraphResolverTests
+{
+    [Fact]
+    public void ResolvesAggregateIncludesAndRidPackAliases()
+    {
+        const string json = """
+        {
+          "version": "10.0.20",
+          "workloads": {
+            "maui": { "extends": [ "maui-mobile" ] },
+            "maui-mobile": { "extends": [ "maui-android" ] },
+            "maui-android": { "packs": [ "Maui.Sdk" ], "extends": [ "android" ] },
+            "android": { "packs": [ "Android.Sdk" ] }
+          },
+          "packs": {
+            "Maui.Sdk": {
+              "version": "10.0.20",
+              "kind": "sdk",
+              "alias-to": { "osx-arm64": "Maui.Sdk.Mac", "any": "Maui.Sdk.Any" }
+            },
+            "Android.Sdk": { "version": "36.1.53", "kind": "sdk" }
+          }
+        }
+        """;
+        var manifest = WorkloadManifestService.ParseManifest(json)!;
+
+        var result = WorkloadGraphResolver.Resolve([manifest], "osx-arm64");
+        var maui = result.Single(item => item.Id == "maui");
+
+        maui.TransitiveIncludes.Should().BeEquivalentTo("maui-mobile", "maui-android", "android");
+        maui.Packs.Should().HaveCount(2);
+        maui.Packs.Single(pack => pack.Id == "Maui.Sdk").ResolvedPackageId.Should().Be("Maui.Sdk.Mac");
+    }
+
+    [Fact]
+    public void RejectsExtendsCycles()
+    {
+        var manifest = new WorkloadManifest
+        {
+            Version = "1",
+            Workloads = new Dictionary<string, WorkloadDefinition>
+            {
+                ["a"] = new() { Id = "a", Extends = ["b"] },
+                ["b"] = new() { Id = "b", Extends = ["a"] }
+            }
+        };
+
+        var action = () => WorkloadGraphResolver.Resolve([manifest], "any");
+
+        action.Should().Throw<InvalidDataException>().WithMessage("*cycle*");
+    }
+}

--- a/tests/MauiSherpa.Workloads.Tests/Services/WorkloadGraphResolverTests.cs
+++ b/tests/MauiSherpa.Workloads.Tests/Services/WorkloadGraphResolverTests.cs
@@ -55,4 +55,66 @@ public class WorkloadGraphResolverTests
 
         action.Should().Throw<InvalidDataException>().WithMessage("*cycle*");
     }
+
+    [Fact]
+    public void RedirectsUseTheReplacementWorkloadGraph()
+    {
+        var manifest = new WorkloadManifest
+        {
+            Version = "1",
+            Workloads = new Dictionary<string, WorkloadDefinition>
+            {
+                ["legacy"] = new() { Id = "legacy", RedirectTo = "current" },
+                ["current"] = new() { Id = "current", Extends = ["base"], Packs = ["Current.Sdk"] },
+                ["base"] = new() { Id = "base", Packs = ["Base.Sdk"] }
+            },
+            Packs = new Dictionary<string, PackDefinition>
+            {
+                ["Current.Sdk"] = new() { Id = "Current.Sdk", Version = "1", Kind = "sdk" },
+                ["Base.Sdk"] = new() { Id = "Base.Sdk", Version = "1", Kind = "sdk" }
+            }
+        };
+
+        var result = WorkloadGraphResolver.Resolve([manifest], "any");
+        var legacy = result.Single(workload => workload.Id == "legacy");
+
+        legacy.RedirectTarget.Should().Be("current");
+        legacy.TransitiveIncludes.Should().BeEquivalentTo("current", "base");
+        legacy.Packs.Select(pack => pack.Id).Should().BeEquivalentTo("Current.Sdk", "Base.Sdk");
+    }
+
+    [Fact]
+    public void RejectsRedirectCycles()
+    {
+        var manifest = new WorkloadManifest
+        {
+            Version = "1",
+            Workloads = new Dictionary<string, WorkloadDefinition>
+            {
+                ["a"] = new() { Id = "a", RedirectTo = "b" },
+                ["b"] = new() { Id = "b", RedirectTo = "a" }
+            }
+        };
+
+        var action = () => WorkloadGraphResolver.Resolve([manifest], "any");
+
+        action.Should().Throw<InvalidDataException>().WithMessage("*redirect cycle*");
+    }
+
+    [Fact]
+    public void RejectsMissingRedirectTargets()
+    {
+        var manifest = new WorkloadManifest
+        {
+            Version = "1",
+            Workloads = new Dictionary<string, WorkloadDefinition>
+            {
+                ["legacy"] = new() { Id = "legacy", RedirectTo = "missing" }
+            }
+        };
+
+        var action = () => WorkloadGraphResolver.Resolve([manifest], "any");
+
+        action.Should().Throw<InvalidDataException>().WithMessage("*missing workload*");
+    }
 }

--- a/tests/MauiSherpa.Workloads.Tests/Services/WorkloadInstallStateReaderTests.cs
+++ b/tests/MauiSherpa.Workloads.Tests/Services/WorkloadInstallStateReaderTests.cs
@@ -1,0 +1,104 @@
+using FluentAssertions;
+using MauiSherpa.Workloads.Models;
+using MauiSherpa.Workloads.Services;
+
+namespace MauiSherpa.Workloads.Tests.Services;
+
+public class WorkloadInstallStateReaderTests : IDisposable
+{
+    private readonly string _root = Path.Combine(
+        Path.GetTempPath(),
+        $"maui-sherpa-workload-state-{Guid.NewGuid():N}");
+
+    [Fact]
+    public void ReadUpdateMode_MissingState_DefaultsToWorkloadSet()
+    {
+        WorkloadInstallStateReader.ReadUpdateMode(CreateTarget())
+            .Should().Be(DotnetWorkloadUpdateMode.WorkloadSet);
+    }
+
+    [Theory]
+    [InlineData("{}", DotnetWorkloadUpdateMode.WorkloadSet)]
+    [InlineData("""{"useWorkloadSets":null}""", DotnetWorkloadUpdateMode.WorkloadSet)]
+    [InlineData("""{"useWorkloadSets":true}""", DotnetWorkloadUpdateMode.WorkloadSet)]
+    [InlineData("""{"useWorkloadSets":false}""", DotnetWorkloadUpdateMode.Manifests)]
+    public void ReadUpdateMode_UsesSdkInstallState(
+        string json,
+        DotnetWorkloadUpdateMode expected)
+    {
+        var path = Path.Combine(
+            _root,
+            "metadata",
+            "workloads",
+            "Arm64",
+            "10.0.300",
+            "InstallState",
+            "default.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, json);
+
+        WorkloadInstallStateReader.ReadUpdateMode(CreateTarget())
+            .Should().Be(expected);
+    }
+
+    [Fact]
+    public void ReadManifestVersions_UsesRecordedVersionsAndFeatureBands()
+    {
+        WriteState("""
+        {
+          "useWorkloadSets": false,
+          "manifests": {
+            "microsoft.net.sdk.ios": "18.5.9219/10.0.100",
+            "microsoft.net.sdk.android": "35.0.50"
+          }
+        }
+        """);
+
+        var manifests = WorkloadInstallStateReader.ReadManifestVersions(CreateTarget());
+
+        manifests.Should().BeEquivalentTo(
+        [
+            new DotnetManifestVersion
+            {
+                ManifestId = "microsoft.net.sdk.ios",
+                Version = "18.5.9219",
+                FeatureBand = "10.0.100"
+            },
+            new DotnetManifestVersion
+            {
+                ManifestId = "microsoft.net.sdk.android",
+                Version = "35.0.50",
+                FeatureBand = "10.0.300"
+            }
+        ]);
+    }
+
+    private void WriteState(string json)
+    {
+        var path = Path.Combine(
+            _root,
+            "metadata",
+            "workloads",
+            "Arm64",
+            "10.0.300",
+            "InstallState",
+            "default.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, json);
+    }
+
+    private DotnetWorkloadTarget CreateTarget() => new()
+    {
+        InstallRoot = _root,
+        DotnetPath = Path.Combine(_root, "dotnet"),
+        Architecture = "arm64",
+        FeatureBand = new SdkFeatureBand("10.0.302"),
+        RepresentativeSdkVersion = "10.0.302"
+    };
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+            Directory.Delete(_root, recursive: true);
+    }
+}

--- a/tests/MauiSherpa.Workloads.Tests/Services/WorkloadInstallationStateResolverTests.cs
+++ b/tests/MauiSherpa.Workloads.Tests/Services/WorkloadInstallationStateResolverTests.cs
@@ -1,0 +1,167 @@
+using FluentAssertions;
+using MauiSherpa.Workloads.Models;
+using MauiSherpa.Workloads.Services;
+
+namespace MauiSherpa.Workloads.Tests.Services;
+
+public class WorkloadInstallationStateResolverTests
+{
+    [Fact]
+    public void AggregateRecordsResolveEffectiveInstalledWorkloads()
+    {
+        var definitions = ResolveDefinitions(
+        [
+            Workload("maui", extends: ["maui-mobile", "maui-desktop"]),
+            Workload("maui-mobile", extends: ["maui-android", "maui-ios"]),
+            Workload("maui-desktop", extends: ["maui-maccatalyst"]),
+            Workload("maui-android", extends: ["maui-core", "android"]),
+            Workload("maui-ios", extends: ["maui-core", "ios"]),
+            Workload("maui-maccatalyst", extends: ["maui-core", "maccatalyst"]),
+            Workload("maui-core", isAbstract: true, packs: ["Maui.Sdk"]),
+            Workload("android", packs: ["Android.Sdk"]),
+            Workload("ios", packs: ["iOS.Sdk"]),
+            Workload("maccatalyst", packs: ["MacCatalyst.Sdk"]),
+            Workload("macos", packs: ["MacOS.Sdk"]),
+            Workload("tvos", packs: ["tvOS.Sdk"]),
+            Workload("wasm-tools", packs: ["Wasm.Sdk"]),
+            Workload("optional-tools", packs: ["Optional.Sdk"])
+        ]);
+        var records = new[]
+        {
+            Installed("maui"),
+            Installed("macos"),
+            Installed("tvos"),
+            Installed("wasm-tools")
+        };
+
+        var result = WorkloadInstallationStateResolver.Resolve(records, definitions);
+
+        result.States.Where(state => state.IsExplicit).Select(state => state.Id)
+            .Should().BeEquivalentTo("maui", "macos", "tvos", "wasm-tools");
+        result.States.Single(state => state.Id == "android").Should().Match<DotnetWorkloadInstallationState>(
+            state =>
+                state.Kind == DotnetWorkloadInstallKind.Included &&
+                !state.CanUninstall &&
+                state.IsUserVisible &&
+                state.IncludedBy.SequenceEqual(new[] { "maui" }));
+        result.States.Single(state => state.Id == "ios").Kind
+            .Should().Be(DotnetWorkloadInstallKind.Included);
+        result.States.Single(state => state.Id == "maccatalyst").Kind
+            .Should().Be(DotnetWorkloadInstallKind.Included);
+        result.States.Single(state => state.Id == "maui-core").IsUserVisible.Should().BeFalse();
+        result.States.Single(state => state.Id == "macos").IncludedBy.Should().BeEmpty();
+        result.States.Single(state => state.Id == "tvos").IncludedBy.Should().BeEmpty();
+        result.States.Single(state => state.Id == "wasm-tools").IncludedBy.Should().BeEmpty();
+        records.Select(record => record.Id).Should().Equal("maui", "macos", "tvos", "wasm-tools");
+        result.Diagnostics.Should().BeEmpty();
+
+        var inventory = new DotnetWorkloadInventory
+        {
+            Target = Target(),
+            InstalledWorkloads = records,
+            EffectiveInstalledWorkloads = result.States,
+            AvailableWorkloads = definitions
+        };
+        inventory.InstallableWorkloads.Select(workload => workload.Id)
+            .Should().Equal("optional-tools");
+    }
+
+    [Fact]
+    public void ExplicitStateWinsWhenAnAggregateAlsoIncludesTheWorkload()
+    {
+        var definitions = ResolveDefinitions(
+        [
+            Workload("maui", extends: ["android"]),
+            Workload("android", packs: ["Android.Sdk"])
+        ]);
+
+        var result = WorkloadInstallationStateResolver.Resolve(
+            [Installed("maui"), Installed("android")],
+            definitions);
+
+        var android = result.States.Single(state => state.Id == "android");
+        android.Kind.Should().Be(DotnetWorkloadInstallKind.Explicit);
+        android.CanUninstall.Should().BeTrue();
+        android.IncludedBy.Should().Equal("maui");
+    }
+
+    [Fact]
+    public void IncludedWorkloadRetainsAllExplicitParents()
+    {
+        var definitions = ResolveDefinitions(
+        [
+            Workload("aggregate-b", extends: ["child"]),
+            Workload("aggregate-a", extends: ["child"]),
+            Workload("child", packs: ["Child.Sdk"])
+        ]);
+
+        var result = WorkloadInstallationStateResolver.Resolve(
+            [Installed("aggregate-b"), Installed("aggregate-a")],
+            definitions);
+
+        result.States.Single(state => state.Id == "child").IncludedBy
+            .Should().Equal("aggregate-a", "aggregate-b");
+    }
+
+    [Fact]
+    public void MissingDefinitionsRemainExplicitAndProduceDiagnostics()
+    {
+        var root = new ResolvedWorkloadDefinition
+        {
+            Id = "aggregate",
+            TransitiveIncludes = ["missing-child"],
+            Packs = [new ResolvedPackDefinition { Id = "Root.Pack", Version = "1", Kind = "sdk" }]
+        };
+
+        var result = WorkloadInstallationStateResolver.Resolve(
+            [Installed("aggregate"), Installed("stale-record")],
+            [root]);
+
+        result.States.Single(state => state.Id == "stale-record").Should().Match<DotnetWorkloadInstallationState>(
+            state => state.IsExplicit && state.CanUninstall && state.IsUserVisible);
+        result.States.Single(state => state.Id == "missing-child").IsUserVisible.Should().BeFalse();
+        result.Diagnostics.Should().Contain(message => message.Contains("stale-record", StringComparison.Ordinal));
+        result.Diagnostics.Should().Contain(message => message.Contains("missing-child", StringComparison.Ordinal));
+    }
+
+    private static IReadOnlyList<ResolvedWorkloadDefinition> ResolveDefinitions(
+        IReadOnlyList<WorkloadDefinition> workloads)
+    {
+        var manifest = new WorkloadManifest
+        {
+            Version = "1",
+            Workloads = workloads.ToDictionary(workload => workload.Id),
+            Packs = workloads
+                .SelectMany(workload => workload.Packs)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(
+                    id => id,
+                    id => new PackDefinition { Id = id, Version = "1", Kind = "sdk" })
+        };
+        return WorkloadGraphResolver.Resolve([manifest], "osx-arm64");
+    }
+
+    private static WorkloadDefinition Workload(
+        string id,
+        IReadOnlyList<string>? extends = null,
+        IReadOnlyList<string>? packs = null,
+        bool isAbstract = false) =>
+        new()
+        {
+            Id = id,
+            Extends = extends ?? [],
+            Packs = packs ?? [],
+            IsAbstract = isAbstract
+        };
+
+    private static DotnetInstalledWorkload Installed(string id) => new() { Id = id };
+
+    private static DotnetWorkloadTarget Target() => new()
+    {
+        InstallRoot = "/tmp/dotnet",
+        DotnetPath = "/tmp/dotnet/dotnet",
+        Architecture = "arm64",
+        FeatureBand = new SdkFeatureBand("10.0.302"),
+        RepresentativeSdkVersion = "10.0.302"
+    };
+}

--- a/tests/MauiSherpa.Workloads.Tests/Services/WorkloadRecommendationPolicyTests.cs
+++ b/tests/MauiSherpa.Workloads.Tests/Services/WorkloadRecommendationPolicyTests.cs
@@ -1,0 +1,23 @@
+using FluentAssertions;
+using MauiSherpa.Workloads.Services;
+
+namespace MauiSherpa.Workloads.Tests.Services;
+
+public class WorkloadRecommendationPolicyTests
+{
+    [Fact]
+    public void DesktopShowsKeyCrossPlatformWorkloads()
+    {
+        WorkloadRecommendationPolicy.GetRecommendedWorkloadIds(isLinux: false)
+            .Should().Equal("maui", "ios", "macos", "tvos", "maccatalyst", "android", "wasm-tools");
+    }
+
+    [Fact]
+    public void LinuxUsesMauiAndroidAndExcludesAppleWorkloads()
+    {
+        var workloads = WorkloadRecommendationPolicy.GetRecommendedWorkloadIds(isLinux: true);
+
+        workloads.Should().Equal("maui-android", "android", "wasm-tools");
+        workloads.Should().NotContain(["maui", "ios", "macos", "tvos", "maccatalyst"]);
+    }
+}

--- a/tests/MauiSherpa.Workloads.Tests/Services/WorkloadSetServiceTests.cs
+++ b/tests/MauiSherpa.Workloads.Tests/Services/WorkloadSetServiceTests.cs
@@ -70,9 +70,9 @@ public class WorkloadSetServiceTests
         result.Should().NotBeNull();
         result!.Version.Should().Be("10.0.100");
         result.FeatureBand.Should().Be(featureBand);
-        result.Workloads.Should().ContainKey("microsoft.net.sdk.maui");
-        result.Workloads["microsoft.net.sdk.maui"].ManifestVersion.Should().Be("10.0.100");
-        result.Workloads["microsoft.net.sdk.maui"].ManifestFeatureBand.Should().Be("10.0.100");
+        result.ManifestEntries.Should().ContainKey("microsoft.net.sdk.maui");
+        result.ManifestEntries["microsoft.net.sdk.maui"].ManifestVersion.Should().Be("10.0.100");
+        result.ManifestEntries["microsoft.net.sdk.maui"].ManifestFeatureBand.Should().Be("10.0.100");
     }
 
     [Fact]


### PR DESCRIPTION
## Why

Sherpa's Doctor already flags when .NET SDKs and workloads are out of date, but until now it stopped short of helping install or update SDKs because we were waiting on `dotnetup` (the new user-level .NET SDK/runtime manager from `dotnet/sdk`) to be ready. It's ready, so this PR wires `dotnetup` into Sherpa and adds a dedicated SDK Manager experience.

## What

**New ".NET SDK Manager" page** (`/dotnet-sdk`) that drives `dotnetup` to install and track SDK channels, list installed components (SDKs, runtimes, ASP.NET Core runtimes), and keep them updated. The page bootstraps `dotnetup` on demand if it isn't present.

**Read-only "what will change?" inspection** before any mutating action:
- **Update preview** (`GetUpdatePreviewAsync` / `DotnetUpdateResolver`) resolves each tracked channel against the official .NET release metadata and reports which channels have a newer version available, without running an install.
- **Project context** (`InspectProjectFolderAsync` / `GlobalJsonResolver`) walks up to the nearest `global.json` the way the `dotnet` host does, derives the dotnetup channel, and reports whether an installed SDK satisfies it and whether it's already tracked. A native macOS folder picker (`NSOpenPanel`) lets the user point at any folder.

**Doctor awareness** so the Doctor page/CLI can surface dotnetup-managed state alongside the existing workload checks.

**Native add-channel modal** (`AddChannelPage` + `AddChannelModal`) replaces the earlier inline HTML dialog: native sheet chrome with a Blazor-hosted channel list, custom version input, and "tracking" badges for already-tracked channels.

**Sidebar:** the entry now lives in the **Tools** group and is named ".NET SDK Manager" in both the Blazor layout and the native macOS sidebar.

**Supporting plumbing:** `dotnetup` argument builder, output parser, downloader/bootstrapper, and runtime-identifier helper in `MauiSherpa.Workloads`, plus docs (`docs/dotnet-sdk-management.md`) and unit tests across the new services (parser, downloader, arguments, RID, global.json, update preview).

## Notes for reviewers

- This branch also forward-migrates to Shiny.Mediator 6.6.2 + MAUI Controls 10.0.60 (two commits), which were prerequisites; that migration also fixes the macOS window/cache serialization path.
- The update-preview and project-context features are intentionally read-only. Installs/updates only happen on explicit user action.
- Tracked-channel installs deliberately pass `terminalMode: false` because Terminal vs Isolation mode is a one-time global choice made by `dotnetup init`, not a per-channel setting.
- UI was validated in both light and dark mode on the macOS head.

## Testing

- `dotnet test tests/MauiSherpa.Workloads.Tests` -> 120 passed.
- macOS head builds clean (0 errors) and was exercised manually.