### PR TITLE
Fix macOS arm64 Copilot runtime load command in release artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -300,6 +300,87 @@ jobs:
           echo "Universal binary created:"
           lipo -info "$DEST_APP/Contents/MacOS/$BINARY_NAME"
 
+      - name: Repair Copilot runtime load command
+        run: |
+          set -euo pipefail
+          APP_PATH=$(find ./artifacts/macos -name "*.app" -type d | head -1)
+          BINARY_PATH="$APP_PATH/Contents/MacOS/MauiSherpa.MacOS"
+
+          # The arm64 slice ships two LC_LOAD_DYLIB entries for the Copilot runtime:
+          # the linker records the dylib's own install name, which is the absolute
+          # path it was built at on the copilot-agent-runtime CI runner, and the
+          # macOS packaging adds a second, correct entry pointing into the bundle.
+          # The absolute one does not exist on user machines, so dyld aborts at
+          # launch (issue #232).
+          STALE_PREFIX="/Users/runner/work/copilot-agent-runtime"
+          BUNDLED="@executable_path/../../Contents/MonoBundle/runtimes/osx-arm64/native/libcopilot_runtime.dylib"
+          # Equivalent spelling of the same file, relative to Contents/MacOS.
+          # Used when $BUNDLED is already linked, because rewriting the stale entry
+          # to that identical string produces a duplicate LC_LOAD_DYLIB, which dyld
+          # rejects just as hard as the missing library ("duplicate linked dylib").
+          # install_name_tool cannot delete a load command, so the stale slot has to
+          # be pointed at something valid rather than removed.
+          BUNDLED_ALT="@executable_path/../MonoBundle/runtimes/osx-arm64/native/libcopilot_runtime.dylib"
+
+          STALE=$(otool -arch arm64 -L "$BINARY_PATH" | awk '{print $1}' | grep -F "$STALE_PREFIX" || true)
+          if [ -n "$STALE" ]; then
+            if otool -arch arm64 -L "$BINARY_PATH" | awk '{print $1}' | grep -Fxq "$BUNDLED"; then
+              TARGET="$BUNDLED_ALT"
+            else
+              TARGET="$BUNDLED"
+            fi
+            echo "Rewriting stale load command:"
+            echo "  $STALE"
+            echo "    -> $TARGET"
+            install_name_tool -change "$STALE" "$TARGET" "$BINARY_PATH"
+          else
+            echo "No stale Copilot runtime load command found."
+          fi
+
+      - name: Verify Copilot runtime load commands
+        run: |
+          set -euo pipefail
+          APP_PATH=$(find ./artifacts/macos -name "*.app" -type d | head -1)
+          BINARY_PATH="$APP_PATH/Contents/MacOS/MauiSherpa.MacOS"
+          FAILED=0
+
+          # No build-machine paths may survive into a shipped artifact.
+          if otool -arch arm64 -L "$BINARY_PATH" | grep -F "/Users/runner/"; then
+            echo "::error::arm64 slice still links a build-machine path"
+            FAILED=1
+          fi
+
+          # dyld refuses to launch an image with two identical LC_LOAD_DYLIB paths.
+          DUPES=$(otool -arch arm64 -l "$BINARY_PATH" \
+            | awk '/LC_LOAD_DYLIB/,/time stamp/' | awk '/name /{print $2}' \
+            | sort | uniq -d || true)
+          if [ -n "$DUPES" ]; then
+            echo "::error::duplicate LC_LOAD_DYLIB entries in arm64 slice: $DUPES"
+            FAILED=1
+          fi
+
+          # Every non-system dependency must resolve inside the bundle.
+          otool -arch arm64 -L "$BINARY_PATH" | tail -n +2 | awk '{print $1}' \
+            | grep -v '^/usr/lib/' | grep -v '^/System/' | while read -r dep; do
+              case "$dep" in
+                @executable_path/*)
+                  resolved="$APP_PATH/Contents/MacOS/${dep#@executable_path/}"
+                  if [ ! -f "$resolved" ]; then
+                    echo "::error::unresolved bundled dependency: $dep"
+                    exit 1
+                  fi
+                  ;;
+                @rpath/*|@loader_path/*) ;;
+                *)
+                  echo "::error::absolute dependency outside the bundle: $dep"
+                  exit 1
+                  ;;
+              esac
+            done || FAILED=1
+
+          [ "$FAILED" -eq 0 ] || exit 1
+          echo "arm64 load commands verified."
+
       - name: Re-sign with Hardened Runtime
         if: env.APPLE_CERTIFICATE_P12 != ''
         env:


### PR DESCRIPTION
Supersedes #233. Fixes #232.

#233 removes the stale path but the resulting artifact still won't launch — I tested the build from that branch on macOS 26.5.2 / Apple Silicon and it aborts in `dyld4::prepare` with `duplicate linked dylib`. Details in [this comment](https://github.com/Redth/MAUI.Sherpa/issues/232#issuecomment-5288283116).

### The problem

The arm64 slice carries **two** `LC_LOAD_DYLIB` entries for the Copilot runtime — the linker records the dylib's own install name (the absolute path it was built at on the `copilot-agent-runtime` runner) *and* a correct entry pointing into the bundle:

```
/Users/runner/work/copilot-agent-runtime/.../libruntime.dylib
@executable_path/../../Contents/MonoBundle/runtimes/osx-arm64/native/libcopilot_runtime.dylib
```

The absolute one doesn't exist on user machines → `Library not loaded`, terminated at launch.

A plain `install_name_tool -change <stale> <bundled>` rewrites the stale entry to a string that is *already linked*, producing two identical load commands. dyld rejects that just as hard (`duplicate linked dylib`), so the crash simply changes shape. `install_name_tool` has no way to delete a load command, so the stale slot has to be pointed at something valid rather than removed.

### The fix

Rewrite the stale entry to an equivalent path spelling for the same file — `@executable_path/../MonoBundle/...` instead of `@executable_path/../../Contents/MonoBundle/...`. Both resolve to the same inode inside the bundle, and dyld's duplicate check compares the load-command strings, so this leaves one logical dependency and launches cleanly. The step falls back to the canonical spelling when the bundled entry isn't already present.

It runs after `lipo` and before the hardened-runtime re-sign, so the signature covers the patched binary.

### Regression guard

A second step fails artifact creation on any of:

- a surviving `/Users/runner/...` path
- duplicate `LC_LOAD_DYLIB` entries
- a non-system dependency that doesn't resolve inside the bundle

The duplicate check is the one that matters here — #233's guard passes on its own broken output, so CI would have stayed green on an artifact that's dead on launch.

### Verification

Ran both steps against real binaries locally:

| Input | Repair | Verify |
|---|---|---|
| Shipped 0.13.1 (stale + correct) | rewrites to alt spelling | ✅ passes |
| #233 output (two identical entries) | no-op | ❌ fails on duplicates |
| Unrepaired stale path | — | ❌ fails on build-machine path |

I applied the same rewrite to my installed 0.13.1 and it launches and runs normally, which is the state this step now produces in CI.

### Still worth a look, separately

- The **x86_64 slice doesn't reference `libcopilot_runtime.dylib` at all** — neither path. Either Intel is silently shipping without the runtime or the arm64 link is unintended. The guard here is arm64-only for that reason.
- The real upstream fix is for the Rust cdylib to carry a sane install name (`-C link-arg=-Wl,-install_name,@rpath/libcopilot_runtime.dylib`) so nothing downstream ever records the CI target path. That's in `copilot-agent-runtime`, not here — this step can be deleted once that lands, and the guard will tell you when it's safe to do so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
