### PR TITLE
Handle missing .NET workload set metadata

### DIFF
--- a/src/MauiSherpa.Core/Services/DotnetWorkloadService.cs
+++ b/src/MauiSherpa.Core/Services/DotnetWorkloadService.cs
@@ -299,10 +299,25 @@ public sealed class DotnetWorkloadService : IDotnetWorkloadService
             ["workload", "--version"],
             commandDirectory,
             cancellationToken).ConfigureAwait(false);
-        if (versionResult.ExitCode != 0)
+        var cliStateAvailable = versionResult.ExitCode == 0;
+        string workloadVersion;
+        if (cliStateAvailable)
+        {
+            workloadVersion = DotnetWorkloadParser.ParseWorkloadVersion(versionResult.Output);
+        }
+        else if (workingDirectory == null &&
+                 TryGetMissingRecordedWorkloadSet(target, out var recordedWorkloadVersion))
+        {
+            workloadVersion = recordedWorkloadVersion;
+            diagnostics.Add(
+                $"The recorded workload set {workloadVersion} is missing from this SDK installation. " +
+                "Run workload repair or update to restore it. Installed workload IDs were read directly from .NET metadata.");
+        }
+        else
+        {
             throw CreateCliException(target, "dotnet workload --version", versionResult);
+        }
 
-        var workloadVersion = DotnetWorkloadParser.ParseWorkloadVersion(versionResult.Output);
         var globalJson = workingDirectory == null
             ? null
             : new GlobalJsonService().GetGlobalJson(workingDirectory);
@@ -316,59 +331,82 @@ public sealed class DotnetWorkloadService : IDotnetWorkloadService
                     : DotnetWorkloadVersionSource.Unknown;
 
         DotnetWorkloadListResult workloadList;
