### PR TITLE
Improve recovery flows and external navigation

### DIFF
--- a/src/MauiSherpa/Components/AppleIdentityPicker.razor
+++ b/src/MauiSherpa/Components/AppleIdentityPicker.razor
@@ -4,9 +4,25 @@
 @inject IAppleIdentityStateService IdentityState
 @inject IPlatformService PlatformInfo
 @inject NavigationManager Navigation
+@inject ILocalVaultAccessService LocalVaultAccess
 @implements IDisposable
 
-@if (PlatformInfo.HasNativeToolbar)
+@if (RequiresLocalVaultAccess)
+{
+    <div class="vault-access-card">
+        <div class="vault-access-content">
+            <i class="fas fa-key"></i>
+            <div>
+                <strong>Unlock Local Vault to use Apple services</strong>
+                <p>Apple credentials are stored in the Local Vault. Grant access to continue using App Store Connect.</p>
+            </div>
+        </div>
+        <button class="btn btn-primary" @onclick="UnlockLocalVaultAsync" disabled="@isUnlocking">
+            <i class="fas @(isUnlocking ? "fa-spinner fa-spin" : "fa-unlock")"></i> Unlock Local Vault
+        </button>
+    </div>
+}
+else if (PlatformInfo.HasNativeToolbar)
 {
     @* Identity picker is in the native toolbar (macOS/Linux/Windows) *@
 }
@@ -124,15 +140,76 @@ else
         align-items: center;
         gap: 0.5rem;
     }
+
+    .vault-access-card {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 1rem;
+        padding: 1rem;
+        margin: 1rem 0;
+        background: var(--card-bg);
+        border-radius: var(--card-radius);
+    }
+
+    .vault-access-content {
+        display: flex;
+        align-items: flex-start;
+        gap: 0.875rem;
+        color: var(--text-secondary);
+    }
+
+    .vault-access-content i {
+        color: var(--accent-primary);
+        margin-top: 0.125rem;
+    }
+
+    .vault-access-content strong {
+        display: block;
+        color: var(--text-primary);
+        margin-bottom: 0.25rem;
+    }
+
+    .vault-access-content p {
+        margin: 0;
+        color: var(--text-muted);
+        font-size: 0.875rem;
+    }
 </style>
 
 @code {
     private List<AppleIdentity> identities = new();
     private string selectedIdentityId = "";
+    private bool isUnlocking;
+
+    private bool RequiresLocalVaultAccess => LocalVaultAccess.GetState().RequiresUserAction;
 
     protected override async Task OnInitializedAsync()
     {
-        identities = (await IdentityService.GetIdentitiesAsync()).ToList();
+        LocalVaultAccess.StateChanged += HandleLocalVaultStateChanged;
+        IdentityState.OnSelectionChanged += HandleExternalSelectionChange;
+        if (RequiresLocalVaultAccess)
+        {
+            IdentityState.SetSelectedIdentity(null);
+            return;
+        }
+
+        await LoadIdentitiesAsync();
+    }
+
+    private async Task LoadIdentitiesAsync()
+    {
+        try
+        {
+            identities = (await IdentityService.GetIdentitiesAsync()).ToList();
+        }
+        catch (LocalVaultUnavailableException)
+        {
+            identities = new();
+            selectedIdentityId = "";
+            IdentityState.SetSelectedIdentity(null);
+            return;
+        }
         
         // Restore selection or select first
         if (IdentityState.SelectedIdentity != null)
@@ -160,7 +237,38 @@ else
             IdentityState.SetSelectedIdentity(identities[0]);
         }
 
-        IdentityState.OnSelectionChanged += HandleExternalSelectionChange;
+    }
+
+    private void HandleLocalVaultStateChanged()
+    {
+        InvokeAsync(async () =>
+        {
+            if (RequiresLocalVaultAccess)
+            {
+                IdentityState.SetSelectedIdentity(null);
+            }
+            else
+            {
+                await LoadIdentitiesAsync();
+            }
+            StateHasChanged();
+        });
+    }
+
+    private async Task UnlockLocalVaultAsync()
+    {
+        isUnlocking = true;
+        try
+        {
+            var state = await LocalVaultAccess.RequestAccessAsync();
+            if (!state.RequiresUserAction)
+                await LoadIdentitiesAsync();
+        }
+        finally
+        {
+            isUnlocking = false;
+            await InvokeAsync(StateHasChanged);
+        }
     }
 
     private void OnSelectionChanged()
@@ -186,5 +294,6 @@ else
     public void Dispose()
     {
         IdentityState.OnSelectionChanged -= HandleExternalSelectionChange;
+        LocalVaultAccess.StateChanged -= HandleLocalVaultStateChanged;
     }
 }

--- a/src/MauiSherpa/Components/GoogleIdentityPicker.razor
+++ b/src/MauiSherpa/Components/GoogleIdentityPicker.razor
@@ -4,9 +4,25 @@
 @inject IGoogleIdentityStateService IdentityState
 @inject IPlatformService PlatformInfo
 @inject NavigationManager Navigation
+@inject ILocalVaultAccessService LocalVaultAccess
 @implements IDisposable
 
