### PR TITLE
Fix Windows profiling navigation crash

### DIFF
--- a/src/MauiSherpa/MauiProgram.cs
+++ b/src/MauiSherpa/MauiProgram.cs
@@ -153,6 +153,7 @@ public static class MauiProgram
         builder.Services.AddSingleton<IFirebasePushService, FirebasePushService>();
         builder.Services.AddSingleton<DeviceInspectorService>();
         builder.Services.AddSingleton<DevFlowInspectorService>();
+        builder.Services.AddSingleton<ProfilingViewerService>();
         // DevFlow v1 spec abstraction — unified client that works with both v1 and legacy agents
         builder.Services.AddHttpClient();
         builder.Services.AddSingleton<MauiSherpa.Core.Interfaces.IAppInspectorClientFactory, MauiSherpa.Core.Services.AppInspectorClientFactory>();


### PR DESCRIPTION
Navigating to Profiling on Windows failed during Blazor component activation because `ProfilingViewerService` was missing from the Windows app's DI container, leaving the WebView unusable until restart.

Register the viewer as a singleton in the Windows app head, matching the existing macOS registration and its window-owning lifetime.

Fixes: #205