### PR TITLE
Fix SDK uninstall channel resolution

### DIFF
--- a/src/MauiSherpa.Workloads/Services/DotnetSdkPresentationBuilder.cs
+++ b/src/MauiSherpa.Workloads/Services/DotnetSdkPresentationBuilder.cs
@@ -57,6 +57,37 @@ public static partial class DotnetSdkPresentationBuilder
             .ToList();
     }
 
+    /// <summary>
+    /// Finds the single tracked SDK spec that owns an installed SDK. dotnetup uninstalls specs,
+    /// rather than concrete SDK versions, so the UI must use this result for SDK removal.
+    /// </summary>
+    public static DotnetUpInstallSpec? FindTrackedSdkSpec(
+        DotnetUpInstallation installation,
+        IReadOnlyList<DotnetUpInstallSpec>? installSpecs)
+    {
+        ArgumentNullException.ThrowIfNull(installation);
+
+        if (installation.Component != DotnetUpComponent.Sdk || installSpecs == null)
+            return null;
+
+        var matches = installSpecs
+            .Where(spec => spec.Component == DotnetUpComponent.Sdk)
+            .Where(spec => string.Equals(
+                spec.InstallRoot,
+                installation.InstallRoot,
+                StringComparison.OrdinalIgnoreCase))
+            .Where(spec => string.IsNullOrWhiteSpace(spec.Architecture) ||
+                           string.Equals(
+                               spec.Architecture,
+                               installation.Architecture,
+                               StringComparison.OrdinalIgnoreCase))
+            .Where(spec => SdkSpecMatchesVersion(spec.VersionOrChannel, installation.Version))
+            .Take(2)
+            .ToList();
+
+        return matches.Count == 1 ? matches[0] : null;
+    }
+
     public static DotnetMajorMinorGroupSummary? BuildProjectInstalledGroup(
         GlobalJsonResolution? projectResolution,
         IReadOnlyList<DotnetUpInstallation>? installations,
@@ -317,6 +348,35 @@ public static partial class DotnetSdkPresentationBuilder
             ? leftVersion == rightVersion
             : string.Equals(left, right, StringComparison.OrdinalIgnoreCase);
 
+    private static bool SdkSpecMatchesVersion(string versionOrChannel, string installedVersion)
+    {
+        var spec = versionOrChannel.Trim();
+        if (VersionsEqual(spec, installedVersion))
+            return true;
+
+        if (!NuGetVersion.TryParse(installedVersion, out var installed))
+            return false;
+
+        if (SdkFeatureBandPattern().Match(spec) is { Success: true } featureBand &&
+            int.TryParse(featureBand.Groups[1].Value, out var featureMajor) &&
+            int.TryParse(featureBand.Groups[2].Value, out var featureMinor) &&
+            int.TryParse(featureBand.Groups[3].Value, out var featureBandHundreds))
+        {
+            return installed.Major == featureMajor &&
+                   installed.Minor == featureMinor &&
+                   installed.Patch / 100 == featureBandHundreds;
+        }
+
+        if (MajorMinorPattern().Match(spec) is { Success: true } majorMinor &&
+            int.TryParse(majorMinor.Groups[1].Value, out var major) &&
+            int.TryParse(majorMinor.Groups[2].Value, out var minor))
+        {
+            return installed.Major == major && installed.Minor == minor;
+        }
+
+        return int.TryParse(spec, out var majorOnly) && installed.Major == majorOnly;
+    }
+
     private sealed class MajorMinorSortComparer : IComparer<(int Major, int Minor)>
     {
         public static MajorMinorSortComparer Instance { get; } = new();
@@ -366,4 +426,10 @@ public static partial class DotnetSdkPresentationBuilder
 
     [GeneratedRegex(@"^\d+\.\d+\.\d+(-[0-9A-Za-z.]+)?$", RegexOptions.Compiled)]
     private static partial Regex ExactVersionPattern();
+
+    [GeneratedRegex(@"^(\d+)\.(\d+)\.(\d+)xx$", RegexOptions.Compiled | RegexOptions.IgnoreCase)]
+    private static partial Regex SdkFeatureBandPattern();
+
+    [GeneratedRegex(@"^(\d+)\.(\d+)$", RegexOptions.Compiled)]
+    private static partial Regex MajorMinorPattern();
 }

--- a/src/MauiSherpa/Pages/DotnetSdk.razor
+++ b/src/MauiSherpa/Pages/DotnetSdk.razor
@@ -598,9 +598,26 @@
     private async Task RunUninstall(DotnetUpInstallation item)
     {
         var label = $"{item.ComponentRaw} {item.Version}";
-        ProcessRequest request = item.Component == DotnetUpComponent.Sdk
-            ? DotnetUp.UninstallSdkRequest(item.Version)
-            : DotnetUp.UninstallRuntimeRequest($"{RuntimeToken(item)}@{item.Version}");
+        ProcessRequest request;
+        if (item.Component == DotnetUpComponent.Sdk)
+        {
+            var spec = DotnetSdkPresentationBuilder.FindTrackedSdkSpec(item, list?.InstallSpecs);
+            if (spec == null)
+            {
+                await AlertService.ShowAlertAsync(
+                    "SDK uninstall unavailable",
+                    $"Sherpa couldn't identify the tracked channel that installed SDK {item.Version}. " +
+                    "Use the Untrack action in Tracked channels to remove it safely.");
+                return;
+            }
+
+            request = DotnetUp.UninstallSdkRequest(spec.VersionOrChannel, spec.Source);
+        }
+        else
+        {
+            request = DotnetUp.UninstallRuntimeRequest($"{RuntimeToken(item)}@{item.Version}");
+        }
+
         request = request with
         {
             Description = $"Remove {label} from {item.InstallRoot}.",

--- a/tests/MauiSherpa.Workloads.Tests/Services/DotnetSdkPresentationBuilderTests.cs
+++ b/tests/MauiSherpa.Workloads.Tests/Services/DotnetSdkPresentationBuilderTests.cs
@@ -82,6 +82,34 @@ public class DotnetSdkPresentationBuilderTests
     }
 
     [Fact]
+    public void FindTrackedSdkSpec_MapsInstalledVersionToItsFeatureBandChannel()
+    {
+        var installation = Installation(DotnetUpComponent.Sdk, "9.0.301");
+        var specs = new[]
+        {
+            Spec(DotnetUpComponent.Sdk, "9.0.1xx"),
+            Spec(DotnetUpComponent.Sdk, "9.0.3xx")
+        };
+
+        var result = DotnetSdkPresentationBuilder.FindTrackedSdkSpec(installation, specs);
+
+        result.Should().BeSameAs(specs[1]);
+    }
+
+    [Fact]
+    public void FindTrackedSdkSpec_ReturnsNullWhenMultipleSpecsMatch()
+    {
+        var installation = Installation(DotnetUpComponent.Sdk, "9.0.301");
+        var specs = new[]
+        {
+            Spec(DotnetUpComponent.Sdk, "9"),
+            Spec(DotnetUpComponent.Sdk, "9.0")
+        };
+
+        DotnetSdkPresentationBuilder.FindTrackedSdkSpec(installation, specs).Should().BeNull();
+    }
+
+    [Fact]
     public void Build_ComputesAggregateUpdateStateIncludingUnresolvedChannels()
     {
         var summary = DotnetSdkPresentationBuilder.Build(


### PR DESCRIPTION
Fixes SDK removal from the Installed components list by resolving the concrete installed SDK version back to its tracked dotnetup channel/spec.

- Maps SDK versions such as `9.0.301` to tracked channels such as `9.0.3xx`
- Preserves the install source when constructing the uninstall request
- Blocks ambiguous mappings and directs users to the safe Untrack action
- Adds regression coverage for feature-band and ambiguous matches

Validation:
- `dotnet test tests/MauiSherpa.Workloads.Tests/MauiSherpa.Workloads.Tests.csproj`
- `dotnet build src/MauiSherpa -f net10.0-maccatalyst`