### PR TITLE
Fix certificate secret resolution during publish (#224)

### DIFF
--- a/src/MauiSherpa.Core/Interfaces.cs
+++ b/src/MauiSherpa.Core/Interfaces.cs
@@ -3388,6 +3388,21 @@ public interface ICertificateSyncService
     Task<bool> DownloadAndInstallAsync(string certificateId, CancellationToken cancellationToken = default);
     
     /// <summary>
+    /// Resolves a certificate's private key (P12) and password for publishing, using a
+    /// resilient lookup order: (1) exact cloud key, (2) fuzzy serial match against cloud
+    /// secrets, (3) export from the local macOS keychain (when supported). When the key is
+    /// found only in the local keychain and <paramref name="autoUploadFromKeychain"/> is true,
+    /// it is best-effort uploaded to cloud storage so subsequent runs (e.g. CI) succeed.
+    /// </summary>
+    /// <param name="serialNumber">The certificate serial number to resolve.</param>
+    /// <param name="autoUploadFromKeychain">Upload the exported key to cloud when resolved from the keychain.</param>
+    /// <returns>The P12 bytes and password, or (null, null) if the key could not be resolved.</returns>
+    Task<(byte[]? P12, string? Password)> GetCertificateSecretsAsync(
+        string serialNumber,
+        bool autoUploadFromKeychain = true,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Gets the cloud secret key for a certificate
     /// </summary>
     string GetCertificateSecretKey(string serialNumber);

--- a/src/MauiSherpa.Core/Services/CertificateSyncService.cs
+++ b/src/MauiSherpa.Core/Services/CertificateSyncService.cs
@@ -160,6 +160,140 @@ public class CertificateSyncService : ICertificateSyncService
         }
     }
 
