### PR TITLE
Improve Copilot models and dashboard toolbar

### DIFF
--- a/src/MauiSherpa.Core/Services/CopilotModelSelector.cs
+++ b/src/MauiSherpa.Core/Services/CopilotModelSelector.cs
@@ -1,0 +1,54 @@
+using MauiSherpa.Core.Interfaces;
+
+namespace MauiSherpa.Core.Services;
+
+public static class CopilotModelSelector
+{
+    public const string AutomaticModelId = "auto";
+
+    public static string SelectPreferred(IEnumerable<CopilotModelOption> models)
+    {
+        return models
+            .Select(model => new
+            {
+                Model = model,
+                Version = GetGptVersion(model.Id),
+                VariantPriority = GetVariantPriority(model.Id)
+            })
+            .Where(candidate => candidate.Version is not null)
+            .OrderByDescending(candidate => candidate.Version)
+            .ThenByDescending(candidate => candidate.VariantPriority)
+            .Select(candidate => candidate.Model.Id)
+            .FirstOrDefault() ?? AutomaticModelId;
+    }
+
+    private static Version? GetGptVersion(string modelId)
+    {
+        var markerIndex = modelId.IndexOf("gpt-", StringComparison.OrdinalIgnoreCase);
+        if (markerIndex < 0 || (markerIndex > 0 && modelId[markerIndex - 1] != '/'))
+            return null;
+
+        var versionStart = markerIndex + "gpt-".Length;
+        var versionEnd = versionStart;
+        while (versionEnd < modelId.Length &&
+               (char.IsDigit(modelId[versionEnd]) || modelId[versionEnd] == '.'))
+        {
+            versionEnd++;
+        }
+
+        var versionText = modelId[versionStart..versionEnd].TrimEnd('.');
+        if (!versionText.Contains('.'))
+            versionText += ".0";
+
+        return Version.TryParse(versionText, out var version) ? version : null;
+    }
+
+    private static int GetVariantPriority(string modelId)
+    {
+        if (modelId.Contains("-sol", StringComparison.OrdinalIgnoreCase))
+            return 2;
+        if (modelId.Contains("-terra", StringComparison.OrdinalIgnoreCase))
+            return 1;
+        return 0;
+    }
+}

--- a/src/MauiSherpa.Core/Services/ToolbarService.cs
+++ b/src/MauiSherpa.Core/Services/ToolbarService.cs
@@ -5,7 +5,8 @@ namespace MauiSherpa.Core.Services;
 /// <summary>
 /// Default implementation of IToolbarService.
 /// Blazor pages call SetItems() on activation; the macOS host observes ToolbarChanged
-/// and rebuilds native toolbar items accordingly.
+/// and rebuilds native toolbar items accordingly. Search and filter state is scoped to
+/// the active page and is reset when a new item set is registered.
 /// </summary>
 public class ToolbarService : IToolbarService
 {
@@ -29,6 +30,10 @@ public class ToolbarService : IToolbarService
     public void SetItems(params ToolbarAction[] items)
     {
         _items = items;
+        _filters = [];
+        _searchPlaceholder = null;
+        _searchText = "";
+        _disabledItems.Clear();
         ToolbarChanged?.Invoke();
     }
 

--- a/src/MauiSherpa.MacOS/BlazorContentPage.cs
+++ b/src/MauiSherpa.MacOS/BlazorContentPage.cs
@@ -36,6 +36,8 @@ public class BlazorContentPage : ContentPage
     private NSMenuToolbarItem? _nativeIdentityMenu;
     private NSMenuToolbarItem? _nativeFilterMenu;
     private NSMenuToolbarItem? _nativePublishMenu;
+    private NSToolbarItem? _nativeReleaseNotesItem;
+    private NSButton? _releaseNotesButton;
     private string _pendingRoute = "/";
     private string _currentRoute = "/";
 
@@ -382,7 +384,7 @@ public class BlazorContentPage : ContentPage
     List<NSObject> _nativeMenuTargets = new();
 
     // Superset signature for the initial build — includes all possible items
-    static readonly string SupersetSignature = "refresh,create,import,install-missing,save,reset,|S|F|I";
+    static readonly string SupersetSignature = "refresh,create,import,install-missing,save,reset,release-notes,|S|F|I";
 
     void OnToolbarChanged()
     {
@@ -527,9 +529,17 @@ public class BlazorContentPage : ContentPage
                         nsItem.PaletteLabel = label;
                         nsItem.ToolTip = label;
                     }
+
                 }
             }
         }