-        var machineList = await RunCaptureAsync(
-            target,
-            ["workload", "list", "--machine-readable"],
-            commandDirectory,
-            cancellationToken).ConfigureAwait(false);
-        var machineReadable = machineList.ExitCode == 0;
-        if (machineReadable)
+        var machineReadable = false;
+        if (!cliStateAvailable)
         {
             try
             {
-                workloadList = DotnetWorkloadParser.ParseMachineReadableList(machineList.Output);
+                workloadList = new DotnetWorkloadListResult
+                {
+                    Installed = WorkloadInstallStateReader.ReadInstalledWorkloads(target)
+                };
             }
-            catch (FormatException ex)
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
             {
-                diagnostics.Add($"Machine-readable workload list was not understood: {ex.Message}");
-                machineReadable = false;
+                diagnostics.Add($"The installed workload records could not be read: {ex.Message}");
+                workloadList = new DotnetWorkloadListResult();
+            }
+        }
+        else
+        {
+            var machineList = await RunCaptureAsync(
+                target,
+                ["workload", "list", "--machine-readable"],
+                commandDirectory,
+                cancellationToken).ConfigureAwait(false);
+            machineReadable = machineList.ExitCode == 0;
+            if (machineReadable)
+            {
+                try
+                {
+                    workloadList = DotnetWorkloadParser.ParseMachineReadableList(machineList.Output);
+                }
+                catch (FormatException ex)
+                {
+                    diagnostics.Add($"Machine-readable workload list was not understood: {ex.Message}");
+                    machineReadable = false;
+                    workloadList = await ReadPlainListAsync(target, commandDirectory, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+            }
+            else
+            {
+                diagnostics.Add("This SDK does not support the machine-readable workload list; using the table fallback.");
                 workloadList = await ReadPlainListAsync(target, commandDirectory, cancellationToken)
                     .ConfigureAwait(false);
             }
         }
-        else
-        {
-            diagnostics.Add("This SDK does not support the machine-readable workload list; using the table fallback.");
-            workloadList = await ReadPlainListAsync(target, commandDirectory, cancellationToken)
-                .ConfigureAwait(false);
-        }
 
         IReadOnlyList<DotnetWorkloadSetVersion> availableSets = [];
-        var versionsResult = await RunCaptureAsync(
-            target,
-            ["workload", "search", "version", "--take", "20", "--format", "json", "--include-previews"],
-            commandDirectory,
-            cancellationToken).ConfigureAwait(false);
-        var jsonVersionSearch = versionsResult.ExitCode == 0;
-        if (jsonVersionSearch)
+        var jsonVersionSearch = false;
+        if (cliStateAvailable)
         {
-            try
+            var versionsResult = await RunCaptureAsync(
+                target,
+                ["workload", "search", "version", "--take", "20", "--format", "json", "--include-previews"],
+                commandDirectory,
+                cancellationToken).ConfigureAwait(false);
+            jsonVersionSearch = versionsResult.ExitCode == 0;
+            if (jsonVersionSearch)
             {
-                availableSets = DotnetWorkloadParser.ParseAvailableSetVersions(versionsResult.Output);
+                try
+                {
+                    availableSets = DotnetWorkloadParser.ParseAvailableSetVersions(versionsResult.Output);
+                }
+                catch (FormatException ex)
+                {
+                    diagnostics.Add($"Available workload-set versions were not understood: {ex.Message}");
+                    jsonVersionSearch = false;
+                }
             }
-            catch (FormatException ex)
+            else
             {
-                diagnostics.Add($"Available workload-set versions were not understood: {ex.Message}");
-                jsonVersionSearch = false;
+                diagnostics.Add($"Available workload-set versions could not be queried: {FirstError(versionsResult)}");
             }
-        }
-        else
-        {
-            diagnostics.Add($"Available workload-set versions could not be queried: {FirstError(versionsResult)}");
         }
 
         IReadOnlyList<DotnetManifestVersion> manifestVersions = [];
-        if (updateMode == DotnetWorkloadUpdateMode.WorkloadSet)
+        if (updateMode == DotnetWorkloadUpdateMode.WorkloadSet && cliStateAvailable)
         {
             var manifestResult = await RunCaptureAsync(
                 target,
@@ -441,7 +479,7 @@ public sealed class DotnetWorkloadService : IDotnetWorkloadService
             Capabilities = new DotnetWorkloadCapabilities
             {
                 MachineReadableList = machineReadable,
-                WorkloadVersion = true,
+                WorkloadVersion = cliStateAvailable,
                 JsonVersionSearch = jsonVersionSearch
             },
             Diagnostics = diagnostics
@@ -561,6 +599,24 @@ public sealed class DotnetWorkloadService : IDotnetWorkloadService
             Description: description,
             UsePseudoTerminal: SupportsTerminalProgress,
             ConfirmationButtonText: confirmationButtonText);
+    }
+
+    private bool TryGetMissingRecordedWorkloadSet(
+        DotnetWorkloadTarget target,
+        out string workloadVersion)
+    {
+        try
+        {
+            workloadVersion = WorkloadInstallStateReader.ReadWorkloadVersion(target) ?? string.Empty;
+            return !string.IsNullOrWhiteSpace(workloadVersion) &&
+                   !WorkloadInstallStateReader.IsWorkloadSetInstalled(target, workloadVersion);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException or FormatException)
+        {
+            _logger.LogDebug($"Could not inspect the recorded workload set for {target.FeatureBand}: {ex.Message}");
+            workloadVersion = string.Empty;
+            return false;
+        }
     }
 
     private static DotnetWorkloadUpdateMode ResolveUpdateMode(

--- a/src/MauiSherpa.Workloads/Services/WorkloadInstallStateReader.cs
+++ b/src/MauiSherpa.Workloads/Services/WorkloadInstallStateReader.cs
@@ -74,6 +74,65 @@ public static class WorkloadInstallStateReader
         return versions;
     }
 
+    public static string? ReadWorkloadVersion(DotnetWorkloadTarget target)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+
+        var path = GetPath(target);
+        if (!File.Exists(path))
+            return null;
+
+        using var document = ReadDocument(path);
+        if (!document.RootElement.TryGetProperty("workloadVersion", out var value) ||
+            value.ValueKind == JsonValueKind.Null)
+            return null;
+        if (value.ValueKind != JsonValueKind.String)
+            throw new FormatException(
+                $"The workload install-state value 'workloadVersion' in '{path}' is not a string.");
+
+        var version = value.GetString();
+        return string.IsNullOrWhiteSpace(version) ? null : version;
+    }
+
+    public static bool IsWorkloadSetInstalled(
+        DotnetWorkloadTarget target,
+        string workloadVersion)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        ArgumentException.ThrowIfNullOrWhiteSpace(workloadVersion);
+
+        var path = Path.Combine(
+            target.InstallRoot,
+            "sdk-manifests",
+            target.FeatureBand.ToString(),
+            "workloadsets",
+            workloadVersion);
+        return Directory.Exists(path) &&
+               Directory.EnumerateFiles(path, "*.workloadset.json").Any();
+    }
+
+    public static IReadOnlyList<DotnetInstalledWorkload> ReadInstalledWorkloads(
+        DotnetWorkloadTarget target)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+
+        var path = Path.Combine(
+            target.InstallRoot,
+            "metadata",
+            "workloads",
+            target.FeatureBand.ToString(),
+            "InstalledWorkloads");
+        if (!Directory.Exists(path))
+            return [];
+
+        return Directory.GetFiles(path)
+            .Select(Path.GetFileName)
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Select(id => new DotnetInstalledWorkload { Id = id! })
+            .OrderBy(workload => workload.Id, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
     private static string GetPath(DotnetWorkloadTarget target) =>
         Path.Combine(
             target.InstallRoot,

--- a/src/MauiSherpa/Components/InstalledDotnetVersionCard.razor
+++ b/src/MauiSherpa/Components/InstalledDotnetVersionCard.razor
@@ -148,7 +148,6 @@
 
 <style>
     .installed-dotnet-version-card {
-        border: 1px solid var(--border-color);
         border-radius: var(--card-radius);
         background: var(--card-bg);
         overflow: hidden;

--- a/src/MauiSherpa/Components/TrackedDotnetChannelsCard.razor
+++ b/src/MauiSherpa/Components/TrackedDotnetChannelsCard.razor
@@ -256,7 +256,6 @@
 
 <style>
     .tdc-card {
-        border: 1px solid var(--border-color);
         border-radius: var(--card-radius);
         background: var(--card-bg);
         overflow: hidden;

--- a/tests/MauiSherpa.Core.Tests/Services/DotnetWorkloadServiceTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/DotnetWorkloadServiceTests.cs
@@ -131,6 +131,116 @@ public class DotnetWorkloadServiceTests
         inventory.UpdateAvailable.Should().BeTrue();
     }
 
+    [Fact]
+    public async Task MissingRecordedWorkloadSetFallsBackToInstallRecords()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var root = CreateFailingDotnetRoot();
+        try
+        {
+            var target = TargetForRoot(root, "10.0.399");
+            WriteInstallState(root, """{"workloadVersion":"10.0.398"}""");
+            var records = Path.Combine(
+                root,
+                "metadata",
+                "workloads",
+                "10.0.300",
+                "InstalledWorkloads");
+            Directory.CreateDirectory(records);
+            File.WriteAllText(Path.Combine(records, "maui"), string.Empty);
+            File.WriteAllText(Path.Combine(records, "android"), string.Empty);
+
+            var inventory = await _service.GetInventoryAsync(target, forceRefresh: true);
+
+            inventory.ActiveWorkloadVersion.Should().Be("10.0.398");
+            inventory.InstalledWorkloads.Select(workload => workload.Id)
+                .Should().Equal("android", "maui");
+            inventory.Capabilities.WorkloadVersion.Should().BeFalse();
+            inventory.Diagnostics.Should().ContainSingle(message =>
+                message.Contains("recorded workload set 10.0.398 is missing"));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task CliFailureIsNotHiddenWhenRecordedWorkloadSetExists()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var root = CreateFailingDotnetRoot();
+        try
+        {
+            var target = TargetForRoot(root, "10.0.399");
+            WriteInstallState(root, """{"workloadVersion":"10.0.398"}""");
+            var workloadSet = Path.Combine(
+                root,
+                "sdk-manifests",
+                "10.0.300",
+                "workloadsets",
+                "10.0.398",
+                "microsoft.net.workloads.workloadset.json");
+            Directory.CreateDirectory(Path.GetDirectoryName(workloadSet)!);
+            File.WriteAllText(workloadSet, "{}");
+
+            var action = () => _service.GetInventoryAsync(target, forceRefresh: true);
+
+            await action.Should().ThrowAsync<InvalidOperationException>()
+                .WithMessage("*simulated workload failure*");
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static string CreateFailingDotnetRoot()
+    {
+        if (OperatingSystem.IsWindows())
+            throw new PlatformNotSupportedException();
+
+        var root = Path.Combine(
+            Path.GetTempPath(),
+            $"maui-sherpa-workload-service-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        var dotnet = Path.Combine(root, "dotnet");
+        File.WriteAllText(dotnet, "#!/bin/sh\necho 'simulated workload failure' >&2\nexit 1\n");
+        File.SetUnixFileMode(
+            dotnet,
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        return root;
+    }
+
+    private static void WriteInstallState(string root, string json)
+    {
+        var path = Path.Combine(
+            root,
+            "metadata",
+            "workloads",
+            "Arm64",
+            "10.0.300",
+            "InstallState",
+            "default.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, json);
+    }
+
+    private static DotnetWorkloadTarget TargetForRoot(string root, string version) => new()
+    {
+        InstallRoot = root,
+        DotnetPath = Path.Combine(root, "dotnet"),
+        Architecture = "arm64",
+        FeatureBand = new SdkFeatureBand(version),
+        RepresentativeSdkVersion = version,
+        IsManagedByDotnetUp = true,
+        CanWrite = true
+    };
+
     private static DotnetUpInstallation Sdk(string version) => new()
     {
         Component = DotnetUpComponent.Sdk,

--- a/tests/MauiSherpa.Workloads.Tests/Services/WorkloadInstallStateReaderTests.cs
+++ b/tests/MauiSherpa.Workloads.Tests/Services/WorkloadInstallStateReaderTests.cs
@@ -73,6 +73,55 @@ public class WorkloadInstallStateReaderTests : IDisposable
         ]);
     }
 
+    [Fact]
+    public void ReadWorkloadVersion_UsesRecordedVersion()
+    {
+        WriteState("""{"workloadVersion":"10.0.302"}""");
+
+        WorkloadInstallStateReader.ReadWorkloadVersion(CreateTarget())
+            .Should().Be("10.0.302");
+    }
+
+    [Fact]
+    public void IsWorkloadSetInstalled_RequiresWorkloadSetFile()
+    {
+        var target = CreateTarget();
+        var path = Path.Combine(
+            _root,
+            "sdk-manifests",
+            "10.0.300",
+            "workloadsets",
+            "10.0.302",
+            "microsoft.net.workloads.workloadset.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+
+        WorkloadInstallStateReader.IsWorkloadSetInstalled(target, "10.0.302")
+            .Should().BeFalse();
+
+        File.WriteAllText(path, "{}");
+
+        WorkloadInstallStateReader.IsWorkloadSetInstalled(target, "10.0.302")
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void ReadInstalledWorkloads_UsesFeatureBandRecords()
+    {
+        var path = Path.Combine(
+            _root,
+            "metadata",
+            "workloads",
+            "10.0.300",
+            "InstalledWorkloads");
+        Directory.CreateDirectory(path);
+        File.WriteAllText(Path.Combine(path, "maui"), string.Empty);
+        File.WriteAllText(Path.Combine(path, "android"), string.Empty);
+
+        WorkloadInstallStateReader.ReadInstalledWorkloads(CreateTarget())
+            .Select(workload => workload.Id)
+            .Should().Equal("android", "maui");
+    }
+
     private void WriteState(string json)
     {
         var path = Path.Combine(


### PR DESCRIPTION
The .NET SDK Manager currently fails its entire inventory when workload install state references a workload set that is no longer present. This change keeps the manager usable in that stale-state scenario while still surfacing diagnostics and preserving normal failures for valid workload sets.

- Read the recorded workload version and installed workload IDs directly from official workload metadata.
- Detect missing workload sets across the actual `*.workloadset.json` naming variants.
- Return degraded inventory data when CLI workload commands cannot run because the recorded set is missing.
- Skip CLI-dependent workload actions while degraded instead of presenting broken operations.
- Align tracked-channel and installed-version cards with the app's borderless card styling.
- Add regression coverage for fallback behavior, metadata parsing, set detection, and preserved failures.

**Validation**
- `MauiSherpa.Workloads.Tests`: 9 targeted tests passed.
- `MauiSherpa.Core.Tests`: 8 targeted tests passed.
- macOS AppKit debug build succeeded.