+    public async Task<(byte[]? P12, string? Password)> GetCertificateSecretsAsync(
+        string serialNumber,
+        bool autoUploadFromKeychain = true,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(serialNumber))
+            return (null, null);
+
+        // 1) Cloud lookup — exact key, then fuzzy serial match against stored CERT_ secrets.
+        if (_cloudSecretsService.ActiveProvider != null)
+        {
+            try
+            {
+                var p12Key = GetCertificateSecretKey(serialNumber);
+                var p12 = await _cloudSecretsService.GetSecretAsync(p12Key, cancellationToken);
+                if (p12 is { Length: > 0 })
+                {
+                    var pwd = await _cloudSecretsService.GetSecretAsync(GetCertificatePasswordKey(serialNumber), cancellationToken);
+                    _logger.LogInformation($"Resolved certificate {serialNumber} from cloud (exact key {p12Key})");
+                    return (p12, pwd is not null ? Encoding.UTF8.GetString(pwd) : null);
+                }
+
+                // Exact key missed — the secret may have been stored under a differently
+                // normalized serial. Scan CERT_*_P12 keys and fuzzy-match the serial.
+                var storedSerial = await FindStoredCertSerialAsync(serialNumber, cancellationToken);
+                if (storedSerial is not null)
+                {
+                    var fuzzyP12Key = $"{SecretPrefix}_{storedSerial}_P12";
+                    var fuzzyP12 = await _cloudSecretsService.GetSecretAsync(fuzzyP12Key, cancellationToken);
+                    if (fuzzyP12 is { Length: > 0 })
+                    {
+                        var fuzzyPwd = await _cloudSecretsService.GetSecretAsync($"{SecretPrefix}_{storedSerial}_PWD", cancellationToken);
+                        _logger.LogInformation($"Resolved certificate {serialNumber} from cloud via fuzzy serial match (key {fuzzyP12Key})");
+                        return (fuzzyP12, fuzzyPwd is not null ? Encoding.UTF8.GetString(fuzzyPwd) : null);
+                    }
+                }
+
+                _logger.LogWarning($"Certificate {serialNumber} not found in cloud storage (tried key {p12Key} and fuzzy serial match)");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning($"Cloud lookup for certificate {serialNumber} failed: {ex.Message}");
+            }
+        }
+        else
+        {
+            _logger.LogWarning($"No active cloud secrets provider while resolving certificate {serialNumber}");
+        }
+
+        // 2) Local macOS keychain fallback — export the private key directly.
+        if (_localCertificateService.IsSupported)
+        {
+            try
+            {
+                var identities = await _localCertificateService.GetSigningIdentitiesAsync();
+                var identity = identities.FirstOrDefault(i => SerialsFuzzyEqual(i.SerialNumber, serialNumber));
+                if (identity is not null)
+                {
+                    var password = GenerateRandomPassword();
+                    var p12 = await _localCertificateService.ExportP12Async(identity.Identity, password);
+                    if (p12 is { Length: > 0 })
+                    {
+                        _logger.LogInformation($"Resolved certificate {serialNumber} from local keychain (identity '{identity.Identity}')");
+
+                        if (autoUploadFromKeychain && _cloudSecretsService.ActiveProvider != null)
+                        {
+                            try
+                            {
+                                var cert = new AppleCertificate(
+                                    Id: string.Empty,
+                                    Name: identity.CommonName,
+                                    CertificateType: string.Empty,
+                                    Platform: string.Empty,
+                                    ExpirationDate: identity.ExpirationDate ?? DateTime.MinValue,
+                                    SerialNumber: serialNumber);
+                                var metadata = new CertificateSecretMetadata(
+                                    CertificateId: string.Empty,
+                                    SerialNumber: serialNumber,
+                                    CommonName: identity.CommonName,
+                                    CertificateType: string.Empty,
+                                    ExpirationDate: identity.ExpirationDate ?? DateTime.MinValue,
+                                    CreatedByMachine: Environment.MachineName,
+                                    CreatedAt: DateTime.UtcNow);
+                                if (await UploadToCloudAsync(cert, p12, password, metadata, cancellationToken))
+                                    _logger.LogInformation($"Auto-uploaded certificate {serialNumber} to cloud storage for future runs");
+                            }
+                            catch (Exception ex)
+                            {
+                                _logger.LogWarning($"Auto-upload of certificate {serialNumber} to cloud failed: {ex.Message}");
+                            }
+                        }
+
+                        return (p12, password);
+                    }
+                }
+                else
+                {
+                    _logger.LogWarning($"No local keychain identity found for certificate serial {serialNumber}");
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning($"Local keychain fallback for certificate {serialNumber} failed: {ex.Message}");
+            }
+        }
+
+        _logger.LogWarning($"Certificate {serialNumber} could not be resolved from cloud storage or local keychain");
+        return (null, null);
+    }
+
+    /// <summary>
+    /// Finds the raw serial segment of a stored CERT_&lt;serial&gt;_P12 secret whose serial
+    /// fuzzy-matches the requested one (tolerant of leading-zero / non-alphanumeric differences).
+    /// </summary>
+    private async Task<string?> FindStoredCertSerialAsync(string serialNumber, CancellationToken cancellationToken)
+    {
+        var keys = await _cloudSecretsService.ListSecretsAsync($"{SecretPrefix}_", cancellationToken);
+        foreach (var key in keys)
+        {
+            if (!key.EndsWith("_P12", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            // Key format: CERT_<serial>_P12 — the serial may itself be empty but never contains '_'
+            // because SanitizeSerialNumber strips non-alphanumerics.
+            var parts = key.Split('_');
+            if (parts.Length < 3)
+                continue;
+            var rawSerial = string.Join('_', parts[1..^1]);
+            if (SerialsFuzzyEqual(rawSerial, serialNumber))
+                return rawSerial;
+        }
+        return null;
+    }
+
     public async Task<bool> DownloadAndInstallAsync(string certificateId, CancellationToken cancellationToken = default)
     {
         if (_cloudSecretsService.ActiveProvider == null)
@@ -374,6 +508,16 @@ public class CertificateSyncService : ICertificateSyncService
         // Strip leading zeros — local keychain may include them but API may not
         return sb.ToString().TrimStart('0');
     }
+
+    /// <summary>
+    /// Compares two certificate serial numbers tolerantly, ignoring case, non-alphanumeric
+    /// characters and leading zeros. Matches the normalization used to build cloud secret keys.
+    /// </summary>
+    private static bool SerialsFuzzyEqual(string? a, string? b)
+        => SanitizeSerialNumber(a ?? string.Empty).Equals(SanitizeSerialNumber(b ?? string.Empty), StringComparison.Ordinal);
+
+    private static string GenerateRandomPassword()
+        => Convert.ToBase64String(Guid.NewGuid().ToByteArray())[..16];
 
     private static string? TryExtractSerialFromMetadataKey(string key)
     {

--- a/src/MauiSherpa.Core/Services/PublishProfileService.cs
+++ b/src/MauiSherpa.Core/Services/PublishProfileService.cs
@@ -159,20 +159,17 @@ public class PublishProfileService : IPublishProfileService
                 progress?.Report($"Fetching certificate for {apple.Label}...");
                 try
                 {
-                    var p12Key = _certSync.GetCertificateSecretKey(apple.CertificateSerialNumber);
-                    var p12Bytes = await _cloudService.GetSecretAsync(p12Key, ct);
+                    var (p12Bytes, certPassword) = await _certSync.GetCertificateSecretsAsync(apple.CertificateSerialNumber, autoUploadFromKeychain: true, ct);
                     if (p12Bytes is not null)
                     {
                         var defaultKey = $"{prefix}_CERTIFICATE_P12";
                         AddMappedSecrets(secrets, apple.KeyMappings, defaultKey, Convert.ToBase64String(p12Bytes));
                     }
 
-                    var pwdKey = _certSync.GetCertificatePasswordKey(apple.CertificateSerialNumber);
-                    var pwdBytes = await _cloudService.GetSecretAsync(pwdKey, ct);
-                    if (pwdBytes is not null)
+                    if (!string.IsNullOrEmpty(certPassword))
                     {
                         var defaultKey = $"{prefix}_CERTIFICATE_PASSWORD";
-                        AddMappedSecrets(secrets, apple.KeyMappings, defaultKey, Encoding.UTF8.GetString(pwdBytes));
+                        AddMappedSecrets(secrets, apple.KeyMappings, defaultKey, certPassword);
                     }
                 }
                 catch (Exception ex)
@@ -187,20 +184,17 @@ public class PublishProfileService : IPublishProfileService
                 progress?.Report($"Fetching installer certificate for {apple.Label}...");
                 try
                 {
-                    var p12Key = _certSync.GetCertificateSecretKey(apple.InstallerCertSerialNumber);
-                    var p12Bytes = await _cloudService.GetSecretAsync(p12Key, ct);
+                    var (p12Bytes, installerPassword) = await _certSync.GetCertificateSecretsAsync(apple.InstallerCertSerialNumber, autoUploadFromKeychain: true, ct);
                     if (p12Bytes is not null)
                     {
                         var defaultKey = $"{prefix}_INSTALLER_P12";
                         AddMappedSecrets(secrets, apple.KeyMappings, defaultKey, Convert.ToBase64String(p12Bytes));
                     }
 
-                    var pwdKey = _certSync.GetCertificatePasswordKey(apple.InstallerCertSerialNumber);
-                    var pwdBytes = await _cloudService.GetSecretAsync(pwdKey, ct);
-                    if (pwdBytes is not null)
+                    if (!string.IsNullOrEmpty(installerPassword))
                     {
                         var defaultKey = $"{prefix}_INSTALLER_PASSWORD";
-                        AddMappedSecrets(secrets, apple.KeyMappings, defaultKey, Encoding.UTF8.GetString(pwdBytes));
+                        AddMappedSecrets(secrets, apple.KeyMappings, defaultKey, installerPassword);
                     }
                 }
                 catch (Exception ex)

--- a/src/MauiSherpa/Pages/Modals/PublishReviewModal.razor
+++ b/src/MauiSherpa/Pages/Modals/PublishReviewModal.razor
@@ -673,7 +673,7 @@
 
                 if (!string.IsNullOrEmpty(apple.CertificateSerialNumber)
                     && !secretsDict.Keys.Any(k => k.StartsWith(applePrefix) && k.Contains("CERTIFICATE")))
-                    resolveWarnings.Add($"Certificate for \"{apple.Label}\" could not be fetched");
+                    resolveWarnings.Add($"Certificate for \"{apple.Label}\" could not be found in cloud storage or your local keychain — upload it from the Certificates page, then try again");
                 if (!string.IsNullOrEmpty(apple.ProfileId)
                     && !secretsDict.Keys.Any(k => k.StartsWith(applePrefix) && k.Contains("PROFILE")))
                     resolveWarnings.Add($"Provisioning profile for \"{apple.Label}\" could not be fetched");

--- a/tests/MauiSherpa.Core.Tests/Services/CertificateSyncServiceTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/CertificateSyncServiceTests.cs
@@ -118,4 +118,97 @@ public class CertificateSyncServiceTests
             "password",
             It.IsAny<CancellationToken>()), Times.Once);
     }