-@if (PlatformInfo.HasNativeToolbar)
+@if (RequiresLocalVaultAccess)
+{
+    <div class="vault-access-card">
+        <div class="vault-access-content">
+            <i class="fas fa-key"></i>
+            <div>
+                <strong>Unlock Local Vault to use Google services</strong>
+                <p>Google service account credentials are stored in the Local Vault. Grant access to continue.</p>
+            </div>
+        </div>
+        <button class="btn btn-primary" @onclick="UnlockLocalVaultAsync" disabled="@isUnlocking">
+            <i class="fas @(isUnlocking ? "fa-spinner fa-spin" : "fa-unlock")"></i> Unlock Local Vault
+        </button>
+    </div>
+}
+else if (PlatformInfo.HasNativeToolbar)
 {
     @* Identity picker is in the native toolbar (macOS/Linux/Windows) *@
 }
@@ -124,15 +140,47 @@ else
         align-items: center;
         gap: 0.5rem;
     }
+
+    .vault-access-card { display: flex; justify-content: space-between; align-items: center; gap: 1rem; padding: 1rem; margin: 1rem 0; background: var(--card-bg); border-radius: var(--card-radius); }
+    .vault-access-content { display: flex; align-items: flex-start; gap: 0.875rem; color: var(--text-secondary); }
+    .vault-access-content i { color: var(--accent-primary); margin-top: 0.125rem; }
+    .vault-access-content strong { display: block; color: var(--text-primary); margin-bottom: 0.25rem; }
+    .vault-access-content p { margin: 0; color: var(--text-muted); font-size: 0.875rem; }
 </style>
 
 @code {
     private List<GoogleIdentity> identities = new();
     private string selectedIdentityId = "";
+    private bool isUnlocking;
+
+    private bool RequiresLocalVaultAccess => LocalVaultAccess.GetState().RequiresUserAction;
 
     protected override async Task OnInitializedAsync()
     {
-        identities = (await IdentityService.GetIdentitiesAsync()).ToList();
+        LocalVaultAccess.StateChanged += HandleLocalVaultStateChanged;
+        IdentityState.OnSelectionChanged += HandleExternalSelectionChange;
+        if (RequiresLocalVaultAccess)
+        {
+            IdentityState.SetSelectedIdentity(null);
+            return;
+        }
+
+        await LoadIdentitiesAsync();
+    }
+
+    private async Task LoadIdentitiesAsync()
+    {
+        try
+        {
+            identities = (await IdentityService.GetIdentitiesAsync()).ToList();
+        }
+        catch (LocalVaultUnavailableException)
+        {
+            identities = new();
+            selectedIdentityId = "";
+            IdentityState.SetSelectedIdentity(null);
+            return;
+        }
 
         if (IdentityState.SelectedIdentity != null)
         {
@@ -159,7 +207,34 @@ else
             IdentityState.SetSelectedIdentity(identities[0]);
         }
 
-        IdentityState.OnSelectionChanged += HandleExternalSelectionChange;
+    }
+
+    private void HandleLocalVaultStateChanged()
+    {
+        InvokeAsync(async () =>
+        {
+            if (RequiresLocalVaultAccess)
+                IdentityState.SetSelectedIdentity(null);
+            else
+                await LoadIdentitiesAsync();
+            StateHasChanged();
+        });
+    }
+
+    private async Task UnlockLocalVaultAsync()
+    {
+        isUnlocking = true;
+        try
+        {
+            var state = await LocalVaultAccess.RequestAccessAsync();
+            if (!state.RequiresUserAction)
+                await LoadIdentitiesAsync();
+        }
+        finally
+        {
+            isUnlocking = false;
+            await InvokeAsync(StateHasChanged);
+        }
     }
 
     private void OnSelectionChanged()
@@ -185,5 +260,6 @@ else
     public void Dispose()
     {
         IdentityState.OnSelectionChanged -= HandleExternalSelectionChange;
+        LocalVaultAccess.StateChanged -= HandleLocalVaultStateChanged;
     }
 }

--- a/src/MauiSherpa/MainPage.cs
+++ b/src/MauiSherpa/MainPage.cs
@@ -23,6 +23,13 @@ public class MainPage : ContentPage
             Selector = "#app",
             ComponentType = typeof(Components.App)
         });
+        _blazorWebView.UrlLoading += (_, e) =>
+        {
+            if (e.Url.Scheme is "http" or "https" &&
+                e.Url.Host.Equals("github.com", StringComparison.OrdinalIgnoreCase) &&
+                e.Url.AbsolutePath.StartsWith("/Redth/MAUI.Sherpa/issues/new", StringComparison.OrdinalIgnoreCase))
+                e.UrlLoadingStrategy = Microsoft.AspNetCore.Components.WebView.UrlLoadingStrategy.OpenExternally;
+        };
 
 #if WINDOWS
         // Set WebView2 user data folder to a writable location so the app works

--- a/src/MauiSherpa/Pages/AppleDevices.razor
+++ b/src/MauiSherpa/Pages/AppleDevices.razor
@@ -14,12 +14,13 @@
 @implements IDisposable
 @inject IToolbarService ToolbarService
 @inject IPlatformService PlatformInfo
+@inject ILocalVaultAccessService LocalVaultAccess
 
 <h1><i class="fas fa-mobile-alt"></i> Registered Devices</h1>
 
 <AppleIdentityPicker />
 
