### PR TITLE
Fix Doctor suggesting a downgrade on a preview .NET SDK

### DIFF
--- a/src/MauiSherpa.Core/Services/DoctorService.cs
+++ b/src/MauiSherpa.Core/Services/DoctorService.cs
@@ -289,6 +289,34 @@ public class DoctorService : IDoctorService
     }
 
     /// <summary>
+    /// Finds the newest available SDK for the same major version that is strictly newer
+    /// (by semantic version) than <paramref name="installed"/>. Returns <c>null</c> when no
+    /// available version is newer.
+    /// </summary>
+    /// <remarks>
+    /// The releases feed may not yet list a preview the user has installed (e.g. a nightly
+    /// <c>10.0.400-preview</c> build). In that case the newest *published* release for the major
+    /// can be an older feature band (e.g. stable <c>10.0.302</c>). Comparing by string equality
+    /// would flag that lower version as an "update", suggesting a downgrade. Comparing by
+    /// <see cref="SdkVersion.SemanticVersion"/> (backed by NuGet version ordering) prevents that.
+    /// </remarks>
+    internal static SdkVersionInfo? FindNewerAvailableSdk(
+        IReadOnlyList<SdkVersionInfo>? available, SdkVersion installed)
+    {
+        if (available == null || available.Count == 0)
+            return null;
+
+        return available
+            .Where(s => s.Major == installed.Major)
+            .Select(s => (Info: s,
+                Parsed: SdkVersion.TryParse(s.Version, out var v) ? v : null))
+            .Where(x => x.Parsed != null && x.Parsed.CompareTo(installed) > 0)
+            .OrderByDescending(x => x.Parsed!.SemanticVersion)
+            .Select(x => x.Info)
+            .FirstOrDefault();
+    }
+
+    /// <summary>
     /// Resolves the effective SDK version based on the rollForward policy from global.json.</summary>
     /// <remarks>
     /// See: https://learn.microsoft.com/dotnet/core/tools/global-json#rollforward
@@ -446,51 +474,52 @@ public class DoctorService : IDoctorService
             }
             else if (latestSdk.IsPreview)
             {
-                // Active SDK is a preview — find the latest available for the SAME major version
-                var latestAvailableForMajor = availableSdkVersions?
-                    .FirstOrDefault(s => s.Major == latestSdk.Major);
-                var isLatestForMajor = latestAvailableForMajor == null 
-                    || latestSdk.Version == latestAvailableForMajor.Version;
-                
+                // Active SDK is a preview — only offer an update when an available version for
+                // the same major is *semantically newer* than the installed preview. A preview
+                // can sit on a higher feature band (e.g. 10.0.400-preview) than the newest
+                // published release (e.g. stable 10.0.302), so never suggest a downgrade.
+                var newerAvailable = FindNewerAvailableSdk(availableSdkVersions, latestSdk);
+                var isLatestForMajor = newerAvailable == null;
+
                 // dotnetup can fix an out-of-date preview by installing the recommended version.
-                var canFix = !isLatestForMajor && _dotnetUpService != null && latestAvailableForMajor != null;
+                var canFix = !isLatestForMajor && _dotnetUpService != null;
 
                 // Add an informational status about being on a preview SDK
                 dependencies.Add(new DependencyStatus(
                     ".NET SDK",
                     DependencyCategory.DotNetSdk,
                     null,
-                    isLatestForMajor ? null : latestAvailableForMajor?.Version,
+                    newerAvailable?.Version,
                     latestSdk.Version,
                     isLatestForMajor ? DependencyStatusType.Info : DependencyStatusType.Warning,
                     isLatestForMajor
                         ? $"Preview SDK ({latestSdk.Version})"
-                        : $"Update available: {latestAvailableForMajor?.Version}",
+                        : $"Update available: {newerAvailable?.Version}",
                     IsFixable: canFix,
-                    FixAction: canFix ? $"dotnetup-update-sdk:{latestAvailableForMajor!.Version}" : null
+                    FixAction: canFix ? $"dotnetup-update-sdk:{newerAvailable!.Version}" : null
                 ));
             }
             else
             {
-                var latestAvailable = availableSdkVersions?
-                    .FirstOrDefault(s => !s.IsPreview);
-                var isLatest = latestAvailable == null || latestSdk.Version == latestAvailable.Version;
+                var newerAvailable = FindNewerAvailableSdk(
+                    availableSdkVersions?.Where(s => !s.IsPreview).ToList(), latestSdk);
+                var isLatest = newerAvailable == null;
 
                 // dotnetup can fix an out-of-date stable SDK by installing the latest.
-                var canFix = !isLatest && _dotnetUpService != null && latestAvailable != null;
+                var canFix = !isLatest && _dotnetUpService != null;
 
                 dependencies.Add(new DependencyStatus(
                     ".NET SDK",
                     DependencyCategory.DotNetSdk,
                     null,
-                    latestAvailable?.Version,
+                    newerAvailable?.Version,
                     latestSdk.Version,
                     isLatest ? DependencyStatusType.Ok : DependencyStatusType.Warning,
                     isLatest 
                         ? $"{sdkVersions.Count} SDK(s) installed, using {latestSdk.Version}"
-                        : $"Update available: {latestAvailable?.Version}",
+                        : $"Update available: {newerAvailable?.Version}",
                     IsFixable: canFix,
-                    FixAction: canFix ? $"dotnetup-update-sdk:{latestAvailable!.Version}" : null
+                    FixAction: canFix ? $"dotnetup-update-sdk:{newerAvailable!.Version}" : null
                 ));
             }
         }