+
+    [Fact]
+    public async Task GetCertificateSecretsAsync_ExactCloudKey_ReturnsP12AndPassword()
+    {
+        var provider = new CloudSecretsProviderConfig("provider-1", "Provider", CloudSecretsProviderType.OnePassword, new());
+        _cloudSecretsService.Setup(x => x.ActiveProvider).Returns(provider);
+        _cloudSecretsService.Setup(x => x.GetSecretAsync("CERT_ABC123_P12", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new byte[] { 0x01, 0x02, 0x03 });
+        _cloudSecretsService.Setup(x => x.GetSecretAsync("CERT_ABC123_PWD", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Encoding.UTF8.GetBytes("password"));
+
+        var (p12, password) = await _sut.GetCertificateSecretsAsync("ABC123");
+
+        Assert.NotNull(p12);
+        Assert.Equal(new byte[] { 0x01, 0x02, 0x03 }, p12);
+        Assert.Equal("password", password);
+        _cloudSecretsService.Verify(x => x.ListSecretsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetCertificateSecretsAsync_ExactKeyMisses_FuzzyMatchesStoredSerialWithLeadingZeros()
+    {
+        var provider = new CloudSecretsProviderConfig("provider-1", "Provider", CloudSecretsProviderType.OnePassword, new());
+        _cloudSecretsService.Setup(x => x.ActiveProvider).Returns(provider);
+        // Exact key for the requested serial does not exist...
+        _cloudSecretsService.Setup(x => x.GetSecretAsync("CERT_ABC123_P12", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((byte[]?)null);
+        // ...but a secret was stored under a differently-normalized serial (leading zeros).
+        _cloudSecretsService.Setup(x => x.ListSecretsAsync("CERT_", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { "CERT_00ABC123_META", "CERT_00ABC123_P12", "CERT_00ABC123_PWD" });
+        _cloudSecretsService.Setup(x => x.GetSecretAsync("CERT_00ABC123_P12", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new byte[] { 0x0A, 0x0B });
+        _cloudSecretsService.Setup(x => x.GetSecretAsync("CERT_00ABC123_PWD", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Encoding.UTF8.GetBytes("secret-pwd"));
+
+        var (p12, password) = await _sut.GetCertificateSecretsAsync("ABC123");
+
+        Assert.NotNull(p12);
+        Assert.Equal(new byte[] { 0x0A, 0x0B }, p12);
+        Assert.Equal("secret-pwd", password);
+    }
+
+    [Fact]
+    public async Task GetCertificateSecretsAsync_CloudMisses_FallsBackToLocalKeychainExport()
+    {
+        var provider = new CloudSecretsProviderConfig("provider-1", "Provider", CloudSecretsProviderType.OnePassword, new());
+        _cloudSecretsService.Setup(x => x.ActiveProvider).Returns(provider);
+        _cloudSecretsService.Setup(x => x.GetSecretAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((byte[]?)null);
+        _cloudSecretsService.Setup(x => x.ListSecretsAsync("CERT_", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<string>());
+
+        _localCertificateService.Setup(x => x.IsSupported).Returns(true);
+        _localCertificateService.Setup(x => x.GetSigningIdentitiesAsync())
+            .ReturnsAsync(new[]
+            {
+                new LocalSigningIdentity(
+                    Identity: "Apple Distribution: Test (TEAM)",
+                    CommonName: "Apple Distribution: Test",
+                    TeamId: "TEAM",
+                    SerialNumber: "00ABC123",
+                    ExpirationDate: DateTime.UtcNow.AddDays(30),
+                    IsValid: true)
+            });
+        _localCertificateService.Setup(x => x.ExportP12Async("Apple Distribution: Test (TEAM)", It.IsAny<string>()))
+            .ReturnsAsync(new byte[] { 0xAA, 0xBB, 0xCC });
+        _cloudSecretsService.Setup(x => x.StoreSecretAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<Dictionary<string, string>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var (p12, password) = await _sut.GetCertificateSecretsAsync("ABC123");
+
+        Assert.NotNull(p12);
+        Assert.Equal(new byte[] { 0xAA, 0xBB, 0xCC }, p12);
+        Assert.False(string.IsNullOrEmpty(password));
+        _localCertificateService.Verify(x => x.ExportP12Async("Apple Distribution: Test (TEAM)", It.IsAny<string>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetCertificateSecretsAsync_NotInCloudOrKeychain_ReturnsNulls()
+    {
+        var provider = new CloudSecretsProviderConfig("provider-1", "Provider", CloudSecretsProviderType.OnePassword, new());
+        _cloudSecretsService.Setup(x => x.ActiveProvider).Returns(provider);
+        _cloudSecretsService.Setup(x => x.GetSecretAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((byte[]?)null);
+        _cloudSecretsService.Setup(x => x.ListSecretsAsync("CERT_", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<string>());
+        _localCertificateService.Setup(x => x.IsSupported).Returns(false);
+
+        var (p12, password) = await _sut.GetCertificateSecretsAsync("ABC123");
+
+        Assert.Null(p12);
+        Assert.Null(password);
+    }
 }

--- a/tests/MauiSherpa.Core.Tests/Services/PublishProfileServiceTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/PublishProfileServiceTests.cs
@@ -117,6 +117,43 @@ public class PublishProfileServiceTests
     }
 
     [Fact]
+    public async Task ResolveSecretsAsync_WithCertificate_MapsResolvedP12AndPassword()
+    {
+        _certSync.Setup(x => x.GetCertificateSecretsAsync("ABC123", It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((new byte[] { 0x01, 0x02, 0x03 }, "cert-pwd"));
+
+        var profile = CreateProfile() with
+        {
+            AppleConfigs = new List<PublishProfileAppleConfig>
+            {
+                new(
+                    Label: "iOS App Store",
+                    IdentityId: null,
+                    Platform: ApplePlatformType.iOS,
+                    DistributionType: AppleDistributionType.AppStore,
+                    CertificateSerialNumber: "ABC123",
+                    InstallerCertSerialNumber: null,
+                    ProfileId: null,
+                    ProfileUuid: null,
+                    IncludeNotarization: false,
+                    NotarizationAppleIdSecretKey: null,
+                    NotarizationPasswordSecretKey: null,
+                    NotarizationTeamIdSecretKey: null,
+                    NotarizationAppleIdManualValue: null,
+                    NotarizationPasswordManualValue: null,
+                    NotarizationTeamIdManualValue: null,
+                    KeyMappings: new Dictionary<string, List<string>>())
+            }
+        };
+
+        var secrets = await _sut.ResolveSecretsAsync(profile);
+
+        secrets.Should().Contain("APPLE_IOS_APPSTORE_CERTIFICATE_P12", Convert.ToBase64String(new byte[] { 0x01, 0x02, 0x03 }));
+        secrets.Should().Contain("APPLE_IOS_APPSTORE_CERTIFICATE_PASSWORD", "cert-pwd");
+        _certSync.Verify(x => x.GetCertificateSecretsAsync("ABC123", It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
     public void DeserializeProfile_WhenIdentityPropertiesAreMissing_UsesEmptyLists()
     {
         var original = CreateProfile();


### PR DESCRIPTION
## Why

Users reported that publishing certificate secrets failed with "Certificate for 'iOS App Store' could not be fetched", even when the certificate was created in Sherpa and clearly visible in the app.

The Review step fetched each certificate's private key (P12) from cloud storage using a single **exact** key (`CERT_<serial>_P12`) with no fallback and no logging. The cloud key normalizes the serial one way (`SanitizeSerialNumber` strips non-alphanumerics *and* leading zeros), while the UI decides a certificate is "present" a different way (`SerialsMatch`, leading zeros only). So a certificate that showed as available could still fail to resolve when its stored key used a differently normalized serial. The private key existing only in the local macOS keychain (never uploaded) produced the same silent failure.

## Approach

Add a resilient resolver, `CertificateSyncService.GetCertificateSecretsAsync`, that tries in order:

1. **Cloud exact key** (existing behavior).
2. **Cloud fuzzy fallback** - lists `CERT_*_P12` secrets and matches the serial tolerantly (ignoring case, non-alphanumerics, and leading zeros), then fetches by the actual stored key.
3. **Local macOS keychain fallback** (guarded by `IsSupported`) - exports the P12 directly from the keychain and best-effort uploads it to cloud storage so future/CI runs succeed.

`PublishProfileService.ResolveSecretsAsync` now uses this for both signing and installer certificates. Each step logs a clear diagnostic, and the review warning is now actionable: "could not be found in cloud storage or your local keychain - upload it from the Certificates page".

## Notes for reviewers

- No new DI registrations: `CertificateSyncService` already had both the cloud and local-keychain dependencies it needs.
- The keychain fallback is macOS-only; on Windows/Linux it is skipped and the flow degrades to cloud exact + fuzzy + a clear message.
- Auto-upload after a keychain export is best-effort - an upload failure does not fail the current publish.

## Testing

Added unit tests covering exact-key hit, fuzzy fallback (serial with leading zeros), local keychain fallback, the all-missing case, and resolver key mapping. All 12 certificate/publish tests pass. The remaining suite failures on this machine are pre-existing and environmental (Xcode/macOS paths, SQLCipher native lib on Windows) and are unrelated to this change.

Fixes: #224