+
+        var releaseNotesItem = toolbar.Items.FirstOrDefault(item =>
+            ReferenceEquals(item, _nativeReleaseNotesItem) ||
+            string.Equals(item.Label, "Release Notes", StringComparison.Ordinal) ||
+            string.Equals(item.PaletteLabel, "Release Notes", StringComparison.Ordinal));
+        if (releaseNotesItem != null)
+            ConfigureReleaseNotesToolbarItem(releaseNotesItem);
 
         // 3. Rebuild filter submenus natively if filters are active
         if (hasFilter)
@@ -549,6 +559,37 @@ public class BlazorContentPage : ContentPage
         // 7. Re-hook native search field — upstream handler may have unsubscribed events
         if (hasSearch)
             Dispatcher.Dispatch(HookNativeSearchField);
+    }
+
+    void ConfigureReleaseNotesToolbarItem(NSToolbarItem toolbarItem)
+    {
+        if (!ReferenceEquals(_nativeReleaseNotesItem, toolbarItem))
+        {
+            var button = new NSButton
+            {
+                Title = "Release Notes",
+                Image = NSImage.GetSystemSymbol("mountain.2", null),
+                ImagePosition = NSCellImagePosition.ImageLeading,
+                BezelStyle = NSBezelStyle.TexturedRounded,
+            };
+            button.SetButtonType(NSButtonType.MomentaryPushIn);
+            button.Activated += (_, _) =>
+                _toolbarService.InvokeToolbarItemClicked("release-notes");
+            button.SizeToFit();
+
+            var fittingSize = button.FittingSize;
+            var buttonSize = new CGSize(Math.Max(132, fittingSize.Width + 16), 30);
+            button.Frame = new CGRect(CGPoint.Empty, buttonSize);
+
+            toolbarItem.View = button;
+            toolbarItem.MinSize = buttonSize;
+            toolbarItem.MaxSize = buttonSize;
+            _nativeReleaseNotesItem = toolbarItem;
+            _releaseNotesButton = button;
+        }
+
+        if (_releaseNotesButton != null)
+            _releaseNotesButton.Enabled = _toolbarService.IsItemEnabled("release-notes");
     }
 
     /// <summary>
@@ -967,6 +1008,8 @@ public class BlazorContentPage : ContentPage
             _actionItemMap.Clear();
             _nativeIdentityMenu = null;
             _nativeFilterMenu = null;
+            _nativeReleaseNotesItem = null;
+            _releaseNotesButton = null;
 
             // Copilot button in sidebar trailing area (convenience mode handles it)
             var copilotItem = CreateCopilotToolbarItem();
@@ -1007,11 +1050,13 @@ public class BlazorContentPage : ContentPage
                 ("save", "Save", "checkmark"),
                 ("reset", "Reset to Defaults", "trash"),
                 ("update-all", "Update Packages", "arrow.up.circle"),
+                ("release-notes", "Release Notes", "mountain.2"),
                 ("refresh", "Refresh", "arrow.clockwise"),
             };
 
             ToolbarItem? refreshItem = null;
             ToolbarItem? updateItem = null;
+            ToolbarItem? releaseNotesItem = null;
             var leadingItems = new List<ToolbarItem>();
             var allToolbarItems = new List<ToolbarItem> { copilotItem, doctorItem, settingsItem };
             foreach (var (id, label, icon) in supersetActions)