--- a/tests/MauiSherpa.Core.Tests/Services/DoctorPreviewSdkTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/DoctorPreviewSdkTests.cs
@@ -1,5 +1,7 @@
 using FluentAssertions;
 using MauiSherpa.Core.Interfaces;
+using MauiSherpa.Core.Services;
+using MauiSherpa.Workloads.Models;
 using Xunit;
 
 namespace MauiSherpa.Core.Tests.Services;
@@ -263,5 +265,95 @@ public class DoctorPreviewSdkTests
         filtered.Should().Contain(s => s.Version == "10.0.102");
         filtered.Should().NotContain(s => s.Version == "10.0.200-preview.1",
             "previews for major 10 should be excluded since user only has stable 10.x");
+    }
+
+    // Regression tests for issue #206: a preview SDK on a higher feature band than the newest
+    // *published* release must not be told to "update" to that lower version (a downgrade).
+
+    [Fact]
+    public void FindNewerAvailableSdk_PreviewOnHigherBandThanPublished_ReturnsNull()
+    {
+        // Installed nightly preview on band 400 that isn't in the releases feed yet.
+        var installed = SdkVersion.Parse("10.0.400-preview.0.26322.102");
+
+        // Feed only knows the newest published stable (band 300) plus older builds.
+        var available = new List<SdkVersionInfo>
+        {
+            new("10.0.302", "10.0.300", 10, 0, false),
+            new("10.0.301", "10.0.300", 10, 0, false),
+            new("10.0.203", "10.0.200", 10, 0, false),
+        };
+
+        var result = DoctorService.FindNewerAvailableSdk(available, installed);
+
+        result.Should().BeNull("a lower published version must never be offered as an update");
+    }
+
+    [Fact]
+    public void FindNewerAvailableSdk_NewerPreviewForSameBand_ReturnsIt()
+    {
+        var installed = SdkVersion.Parse("11.0.100-preview.1");
+
+        var available = new List<SdkVersionInfo>
+        {
+            new("11.0.100-preview.2", "11.0.100", 11, 0, true),
+            new("11.0.100-preview.1", "11.0.100", 11, 0, true),
+            new("10.0.302", "10.0.300", 10, 0, false),
+        };
+
+        var result = DoctorService.FindNewerAvailableSdk(available, installed);
+
+        result.Should().NotBeNull();
+        result!.Version.Should().Be("11.0.100-preview.2");
+    }
+
+    [Fact]
+    public void FindNewerAvailableSdk_NewerStableForSameMajor_ReturnsIt()
+    {
+        var installed = SdkVersion.Parse("10.0.302");
+
+        var available = new List<SdkVersionInfo>
+        {
+            new("10.0.303", "10.0.300", 10, 0, false),
+            new("10.0.302", "10.0.300", 10, 0, false),
+        };
+
+        var result = DoctorService.FindNewerAvailableSdk(available, installed);
+
+        result.Should().NotBeNull();
+        result!.Version.Should().Be("10.0.303");
+    }
+
+    [Fact]
+    public void FindNewerAvailableSdk_AlreadyLatest_ReturnsNull()
+    {
+        var installed = SdkVersion.Parse("10.0.303");
+
+        var available = new List<SdkVersionInfo>
+        {
+            new("10.0.303", "10.0.300", 10, 0, false),
+            new("10.0.302", "10.0.300", 10, 0, false),
+        };
+
+        var result = DoctorService.FindNewerAvailableSdk(available, installed);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void FindNewerAvailableSdk_IgnoresOtherMajorVersions()
+    {
+        var installed = SdkVersion.Parse("10.0.400-preview.1");
+
+        // A newer major exists but must not be offered as an update for a major-10 SDK.
+        var available = new List<SdkVersionInfo>
+        {
+            new("11.0.100", "11.0.100", 11, 0, false),
+            new("10.0.302", "10.0.300", 10, 0, false),
+        };
+
+        var result = DoctorService.FindNewerAvailableSdk(available, installed);
+
+        result.Should().BeNull();
     }
 }


### PR DESCRIPTION
## Why

When the active .NET SDK is a preview sitting on a higher feature band than the newest *published* release, Doctor wrongly reported an "update" that is actually a downgrade. For example, with `10.0.400-preview.0.26322.102` installed (band 400, a nightly not yet in the releases feed), Doctor showed:

> .NET SDK ⚠️ Update available: 10.0.302

`10.0.302` (band 300, stable) is *older* than the installed preview, so this is a downgrade, not an update. This is what issue #206 reports ("if I am on a .net preview doctor will yell at me").

## What changed

The `.NET SDK` check in `DoctorService.RunDoctorAsync` picked the "latest available" release for the major with `FirstOrDefault(s => s.Major == ...)` and compared it to the installed version using **string inequality**. Any differing string counted as an update, even a lower one.

- Added an internal helper `FindNewerAvailableSdk(available, installed)` that returns the newest available SDK for the same major that is **semantically newer** than the installed one, using the existing `SdkVersion.SemanticVersion` / `NuGetVersion` ordering. It returns `null` when nothing newer exists.
- The preview branch now keeps the informational `Preview SDK (...)` status unless a genuinely newer version is available, so a lower published release is never offered as an update.
- Applied the same strictly-newer guard to the stable branch for symmetry, so a stable SDK ahead of the feed can't be told to downgrade either.
- The dotnetup managed-channel path is unchanged; it already reports exactly what its tracked channel resolves to.

## Tests

Added 5 unit tests in `DoctorPreviewSdkTests.cs` for the new helper: higher-band preview vs lower published stable (no update), genuinely newer preview (returned), newer stable (returned), already latest (none), and other-major versions ignored. Full `MauiSherpa.Core.Tests` Doctor suite passes (14/14).

Fixes: #206