### PR TITLE
Publish Windows app as a single executable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -489,7 +489,11 @@ jobs:
             $x64Dir = Get-ChildItem -Path "src/MauiSherpa/bin/Release" -Filter "publish" -Recurse -Directory |
               Where-Object { $_.FullName -like "*win-x64*" } | Select-Object -First 1 -ExpandProperty FullName
           }
-          Compress-Archive -Path "$x64Dir/*" -DestinationPath ./artifacts/MAUI-Sherpa.win-x64.zip
+          $x64Files = @(Get-ChildItem -Path $x64Dir -File -Recurse)
+          if ($x64Files.Count -ne 1 -or $x64Files[0].Name -ne "MauiSherpa.exe") {
+            throw "Expected a single self-contained MauiSherpa.exe for win-x64, but found: $($x64Files.FullName -join ', ')"
+          }
+          Compress-Archive -Path $x64Files[0].FullName -DestinationPath ./artifacts/MAUI-Sherpa.win-x64.zip
           Write-Host "Created: MAUI-Sherpa.win-x64.zip"
           Get-Item ./artifacts/MAUI-Sherpa.win-x64.zip | Format-List Name, Length
 
@@ -498,7 +502,11 @@ jobs:
             $arm64Dir = Get-ChildItem -Path "src/MauiSherpa/bin/Release" -Filter "publish" -Recurse -Directory |
               Where-Object { $_.FullName -like "*win-arm64*" } | Select-Object -First 1 -ExpandProperty FullName
           }
-          Compress-Archive -Path "$arm64Dir/*" -DestinationPath ./artifacts/MAUI-Sherpa.win-arm64.zip
+          $arm64Files = @(Get-ChildItem -Path $arm64Dir -File -Recurse)
+          if ($arm64Files.Count -ne 1 -or $arm64Files[0].Name -ne "MauiSherpa.exe") {
+            throw "Expected a single self-contained MauiSherpa.exe for win-arm64, but found: $($arm64Files.FullName -join ', ')"
+          }
+          Compress-Archive -Path $arm64Files[0].FullName -DestinationPath ./artifacts/MAUI-Sherpa.win-arm64.zip
           Write-Host "Created: MAUI-Sherpa.win-arm64.zip"
           Get-Item ./artifacts/MAUI-Sherpa.win-arm64.zip | Format-List Name, Length
 

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ This becomes available once the generated manifest is accepted into the upstream
 #### Windows (Manual)
 1. Download `MAUI-Sherpa.win-x64.zip` or `MAUI-Sherpa.win-arm64.zip`
 2. Extract to your preferred location
-3. Run `MauiSherpa.exe`
+3. Run the self-contained `MauiSherpa.exe` (no separate .NET or Windows App SDK installation required)
 
 #### Linux
 Download AppImage, .deb, or Flatpak from the releases page for your architecture (x64 or arm64).

--- a/src/MauiSherpa/MauiSherpa.csproj
+++ b/src/MauiSherpa/MauiSherpa.csproj
@@ -37,6 +37,13 @@
   <!-- Workaround for WindowsAppSDK Issue #3337 -->
   <PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows' and '$(RuntimeIdentifierOverride)' != ''">
     <RuntimeIdentifier>$(RuntimeIdentifierOverride)</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+    <IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>
+    <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
+    <DebugType>embedded</DebugType>
   </PropertyGroup>
 
   <PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">


### PR DESCRIPTION
Publishes each Windows architecture as one unpackaged, self-contained `MauiSherpa.exe`, following the .NET 10 MAUI unpackaged deployment guidance and .NET single-file deployment settings.

The .NET runtime, Windows App SDK, native libraries, and application content are bundled into the executable and extracted at startup as needed. The release workflow keeps the existing x64 and arm64 ZIP contract, but verifies that each publish directory contains exactly one `MauiSherpa.exe` before creating its archive.

Validation:
- Evaluated the Release `win-x64` MSBuild properties: self-contained, Windows App SDK self-contained, single-file, native/content extraction, compression, and embedded symbols are enabled
- Parsed the edited GitHub Actions workflow successfully
- Core and Workloads test suites passed
- App Inspector CLI tests: 6 passed

Windows CI is the authoritative publish check because WinUI publishing cannot be executed on this macOS host.