-@if (IdentityState.SelectedIdentity != null)
+@if (IdentityState.SelectedIdentity != null && !LocalVaultAccess.GetState().RequiresUserAction)
 {
     @if (!PlatformInfo.HasNativeToolbar)
     {
@@ -426,6 +427,9 @@
 
     private async Task RefreshData(bool forceRefresh = false)
     {
+        if (IdentityState.SelectedIdentity == null || LocalVaultAccess.GetState().RequiresUserAction)
+            return;
+
         if (IdentityState.SelectedIdentity == null) return;
 
         isLoading = true;

--- a/src/MauiSherpa/Pages/BundleIds.razor
+++ b/src/MauiSherpa/Pages/BundleIds.razor
@@ -16,12 +16,13 @@
 @inject IPlatformService PlatformInfo
 @inject IFormModalService FormModalService
 @inject MauiSherpa.Pages.Forms.ModalParameterService ModalParams
+@inject ILocalVaultAccessService LocalVaultAccess
 
 <h1><i class="fas fa-fingerprint"></i> Bundle IDs</h1>
 
 <AppleIdentityPicker />
 
-@if (IdentityState.SelectedIdentity != null)
+@if (IdentityState.SelectedIdentity != null && !RequiresLocalVaultAccess)
 {
     @if (!PlatformInfo.HasNativeToolbar)
     {
@@ -349,6 +350,7 @@
     private Dictionary<string, List<AppleBundleIdCapability>> capabilitiesCache = new();
 
     private bool HasActiveFilters => !string.IsNullOrEmpty(searchQuery) || !string.IsNullOrEmpty(filterPlatform);
+    private bool RequiresLocalVaultAccess => LocalVaultAccess.GetState().RequiresUserAction;
 
     private IEnumerable<AppleBundleId> FilteredBundleIds => bundleIds
         .Where(b => string.IsNullOrEmpty(searchQuery) || 
@@ -387,6 +389,12 @@
     {
         InvokeAsync(async () =>
         {
+            if (RequiresLocalVaultAccess)
+            {
+                StateHasChanged();
+                return;
+            }
+
             await RefreshData(forceRefresh: false); // Use cache when identity changes (different identity = different cache key)
             StateHasChanged();
         });
@@ -437,6 +445,9 @@
 
     private async Task RefreshData(bool forceRefresh = false)
     {
+        if (IdentityState.SelectedIdentity == null || RequiresLocalVaultAccess)
+            return;
+
         // Set loading states
         isRefreshing = true;
         if (!forceRefresh && bundleIds.Count > 0)
@@ -482,6 +493,9 @@
 
     private async Task ShowCreateDialog()
     {
+        if (RequiresLocalVaultAccess)
+            return;
+
         var page = new MauiSherpa.Pages.Forms.CreateBundleIdPage(AppleService);
         var result = await FormModalService.ShowAsync<AppleBundleId>(page);
         if (result != null)

--- a/src/MauiSherpa/Pages/Certificates.razor
+++ b/src/MauiSherpa/Pages/Certificates.razor
@@ -24,12 +24,13 @@
 @inject IToolbarService ToolbarService
 @inject IPlatformService PlatformInfo
 @inject IPreferences AppPreferences
+@inject ILocalVaultAccessService LocalVaultAccess
 
 <h1><i class="fas fa-certificate"></i> Certificates</h1>
 
 <AppleIdentityPicker />
 
-@if (IdentityState.SelectedIdentity != null)
+@if (IdentityState.SelectedIdentity != null && !LocalVaultAccess.GetState().RequiresUserAction)
 {
     @if (!PlatformInfo.HasNativeToolbar)
     {
@@ -666,6 +667,9 @@
 
     private async Task RefreshData(bool forceRefresh = false)
     {
+        if (IdentityState.SelectedIdentity == null || LocalVaultAccess.GetState().RequiresUserAction)
+            return;
+
         if (IdentityState.SelectedIdentity == null) return;
 
         isLoading = true;

--- a/src/MauiSherpa/Pages/Doctor.razor
+++ b/src/MauiSherpa/Pages/Doctor.razor
@@ -16,6 +16,7 @@
 @inject ILogger<Doctor> Logger
 @inject IToolbarService ToolbarService
 @inject IPlatformService PlatformInfo
+@inject ILauncher AppLauncher
 @implements IDisposable
 
 <h1><i class="fas fa-stethoscope"></i> Environment Doctor</h1>
@@ -228,7 +229,7 @@
                                 }
                                 else
                                 {
-                                    <a href="@GetSdkDownloadUrl(sdk.Version)" target="_blank" class="download-link" title="Download SDK">
+                                    <a href="@GetSdkDownloadUrl(sdk.Version)" target="_blank" class="download-link" title="Download SDK" @onclick="() => OpenUrl(GetSdkDownloadUrl(sdk.Version))" @onclick:preventDefault>
                                         <i class="fas fa-download"></i> Download
                                     </a>
                                 }
@@ -1198,6 +1199,11 @@ else
         }
         // Fallback to main download page
         return "https://dotnet.microsoft.com/download/dotnet";
+    }
+
+    private async Task OpenUrl(string url)
+    {
+        await AppLauncher.OpenAsync(new Uri(url));
     }
 
     private async Task CopyToClipboard(string text)

--- a/src/MauiSherpa/Pages/FirebasePush.razor
+++ b/src/MauiSherpa/Pages/FirebasePush.razor
@@ -11,6 +11,7 @@
 @inject IFileSystemService FileSystem
 @inject BlazorToastService ToastService
 @inject IToolbarService ToolbarService
+@inject ILocalVaultAccessService LocalVaultAccess
 @implements IDisposable
 
 <h1><i class="fas fa-paper-plane"></i> Firebase Push Testing</h1>
@@ -569,20 +570,32 @@
 
     private async Task SyncCredentialsFromIdentity()
     {
-        var identity = GoogleIdentityState.SelectedIdentity;
-        if (identity != null && !string.IsNullOrEmpty(identity.ServiceAccountJson))
+        if (LocalVaultAccess.GetState().RequiresUserAction)
         {
-            await PushService.SaveServiceAccountAsync(identity.ServiceAccountJson);
-            hasCredentials = true;
-            projectId = identity.ProjectId;
+            hasCredentials = false;
+            projectId = null;
+            return;
         }
-        else
+
+        try
         {
-            hasCredentials = await PushService.HasCredentialsAsync();
-            if (hasCredentials)
-                projectId = await PushService.GetProjectIdAsync();
+            var identity = GoogleIdentityState.SelectedIdentity;
+            if (identity != null && !string.IsNullOrEmpty(identity.ServiceAccountJson))
+            {
+                await PushService.SaveServiceAccountAsync(identity.ServiceAccountJson);
+                hasCredentials = true;
+                projectId = identity.ProjectId;
+            }
             else
-                projectId = null;
+            {
+                hasCredentials = await PushService.HasCredentialsAsync();
+                projectId = hasCredentials ? await PushService.GetProjectIdAsync() : null;
+            }
+        }
+        catch (LocalVaultUnavailableException)
+        {
+            hasCredentials = false;
+            projectId = null;
         }
     }
 

--- a/src/MauiSherpa/Pages/Keystores.razor
+++ b/src/MauiSherpa/Pages/Keystores.razor
@@ -25,8 +25,26 @@
 @inject IToolbarService ToolbarService
 @inject IPlatformService PlatformInfo
 @inject IPreferences AppPreferences
+@inject ILocalVaultAccessService LocalVaultAccess
 
 <h1><i class="fas fa-key"></i> Keystores</h1>
+@if (RequiresLocalVaultAccess)
+{
+    <div class="vault-access-card">
+        <div class="vault-access-content">
+            <i class="fas fa-key"></i>
+            <div>
+                <strong>Unlock Local Vault to manage keystores</strong>
+                <p>Keystore passwords and sync credentials are stored in the Local Vault. Grant access to continue.</p>
+            </div>
+        </div>
+        <button class="btn btn-primary" @onclick="UnlockLocalVaultAsync" disabled="@isUnlockingLocalVault">
+            <i class="fas @(isUnlockingLocalVault ? "fa-spinner fa-spin" : "fa-unlock")"></i> Unlock Local Vault
+        </button>
+    </div>
+}
+else
+{
 @if (!PlatformInfo.HasNativeToolbar)
 {
 <div class="toolbar">
@@ -199,6 +217,7 @@ else
         }
     </div>
 }
+}
 
 <style>
     h1 { margin-bottom: 20px; }
@@ -207,6 +226,11 @@ else
     .empty-state i { margin-bottom: 16px; opacity: 0.4; }
     .empty-state h3 { color: var(--text-primary); margin-bottom: 8px; }
     .loading-card { text-align: center; padding: 40px; color: var(--text-muted); }
+    .vault-access-card { display: flex; justify-content: space-between; align-items: center; gap: 1rem; padding: 1rem; background: var(--card-bg); border-radius: var(--card-radius); }
+    .vault-access-content { display: flex; align-items: flex-start; gap: 0.875rem; color: var(--text-secondary); }
+    .vault-access-content i { color: var(--accent-primary); margin-top: 0.125rem; }
+    .vault-access-content strong { display: block; color: var(--text-primary); margin-bottom: 0.25rem; }
+    .vault-access-content p { margin: 0; color: var(--text-muted); font-size: 0.875rem; }
 
     .keystores-grid { display: flex; flex-direction: column; gap: 12px; }
     .keystore-card {
@@ -297,6 +321,7 @@ else
                     (k.KeystoreType?.Contains(searchQuery, StringComparison.OrdinalIgnoreCase) ?? false));
 
     private bool isLoading;
+    private bool isUnlockingLocalVault;
     private bool demoMode = false;
     private string? jdkPath;
 
@@ -309,6 +334,7 @@ else
 
     private bool HasCloudOnlyKeystores => cloudOnlyStatuses.Count > 0;
     private bool HasLocalOnlyKeystores => syncStatuses.Values.Any(s => s.HasLocal && !s.HasCloud);
+    private bool RequiresLocalVaultAccess => LocalVaultAccess.GetState().RequiresUserAction;
 
 
 
@@ -322,20 +348,25 @@ else
         ToolbarService.SetSearch("Search keystores...");
         ToolbarService.ToolbarItemClicked += OnToolbarItemClicked;
         ToolbarService.SearchTextChanged += OnSearchTextChanged;
+        LocalVaultAccess.StateChanged += OnLocalVaultStateChanged;
 
         try { var settings = await SettingsService.GetSettingsAsync(); demoMode = settings.Preferences.DemoMode; } catch { }
         syncHintDismissed = AppPreferences.Get(SyncHintDismissedKey, false);
         CloudSecretsService.OnActiveProviderChanged += OnActiveProviderChanged;
 
-        // Initialize cloud secrets service to load active provider
-        if (CloudSecretsService is MauiSherpa.Core.Services.CloudSecretsService svc)
-            await svc.InitializeAsync();
-
-        await RefreshData(false);
+        if (!RequiresLocalVaultAccess)
+        {
+            if (CloudSecretsService is MauiSherpa.Core.Services.CloudSecretsService svc)
+                await svc.InitializeAsync();
+            await RefreshData(false);
+        }
     }
 
     private async Task RefreshData(bool forceRefresh)
     {
+        if (RequiresLocalVaultAccess)
+            return;
+
         isLoading = true;
         StateHasChanged();
         try
@@ -726,6 +757,31 @@ else
         ToolbarService.ToolbarItemClicked -= OnToolbarItemClicked;
         ToolbarService.SearchTextChanged -= OnSearchTextChanged;
         CloudSecretsService.OnActiveProviderChanged -= OnActiveProviderChanged;
+        LocalVaultAccess.StateChanged -= OnLocalVaultStateChanged;
+    }
+
+    private void OnLocalVaultStateChanged() => InvokeAsync(StateHasChanged);
+
+    private async Task UnlockLocalVaultAsync()
+    {
+        isUnlockingLocalVault = true;
+        try
+        {
+            var state = await LocalVaultAccess.RequestAccessAsync();
+            if (state.RequiresUserAction)
+            {
+                ToastService.ShowError("Local Vault access was not granted.");
+                return;
+            }
+
+            ToastService.ShowSuccess("Local Vault unlocked.");
+            await RefreshData(false);
+        }
+        finally
+        {
+            isUnlockingLocalVault = false;
+            await InvokeAsync(StateHasChanged);
+        }
     }
 
     private void OnToolbarItemClicked(string actionId)

--- a/src/MauiSherpa/Pages/Modals/CISecretsWizardModal.razor
+++ b/src/MauiSherpa/Pages/Modals/CISecretsWizardModal.razor
@@ -18,6 +18,7 @@
 @inject ILauncher AppLauncher
 @inject ICertificateSyncService CertificateSyncService
 @inject ICloudSecretsService CloudSecretsService
+@inject ILocalVaultAccessService LocalVaultAccess
 @implements IDisposable
 
 @{
@@ -1856,6 +1857,18 @@
 
     private async Task LoadDataAsync()
     {
+        if (LocalVaultAccess.GetState().RequiresUserAction)
+        {
+            var state = await LocalVaultAccess.RequestAccessAsync();
+            if (state.RequiresUserAction)
+            {
+                await AlertService.ShowAlertAsync(
+                    "Local Vault Locked",
+                    "Unlock the Local Vault to load Apple identities, certificates, profiles, and signing secrets.");
+                return;
+            }
+        }
+
         // Auto-select first identity if none selected (wizard may open before Apple pages are visited)
         if (IdentityState.SelectedIdentity == null)
         {

--- a/src/MauiSherpa/Pages/Modals/GoogleIdentityModal.razor
+++ b/src/MauiSherpa/Pages/Modals/GoogleIdentityModal.razor
@@ -4,6 +4,7 @@
 @inject MauiSherpa.Pages.Forms.ModalParameterService ModalParams
 @inject IDialogService DialogService
 @inject IFileSystemService FileSystem
+@inject ILauncher AppLauncher
 
 <div class="dialog-content">
     <div class="dialog-header">
@@ -18,7 +19,7 @@
         <div class="form-group">
             <label>Service Account JSON</label>
             <div class="help-text" style="margin-bottom: 0.5rem;">
-                Download from <a href="https://console.firebase.google.com/project/_/settings/serviceaccounts/adminsdk" target="_blank">Firebase Console → Project Settings → Service Accounts</a> → Generate New Private Key
+                Download from <a href="https://console.firebase.google.com/project/_/settings/serviceaccounts/adminsdk" target="_blank" @onclick='() => OpenUrl("https://console.firebase.google.com/project/_/settings/serviceaccounts/adminsdk")' @onclick:preventDefault>Firebase Console → Project Settings → Service Accounts</a> → Generate New Private Key
             </div>
             <div class="p8-input-toggle">
                 <button class="toggle-btn @(saJsonInputMode == "file" ? "active" : "")" @onclick="@(() => saJsonInputMode = "file")">
@@ -103,6 +104,11 @@
     }
 
     private void Cancel() => ModalParams.Cancel();
+
+    private async Task OpenUrl(string url)
+    {
+        await AppLauncher.OpenAsync(new Uri(url));
+    }
 
     private void Save()
     {

--- a/src/MauiSherpa/Pages/Modals/XcodeDownloadAuthModal.razor
+++ b/src/MauiSherpa/Pages/Modals/XcodeDownloadAuthModal.razor
@@ -26,7 +26,8 @@
             </div>
         </div>
 
-        <div class="wizard-body">
+        <form class="wizard-body" @onsubmit="OnFormSubmitted" @onsubmit:preventDefault>
+            <button type="submit" tabindex="-1" hidden></button>
             @if (currentStep == AuthStep.Credentials)
             {
                 <div class="step-content">
@@ -107,7 +108,7 @@
                     <span>@authError</span>
                 </div>
             }
-        </div>
+        </form>
     </div>
 }
 
@@ -149,6 +150,13 @@
     };
 
     private void OnFieldChanged() => UpdateWizardState();
+
+    private async Task OnFormSubmitted()
+    {
+        var bridge = BridgeHolder.Current;
+        if (bridge != null && CanSubmitCurrentStep && !isAuthenticating)
+            await bridge.RequestSubmitAsync();
+    }
 
     private async Task OnPhoneSelectionChanged()
     {

--- a/src/MauiSherpa/Pages/ProvisioningProfiles.razor
+++ b/src/MauiSherpa/Pages/ProvisioningProfiles.razor
@@ -16,13 +16,14 @@
 @inject IEncryptedSettingsService SettingsService
 @inject IToolbarService ToolbarService
 @inject IPlatformService PlatformInfo
+@inject ILocalVaultAccessService LocalVaultAccess
 @implements IDisposable
 
 <h1><i class="fas fa-id-card"></i> Provisioning Profiles</h1>
 
 <AppleIdentityPicker />
 
-@if (IdentityState.SelectedIdentity != null)
+@if (IdentityState.SelectedIdentity != null && !LocalVaultAccess.GetState().RequiresUserAction)
 {
     @if (!PlatformInfo.HasNativeToolbar)
     {
@@ -584,6 +585,9 @@
 
     private async Task RefreshData(bool forceRefresh = false)
     {
+        if (IdentityState.SelectedIdentity == null || LocalVaultAccess.GetState().RequiresUserAction)
+            return;
+
         if (IdentityState.SelectedIdentity == null) return;
 
         isLoading = true;

--- a/src/MauiSherpa/Pages/PushTesting.razor
+++ b/src/MauiSherpa/Pages/PushTesting.razor
@@ -8,6 +8,7 @@
 @inject BlazorToastService ToastService
 @inject ILoggingService Logger
 @inject IToolbarService ToolbarService
+@inject ILocalVaultAccessService LocalVaultAccess
 @implements IDisposable
 
 <h1><i class="fas fa-paper-plane"></i> Push Testing</h1>
@@ -33,7 +34,24 @@
 
             @if (authMode == "identity")
             {
-                <div class="form-group">
+                @if (RequiresLocalVaultAccess)
+                {
+                    <div class="vault-access-card">
+                        <div class="vault-access-content">
+                            <i class="fas fa-key"></i>
+                            <div>
+                                <strong>Unlock Local Vault to use a stored identity</strong>
+                                <p>Unlock the vault, or select the .p8 filesystem option above.</p>
+                            </div>
+                        </div>
+                        <button class="btn btn-primary" @onclick="UnlockLocalVaultAsync" disabled="@isUnlockingLocalVault">
+                            <i class="fas @(isUnlockingLocalVault ? "fa-spinner fa-spin" : "fa-unlock")"></i> Unlock Local Vault
+                        </button>
+                    </div>
+                }
+                else
+                {
+                    <div class="form-group">
                     <label>Apple Identity</label>
                     @if (identities.Count == 0)
                     {
@@ -49,7 +67,8 @@
                             }
                         </select>
                     }
-                </div>
+                    </div>
+                }
                 <div class="form-group">
                     <label>Team ID</label>
                     <input type="text" @bind="teamId" @bind:after="MarkDirty" placeholder="e.g. ABC1234DEF" />
@@ -222,6 +241,12 @@
         border-radius: var(--card-radius, 1rem);
         overflow: hidden;
     }
+
+    .vault-access-card { display: flex; justify-content: space-between; align-items: center; gap: 1rem; padding: 1rem; background: var(--bg-tertiary); border-radius: 0.5rem; }
+    .vault-access-content { display: flex; align-items: flex-start; gap: 0.875rem; color: var(--text-secondary); }
+    .vault-access-content i { color: var(--accent-primary); margin-top: 0.125rem; }
+    .vault-access-content strong { display: block; color: var(--text-primary); margin-bottom: 0.25rem; }
+    .vault-access-content p { margin: 0; color: var(--text-muted); font-size: 0.875rem; }
 
     .section-title {
         font-weight: 600;
@@ -438,6 +463,8 @@
 </style>
 
 @code {
+    bool isUnlockingLocalVault;
+    bool RequiresLocalVaultAccess => LocalVaultAccess.GetState().RequiresUserAction;
     PushProjectBar? projectBar;
     List<AppleIdentity> identities = new();
     PushProject? activeProject;
@@ -491,7 +518,9 @@
     protected override async Task OnInitializedAsync()
     {
         ToolbarService.ClearItems();
-        identities = (await IdentityService.GetIdentitiesAsync()).ToList();
+        LocalVaultAccess.StateChanged += OnLocalVaultStateChanged;
+        if (!RequiresLocalVaultAccess)
+            identities = (await IdentityService.GetIdentitiesAsync()).ToList();
 
         // Migrate legacy settings if needed
         var migrated = await ProjectService.MigrateFromLegacyAsync();
@@ -502,6 +531,30 @@
         {
             var selected = migrated ?? projects[0];
             LoadFromProject(selected);
+        }
+    }
+
+    void OnLocalVaultStateChanged() => InvokeAsync(StateHasChanged);
+
+    async Task UnlockLocalVaultAsync()
+    {
+        isUnlockingLocalVault = true;
+        try
+        {
+            var state = await LocalVaultAccess.RequestAccessAsync();
+            if (state.RequiresUserAction)
+            {
+                ToastService.ShowError("Local Vault access was not granted.");
+                return;
+            }
+
+            identities = (await IdentityService.GetIdentitiesAsync()).ToList();
+            ToastService.ShowSuccess("Local Vault unlocked.");
+        }
+        finally
+        {
+            isUnlockingLocalVault = false;
+            await InvokeAsync(StateHasChanged);
         }
     }
 
@@ -736,5 +789,6 @@
 
     public void Dispose()
     {
+        LocalVaultAccess.StateChanged -= OnLocalVaultStateChanged;
     }
 }

--- a/src/MauiSherpa/Pages/Settings.razor
+++ b/src/MauiSherpa/Pages/Settings.razor
@@ -153,7 +153,7 @@
                         {
                             <button class="btn btn-sm btn-update-available" @onclick="ShowUpdateDialog">
                                 <i class="fas fa-arrow-circle-up"></i>
-                                @(updateResult.LatestRelease.TagName) available
+                                Upgrade to @(updateResult.LatestRelease.TagName)
                             </button>
                         }
                     </div>
@@ -287,7 +287,7 @@
     <h2><i class="fab fa-apple"></i> Apple Identities</h2>
     <p class="section-description">
         Configure App Store Connect API credentials for managing Apple Developer resources.
-        <a href="https://appstoreconnect.apple.com/access/integrations/api" target="_blank">Get API keys</a>
+        <a href="https://appstoreconnect.apple.com/access/integrations/api" target="_blank" @onclick='() => OpenUrl("https://appstoreconnect.apple.com/access/integrations/api")' @onclick:preventDefault>Get API keys</a>
     </p>
     
     @if (appleIdentities.Count == 0)
@@ -357,7 +357,7 @@
     <h2><i class="fab fa-google"></i> Google Identities</h2>
     <p class="section-description">
         Configure Google Cloud / Firebase service account credentials for push notifications and project management.
-        <a href="https://console.firebase.google.com/project/_/settings/serviceaccounts/adminsdk" target="_blank">Get service account JSON</a>
+        <a href="https://console.firebase.google.com/project/_/settings/serviceaccounts/adminsdk" target="_blank" @onclick='() => OpenUrl("https://console.firebase.google.com/project/_/settings/serviceaccounts/adminsdk")' @onclick:preventDefault>Get service account JSON</a>
     </p>
     
     @if (googleIdentities.Count == 0)
@@ -458,7 +458,7 @@
                             <span class="provider-name">@provider.Name</span>
                             @if (!string.IsNullOrEmpty(providerUrl))
                             {
-                                <a href="@providerUrl" target="_blank" class="provider-link" title="Open in browser">
+                                <a href="@providerUrl" target="_blank" class="provider-link" title="Open in browser" @onclick="() => OpenUrl(providerUrl)" @onclick:preventDefault>
                                     <i class="fas fa-external-link-alt"></i>
                                 </a>
                             }
@@ -1498,7 +1498,7 @@
         await LoadGeneralPreferences();
         
         appVersion = TruncateVersion(UpdateService.GetCurrentVersion());
-        updateResult = UpdateService.CachedResult;
+        updateResult = await UpdateService.CheckForUpdateAsync();
     }
 
     private static string TruncateVersion(string version)
@@ -1625,6 +1625,8 @@
             if (CloudSecretsService is CloudSecretsService svc)
                 await svc.InitializeAsync();
             await LoadCloudProviders();
+            await LoadAppleIdentities();
+            await LoadGoogleIdentities();
         }
         finally
         {
@@ -1635,23 +1637,41 @@
 
     private async Task LoadAppleIdentities()
     {
-        appleIdentities = (await AppleIdentityService.GetIdentitiesAsync()).ToList();
+        try
+        {
+            appleIdentities = (await AppleIdentityService.GetIdentitiesAsync()).ToList();
+        }
+        catch (LocalVaultUnavailableException)
+        {
+            appleIdentities = new();
+        }
     }
 
     private async Task LoadGoogleIdentities()
     {
-        googleIdentities = (await GoogleIdentityService.GetIdentitiesAsync()).ToList();
+        try
+        {
+            googleIdentities = (await GoogleIdentityService.GetIdentitiesAsync()).ToList();
+        }
+        catch (LocalVaultUnavailableException)
+        {
+            googleIdentities = new();
+        }
     }
     
     private async Task LoadCloudProviders()
     {
-        // Initialize service if needed
-        if (CloudSecretsService is CloudSecretsService svc)
+        try
         {
-            await svc.InitializeAsync();
-        }
+            if (CloudSecretsService is CloudSecretsService svc)
+                await svc.InitializeAsync();
 
-        cloudProviders = (await CloudSecretsService.GetProvidersAsync()).ToList();
+            cloudProviders = (await CloudSecretsService.GetProvidersAsync()).ToList();
+        }
+        catch (LocalVaultUnavailableException)
+        {
+            cloudProviders = new();
+        }
     }
 
     private async Task LoadSecretsPublishers()

--- a/src/MauiSherpa/wwwroot/index.html
+++ b/src/MauiSherpa/wwwroot/index.html
@@ -72,31 +72,71 @@
             bottom: 0;
             left: 0;
             right: 0;
-            padding: 1rem;
+            padding: 0.75rem 1rem;
             background: #f44336;
             color: white;
-            text-align: center;
+            z-index: 10000;
+        }
+
+        #blazor-error-ui .error-actions {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            flex-wrap: wrap;
+            gap: 0.75rem;
+        }
+
+        #blazor-error-ui button,
+        #blazor-error-ui a {
+            color: white;
+            font: inherit;
+        }
+
+        #blazor-error-ui button {
+            padding: 0;
+            border: 0;
+            background: transparent;
+            cursor: pointer;
+            text-decoration: underline;
+        }
+
+        #blazor-error-ui .error-details {
+            max-height: 12rem;
+            margin: 0.75rem auto 0;
+            padding: 0.75rem;
+            overflow: auto;
+            background: rgba(0, 0, 0, 0.2);
+            color: white;
+            font: 0.75rem/1.4 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+            text-align: left;
+            white-space: pre-wrap;
+            user-select: text;
         }
 
         #blazor-error-ui .dismiss {
             cursor: pointer;
-            margin-left: 1rem;
         }
     </style>
 </head>
 <body>
     <div id="app"></div>
 
-    <div id="blazor-error-ui" data-nosnippet>
-        An unhandled error has occurred.
-        <a href="." class="reload" style="color: white;">Reload</a>
-        <span class="dismiss"><i class="fas fa-times"></i></span>
+    <div id="blazor-error-ui" data-nosnippet role="alert" aria-live="assertive">
+        <div class="error-actions">
+            <span>An unhandled error has occurred.</span>
+            <button type="button" data-error-action="details" aria-expanded="false">Show details</button>
+            <a data-error-action="report" rel="noreferrer">Report issue</a>
+            <a href="." class="reload">Reload</a>
+            <button type="button" class="dismiss" data-error-action="dismiss" aria-label="Dismiss error"><i class="fas fa-times"></i></button>
+        </div>
+        <pre class="error-details" hidden></pre>
     </div>
 
     <script src="_framework/blazor.webview.js" autostart="false"></script>
     <script src="js/terminal.js"></script>
     <script src="js/modalInterop.js"></script>
     <script src="js/logScrollInterop.js"></script>
+    <script src="js/errorInterop.js"></script>
     <script>
         window.highlightCode = function(elementId) {
             var el = document.getElementById(elementId);

--- a/src/MauiSherpa/wwwroot/js/errorInterop.js
+++ b/src/MauiSherpa/wwwroot/js/errorInterop.js
@@ -1,0 +1,113 @@
+(function () {
+    const maxErrorLength = 4000;
+    let latestError = '';
+
+    function formatError(value) {
+        if (value instanceof Error) {
+            return value.stack || `${value.name}: ${value.message}`;
+        }
+
+        if (typeof value === 'string') {
+            return value;
+        }
+
+        try {
+            return JSON.stringify(value);
+        } catch {
+            return String(value);
+        }
+    }
+
+    function captureError(message) {
+        if (!message) {
+            return;
+        }
+
+        latestError = String(message).slice(0, maxErrorLength);
+        refreshErrorUi();
+    }
+
+    const originalConsoleError = console.error.bind(console);
+    console.error = function (...args) {
+        captureError(args.map(formatError).join(' '));
+        originalConsoleError(...args);
+    };
+
+    window.addEventListener('error', (event) => {
+        captureError(event.error?.stack || event.message);
+    });
+
+    window.addEventListener('unhandledrejection', (event) => {
+        captureError(formatError(event.reason));
+    });
+
+    function getErrorUi() {
+        return document.getElementById('blazor-error-ui');
+    }
+
+    function getIssueBody() {
+        const details = latestError || 'No browser error details were captured. Please attach the Maui Sherpa application logs.';
+        return [
+            '## Unhandled Blazor error',
+            '',
+            '```text',
+            details,
+            '```',
+            '',
+            `User agent: ${navigator.userAgent}`
+        ].join('\n');
+    }
+
+    function refreshErrorUi() {
+        const errorUi = getErrorUi();
+        if (!errorUi) {
+            return;
+        }
+
+        const details = errorUi.querySelector('.error-details');
+        const report = errorUi.querySelector('[data-error-action="report"]');
+        if (details) {
+            details.textContent = latestError || 'No browser error details were captured. Check the Maui Sherpa application logs for more information.';
+        }
+        if (report) {
+            const query = new URLSearchParams({
+                title: 'Unhandled Blazor error',
+                body: getIssueBody()
+            });
+            report.href = `https://github.com/Redth/MAUI.Sherpa/issues/new?${query}`;
+        }
+    }
+
+    function initializeErrorUi() {
+        const errorUi = getErrorUi();
+        if (!errorUi) {
+            return;
+        }
+
+        const details = errorUi.querySelector('.error-details');
+        const detailsButton = errorUi.querySelector('[data-error-action="details"]');
+        const dismissButton = errorUi.querySelector('[data-error-action="dismiss"]');
+
+        detailsButton?.addEventListener('click', () => {
+            const isExpanded = detailsButton.getAttribute('aria-expanded') === 'true';
+            detailsButton.setAttribute('aria-expanded', String(!isExpanded));
+            detailsButton.textContent = isExpanded ? 'Show details' : 'Hide details';
+            if (details) {
+                details.hidden = isExpanded;
+            }
+            refreshErrorUi();
+        });
+
+        dismissButton?.addEventListener('click', () => {
+            errorUi.style.display = 'none';
+        });
+
+        new MutationObserver(refreshErrorUi).observe(errorUi, {
+            attributes: true,
+            attributeFilter: ['style', 'class']
+        });
+        refreshErrorUi();
+    }
+
+    initializeErrorUi();
+})();


### PR DESCRIPTION
## Summary

- add recoverable Local Vault unlock flows across Apple, Google, keystore, push, settings, and CI wizard experiences
- make Settings show the current version and launch the existing upgrade flow when an update is available
- open external links through the native browser and make Xcode sign-in submit with Enter
- expand the Blazor error bar with captured diagnostics and a prefilled upstream issue action

## Code review

Reviewed the complete diff for initialization races, event cleanup, internal versus external navigation, duplicate recovery UI, first-access vault failures, and Razor submission behavior. The identified issues were fixed before this PR.

## Validation

- `dotnet build src/MauiSherpa/MauiSherpa.csproj -f net10.0-maccatalyst --verbosity minimal`
- `dotnet test tests/MauiSherpa.Core.Tests/MauiSherpa.Core.Tests.csproj --filter "FullyQualifiedName~UpdateServiceTests" --verbosity minimal` (17 passed)
- `node --check src/MauiSherpa/wwwroot/js/errorInterop.js`
- `git diff --check`