@@ -1036,6 +1081,8 @@ public class BlazorContentPage : ContentPage
                     refreshItem = item;
                 else if (actionId == "update-all")
                     updateItem = item;
+                else if (actionId == "release-notes")
+                    releaseNotesItem = item;
                 else
                     leadingItems.Add(item);
             }
@@ -1155,6 +1202,8 @@ public class BlazorContentPage : ContentPage
                 layout.Add(MacOSToolbarLayoutItem.Item(item));
             layout.Add(MacOSToolbarLayoutItem.FlexibleSpace);
             layout.Add(MacOSToolbarLayoutItem.Search(_searchItem));
+            if (releaseNotesItem != null)
+                layout.Add(MacOSToolbarLayoutItem.Item(releaseNotesItem));
             if (updateItem != null)
                 layout.Add(MacOSToolbarLayoutItem.Item(updateItem));
             if (refreshItem != null)

--- a/src/MauiSherpa.MacOS/MauiSherpa.MacOS.csproj
+++ b/src/MauiSherpa.MacOS/MauiSherpa.MacOS.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="Blazorise.Icons.FontAwesome" Version="1.7.2" />
     <!-- Reference the SDK directly so its build targets run with the AppKit publish RID
          instead of inheriting the build-host architecture from MauiSherpa.Core. -->
-    <PackageReference Include="GitHub.Copilot.SDK" Version="1.0.8" PrivateAssets="all" />
+    <PackageReference Include="GitHub.Copilot.SDK" Version="1.0.9" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Components.QuickGrid" Version="10.0.1" />
     <PackageReference Include="Markdig" Version="0.44.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="10.0.1" />

--- a/src/MauiSherpa/Components/ReleaseNotesDialog.razor
+++ b/src/MauiSherpa/Components/ReleaseNotesDialog.razor
@@ -8,17 +8,26 @@
 
 @if (IsOpen)
 {
-    <div class="release-overlay" @onclick="CloseAsync">
-        <div class="release-dialog" id="release-notes-dialog" role="dialog" aria-modal="true" aria-labelledby="release-notes-title" @onclick:stopPropagation="true">
-            <header class="release-dialog-header">
-                <div>
-                    <h2 id="release-notes-title"><i class="fas fa-mountain"></i> Release Notes</h2>
-                    <p>What's new in MAUI Sherpa</p>
-                </div>
-                <button class="release-close" @onclick="CloseAsync" title="Close release notes" aria-label="Close release notes">
-                    <i class="fas fa-xmark"></i>
-                </button>
-            </header>
+    <div class="@(Embedded ? "release-native-host" : "release-overlay")" @onclick="HandleBackdropClickAsync">
+        <div class="@(Embedded ? "release-native-content" : "release-dialog")"
+             id="release-notes-dialog"
+             role="dialog"
+             aria-modal="true"
+             aria-label="@(Embedded ? "Release Notes" : null)"
+             aria-labelledby="@(!Embedded ? "release-notes-title" : null)"
+             @onclick:stopPropagation="true">
+            @if (!Embedded)
+            {
+                <header class="release-dialog-header">
+                    <div>
+                        <h2 id="release-notes-title"><i class="fas fa-mountain"></i> Release Notes</h2>
+                        <p>What's new in MAUI Sherpa</p>
+                    </div>
+                    <button class="release-close" @onclick="CloseAsync" title="Close release notes" aria-label="Close release notes">
+                        <i class="fas fa-xmark"></i>
+                    </button>
+                </header>
+            }
 
             <div class="release-dialog-body">
                 @if (isLoading && releases.Count == 0)
@@ -95,6 +104,25 @@
         border: 1px solid var(--border-color);
         border-radius: 0.5rem;
         box-shadow: 0 20px 50px rgba(0, 0, 0, 0.25);
+    }
+
+    .release-native-host,
+    .release-native-content {
+        width: 100%;
+        height: 100%;
+        min-height: 0;
+    }
+
+    .release-native-content {
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+        background: var(--card-bg);
+    }
+
+    .release-native-content .release-dialog-body {
+        flex: 1;
+        padding: 1rem 1.25rem;
     }
 
     .release-dialog-header {
@@ -205,6 +233,7 @@
     private string errorMessage = "";
 
     [Parameter] public bool IsOpen { get; set; }
+    [Parameter] public bool Embedded { get; set; }
     [Parameter] public EventCallback OnClose { get; set; }
 
     protected override async Task OnParametersSetAsync()
@@ -223,8 +252,11 @@
         if (!hasLoaded)
             await LoadReleasesAsync();
 
-        dotNetReference ??= DotNetObjectReference.Create(this);
-        initializeFocus = true;
+        if (!Embedded)
+        {
+            dotNetReference ??= DotNetObjectReference.Create(this);
+            initializeFocus = true;
+        }
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -314,6 +346,8 @@
         await JS.InvokeVoidAsync("modalInterop.dispose", "release-notes-dialog");
         await OnClose.InvokeAsync();
     }
