### PR TITLE
Fix Homebrew macOS dependency instructions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1033,7 +1033,7 @@ jobs:
             desc "Desktop app for managing .NET MAUI developer tools"
             homepage "https://github.com/Redth/MAUI.Sherpa"
 
-            depends_on macos: ">= :ventura"
+            depends_on macos: :ventura
 
             app "MAUI Sherpa.app"
 

--- a/website/getting-started.html
+++ b/website/getting-started.html
@@ -81,7 +81,7 @@
                         <span class="code-block__lang">Terminal</span>
                         <button class="code-block__copy">Copy</button>
                     </div>
-                    <pre><code><span class="token-command">brew</span> <span class="token-function">tap</span> <span class="token-param">redth/tap</span>
+                    <pre><code><span class="token-command">brew</span> <span class="token-function">tap</span> <span class="token-flag">--trust</span> <span class="token-param">redth/tap</span>
 <span class="token-command">brew</span> <span class="token-function">install</span> <span class="token-flag">--cask</span> <span class="token-param">maui-sherpa</span></code></pre>
                 </div>
 


### PR DESCRIPTION
## Summary

Fixes the Homebrew Cask macOS dependency declaration for Ventura. The cask now uses Homebrew's supported symbolic syntax, `depends_on macos: :ventura`, instead of a quoted version comparison that Homebrew rejects.

This keeps MAUI Sherpa's cask metadata valid and ensures the installation path remains reliable for supported macOS releases.

The Getting Started command is also updated to use `brew tap --trust redth/tap`, matching the trusted tap flow required for installation.