### PR TITLE
Make dotnetup's managed root authoritative for Doctor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ MauiSherpa is a .NET 10 MAUI Blazor Hybrid desktop application for managing deve
 - .NET SDK management via `dotnetup` (install/update SDKs & runtimes — see `docs/dotnet-sdk-management.md`)
 - GitHub Copilot integration
 
-**Platforms:** Mac Catalyst, Windows
+**Platforms:** macOS (AppKit), Windows, Linux (GTK)
 **Bundle Identifier:** `codes.redth.mauisherpa`
 
 ## Project Structure
@@ -24,12 +24,14 @@ MAUI.Sherpa/
 │   │   ├── Services/             # Service implementations
 │   │   ├── ViewModels/           # MVVM ViewModels
 │   │   └── Interfaces.cs         # All interface definitions
-│   ├── MauiSherpa/               # MAUI app with Blazor UI
+│   ├── MauiSherpa/               # Shared MAUI app with Blazor UI (Windows head)
 │   │   ├── Components/           # Reusable Blazor components
 │   │   ├── Pages/                # Blazor page components
 │   │   ├── Services/             # Platform-specific service implementations
-│   │   ├── Platforms/            # Platform-specific code (MacCatalyst, Windows)
+│   │   ├── Platforms/            # Platform-specific code (Windows)
 │   │   └── wwwroot/              # Static assets (CSS, JS, index.html)
+│   ├── MauiSherpa.MacOS/         # macOS AppKit app head (net10.0-macos)
+│   ├── MauiSherpa.LinuxGtk/      # Linux GTK app head
 │   └── MauiSherpa.Workloads/     # .NET SDK workload querying library
 │       ├── Models/               # Workload data models
 │       ├── Services/             # Workload services
@@ -43,8 +45,8 @@ MAUI.Sherpa/
 ## Build Commands
 
 ```bash
-# Build for Mac Catalyst
-dotnet build src/MauiSherpa -f net10.0-maccatalyst
+# Build for macOS (AppKit head)
+dotnet build src/MauiSherpa.MacOS -f net10.0-macos
 
 # Build for Windows (on Windows only)
 dotnet build src/MauiSherpa -f net10.0-windows10.0.19041.0
@@ -55,23 +57,26 @@ dotnet build MauiSherpa.sln
 # Run all tests
 dotnet test MauiSherpa.sln
 
-# Publish Mac Catalyst app
-dotnet publish src/MauiSherpa -f net10.0-maccatalyst -c Release
+# Publish macOS app
+dotnet publish src/MauiSherpa.MacOS -f net10.0-macos -c Release
 
 # Publish Windows app
 dotnet publish src/MauiSherpa -f net10.0-windows10.0.19041.0 -c Release
 ```
+
+`src/MauiSherpa` is the shared UI project and the Windows head. It only builds on Windows — on
+macOS and Linux its `Build`/`Rebuild`/`Publish` targets are no-ops so solution builds still work.
 
 ### Launching the App
 
 **IMPORTANT:** `dotnet run` does NOT work for .NET MAUI apps (until .NET 11). Use one of:
 ```bash
 # Option 1: Build with -t:Run target (keeps process alive until app exits)
-dotnet build src/MauiSherpa -f net10.0-maccatalyst -t:Run
+dotnet build src/MauiSherpa.MacOS -f net10.0-macos -t:Run
 
 # Option 2: Build then manually open the .app bundle
-dotnet build src/MauiSherpa -f net10.0-maccatalyst
-open "src/MauiSherpa/bin/Debug/net10.0-maccatalyst/maccatalyst-arm64/MAUI Sherpa.app"
+dotnet build src/MauiSherpa.MacOS -f net10.0-macos
+open "src/MauiSherpa.MacOS/bin/Debug/net10.0-macos/osx-arm64/MAUI Sherpa.app"
 ```
 
 **Always launch from `bin/` path**, NOT `artifacts/`. The `artifacts/` copy may be stale and missing DLLs.
@@ -169,7 +174,7 @@ All modals use `modalInterop.js` (`wwwroot/js/modalInterop.js`) for focus trappi
 - Escape closes the modal
 - Auto-focuses `.btn-primary:not([disabled])` on open
 
-**CRITICAL:** In Blazor WebView (Mac Catalyst), browser default Tab navigation does NOT work. All Tab keypresses must be intercepted with `preventDefault()` and explicit `.focus()` calls via JS interop.
+**CRITICAL:** In Blazor WebView (macOS), browser default Tab navigation does NOT work. All Tab keypresses must be intercepted with `preventDefault()` and explicit `.focus()` calls via JS interop.
 
 ### Text Selection Prevention
 Global `user-select: none` is applied on `*` to prevent accidental text selection in the hybrid app. Selectively re-enabled on: `input`, `textarea`, `select`, `code`, `pre`, `.mono`, `.terminal-output`, `.log-entry`, `.error-message`, `.chat-message`, and `.text-selectable`.
@@ -205,7 +210,7 @@ When making or reviewing UI changes, always verify:
 
 ## Platform-Specific Notes
 
-### Mac Catalyst
+### macOS
 
 **App data path:** Use `AppDataPath.GetAppDataDirectory()` which returns `~/Library/Application Support/MauiSherpa/`. Do NOT use `SpecialFolder.ApplicationData` (resolves to `~/Documents/.config/` which is TCC-protected).
 
@@ -213,9 +218,7 @@ When making or reviewing UI changes, always verify:
 
 **File save dialogs:** `PickSaveFileAsync` (native `NSSavePanel`) creates an empty file at the chosen path. Tools like `keytool` that refuse to overwrite existing files need the empty file deleted first.
 
-**Mac Catalyst delegate:** Use `DidPickDocumentAtUrls` (plural), NOT `DidPickDocument` (singular). The singular form doesn't fire on modern Mac Catalyst.
-
-**Hardened runtime:** MSBuild `EnableHardenedRuntime=true` does NOT work for .NET MAUI Mac Catalyst. Must re-sign with `codesign --force --options runtime --timestamp` after publish.
+**Duplicate native libraries:** The app heads reference both `MauiSherpa.AppInspector` and `MauiSherpa.Core`, and AppInspector also references Core, so `GitHub.Copilot.SDK` stages `libcopilot_runtime.dylib` several times over. The Apple SDK's `InstallNameTool` task runs its items in parallel against a shared `.tmp` path and crashes on duplicates, so `build/DedupeNativeReferences.targets` collapses each destination to one entry. Import it from any new Apple app head.
 
 **Logging:** Logs saved to `~/Library/Application Support/MauiSherpa/logs/maui-sherpa-{yyyy-MM-dd}.log`.
 

--- a/README.md
+++ b/README.md
@@ -284,10 +284,7 @@ dotnet restore
 # Build for macOS (AppKit)
 dotnet build src/MauiSherpa.MacOS -f net10.0-macos
 
-# Build for Mac Catalyst
-dotnet build src/MauiSherpa -f net10.0-maccatalyst
-
-# Build for Windows
+# Build for Windows (Windows only)
 dotnet build src/MauiSherpa -f net10.0-windows10.0.19041.0
 
 # Run tests