+
+    private Task HandleBackdropClickAsync() => Embedded ? Task.CompletedTask : CloseAsync();
 
     public async ValueTask DisposeAsync()
     {

--- a/src/MauiSherpa/Pages/Copilot.razor
+++ b/src/MauiSherpa/Pages/Copilot.razor
@@ -1,4 +1,5 @@
 @using MauiSherpa.Core.Interfaces
+@using MauiSherpa.Core.Services
 @using Markdig
 @inject ICopilotService CopilotService
 @inject IAlertService AlertService
@@ -193,7 +194,7 @@ else
         <div class="chat-container">
             <div class="model-selector">
                 <label for="copilot-model"><i class="fas fa-robot"></i> Model</label>
-                <select id="copilot-model" value="@selectedModel" @onchange="SelectModelAsync" disabled="@isBusy">
+                <select id="copilot-model" value="@selectedModel" @onchange="SelectModelAsync" disabled="@(isBusy || isConnecting)">
                     @foreach (var model in availableModels)
                     {
                         <option value="@model.Id">@model.Name</option>
@@ -414,7 +415,7 @@ else
                 else if (CopilotService.IsConnected)
                 {
                     <div class="usage-info subtle">
-                        <span class="usage-item"><i class="fas fa-robot"></i> claude-opus-4-5-20250514</span>
+                        <span class="usage-item"><i class="fas fa-robot"></i> @SelectedModelDisplayName</span>
                         <span class="usage-item muted">Waiting for response...</span>
                     </div>
                 }
@@ -2219,6 +2220,10 @@ else
     private bool isBusy = false;
     private string selectedModel = "auto";
     private List<CopilotModelOption> availableModels = [new("auto", "Auto")];
+    private bool modelsLoaded = false;
+    private string SelectedModelDisplayName => availableModels
+        .FirstOrDefault(model => string.Equals(model.Id, selectedModel, StringComparison.OrdinalIgnoreCase))
+        ?.Name ?? selectedModel;
     private bool suggestionsCollapsed = false;
     private string userInput = "";
     private string currentResponse = "";
@@ -2419,7 +2424,7 @@ else
             isCheckingAvailability = false;
             
             // Auto-connect if Copilot is available and authenticated
-            if (availability.IsInstalled && availability.IsAuthenticated && CopilotService.CurrentSessionId == null)
+            if (availability.IsInstalled && availability.IsAuthenticated)
             {
                 try
                 {
@@ -2442,7 +2447,7 @@ else
             availability = await CopilotService.CheckAvailabilityAsync(forceRefresh);
             
             // Auto-connect if Copilot is available and authenticated
-            if (availability.IsInstalled && availability.IsAuthenticated && CopilotService.CurrentSessionId == null)
+            if (availability.IsInstalled && availability.IsAuthenticated)
             {
                 try
                 {
@@ -2478,7 +2483,7 @@ else
 
     private async Task Connect()
     {
-        if (isConnecting || CopilotService.IsConnected)
+        if (isConnecting)
             return;
 
         isConnecting = true;
@@ -2487,8 +2492,13 @@ else
         try
         {
             await CopilotService.ConnectAsync();
-            await CopilotService.StartSessionAsync(selectedModel, _systemPrompt);
             await LoadModelsAsync();
+
+            if (CopilotService.CurrentSessionId == null)
+            {
+                await CopilotService.StartSessionAsync(selectedModel, _systemPrompt);
+            }
+
             availability = availability is null
                 ? new CopilotAvailability(true, true, null, null, null)
                 : availability with { IsInstalled = true, IsAuthenticated = true, ErrorMessage = null };
@@ -2574,8 +2584,10 @@ else
             if (!CopilotService.IsConnected)
             {
                 await CopilotService.ConnectAsync();
-                await LoadModelsAsync();
             }
+
+            if (!modelsLoaded)
+                await LoadModelsAsync();
 
             if (CopilotService.CurrentSessionId == null)
             {
@@ -2601,11 +2613,31 @@ else
             var models = await CopilotService.ListModelsAsync();
             availableModels = [
                 new CopilotModelOption("auto", "Auto"),
-                .. models.Where(model => !string.Equals(model.Id, "auto", StringComparison.OrdinalIgnoreCase))
+                .. models
+                    .Where(model =>
+                        !string.IsNullOrWhiteSpace(model.Id) &&
+                        !string.Equals(model.Id, "auto", StringComparison.OrdinalIgnoreCase))
+                    .DistinctBy(model => model.Id, StringComparer.OrdinalIgnoreCase)
             ];
+
+            modelsLoaded = true;
+
+            var selectedModelIsAvailable = availableModels.Any(model =>
+                string.Equals(model.Id, selectedModel, StringComparison.OrdinalIgnoreCase));
+            if (!selectedModelIsAvailable ||
+                (CopilotService.CurrentSessionId == null &&
+                 string.Equals(selectedModel, CopilotModelSelector.AutomaticModelId, StringComparison.OrdinalIgnoreCase)))
+            {
+                selectedModel = CopilotModelSelector.SelectPreferred(availableModels);
+            }
+
+            _logger.LogInformation($"Loaded {availableModels.Count - 1} selectable Copilot models");
         }
         catch (Exception ex)
         {
+            modelsLoaded = false;
+            availableModels = [new CopilotModelOption("auto", "Auto")];
+            selectedModel = "auto";
             _logger.LogWarning($"Unable to load Copilot models: {ex.Message}");
         }
     }

--- a/src/MauiSherpa/Pages/Dashboard.razor
+++ b/src/MauiSherpa/Pages/Dashboard.razor
@@ -3,9 +3,11 @@
 @using MauiSherpa.Core.Interfaces
 @using MauiSherpa.Core.Services
 @using MauiSherpa.Services
+@using MauiSherpa.Pages.Modals
 @implements IDisposable
 @inject DashboardViewModel ViewModel
 @inject IToolbarService ToolbarService
+@inject IFormModalService FormModalService
 @inject IPlatformService PlatformInfo
 @inject IDeviceMonitorService DeviceMonitor
 @inject IDoctorService DoctorService
@@ -18,10 +20,6 @@
         <h1><i class="fas fa-home"></i> @ViewModel.Title</h1>
         <p class="welcome">@ViewModel.WelcomeMessage</p>
     </div>
-    <button class="release-notes-trigger" @onclick="() => showReleaseNotes = true">
-        <i class="fas fa-mountain"></i>
-        <span>Release Notes</span>
-    </button>
 </div>
 
 <div class="environment-section">
@@ -154,8 +152,6 @@
     </div>
 </div>
 
-<ReleaseNotesDialog IsOpen="showReleaseNotes" OnClose="() => showReleaseNotes = false" />
-
 <style>
     h1 {
         margin-bottom: 0.375rem;
@@ -177,24 +173,6 @@
         font-size: 1rem;
         color: var(--text-muted);
     }
-
-    .release-notes-trigger {
-        flex-shrink: 0;
-        display: inline-flex;
-        align-items: center;
-        gap: 0.45rem;
-        padding: 0.55rem 0.75rem;
-        border: 1px solid var(--border-color);
-        border-radius: 0.45rem;
-        background: var(--card-bg);
-        color: var(--text-secondary);
-        cursor: pointer;
-        font: inherit;
-        font-size: 0.8rem;
-        font-weight: 600;
-    }
-
-    .release-notes-trigger:hover { color: var(--text-primary); background: var(--bg-hover); }
 
     .environment-section { margin-bottom: 2rem; }
 
@@ -252,8 +230,10 @@
         min-height: 112px;
         padding: 1rem;
         background: var(--card-bg);
-        border-left: 3px solid var(--border-color);
-        border-radius: 0.5rem;
+        border: 1px solid var(--border-color);
+        border-left: 4px solid var(--border-color);
+        border-radius: 0.875rem;
+        overflow: hidden;
     }
 
     .environment-card.status-ok { border-left-color: var(--accent-success); }
@@ -469,13 +449,15 @@
 @code {
     private DoctorReport? doctorReport;
     private bool isDoctorLoading;
+    private bool isReleaseNotesOpen;
     private string doctorError = "";
     private bool isDisposed;
-    private bool showReleaseNotes;
-
     protected override void OnInitialized()
     {
-        ToolbarService.SetItems();
+        ToolbarService.SetItems(
+            new ToolbarAction("release-notes", "Release Notes", "mountain.2")
+        );
+        ToolbarService.ToolbarItemClicked += OnToolbarItemClicked;
         DeviceMonitor.Changed += OnDevicesChanged;
     }
 
@@ -585,9 +567,33 @@
         InvokeAsync(StateHasChanged);
     }
 
+    private async void OnToolbarItemClicked(string actionId)
+    {
+        if (actionId != "release-notes")
+            return;
+
+        await InvokeAsync(async () =>
+        {
+            if (isReleaseNotesOpen)
+                return;
+
+            isReleaseNotesOpen = true;
+            try
+            {
+                var page = new ReleaseNotesPage();
+                await FormModalService.ShowViewAsync(page, page.WaitForCloseAsync);
+            }
+            finally
+            {
+                isReleaseNotesOpen = false;
+            }
+        });
+    }
+
     public void Dispose()
     {
         isDisposed = true;
+        ToolbarService.ToolbarItemClicked -= OnToolbarItemClicked;
         DeviceMonitor.Changed -= OnDevicesChanged;
     }
 

--- a/src/MauiSherpa/Pages/Modals/ReleaseNotesModal.razor
+++ b/src/MauiSherpa/Pages/Modals/ReleaseNotesModal.razor
@@ -1,0 +1,3 @@
+@page "/modal/release-notes"
+
+<ReleaseNotesDialog IsOpen="true" Embedded="true" />

--- a/src/MauiSherpa/Pages/Modals/ReleaseNotesPage.cs
+++ b/src/MauiSherpa/Pages/Modals/ReleaseNotesPage.cs
@@ -1,0 +1,26 @@
+using MauiSherpa.Pages.Forms;
+#if MACOSAPP
+using Microsoft.Maui.Platforms.MacOS.Platform;
+#endif
+#if LINUXGTK
+using Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
+#endif
+
+namespace MauiSherpa.Pages.Modals;
+
+public sealed class ReleaseNotesPage : HybridViewPage
+{
+    protected override string FormTitle => "Release Notes";
+    protected override string BlazorRoute => "/modal/release-notes";
+
+    public ReleaseNotesPage()
+    {
+#if MACOSAPP
+        MacOSPage.SetModalSheetWidth(this, 760);
+        MacOSPage.SetModalSheetHeight(this, 680);
+#elif LINUXGTK
+        GtkPage.SetModalWidth(this, 760);
+        GtkPage.SetModalHeight(this, 680);
+#endif
+    }
+}

--- a/tests/MauiSherpa.Core.Tests/Services/CopilotModelSelectorTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/CopilotModelSelectorTests.cs
@@ -1,0 +1,46 @@
+using FluentAssertions;
+using MauiSherpa.Core.Interfaces;
+using MauiSherpa.Core.Services;
+
+namespace MauiSherpa.Core.Tests.Services;
+
+public class CopilotModelSelectorTests
+{
+    [Fact]
+    public void SelectPreferred_PicksSolBeforeTerraForSameVersion()
+    {
+        CopilotModelOption[] models =
+        [
+            new("auto", "Auto"),
+            new("gpt-5.6-terra", "GPT-5.6 Terra"),
+            new("gpt-5.6-sol", "GPT-5.6 Sol"),
+            new("gpt-5.5", "GPT-5.5")
+        ];
+
+        CopilotModelSelector.SelectPreferred(models).Should().Be("gpt-5.6-sol");
+    }
+
+    [Fact]
+    public void SelectPreferred_PicksNewerGptVersionBeforePreferredVariant()
+    {
+        CopilotModelOption[] models =
+        [
+            new("gpt-5.6-sol", "GPT-5.6 Sol"),
+            new("gpt-5.7-luna", "GPT-5.7 Luna")
+        ];
+
+        CopilotModelSelector.SelectPreferred(models).Should().Be("gpt-5.7-luna");
+    }
+
+    [Fact]
+    public void SelectPreferred_FallsBackToAutoWithoutGptModels()
+    {
+        CopilotModelOption[] models =
+        [
+            new("auto", "Auto"),
+            new("claude-sonnet-5", "Claude Sonnet 5")
+        ];
+
+        CopilotModelSelector.SelectPreferred(models).Should().Be("auto");
+    }
+}

--- a/tests/MauiSherpa.Core.Tests/Services/ToolbarServiceTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/ToolbarServiceTests.cs
@@ -1,0 +1,27 @@
+using FluentAssertions;
+using MauiSherpa.Core.Interfaces;
+using MauiSherpa.Core.Services;
+
+namespace MauiSherpa.Core.Tests.Services;
+
+public class ToolbarServiceTests
+{
+    [Fact]
+    public void SetItems_ClearsStateFromPreviousPage()
+    {
+        var service = new ToolbarService();
+        service.SetItems(new ToolbarAction("refresh", "Refresh", "arrow.clockwise"));
+        service.SetSearch("Search packages...");
+        service.NotifySearchTextChanged("android");
+        service.SetFilters(new ToolbarFilter("category", "Category", ["All", "Tools"]));
+        service.SetItemEnabled("refresh", false);
+
+        service.SetItems(new ToolbarAction("release-notes", "Release Notes", "mountain.2"));
+
+        service.CurrentItems.Should().ContainSingle(item => item.Id == "release-notes");
+        service.SearchPlaceholder.Should().BeNull();
+        service.SearchText.Should().BeEmpty();
+        service.CurrentFilters.Should().BeEmpty();
+        service.IsItemEnabled("refresh").Should().BeTrue();
+    }
+}


### PR DESCRIPTION
The Copilot model picker could remain empty or display a stale hardcoded model, while dashboard toolbar state and Release Notes presentation were inconsistent across navigation and platforms. This update makes model selection reflect the authenticated user's available models and gives the dashboard a more polished, native desktop experience.

## What changed

- Load available Copilot models even when an SDK client is already connected, and display the actual selected model.
- Prefer the newest available GPT model by default, with Sol favored over Terra for equal versions and Auto as the fallback.
- Move Release Notes to a native hybrid sheet while reusing the existing Blazor release content.
- Add a labeled native macOS Release Notes toolbar control and improve development environment card borders and corner treatment.
- Reset page-scoped toolbar search, filters, text, and disabled state when navigating to a page with a new toolbar definition.
- Align the macOS GitHub Copilot SDK package version with Core.

## Validation

- Added focused coverage for preferred Copilot model selection and toolbar state replacement.
- Built the macOS AppKit head and exercised the updated app locally.