### PR TITLE
Prepare v0.12.0 release

### DIFF
--- a/docs/release-notes/v0.12.0.md
+++ b/docs/release-notes/v0.12.0.md
@@ -1,0 +1,37 @@
+## 🏔️ v0.12.0 — "Traversing the Toolchain Ridge"
+
+The expedition is moving onto new terrain, and this release brings the gear to manage the
+toolchain along the way. MAUI Sherpa can now guide both .NET and Android SDK maintenance,
+from scouting available updates to installing the right components for the route ahead.
+
+### 🆕 New Features
+
+- **.NET SDK Manager** — Install, track, inspect, and update .NET SDK and runtime channels through
+  `dotnetup`, with update previews, project-aware `global.json` guidance, and workload management
+  built into the app. (#197)
+- **Android SDK Package Updates** — A unified package view identifies newer stable releases and
+  handles in-place and side-by-side updates, including optional cleanup of older tools without
+  cutting loose versions that existing projects still need. (#195)
+
+### ✨ Improvements
+
+- **A More Capable Doctor** — Doctor now understands `dotnetup`-managed SDKs and workloads, giving
+  both the app and CLI a clearer view of the development environment before the climb begins.
+  (#197)
+- **Polished Camp Surfaces** — Cards, dialogs, modal padding, scrollbars, and light/dark theme
+  colors now form a flatter, more consistent interface across the expedition. (#196)
+
+### 🐛 Bug Fixes
+
+- **Windows Copilot Stability** — Release builds no longer hit a CSPRNG crash when starting the
+  bundled Copilot CLI on Windows. (#190)
+
+### 🔧 Infrastructure
+
+- **Fresh Expedition Kit** — The .NET SDK moved to 10.0.301, core dependencies received a broad
+  refresh, and grouped Dependabot updates keep future supply drops easier to review.
+  (#191, #192, #193, #194)
+
+---
+
+*The ridge is broader now, and every tool in the pack has a clearer path forward.* 🧭


### PR DESCRIPTION
## Summary

- add mountaineering-themed v0.12.0 release notes
- cover the new .NET SDK Manager, Android SDK package updates, UI polish, and Windows Copilot fix

## Release

This prepares the repository for the v0.12.0 tag and GitHub release.