@@ -299,11 +296,11 @@ dotnet test
 ```
 MAUI.Sherpa/
 ├── src/
-│   ├── MauiSherpa/               # Main MAUI Blazor Hybrid app
+│   ├── MauiSherpa/               # Shared MAUI Blazor Hybrid UI + Windows app head
 │   │   ├── Components/           # Reusable Blazor components
 │   │   ├── Pages/                # Blazor page components
 │   │   ├── Services/             # Platform-specific services
-│   │   └── Platforms/            # Platform code (MacCatalyst, Windows)
+│   │   └── Platforms/            # Platform code (Windows)
 │   ├── MauiSherpa.MacOS/         # macOS AppKit app head
 │   ├── MauiSherpa.LinuxGtk/      # Linux GTK4 app head
 │   ├── MauiSherpa.Core/          # Business logic library

--- a/build/DedupeNativeReferences.targets
+++ b/build/DedupeNativeReferences.targets
@@ -1,0 +1,56 @@
+<Project>
+
+  <!--
+    App heads reference both MauiSherpa.AppInspector and MauiSherpa.Core, and AppInspector itself
+    references Core. GitHub.Copilot.SDK's transitive targets stage libcopilot_runtime.dylib for
+    every project that references it, so the head resolves the same native library several times
+    over: byte-identical content, identical RelativePath, but differing source paths and project
+    bookkeeping metadata.
+
+    The Apple SDK's InstallNameTool task processes items in parallel (Task.WaitAll) and derives its
+    scratch file from the destination, so entries sharing a ReidentifiedPath race on the same
+    "<name>.tmp" and the build dies with:
+
+      install_name_tool: cannot rename .../libcopilot_runtime.dylib.tmp to ....tmp.XXXXXX
+      The "InstallNameTool" task failed unexpectedly.
+
+    Collapse each destination down to a single native reference before the SDK computes what to
+    re-identify. Batched per RelativePath; MatchOnMetadata scopes the removal to that destination so
+    a source file legitimately published to more than one location is left alone.
+  -->
+  <Target Name="_RemoveDuplicateNativeReferences"
+          BeforeTargets="_ComputeDynamicLibrariesToReidentify"
+          Outputs="%(_FileNativeReference.RelativePath)"
+          Condition="'@(_FileNativeReference)' != ''">
+
+    <ItemGroup>
+      <_NativeReferencesForPath Include="@(_FileNativeReference)" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <_NativeReferencesForPathCount>@(_NativeReferencesForPath->Count())</_NativeReferencesForPathCount>
+      <_NativeReferenceToKeep />
+    </PropertyGroup>
+
+    <!-- Task batching leaves the last item's identity behind, which is all we need: any one of the
+         duplicates will do, we just have to pick the same one every time. -->
+    <PropertyGroup Condition="$(_NativeReferencesForPathCount) &gt; 1">
+      <_NativeReferenceToKeep>%(_NativeReferencesForPath.Identity)</_NativeReferenceToKeep>
+    </PropertyGroup>
+
+    <Message Importance="normal"
+             Condition="$(_NativeReferencesForPathCount) &gt; 1"
+             Text="Collapsing $(_NativeReferencesForPathCount) native references for '%(_FileNativeReference.RelativePath)' to '$(_NativeReferenceToKeep)'." />
+
+    <ItemGroup Condition="$(_NativeReferencesForPathCount) &gt; 1">
+      <_FileNativeReference Remove="@(_NativeReferencesForPath)" MatchOnMetadata="RelativePath" />
+      <_FileNativeReference Include="@(_NativeReferencesForPath)"
+                            Condition="'%(Identity)' == '$(_NativeReferenceToKeep)'" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <_NativeReferencesForPath Remove="@(_NativeReferencesForPath)" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/docs/dotnet-sdk-management.md
+++ b/docs/dotnet-sdk-management.md
@@ -30,15 +30,47 @@ https://aka.ms/dotnet/dotnetup/{quality}/dotnetup-{rid}[.exe]   (+ ".sha512")
 - Installed into `~/.dotnetup` (matches the official installer, so an existing install is reused).
 
 ### Doctor integration
-- The `.NET SDK` "Update available" check is now **fixable**. Its `FixAction` is
-  `dotnetup-update-sdk:<version>`; applying it bootstraps `dotnetup` if missing, then runs
-  `sdk install <version> --set-default-install` (Terminal Mode).
+
+#### Which install root wins
+
+Doctor and the SDK Manager must agree on *one* .NET install root, otherwise they report different
+active SDKs, feature bands, and workload sets. `DotnetSdkSourceResolver`
+(`MauiSherpa.Workloads/Services`) is the single decision point. Precedence:
+
+1. A repo-local `.dotnet/sdk` next to the scanned project directory.
+2. The **dotnetup-managed root**, whenever dotnetup manages at least one valid SDK. When several
+   managed roots exist, it prefers the one matching the process architecture, then the one with the
+   newest SDK, then ordinal install-root order.
+3. The machine-discovered root (`/etc/dotnet/install_location*`, `DOTNET_ROOT`, `PATH`, defaults).
+
+When the managed root wins it is the **sole** source of truth: installed SDK list, active SDK,
+feature band, manifests, workload set, and the `dotnet` executable Doctor invokes all come from it,
+and system SDKs are ignored. `DoctorService` pins a `LocalSdkService` to that root
+(`GetSdkServiceForRoot`) so manifest and workload-set probing reads the same place.
+
+This matters because the GUI Doctor does not inherit shell `PATH`/`DOTNET_ROOT`, and on macOS the
+managed root defaults to `~/Library/Application Support/dotnet` — which the machine scan never finds.
+`DoctorContext.UsesDotnetUpManagedSdk` reports the outcome, and the Doctor page shows a `dotnetup`
+badge on the ".NET SDK Path" row.
+
+#### Prerelease-aware ordering
+
+`SdkVersion` implements `IComparable<SdkVersion>` over a full `NuGetVersion`, and every consumer
+sorts through `SdkVersion.SortDescending`. Without this, `11.0.100-preview.4`, `-preview.5`,
+`-preview.6` and stable `11.0.100` all compare equal on `Major`/`Minor`/`Patch` and directory or feed
+enumeration order silently picks the "active" SDK — which then produces a feature band that matches
+no dotnetup workload target and downgrades Doctor to a NuGet-only workload path.
+
+#### Checks and fixes
+
+- The `.NET SDK` "Update available" check is **fixable**. When the managed root is in use, Doctor
+  reuses dotnetup's own tracked-channel update preview — the same data the SDK Manager shows — and
+  emits `FixAction: dotnetup-update-sdk:<channel>` (e.g. `11.0.1xx`). Specific channels are preferred
+  over moving aliases (`latest`, `lts`, `sts`, `preview`), and pinned specs are skipped. Otherwise it
+  falls back to `dotnetup-update-sdk:<version>`. Applying the fix bootstraps `dotnetup` if missing,
+  then runs `sdk install <channel|version> --set-default-install` (Terminal Mode).
 - A **dotnetup presence** check (Info) shows the installed version, or offers an
   `install-dotnetup` fix when it is missing.
-- Doctor reconciles **dotnetup-managed SDKs** into the installed-SDK set
-  (`MergeManagedSdks`) so an applied update actually clears the warning. This matters because
-  the GUI Doctor does not read shell `PATH`, and on macOS the managed root defaults to
-  `~/Library/Application Support/dotnet` — which `LocalSdkService` does not otherwise scan.
 
 ### SDK Manager page (`/dotnet-sdk`)
 
@@ -185,6 +217,8 @@ participate in resolution.
   - `Services/WorkloadInstallationStateResolver.cs` — overlays direct SDK installation records on
     the active transitive workload graph to classify explicit, included, and available IDs without
     inferring state from shared pack folders.
+  - `Services/DotnetSdkSourceResolver.cs` — pure resolution of the authoritative install root and
+    SDK set from a local machine scan plus a `DotnetUpListResult`.
   - `Services/GlobalJsonWorkloadPinEditor.cs` — JSONC-preserving atomic
     `sdk.workloadVersion` edits.
 - **`MauiSherpa.Core`** — `IDotnetUpService` (`Interfaces.cs`) + `DotnetUpService`: resolves the
@@ -192,11 +226,16 @@ participate in resolution.
   builds `ProcessRequest`s for install/update/uninstall. `IDotnetWorkloadService` discovers
   feature-band targets, orchestrates inventory queries, builds workload process requests, and
   invalidates per-root caches after writes. Both app heads register these services.
-- **Doctor** consumes the same `IDotnetWorkloadService` target, availability result, environment,
-  command builder, and refresh path as the SDK Manager so the two surfaces cannot disagree.
+- **Doctor** resolves its install root through `DotnetSdkSourceResolver`, then consumes the same
+  `IDotnetWorkloadService` target, availability result, environment, command builder, update
+  previews, and refresh path as the SDK Manager. Because both surfaces start from the same root and
+  the same prerelease-aware ordering, they cannot disagree.
 
 ## Testing
 
 Pure helpers are covered by unit tests in `tests/MauiSherpa.Workloads.Tests` (RID/URL building,
-SHA-512 verify, `list`/`--info` parsing, argument building). Doctor reconciliation and the new
-dependency-status shapes are covered in `tests/MauiSherpa.Core.Tests/Services/DoctorDotnetUpTests.cs`.
+SHA-512 verify, `list`/`--info` parsing, argument building, install-root resolution in
+`Services/DotnetSdkSourceResolverTests.cs`, and prerelease ordering in
+`Models/SdkVersionTests.cs`). Doctor source-of-truth selection, channel-preview matching, and the
+dependency-status shapes are covered in
+`tests/MauiSherpa.Core.Tests/Services/DoctorDotnetUpTests.cs`.

--- a/src/MauiSherpa.Core/Interfaces.cs
+++ b/src/MauiSherpa.Core/Interfaces.cs
@@ -1730,7 +1730,8 @@ public record DoctorContext(
     bool DotnetUpInstalled = false,
     string? DotnetUpVersion = null,
     string? DotnetUpManagedInstallRoot = null,
-    string? DotNetArchitecture = null
+    string? DotNetArchitecture = null,
+    bool UsesDotnetUpManagedSdk = false
 );
 
 /// <summary>

--- a/src/MauiSherpa.Core/Services/DoctorService.cs
+++ b/src/MauiSherpa.Core/Services/DoctorService.cs
@@ -27,6 +27,9 @@ public class DoctorService : IDoctorService
     
     // MauiSherpa.Workloads services - instantiated on demand
     private LocalSdkService? _localSdkService;
+    private LocalSdkService? _rootedSdkService;
+    private string? _rootedSdkServiceRoot;
+    private string? _authoritativeSdkRoot;
     private GlobalJsonService? _globalJsonService;
     private NuGetClient? _nugetClient;
     private WorkloadSetService? _workloadSetService;
@@ -54,6 +57,27 @@ public class DoctorService : IDoctorService
     }
     
     private LocalSdkService GetLocalSdkService() => _localSdkService ??= new LocalSdkService(_loggerFactory.CreateLogger<LocalSdkService>());
+
+    /// <summary>
+    /// Returns a <see cref="LocalSdkService"/> pinned to <paramref name="installRoot"/> so manifest,
+    /// workload-set, and dependency reads come from the same root Doctor decided is authoritative
+    /// (which is the dotnetup-managed root whenever the user has opted into dotnetup).
+    /// </summary>
+    private LocalSdkService GetSdkServiceForRoot(string? installRoot)
+    {
+        if (string.IsNullOrWhiteSpace(installRoot))
+            return GetLocalSdkService();
+
+        if (_rootedSdkService != null &&
+            string.Equals(_rootedSdkServiceRoot, installRoot, StringComparison.OrdinalIgnoreCase))
+            return _rootedSdkService;
+
+        _rootedSdkServiceRoot = installRoot;
+        _rootedSdkService = new LocalSdkService(
+            _loggerFactory.CreateLogger<LocalSdkService>(), installRoot);
+        return _rootedSdkService;
+    }
+
     private GlobalJsonService GetGlobalJsonService() => _globalJsonService ??= new GlobalJsonService();
     private NuGetClient GetNuGetClient() => _nugetClient ??= new NuGetClient();
     private WorkloadSetService GetWorkloadSetService() => _workloadSetService ??= new WorkloadSetService(GetNuGetClient());
@@ -61,17 +85,22 @@ public class DoctorService : IDoctorService
     /// <summary>
     /// Resolves the full path to the dotnet executable.
     /// GUI apps on macOS don't inherit the user's shell PATH, so bare "dotnet" won't resolve.
+    /// Prefers the root Doctor last resolved as authoritative (the dotnetup-managed root when the
+    /// user opted into dotnetup) so muxer-based commands run against the SDK Doctor reported on.
     /// </summary>
     private string ResolveDotNetExecutable()
     {
-        var sdkPath = GetLocalSdkService().GetDotNetSdkPath();
-        if (!string.IsNullOrEmpty(sdkPath))
+        var exeName = OperatingSystem.IsWindows() ? "dotnet.exe" : "dotnet";
+
+        foreach (var root in new[] { _authoritativeSdkRoot, GetLocalSdkService().GetDotNetSdkPath() })
         {
-            var exeName = OperatingSystem.IsWindows() ? "dotnet.exe" : "dotnet";
-            var fullPath = Path.Combine(sdkPath, exeName);
+            if (string.IsNullOrEmpty(root))
+                continue;
+            var fullPath = Path.Combine(root, exeName);
             if (File.Exists(fullPath))
                 return fullPath;
         }
+
         // Fallback to bare name (works if dotnet is on PATH)
         return "dotnet";
     }
@@ -83,7 +112,6 @@ public class DoctorService : IDoctorService
     public async Task<DoctorContext> GetContextAsync(string? workingDirectory = null)
     {
         var globalJsonService = GetGlobalJsonService();
-        var localSdkService = GetLocalSdkService();
         
         // Determine working directory
         var effectiveDir = workingDirectory ?? Environment.CurrentDirectory;
@@ -102,29 +130,19 @@ public class DoctorService : IDoctorService
             dotnetUpList = await TryGetDotnetUpListAsync();
         }
 
-        // Get SDK path - LocalSdkService already checks for .dotnet/, DOTNET_ROOT, etc.
-        string? sdkPath = null;
-        var sdkArchitecture = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
-        
-        // Check for local .dotnet in working directory
-        var localDotnet = Path.Combine(effectiveDir, ".dotnet");
-        if (Directory.Exists(localDotnet) && Directory.Exists(Path.Combine(localDotnet, "sdk")))
-        {
-            sdkPath = localDotnet;
-        }
-        else
-        {
-            sdkPath = localSdkService.GetDotNetSdkPath();
-        }
-        
-        // Resolve against local and dotnetup-managed SDKs before choosing the exact root.
+        // Pick the authoritative install root before anything else — when the user opted into
+        // dotnetup, its managed root is what the shell actually resolves, so Doctor must not mix
+        // in machine-wide SDKs from /usr/local/share/dotnet (or Program Files).
+        var source = ResolveSdkSource(effectiveDir, dotnetUpList);
+        var sdkPath = source.InstallRoot;
+        var sdkArchitecture = source.Architecture
+            ?? RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
+        var sdks = source.Sdks;
+
         string? featureBand = null;
         bool isPreviewSdk = false;
         string? activeSdkVersion = null;
         string? resolvedSdkVersion = null;
-        var sdks = localSdkService.GetInstalledSdkVersions();
-        if (dotnetUpList != null)
-            sdks = MergeManagedSdks(sdks, dotnetUpList);
         if (sdks.Count > 0)
         {
             SdkVersion effectiveSdk;
@@ -143,42 +161,6 @@ public class DoctorService : IDoctorService
             featureBand = effectiveSdk.FeatureBand;
             isPreviewSdk = effectiveSdk.IsPreview;
             activeSdkVersion = effectiveSdk.Version;
-
-            var localRootContainsSdk = sdkPath != null &&
-                                       Directory.Exists(Path.Combine(sdkPath, "sdk", effectiveSdk.Version));
-            var matchingSpec = globalJson?.Path == null || dotnetUpList == null
-                ? null
-                : dotnetUpList.InstallSpecs.FirstOrDefault(spec =>
-                    spec.Component == DotnetUpComponent.Sdk &&
-                    string.Equals(spec.GlobalJsonPath, globalJson.Path, StringComparison.OrdinalIgnoreCase));
-            if (dotnetUpList != null && (matchingSpec != null || !localRootContainsSdk))
-            {
-                var managedInstallation = dotnetUpList.Installations
-                    .Where(installation =>
-                        installation.Component == DotnetUpComponent.Sdk &&
-                        installation.IsValid &&
-                        string.Equals(
-                            installation.Version,
-                            effectiveSdk.Version,
-                            StringComparison.OrdinalIgnoreCase))
-                    .OrderByDescending(installation =>
-                        matchingSpec != null &&
-                        string.Equals(
-                            installation.InstallRoot,
-                            matchingSpec.InstallRoot,
-                            StringComparison.OrdinalIgnoreCase) &&
-                        (string.IsNullOrWhiteSpace(matchingSpec.Architecture) ||
-                         string.Equals(
-                             installation.Architecture,
-                             matchingSpec.Architecture,
-                             StringComparison.OrdinalIgnoreCase)))
-                    .FirstOrDefault();
-                if (managedInstallation != null)
-                {
-                    sdkPath = managedInstallation.InstallRoot;
-                    sdkArchitecture = managedInstallation.Architecture ?? sdkArchitecture;
-                }
-            }
         }
 
         return new DoctorContext(
@@ -194,9 +176,42 @@ public class DoctorService : IDoctorService
             ResolvedSdkVersion: resolvedSdkVersion,
             DotnetUpInstalled: dotnetUpInstalled,
             DotnetUpVersion: dotnetUpVersion,
-            DotnetUpManagedInstallRoot: dotnetUpList?.InstallRoots.FirstOrDefault(),
-            DotNetArchitecture: sdkArchitecture
+            DotnetUpManagedInstallRoot: source.IsDotnetUpManaged
+                ? source.InstallRoot
+                : dotnetUpList?.InstallRoots.FirstOrDefault(),
+            DotNetArchitecture: sdkArchitecture,
+            UsesDotnetUpManagedSdk: source.IsDotnetUpManaged
         );
+    }
+
+    /// <summary>
+    /// Resolves which .NET install root Doctor should inspect, in priority order:
+    /// a repo-local <c>.dotnet</c> (an explicit per-project override), then the dotnetup-managed
+    /// root when the user opted into dotnetup, then the machine's discovered install.
+    /// </summary>
+    private DotnetSdkSource ResolveSdkSource(string effectiveDir, DotnetUpListResult? dotnetUpList)
+    {
+        var repoLocalRoot = Path.Combine(effectiveDir, ".dotnet");
+        if (Directory.Exists(Path.Combine(repoLocalRoot, "sdk")))
+        {
+            var repoLocalService = GetSdkServiceForRoot(repoLocalRoot);
+            _authoritativeSdkRoot = repoLocalRoot;
+            return new DotnetSdkSource
+            {
+                Sdks = repoLocalService.GetInstalledSdkVersions(),
+                InstallRoot = repoLocalRoot,
+                Architecture = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant(),
+                IsDotnetUpManaged = false
+            };
+        }
+
+        var machineService = GetLocalSdkService();
+        var resolved = DotnetSdkSourceResolver.Resolve(
+            machineService.GetInstalledSdkVersions(),
+            machineService.GetDotNetSdkPath(),
+            dotnetUpList);
+        _authoritativeSdkRoot = resolved.InstallRoot;
+        return resolved;
     }
 
     private async Task<MauiSherpa.Workloads.Models.DotnetUpToolInfo?> TryGetDotnetUpInfoAsync()
@@ -229,30 +244,48 @@ public class DoctorService : IDoctorService
         }
     }
     
-    /// <summary>
-    /// Merges dotnetup-managed SDK versions into the locally discovered set, de-duplicating by
-    /// version string and re-sorting descending so the "latest installed" reflects dotnetup installs.
-    /// </summary>
-    internal static IReadOnlyList<SdkVersion> MergeManagedSdks(
-        IReadOnlyList<SdkVersion> localSdks, MauiSherpa.Workloads.Models.DotnetUpListResult dotnetUpList)
+    private async Task<IReadOnlyList<DotnetUpdatePreview>?> TryGetDotnetUpUpdatePreviewAsync(
+        DotnetUpListResult list)
     {
-        var byVersion = new Dictionary<string, SdkVersion>(StringComparer.OrdinalIgnoreCase);
-        foreach (var sdk in localSdks)
-            byVersion[sdk.Version] = sdk;
-
-        foreach (var managed in DotnetUpParser.GetManagedSdkVersions(dotnetUpList))
+        if (_dotnetUpService is null)
+            return null;
+        try
         {
-            if (byVersion.ContainsKey(managed))
-                continue;
-            if (SdkVersion.TryParse(managed, out var parsed) && parsed != null)
-                byVersion[managed] = parsed;
+            return await _dotnetUpService.GetUpdatePreviewAsync(list);
         }
+        catch (Exception ex)
+        {
+            _logger.LogWarning($"Failed to resolve dotnetup update preview: {ex.Message}");
+            return null;
+        }
+    }
 
-        return byVersion.Values
-            .OrderByDescending(v => v.Major)
-            .ThenByDescending(v => v.Minor)
-            .ThenByDescending(v => v.Patch)
-            .ToList();
+    private static readonly string[] AliasChannels = ["latest", "lts", "sts", "preview"];
+
+    /// <summary>
+    /// Finds the dotnetup tracked SDK channel that currently resolves to <paramref name="activeSdk"/>,
+    /// preferring a specific channel (e.g. <c>11.0.1xx</c>) over a moving alias (e.g. <c>preview</c>)
+    /// so the offered fix targets the narrowest channel that owns the SDK.
+    /// </summary>
+    internal static DotnetUpdatePreview? FindSdkChannelPreview(
+        IReadOnlyList<DotnetUpdatePreview>? previews, SdkVersion activeSdk)
+    {
+        if (previews == null || previews.Count == 0)
+            return null;
+
+        return previews
+            .Where(preview =>
+                preview.Component == DotnetUpComponent.Sdk &&
+                !preview.IsPinned &&
+                string.Equals(
+                    preview.InstalledVersion,
+                    activeSdk.Version,
+                    StringComparison.OrdinalIgnoreCase))
+            .OrderBy(preview => AliasChannels.Contains(
+                preview.Channel, StringComparer.OrdinalIgnoreCase) ? 1 : 0)
+            .ThenByDescending(preview => preview.UpdateAvailable)
+            .ThenBy(preview => preview.Channel, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault();
     }
 
     /// <summary>
@@ -318,20 +351,24 @@ public class DoctorService : IDoctorService
         
         progress?.Report("Checking .NET SDK installation...");
         
-        var localSdkService = GetLocalSdkService();
+        // Read everything from the root the context settled on. When dotnetup manages the active
+        // SDK that is the dotnetup root, so Doctor and the .NET SDK Manager inspect the same files.
+        var localSdkService = GetSdkServiceForRoot(context.DotNetSdkPath);
         var dependencies = new List<DependencyStatus>();
         
         // Get installed SDKs
         var sdkVersions = localSdkService.GetInstalledSdkVersions();
 
-        // Merge in SDKs managed by dotnetup. dotnetup installs to a user-level root
-        // (e.g. ~/Library/Application Support/dotnet on macOS) that LocalSdkService does not
-        // scan, so without this the GUI Doctor would never "see" a dotnetup-applied update.
         var dotnetUpList = await TryGetDotnetUpListAsync();
         var dotnetUpInstalled = _dotnetUpService is { IsInstalled: true };
-        if (dotnetUpList != null)
+
+        // When dotnetup owns the active SDK, reuse the same tracked-channel update preview the
+        // .NET SDK Manager renders so the two pages cannot report different versions.
+        IReadOnlyList<DotnetUpdatePreview>? updatePreviews = null;
+        if (context.UsesDotnetUpManagedSdk && dotnetUpList != null)
         {
-            sdkVersions = MergeManagedSdks(sdkVersions, dotnetUpList);
+            progress?.Report("Checking dotnetup tracked channels...");
+            updatePreviews = await TryGetDotnetUpUpdatePreviewAsync(dotnetUpList);
         }
 
         var sdkInfos = sdkVersions.Select(s => new SdkVersionInfo(
@@ -381,8 +418,33 @@ public class DoctorService : IDoctorService
         else
         {
             var latestSdk = sdkVersions[0];
-            
-            if (latestSdk.IsPreview)
+            var managedChannel = FindSdkChannelPreview(updatePreviews, latestSdk);
+
+            if (managedChannel != null)
+            {
+                // dotnetup owns this SDK — report exactly what its tracked channel resolves to.
+                var hasUpdate = managedChannel.UpdateAvailable;
+                var available = managedChannel.AvailableVersion;
+
+                dependencies.Add(new DependencyStatus(
+                    ".NET SDK",
+                    DependencyCategory.DotNetSdk,
+                    null,
+                    hasUpdate ? available : null,
+                    latestSdk.Version,
+                    hasUpdate
+                        ? DependencyStatusType.Warning
+                        : latestSdk.IsPreview ? DependencyStatusType.Info : DependencyStatusType.Ok,
+                    hasUpdate
+                        ? $"Update available: {available} (dotnetup channel {managedChannel.Channel})"
+                        : latestSdk.IsPreview
+                            ? $"Preview SDK ({latestSdk.Version}) — managed by dotnetup"
+                            : $"{sdkVersions.Count} SDK(s) managed by dotnetup, using {latestSdk.Version}",
+                    IsFixable: hasUpdate,
+                    FixAction: hasUpdate ? $"dotnetup-update-sdk:{managedChannel.Channel}" : null
+                ));
+            }
+            else if (latestSdk.IsPreview)
             {
                 // Active SDK is a preview — find the latest available for the SAME major version
                 var latestAvailableForMajor = availableSdkVersions?
@@ -603,7 +665,7 @@ public class DoctorService : IDoctorService
     {
         if (context.EffectiveFeatureBand == null) return;
         
-        var localSdkService = GetLocalSdkService();
+        var localSdkService = GetSdkServiceForRoot(context.DotNetSdkPath);
         // Collect all dependencies from installed manifests
         var manifestIds = localSdkService.GetInstalledWorkloadManifests(context.EffectiveFeatureBand);
         

--- a/src/MauiSherpa.MacOS/MauiSherpa.MacOS.csproj
+++ b/src/MauiSherpa.MacOS/MauiSherpa.MacOS.csproj
@@ -133,5 +133,6 @@
   </Target>
 
   <Import Project="..\..\build\BundleUnxip.targets" />
+  <Import Project="..\..\build\DedupeNativeReferences.targets" />
 
 </Project>

--- a/src/MauiSherpa.Workloads/Models/SdkVersion.cs
+++ b/src/MauiSherpa.Workloads/Models/SdkVersion.cs
@@ -1,9 +1,11 @@
+using NuGet.Versioning;
+
 namespace MauiSherpa.Workloads.Models;
 
 /// <summary>
 /// Represents a .NET SDK version with its components parsed.
 /// </summary>
-public record SdkVersion
+public record SdkVersion : IComparable<SdkVersion>
 {
     /// <summary>
     /// The full version string (e.g., "9.0.100").
@@ -47,6 +49,27 @@ public record SdkVersion
     /// The preview label if applicable (e.g., "preview.1", "rc.1").
     /// </summary>
     public string? PreviewLabel { get; init; }
+
+    /// <summary>
+    /// The full semantic version, including prerelease labels. Used for ordering so that
+    /// <c>11.0.100-preview.6</c> correctly sorts above <c>11.0.100-preview.5</c>.
+    /// </summary>
+    public NuGetVersion SemanticVersion =>
+        NuGetVersion.TryParse(Version, out var parsed)
+            ? parsed
+            : new NuGetVersion(Major, Minor, Patch);
+
+    /// <summary>
+    /// Compares by full semantic version so prerelease labels participate in ordering.
+    /// </summary>
+    public int CompareTo(SdkVersion? other) =>
+        other is null ? 1 : SemanticVersion.CompareTo(other.SemanticVersion);
+
+    /// <summary>
+    /// Orders SDK versions newest-first, honouring prerelease labels.
+    /// </summary>
+    public static IReadOnlyList<SdkVersion> SortDescending(IEnumerable<SdkVersion> versions) =>
+        versions.OrderByDescending(v => v.SemanticVersion).ToList();
 
     /// <summary>
     /// Parses an SDK version string into an SdkVersion object.

--- a/src/MauiSherpa.Workloads/Services/DotnetSdkSourceResolver.cs
+++ b/src/MauiSherpa.Workloads/Services/DotnetSdkSourceResolver.cs
@@ -1,0 +1,131 @@
+using System.Runtime.InteropServices;
+using MauiSherpa.Workloads.Models;
+
+namespace MauiSherpa.Workloads.Services;
+
+/// <summary>
+/// The .NET install root that surfaces such as Doctor should treat as authoritative, along with
+/// the SDKs it contains.
+/// </summary>
+public sealed record DotnetSdkSource
+{
+    /// <summary>SDK versions found in <see cref="InstallRoot"/>, newest first.</summary>
+    public IReadOnlyList<SdkVersion> Sdks { get; init; } = [];
+
+    /// <summary>The install root the SDKs belong to, or null when none could be resolved.</summary>
+    public string? InstallRoot { get; init; }
+
+    /// <summary>The architecture of the install root (e.g. <c>arm64</c>).</summary>
+    public string? Architecture { get; init; }
+
+    /// <summary>True when the root is managed by dotnetup rather than discovered on the machine.</summary>
+    public bool IsDotnetUpManaged { get; init; }
+}
+
+/// <summary>
+/// Decides which .NET install root is authoritative.
+///
+/// When the user has opted into dotnetup (the tool is installed and manages at least one valid
+/// SDK), the dotnetup-managed root wins outright: dotnetup's Terminal Mode points <c>PATH</c> and
+/// <c>DOTNET_ROOT</c> at it, so it is the SDK the user actually builds with. Mixing it with a
+/// machine-wide install at <c>/usr/local/share/dotnet</c> produces an SDK/feature-band pair that
+/// matches neither root, which in turn breaks workload-state lookups.
+/// </summary>
+public static class DotnetSdkSourceResolver
+{
+    /// <summary>
+    /// Resolves the authoritative source from a machine scan and dotnetup's reported state.
+    /// </summary>
+    /// <param name="localSdks">SDKs discovered by scanning the machine's default install root.</param>
+    /// <param name="localInstallRoot">The machine's default install root, if one was found.</param>
+    /// <param name="dotnetUpList">dotnetup's <c>list --format Json</c> result, if available.</param>
+    /// <param name="preferredArchitecture">
+    /// Architecture to prefer when dotnetup manages more than one; defaults to the process architecture.
+    /// </param>
+    public static DotnetSdkSource Resolve(
+        IReadOnlyList<SdkVersion> localSdks,
+        string? localInstallRoot,
+        DotnetUpListResult? dotnetUpList,
+        string? preferredArchitecture = null)
+    {
+        var managed = ResolveManaged(dotnetUpList, preferredArchitecture);
+        if (managed != null)
+            return managed;
+
+        return new DotnetSdkSource
+        {
+            Sdks = SdkVersion.SortDescending(localSdks),
+            InstallRoot = localInstallRoot,
+            Architecture = preferredArchitecture ?? CurrentArchitecture,
+            IsDotnetUpManaged = false
+        };
+    }
+
+    private static DotnetSdkSource? ResolveManaged(
+        DotnetUpListResult? dotnetUpList, string? preferredArchitecture)
+    {
+        if (dotnetUpList == null)
+            return null;
+
+        var wanted = string.IsNullOrWhiteSpace(preferredArchitecture)
+            ? CurrentArchitecture
+            : preferredArchitecture;
+
+        var groups = dotnetUpList.Installations
+            .Where(installation =>
+                installation.Component == DotnetUpComponent.Sdk &&
+                installation.IsValid &&
+                !string.IsNullOrWhiteSpace(installation.InstallRoot) &&
+                SdkVersion.TryParse(installation.Version, out _))
+            .GroupBy(
+                installation => (
+                    Root: installation.InstallRoot,
+                    Architecture: installation.Architecture ?? string.Empty),
+                TupleComparer)
+            .Select(group => new DotnetSdkSource
+            {
+                Sdks = SdkVersion.SortDescending(
+                    group
+                        .Select(installation =>
+                            SdkVersion.TryParse(installation.Version, out var parsed) ? parsed : null)
+                        .Where(version => version != null)
+                        .Select(version => version!)
+                        .DistinctBy(version => version.Version, StringComparer.OrdinalIgnoreCase)),
+                InstallRoot = group.Key.Root,
+                Architecture = string.IsNullOrWhiteSpace(group.Key.Architecture)
+                    ? wanted
+                    : group.Key.Architecture,
+                IsDotnetUpManaged = true
+            })
+            .Where(source => source.Sdks.Count > 0)
+            .ToList();
+
+        if (groups.Count == 0)
+            return null;
+
+        return groups
+            .OrderByDescending(source => string.Equals(
+                source.Architecture, wanted, StringComparison.OrdinalIgnoreCase))
+            .ThenByDescending(source => source.Sdks[0].SemanticVersion)
+            .ThenBy(source => source.InstallRoot, StringComparer.OrdinalIgnoreCase)
+            .First();
+    }
+
+    private static string CurrentArchitecture =>
+        RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
+
+    private static readonly IEqualityComparer<(string Root, string Architecture)> TupleComparer =
+        new RootArchitectureComparer();
+
+    private sealed class RootArchitectureComparer : IEqualityComparer<(string Root, string Architecture)>
+    {
+        public bool Equals((string Root, string Architecture) x, (string Root, string Architecture) y) =>
+            StringComparer.OrdinalIgnoreCase.Equals(x.Root, y.Root) &&
+            StringComparer.OrdinalIgnoreCase.Equals(x.Architecture, y.Architecture);
+
+        public int GetHashCode((string Root, string Architecture) obj) =>
+            HashCode.Combine(
+                StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Root),
+                StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Architecture));
+    }
+}

--- a/src/MauiSherpa.Workloads/Services/LocalSdkService.cs
+++ b/src/MauiSherpa.Workloads/Services/LocalSdkService.cs
@@ -14,7 +14,8 @@ namespace MauiSherpa.Workloads.Services;
 public class LocalSdkService : ILocalSdkService
 {
     private readonly ILogger<LocalSdkService> _logger;
-    
+    private readonly string? _installRootOverride;
+
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         PropertyNameCaseInsensitive = true,
@@ -25,13 +26,28 @@ public class LocalSdkService : ILocalSdkService
     public LocalSdkService() : this(NullLogger<LocalSdkService>.Instance) { }
     
     public LocalSdkService(ILogger<LocalSdkService> logger)
+        : this(logger, installRootOverride: null) { }
+
+    /// <param name="installRootOverride">
+    /// When set, every lookup is rooted at this .NET install directory instead of discovering one
+    /// from <c>DOTNET_ROOT</c>/registered install locations. Used to inspect a specific install root
+    /// (for example a dotnetup-managed one) rather than whatever the machine resolves by default.
+    /// </param>
+    public LocalSdkService(ILogger<LocalSdkService> logger, string? installRootOverride)
     {
         _logger = logger;
+        _installRootOverride = string.IsNullOrWhiteSpace(installRootOverride) ? null : installRootOverride;
     }
 
     /// <inheritdoc />
     public string? GetDotNetSdkPath()
     {
+        if (_installRootOverride != null)
+        {
+            _logger.LogDebug("Using explicit SDK install root: {Path}", _installRootOverride);
+            return Directory.Exists(_installRootOverride) ? _installRootOverride : null;
+        }
+
         _logger.LogDebug("Starting SDK path detection");
         
         // Try common installation paths
@@ -118,11 +134,7 @@ public class LocalSdkService : ILocalSdkService
             }
         }
 
-        return versions
-            .OrderByDescending(v => v.Major)
-            .ThenByDescending(v => v.Minor)
-            .ThenByDescending(v => v.Patch)
-            .ToList();
+        return SdkVersion.SortDescending(versions);
     }
 
     /// <inheritdoc />

--- a/src/MauiSherpa.Workloads/Services/SdkVersionService.cs
+++ b/src/MauiSherpa.Workloads/Services/SdkVersionService.cs
@@ -39,11 +39,7 @@ public class SdkVersionService : ISdkVersionService
             }
         }
 
-        return sdkVersions
-            .OrderByDescending(v => v.Major)
-            .ThenByDescending(v => v.Minor)
-            .ThenByDescending(v => v.Patch)
-            .ToList();
+        return SdkVersion.SortDescending(sdkVersions);
     }
 
     /// <inheritdoc />
@@ -88,9 +84,7 @@ public class SdkVersionService : ISdkVersionService
             }
         }
 
-        return sdkVersions
-            .OrderByDescending(v => v.Patch)
-            .ToList();
+        return SdkVersion.SortDescending(sdkVersions);
     }
 
     /// <inheritdoc />

--- a/src/MauiSherpa/MauiSherpa.csproj
+++ b/src/MauiSherpa/MauiSherpa.csproj
@@ -1,8 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk.Razor">
+<Project>
+
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk.Razor" />
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
+    <!-- Windows-only head. macOS is served by src/MauiSherpa.MacOS (net10.0-macos AppKit head),
+         which is what CI publishes; the Mac Catalyst head has been retired. -->
+    <TargetFrameworks>net10.0-windows10.0.19041.0</TargetFrameworks>
 
     <OutputType>Exe</OutputType>
     <RootNamespace>MauiSherpa</RootNamespace>
@@ -19,19 +22,8 @@
     <ApplicationDisplayVersion>$(AppVersion)</ApplicationDisplayVersion>
     <ApplicationVersion>1</ApplicationVersion>
 
-    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">15.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-    <EnableHardenedRuntime>true</EnableHardenedRuntime>
-    <CodesignEntitlements>Platforms/MacCatalyst/Entitlements.plist</CodesignEntitlements>
-    <UseInterpreter>true</UseInterpreter>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst' and '$(Configuration)' == 'Debug'">
-    <CodeSignEntitlements>Platforms/MacCatalyst/Entitlements.Debug.plist</CodeSignEntitlements>
   </PropertyGroup>
 
   <!-- Workaround for WindowsAppSDK Issue #3337 -->
@@ -81,30 +73,15 @@
     <MauiAsset Include="Resources/Raw/**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
 
-  <!-- Bundle Copilot CLI binary into the Mac Catalyst app.
-       The GitHub.Copilot.SDK targets download the binary under osx-arm64/osx-x64,
-       but at runtime on Mac Catalyst, RuntimeInformation.RuntimeIdentifier returns
-       maccatalyst-arm64/maccatalyst-x64. We copy the downloaded binary directly
-       into the app bundle at the path the SDK expects at runtime. -->
-  <Target Name="_BundleCopilotCliForMacCatalyst" AfterTargets="Build" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-    <PropertyGroup>
-      <_CopilotMacCatRid Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64'">maccatalyst-arm64</_CopilotMacCatRid>
-      <_CopilotMacCatRid Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X64'">maccatalyst-x64</_CopilotMacCatRid>
-      <_CopilotOsxRid Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64'">osx-arm64</_CopilotOsxRid>
-      <_CopilotOsxRid Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X64'">osx-x64</_CopilotOsxRid>
-      <_CopilotSourceBinary>$(OutDir)runtimes/$(_CopilotOsxRid)/native/copilot</_CopilotSourceBinary>
-      <_CopilotAppBundle>$(OutDir)$(ApplicationTitle).app/Contents/MonoBundle/runtimes/$(_CopilotMacCatRid)/native</_CopilotAppBundle>
-      <!-- Also copy to osx-{arch} since RuntimeIdentifier reports osx-arm64 at runtime on Mac Catalyst -->
-      <_CopilotAppBundleOsx>$(OutDir)$(ApplicationTitle).app/Contents/MonoBundle/runtimes/$(_CopilotOsxRid)/native</_CopilotAppBundleOsx>
-    </PropertyGroup>
-    <MakeDir Directories="$(_CopilotAppBundle)" Condition="Exists('$(_CopilotSourceBinary)')" />
-    <Copy SourceFiles="$(_CopilotSourceBinary)" DestinationFolder="$(_CopilotAppBundle)" SkipUnchangedFiles="true" Condition="Exists('$(_CopilotSourceBinary)')" />
-    <Exec Command="chmod +x &quot;$(_CopilotAppBundle)/copilot&quot;" Condition="Exists('$(_CopilotSourceBinary)')" />
-    <MakeDir Directories="$(_CopilotAppBundleOsx)" Condition="Exists('$(_CopilotSourceBinary)')" />
-    <Copy SourceFiles="$(_CopilotSourceBinary)" DestinationFolder="$(_CopilotAppBundleOsx)" SkipUnchangedFiles="true" Condition="Exists('$(_CopilotSourceBinary)')" />
-    <Exec Command="chmod +x &quot;$(_CopilotAppBundleOsx)/copilot&quot;" Condition="Exists('$(_CopilotSourceBinary)')" />
-  </Target>
-
   <Import Project="..\..\build\BundleUnxip.targets" />
+
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk.Razor" />
+
+  <!-- This head only builds on Windows (WinUI XAML compilation is Windows-only), so make it a
+       no-op elsewhere. That keeps `dotnet build MauiSherpa.sln` working on macOS and Linux, where
+       the desktop app is served by src/MauiSherpa.MacOS and src/MauiSherpa.LinuxGtk. -->
+  <Target Name="Build" Condition="!$([MSBuild]::IsOSPlatform('windows'))" />
+  <Target Name="Rebuild" Condition="!$([MSBuild]::IsOSPlatform('windows'))" />
+  <Target Name="Publish" Condition="!$([MSBuild]::IsOSPlatform('windows'))" />
 
 </Project>

--- a/src/MauiSherpa/Pages/Doctor.razor
+++ b/src/MauiSherpa/Pages/Doctor.razor
@@ -96,7 +96,15 @@
                         </span>
                     </div>
                     <div class="context-item full-width">
-                        <span class="context-label">.NET SDK Path</span>
+                        <span class="context-label">
+                            .NET SDK Path
+                            @if (report.Context.UsesDotnetUpManagedSdk)
+                            {
+                                <span class="badge badge-info context-label-badge" title="dotnetup manages this install root, so Doctor reports the same SDKs and workloads as the .NET SDK Manager.">
+                                    <i class="fas fa-layer-group"></i> dotnetup
+                                </span>
+                            }
+                        </span>
                         <span class="context-value mono path-value">
                             @(report.Context.DotNetSdkPath ?? "Not found")
                             @if (!string.IsNullOrEmpty(report.Context.DotNetSdkPath))
@@ -476,7 +484,8 @@ else
     .context-item { display: flex; flex-direction: column; gap: 0.25rem; padding: 0.625rem 1.25rem; border-bottom: 1px solid var(--border-color); }
     .context-item:last-child { border-bottom: none; }
     .context-item.full-width { grid-column: 1 / -1; }
-    .context-label { font-size: 0.75rem; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
+    .context-label { font-size: 0.75rem; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em; display: flex; align-items: center; gap: 0.5rem; }
+    .context-label-badge { text-transform: none; letter-spacing: 0; font-family: monospace; }
     .context-value { font-size: 0.875rem; color: var(--text-primary); }
     .context-value.path-value { display: flex; align-items: center; gap: 0.5rem; padding: 0.5rem 0.75rem; border-radius: 0.375rem; }
     .mono { font-family: monospace; font-size: 0.8125rem; word-break: break-all; }

--- a/tests/MauiSherpa.Core.Tests/Services/DoctorDotnetUpTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/DoctorDotnetUpTests.cs
@@ -22,6 +22,7 @@ public class DoctorDotnetUpTests
         context.DotnetUpInstalled.Should().BeFalse();
         context.DotnetUpVersion.Should().BeNull();
         context.DotnetUpManagedInstallRoot.Should().BeNull();
+        context.UsesDotnetUpManagedSdk.Should().BeFalse();
     }
 
     [Fact]
@@ -31,11 +32,13 @@ public class DoctorDotnetUpTests
             "/test", "/dotnet", null, null, null, "10.0.100",
             DotnetUpInstalled: true,
             DotnetUpVersion: "0.1.4-preview.6.26323.4",
-            DotnetUpManagedInstallRoot: "/Users/x/Library/Application Support/dotnet");
+            DotnetUpManagedInstallRoot: "/Users/x/Library/Application Support/dotnet",
+            UsesDotnetUpManagedSdk: true);
 
         context.DotnetUpInstalled.Should().BeTrue();
         context.DotnetUpVersion.Should().Be("0.1.4-preview.6.26323.4");
         context.DotnetUpManagedInstallRoot.Should().Be("/Users/x/Library/Application Support/dotnet");
+        context.UsesDotnetUpManagedSdk.Should().BeTrue();
     }
 
     [Fact]
@@ -94,37 +97,195 @@ public class DoctorDotnetUpTests
     }
 
     [Fact]
-    public void MergeManagedSdks_AddsDotnetUpVersionsAndSortsDescending()
+    public void SdkSource_PrefersDotnetUpManagedRoot_OverMachineInstall()
     {
+        // The machine root has an older .NET 11 preview than dotnetup's managed root.
         var local = new List<SdkVersion>
         {
-            SdkVersion.Parse("9.0.305")
+            SdkVersion.Parse("11.0.100-preview.5.26302.115"),
+            SdkVersion.Parse("11.0.100-preview.4.26230.115"),
+            SdkVersion.Parse("10.0.300")
         };
 
         var dotnetUpList = DotnetUpParser.ParseList("""
         { "installations": [
-          { "component": "SDK", "version": "10.0.300", "installRoot": "/u/dotnet", "architecture": "arm64", "isValid": true },
-          { "component": "SDK", "version": "9.0.305", "installRoot": "/u/dotnet", "architecture": "arm64", "isValid": true },
-          { "component": "Runtime", "version": "10.0.8", "installRoot": "/u/dotnet", "architecture": "arm64", "isValid": true }
+          { "component": "SDK", "version": "11.0.100-preview.6.26359.118", "installRoot": "/u/managed", "architecture": "arm64", "isValid": true },
+          { "component": "SDK", "version": "10.0.302", "installRoot": "/u/managed", "architecture": "arm64", "isValid": true },
+          { "component": "Runtime", "version": "10.0.10", "installRoot": "/u/managed", "architecture": "arm64", "isValid": true }
         ] }
         """);
 
-        var merged = DoctorService.MergeManagedSdks(local, dotnetUpList);
+        var source = DotnetSdkSourceResolver.Resolve(
+            local, "/usr/local/share/dotnet", dotnetUpList, "arm64");
 
-        merged.Select(s => s.Version).Should().ContainInOrder("10.0.300", "9.0.305");
-        merged.Should().HaveCount(2, "the duplicate 9.0.305 is de-duplicated and runtimes are excluded");
-        merged[0].Version.Should().Be("10.0.300", "newest SDK should sort first");
+        source.IsDotnetUpManaged.Should().BeTrue();
+        source.InstallRoot.Should().Be("/u/managed");
+        source.Architecture.Should().Be("arm64");
+        source.Sdks.Select(s => s.Version).Should().Equal(
+            "11.0.100-preview.6.26359.118", "10.0.302");
+        source.Sdks.Should().NotContain(
+            s => s.Version == "11.0.100-preview.5.26302.115",
+            "machine-wide SDKs are ignored once dotnetup owns the toolchain");
     }
 
     [Fact]
-    public void MergeManagedSdks_IgnoresInvalidManaged_AndEmptyList()
+    public void SdkSource_SortsPreviewsByPrereleaseLabel()
+    {
+        var dotnetUpList = DotnetUpParser.ParseList("""
+        { "installations": [
+          { "component": "SDK", "version": "11.0.100-preview.5.26302.115", "installRoot": "/u/managed", "architecture": "arm64", "isValid": true },
+          { "component": "SDK", "version": "11.0.100-preview.6.26359.118", "installRoot": "/u/managed", "architecture": "arm64", "isValid": true },
+          { "component": "SDK", "version": "11.0.100-preview.4.26230.115", "installRoot": "/u/managed", "architecture": "arm64", "isValid": true }
+        ] }
+        """);
+
+        var source = DotnetSdkSourceResolver.Resolve([], null, dotnetUpList, "arm64");
+
+        source.Sdks[0].Version.Should().Be(
+            "11.0.100-preview.6.26359.118",
+            "prerelease labels must participate in ordering, not just major.minor.patch");
+    }
+
+    [Fact]
+    public void SdkSource_PrefersManagedRootMatchingProcessArchitecture()
+    {
+        var dotnetUpList = DotnetUpParser.ParseList("""
+        { "installations": [
+          { "component": "SDK", "version": "10.0.400", "installRoot": "/u/x64", "architecture": "x64", "isValid": true },
+          { "component": "SDK", "version": "10.0.302", "installRoot": "/u/arm64", "architecture": "arm64", "isValid": true }
+        ] }
+        """);
+
+        var source = DotnetSdkSourceResolver.Resolve([], null, dotnetUpList, "arm64");
+
+        source.InstallRoot.Should().Be(
+            "/u/arm64", "architecture match wins over a newer SDK in a foreign-architecture root");
+    }
+
+    [Fact]
+    public void SdkSource_WithoutManagedSdks_FallsBackToMachineInstall()
     {
         var local = new List<SdkVersion> { SdkVersion.Parse("10.0.103") };
-        var empty = new DotnetUpListResult();
 
-        var merged = DoctorService.MergeManagedSdks(local, empty);
+        // dotnetup is present but only tracks runtimes / has invalid SDK entries.
+        var dotnetUpList = DotnetUpParser.ParseList("""
+        { "installations": [
+          { "component": "Runtime", "version": "10.0.10", "installRoot": "/u/managed", "architecture": "arm64", "isValid": true },
+          { "component": "SDK", "version": "10.0.302", "installRoot": "/u/managed", "architecture": "arm64", "isValid": false }
+        ] }
+        """);
 
-        merged.Should().ContainSingle().Which.Version.Should().Be("10.0.103");
+        var source = DotnetSdkSourceResolver.Resolve(
+            local, "/usr/local/share/dotnet", dotnetUpList, "arm64");
+
+        source.IsDotnetUpManaged.Should().BeFalse();
+        source.InstallRoot.Should().Be("/usr/local/share/dotnet");
+        source.Sdks.Should().ContainSingle().Which.Version.Should().Be("10.0.103");
+    }
+
+    [Fact]
+    public void SdkSource_WithoutDotnetUp_UsesMachineInstall()
+    {
+        var local = new List<SdkVersion>
+        {
+            SdkVersion.Parse("11.0.100-preview.4.26230.115"),
+            SdkVersion.Parse("11.0.100-preview.5.26302.115")
+        };
+
+        var source = DotnetSdkSourceResolver.Resolve(
+            local, "/usr/local/share/dotnet", dotnetUpList: null, "arm64");
+
+        source.IsDotnetUpManaged.Should().BeFalse();
+        source.Sdks[0].Version.Should().Be("11.0.100-preview.5.26302.115");
+    }
+
+    [Fact]
+    public void FindSdkChannelPreview_PrefersSpecificChannelOverMovingAlias()
+    {
+        var active = SdkVersion.Parse("11.0.100-preview.6.26359.118");
+        var previews = new List<DotnetUpdatePreview>
+        {
+            new()
+            {
+                Component = DotnetUpComponent.Sdk,
+                Channel = "preview",
+                InstalledVersion = active.Version,
+                AvailableVersion = active.Version
+            },
+            new()
+            {
+                Component = DotnetUpComponent.Sdk,
+                Channel = "11.0.1xx",
+                InstalledVersion = active.Version,
+                AvailableVersion = active.Version
+            },
+            new()
+            {
+                Component = DotnetUpComponent.Sdk,
+                Channel = "10.0.3xx",
+                InstalledVersion = "10.0.302",
+                AvailableVersion = "10.0.302"
+            }
+        };
+
+        var match = DoctorService.FindSdkChannelPreview(previews, active);
+
+        match.Should().NotBeNull();
+        match!.Channel.Should().Be("11.0.1xx");
+    }
+
+    [Fact]
+    public void FindSdkChannelPreview_WhenNoChannelOwnsTheActiveSdk_ReturnsNull()
+    {
+        var active = SdkVersion.Parse("11.0.100-preview.6.26359.118");
+        var previews = new List<DotnetUpdatePreview>
+        {
+            new()
+            {
+                Component = DotnetUpComponent.Sdk,
+                Channel = "10.0.3xx",
+                InstalledVersion = "10.0.302",
+                AvailableVersion = "10.0.302"
+            }
+        };
+
+        DoctorService.FindSdkChannelPreview(previews, active).Should().BeNull();
+    }
+
+    [Fact]
+    public void FindSdkChannelPreview_IgnoresPinnedSpecs()
+    {
+        var active = SdkVersion.Parse("10.0.302");
+        var previews = new List<DotnetUpdatePreview>
+        {
+            new()
+            {
+                Component = DotnetUpComponent.Sdk,
+                Channel = "10.0.302",
+                InstalledVersion = "10.0.302",
+                AvailableVersion = "10.0.302",
+                IsPinned = true
+            }
+        };
+
+        DoctorService.FindSdkChannelPreview(previews, active).Should().BeNull(
+            "a pinned exact version has no channel update to offer");
+    }
+
+    [Fact]
+    public void ManagedSdkStatus_UsesChannelInFixAction()
+    {
+        // The managed branch offers the tracked channel, not an exact version, so applying the
+        // fix installs whatever that channel resolves to — the same thing the SDK Manager does.
+        var dep = new DependencyStatus(
+            ".NET SDK", DependencyCategory.DotNetSdk,
+            null, "11.0.100-preview.7.26400.1", "11.0.100-preview.6.26359.118",
+            DependencyStatusType.Warning,
+            "Update available: 11.0.100-preview.7.26400.1 (dotnetup channel 11.0.1xx)",
+            IsFixable: true,
+            FixAction: "dotnetup-update-sdk:11.0.1xx");
+
+        dep.FixAction!["dotnetup-update-sdk:".Length..].Should().Be("11.0.1xx");
     }
 
     private static DoctorReport MakeReport(params DependencyStatus[] deps) =>

--- a/tests/MauiSherpa.Workloads.Tests/Models/SdkVersionTests.cs
+++ b/tests/MauiSherpa.Workloads.Tests/Models/SdkVersionTests.cs
@@ -122,4 +122,55 @@ public class SdkVersionTests
         success.Should().BeFalse();
         result.Should().BeNull();
     }
+
+    [Fact]
+    public void SortDescending_OrdersPreviewsByPrereleaseLabel()
+    {
+        // Every 11.0.100-preview.* shares major.minor.patch, so ordering must fall through to the
+        // prerelease labels rather than leaving the newest install to enumeration order.
+        var versions = new[]
+        {
+            SdkVersion.Parse("11.0.100-preview.5.26302.115"),
+            SdkVersion.Parse("11.0.100-preview.4.26230.115"),
+            SdkVersion.Parse("11.0.100-preview.6.26359.118"),
+        };
+
+        var sorted = SdkVersion.SortDescending(versions);
+
+        sorted.Select(v => v.Version).Should().Equal(
+            "11.0.100-preview.6.26359.118",
+            "11.0.100-preview.5.26302.115",
+            "11.0.100-preview.4.26230.115");
+    }
+
+    [Fact]
+    public void SortDescending_RanksStableAboveItsOwnPreviews()
+    {
+        var versions = new[]
+        {
+            SdkVersion.Parse("11.0.100-rc.1.25451.107"),
+            SdkVersion.Parse("11.0.100"),
+            SdkVersion.Parse("11.0.100-preview.6.26359.118"),
+            SdkVersion.Parse("10.0.302"),
+        };
+
+        var sorted = SdkVersion.SortDescending(versions);
+
+        sorted.Select(v => v.Version).Should().Equal(
+            "11.0.100",
+            "11.0.100-rc.1.25451.107",
+            "11.0.100-preview.6.26359.118",
+            "10.0.302");
+    }
+
+    [Fact]
+    public void CompareTo_UsesFullSemanticVersion()
+    {
+        var newer = SdkVersion.Parse("11.0.100-preview.6.26359.118");
+        var older = SdkVersion.Parse("11.0.100-preview.5.26302.115");
+
+        newer.CompareTo(older).Should().BePositive();
+        older.CompareTo(newer).Should().BeNegative();
+        newer.CompareTo(null).Should().BePositive();
+    }
 }

--- a/tests/MauiSherpa.Workloads.Tests/Services/DotnetSdkSourceResolverTests.cs
+++ b/tests/MauiSherpa.Workloads.Tests/Services/DotnetSdkSourceResolverTests.cs
@@ -1,0 +1,133 @@
+using FluentAssertions;
+using MauiSherpa.Workloads.Models;
+using MauiSherpa.Workloads.Services;
+
+namespace MauiSherpa.Workloads.Tests.Services;
+
+/// <summary>
+/// The resolver decides which .NET install root a surface such as Doctor should trust. Once a user
+/// opts into dotnetup, the managed root wins outright — mixing it with a machine-wide install
+/// produces an SDK/feature-band pair that belongs to neither root.
+/// </summary>
+public class DotnetSdkSourceResolverTests
+{
+    [Fact]
+    public void Resolve_WithNoDotnetUpList_UsesMachineInstall()
+    {
+        var local = new[] { SdkVersion.Parse("10.0.302"), SdkVersion.Parse("10.0.204") };
+
+        var source = DotnetSdkSourceResolver.Resolve(local, "/usr/local/share/dotnet", null, "arm64");
+
+        source.IsDotnetUpManaged.Should().BeFalse();
+        source.InstallRoot.Should().Be("/usr/local/share/dotnet");
+        source.Architecture.Should().Be("arm64");
+        source.Sdks.Select(s => s.Version).Should().Equal("10.0.302", "10.0.204");
+    }
+
+    [Fact]
+    public void Resolve_WithManagedSdks_IgnoresMachineInstallEntirely()
+    {
+        var local = new[]
+        {
+            SdkVersion.Parse("11.0.100-preview.5.26302.115"),
+            SdkVersion.Parse("10.0.300")
+        };
+        var list = Parse("""
+        { "installations": [
+          { "component": "SDK", "version": "11.0.100-preview.6.26359.118", "installRoot": "/managed", "architecture": "arm64", "isValid": true }
+        ] }
+        """);
+
+        var source = DotnetSdkSourceResolver.Resolve(local, "/usr/local/share/dotnet", list, "arm64");
+
+        source.IsDotnetUpManaged.Should().BeTrue();
+        source.InstallRoot.Should().Be("/managed");
+        source.Sdks.Select(s => s.Version).Should().Equal("11.0.100-preview.6.26359.118");
+    }
+
+    [Fact]
+    public void Resolve_DeduplicatesRepeatedManagedVersions()
+    {
+        var list = Parse("""
+        { "installations": [
+          { "component": "SDK", "version": "10.0.302", "installRoot": "/managed", "architecture": "arm64", "isValid": true },
+          { "component": "SDK", "version": "10.0.302", "installRoot": "/managed", "architecture": "arm64", "isValid": true }
+        ] }
+        """);
+
+        var source = DotnetSdkSourceResolver.Resolve([], null, list, "arm64");
+
+        source.Sdks.Should().ContainSingle().Which.Version.Should().Be("10.0.302");
+    }
+
+    [Fact]
+    public void Resolve_SkipsRuntimesAndInvalidInstallations()
+    {
+        var list = Parse("""
+        { "installations": [
+          { "component": "Runtime", "version": "10.0.10", "installRoot": "/managed", "architecture": "arm64", "isValid": true },
+          { "component": "ASPNETCore", "version": "10.0.10", "installRoot": "/managed", "architecture": "arm64", "isValid": true },
+          { "component": "SDK", "version": "10.0.302", "installRoot": "/managed", "architecture": "arm64", "isValid": false }
+        ] }
+        """);
+
+        var source = DotnetSdkSourceResolver.Resolve(
+            [SdkVersion.Parse("9.0.305")], "/usr/local/share/dotnet", list, "arm64");
+
+        source.IsDotnetUpManaged.Should().BeFalse();
+        source.Sdks.Should().ContainSingle().Which.Version.Should().Be("9.0.305");
+    }
+
+    [Fact]
+    public void Resolve_PrefersArchitectureMatchOverNewerSdk()
+    {
+        var list = Parse("""
+        { "installations": [
+          { "component": "SDK", "version": "11.0.100-preview.6.26359.118", "installRoot": "/managed-x64", "architecture": "x64", "isValid": true },
+          { "component": "SDK", "version": "10.0.302", "installRoot": "/managed-arm64", "architecture": "arm64", "isValid": true }
+        ] }
+        """);
+
+        var source = DotnetSdkSourceResolver.Resolve([], null, list, "arm64");
+
+        source.InstallRoot.Should().Be("/managed-arm64");
+        source.Architecture.Should().Be("arm64");
+    }
+
+    [Fact]
+    public void Resolve_WithSameArchitecture_PrefersRootWithNewestSdk()
+    {
+        var list = Parse("""
+        { "installations": [
+          { "component": "SDK", "version": "10.0.204", "installRoot": "/managed-a", "architecture": "arm64", "isValid": true },
+          { "component": "SDK", "version": "11.0.100-preview.6.26359.118", "installRoot": "/managed-b", "architecture": "arm64", "isValid": true }
+        ] }
+        """);
+
+        var source = DotnetSdkSourceResolver.Resolve([], null, list, "arm64");
+
+        source.InstallRoot.Should().Be("/managed-b");
+    }
+
+    [Fact]
+    public void Resolve_WithEmptyList_FallsBackToMachineInstall()
+    {
+        var source = DotnetSdkSourceResolver.Resolve(
+            [SdkVersion.Parse("10.0.103")], "/usr/local/share/dotnet", new DotnetUpListResult(), "arm64");
+
+        source.IsDotnetUpManaged.Should().BeFalse();
+        source.InstallRoot.Should().Be("/usr/local/share/dotnet");
+    }
+
+    [Fact]
+    public void Resolve_WithNothingInstalled_ReturnsEmptySource()
+    {
+        var source = DotnetSdkSourceResolver.Resolve([], null, null, "arm64");
+
+        source.Sdks.Should().BeEmpty();
+        source.InstallRoot.Should().BeNull();
+        source.IsDotnetUpManaged.Should().BeFalse();
+    }
+
+    private static DotnetUpListResult Parse(string json) => DotnetUpParser.ParseList(json);
+}


### PR DESCRIPTION
## Why

The Doctor page and the .NET SDK Manager page disagreed about .NET 11. Doctor reported `11.0.100-preview.5` and offered to install a workload set for that band, while the SDK Manager correctly showed the `preview.6` SDK that dotnetup had actually installed. Acting on Doctor's advice would have installed workloads into an SDK the user was not building with.

## What was actually wrong

Two independent bugs compounded:

1. **`SdkVersion` had no prerelease ordering.** It only exposed `Major`/`Minor`/`Patch`, and every sort in the Workloads library was `OrderByDescending(Major).ThenBy...(Patch)`. That meant `11.0.100-preview.4`, `-preview.5`, `-preview.6` and stable `11.0.100` all compared equal, so LINQ's stable sort let directory enumeration order decide the "newest" SDK.

2. **Doctor never treated the dotnetup root as authoritative.** It resolved `dotnet` through the machine install location (`/etc/dotnet/install_location_arm64` -> `/usr/local/share/dotnet` for a GUI process, which does not inherit a shell `DOTNET_ROOT`), then merged dotnetup's SDK list on top. The resulting feature band matched no dotnetup-managed workload target, so Doctor silently fell back to a NuGet-only workload path and reported against a different install root than the SDK Manager.

## Approach

`DotnetSdkSourceResolver` is a new pure function that is the single decision point for "which .NET install root is authoritative." It groups dotnetup's SDK list by (install root, architecture), prefers the process architecture, then the newest SDK, and falls back to the machine scan when dotnetup has nothing valid installed. Precedence is repo-local `.dotnet/sdk` > dotnetup-managed root > machine-discovered root.

`DoctorService` now builds a `LocalSdkService` rooted at that path (new `installRootOverride` constructor argument), so SDK enumeration, workload manifests, and workload sets all read from the same place instead of three different ones. `MergeManagedSdks` is gone, since there is nothing left to merge once one root wins.

`SdkVersion` implements `IComparable<SdkVersion>` backed by `NuGetVersion`, and every call site uses the new `SdkVersion.SortDescending` helper.

When the active SDK is dotnetup-managed, the update check reuses dotnetup's own tracked channels and the fix action becomes `dotnetup-update-sdk:<channel>` (for example `11.0.1xx`) instead of a raw version install, so Doctor's remediation stays inside dotnetup rather than fighting it.

The Doctor context section gets a small `dotnetup` badge on the .NET SDK Path row so it is obvious at a glance which root is being inspected. It reuses the existing `badge-info` classes, so light and dark mode are already covered by the theme variables.

## Verification

Confirmed live in the running app: Doctor now reports SDK path `~/Library/Application Support/dotnet` with the dotnetup badge, `.NET SDK 11.0.100-preview.6.26359.118` "managed by dotnetup", and workload set `11.0.100-preview.6.26364.2` "Up to date" - matching the SDK Manager. Tests: 191 Workloads, 508 Core.

Note for anyone writing tests here: running `dotnet test` from a shell that has `DOTNET_ROOT` exported masks the GUI behaviour, since the GUI process does not inherit it. A probe has to clear `DOTNET_ROOT`, `DOTNET_ROOT_X64` and `DOTNET_ROOT_ARM64` in-process to reproduce what the app actually sees.

## Second commit: dropping the Mac Catalyst head

This started as collateral. The Mac Catalyst build was already broken on `main`, which blocked verifying any of the above, so it had to be dealt with.

`src/MauiSherpa.MacOS` (net10.0-macos, AppKit) is the real macOS app and is what CI publishes, so `net10.0-maccatalyst` is removed from `src/MauiSherpa`, leaving it a Windows-only head. `Build`/`Rebuild`/`Publish` there are no-ops off Windows so `dotnet build MauiSherpa.sln` succeeds on macOS and Linux.

The underlying build failure also affected the macOS head, so it is fixed properly rather than sidestepped:

```
install_name_tool: cannot rename ... libcopilot_runtime.dylib.tmp ...
The "InstallNameTool" task failed unexpectedly
```

`GitHub.Copilot.SDK` stages its native runtime once per referencing project, and the diamond (app head -> AppInspector -> Core, plus app head -> Core directly) produced three `_FileNativeReference` items pointing at the same destination. The Apple SDK's `InstallNameTool` task runs its items in parallel and derives its scratch file from the destination path, so those items raced on the same `.tmp`. Note that `-m:1` does not help, because the parallelism is inside the task rather than in MSBuild's scheduler.

`build/DedupeNativeReferences.targets` collapses items sharing a `RelativePath` down to one before `_ComputeDynamicLibrariesToReidentify` runs. It has to match on `RelativePath` rather than ItemSpec, because the duplicates can share an identical ItemSpec and differ only in `MSBuildSourceProjectFile`, which is why a plain `Distinct()` does not fix it. Any future Apple app head will need to import this too.

## Left alone

- `src/MauiSherpa/Platforms/MacCatalyst/` and the Catalyst entitlements are still on disk, now unreferenced. Kept for minimal churn and easy revival; happy to delete in a follow-up.
- `RunDoctorAsync` still reports against `sdkVersions[0]` rather than `context.ActiveSdkVersion`. That is pre-existing behaviour and was deliberately not changed here.