### PR TITLE
Fix Windows toolbar and Winget distribution

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -583,18 +583,66 @@ jobs:
           Write-Host "Created: MAUI-Sherpa.win-arm64.zip"
           Get-Item ./artifacts/MAUI-Sherpa.win-arm64.zip | Format-List Name, Length
 
+      - name: Create Windows installers
+        shell: pwsh
+        run: |
+          function Find-InnoCompiler {
+           @(
+             "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe"
+             "$env:ProgramFiles\Inno Setup 6\ISCC.exe"
+             "$env:LOCALAPPDATA\Programs\Inno Setup 6\ISCC.exe"
+           ) | Where-Object { Test-Path $_ -PathType Leaf } | Select-Object -First 1
+          }
+
+          $compiler = Find-InnoCompiler
+          if ([string]::IsNullOrWhiteSpace($compiler)) {
+           winget install --id JRSoftware.InnoSetup --exact --source winget --accept-package-agreements --accept-source-agreements --disable-interactivity
+           if ($LASTEXITCODE -ne 0) {
+             throw "Failed to install Inno Setup."
+           }
+           $compiler = Find-InnoCompiler
+          }
+          if ([string]::IsNullOrWhiteSpace($compiler)) {
+           throw "Inno Setup compiler was not found after installation."
+          }
+
+          $outputDir = (Resolve-Path "./artifacts").Path
+          $version = "${{ steps.version.outputs.app_version }}"
+          foreach ($arch in @("x64", "arm64")) {
+           $sourceDir = (Resolve-Path "./artifacts/win-$arch").Path
+           & $compiler `
+             "/DMyAppVersion=$version" `
+             "/DMyAppArch=$arch" `
+             "/DMySourceDir=$sourceDir" `
+             "/DMyOutputDir=$outputDir" `
+             "build/windows/MauiSherpa.iss"
+           if ($LASTEXITCODE -ne 0) {
+             throw "Failed to create the Windows $arch installer."
+           }
+
+           $installer = "./artifacts/MAUI-Sherpa.Setup.win-$arch.exe"
+           if (-not (Test-Path $installer -PathType Leaf)) {
+             throw "Expected installer at $installer."
+           }
+           Get-Item $installer | Format-List Name, Length
+          }
+
       - name: Upload Windows App (x64)
         uses: actions/upload-artifact@v4
         with:
           name: MAUI-Sherpa.win-x64
-          path: ./artifacts/MAUI-Sherpa.win-x64.zip
+          path: |
+           ./artifacts/MAUI-Sherpa.win-x64.zip
+           ./artifacts/MAUI-Sherpa.Setup.win-x64.exe
           retention-days: 30
 
       - name: Upload Windows App (arm64)
         uses: actions/upload-artifact@v4
         with:
           name: MAUI-Sherpa.win-arm64
-          path: ./artifacts/MAUI-Sherpa.win-arm64.zip
+          path: |
+            ./artifacts/MAUI-Sherpa.win-arm64.zip
+            ./artifacts/MAUI-Sherpa.Setup.win-arm64.exe
           retention-days: 30
 
       - name: Set commit status with artifact link
@@ -1070,6 +1118,8 @@ jobs:
             ./release/MAUI-Sherpa.macos.zip
             ./release/MAUI-Sherpa.win-x64.zip
             ./release/MAUI-Sherpa.win-arm64.zip
+            ./release/MAUI-Sherpa.Setup.win-x64.exe
+            ./release/MAUI-Sherpa.Setup.win-arm64.exe
             ./release/MAUI-Sherpa.linux-x64.tar.gz
             ./release/MAUI-Sherpa.linux-arm64.tar.gz
             ./release/*.deb

--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -1,13 +1,13 @@
 name: Publish WinGet Manifest
 
 # Publishes a validated WinGet manifest branch to Redth/winget-pkgs and provides
-# a link for opening the pull request against microsoft/winget-pkgs. Called
+# a prefilled browser link for opening the upstream pull request. Called
 # automatically by the Build & Release workflow after a stable release is
 # created, or run manually for an existing release.
 #
 # A repository-scoped deploy key avoids the short-lived SAML authorization
-# required by Microsoft for personal access tokens. Opening the upstream pull
-# request remains a deliberate one-click browser action.
+# required by Microsoft for personal access tokens. The final pull request is
+# opened through the user's existing browser session, so no PAT is required.
 
 on:
   workflow_call:
@@ -49,7 +49,7 @@ jobs:
           "RELEASE_TAG=$tag" >> $env:GITHUB_ENV
           "PACKAGE_VERSION=$($Matches.version)" >> $env:GITHUB_ENV
 
-      - name: Download release ZIP packages
+      - name: Download release installers
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -57,15 +57,15 @@ jobs:
           New-Item -ItemType Directory -Force -Path packages | Out-Null
           gh release download $env:RELEASE_TAG `
             --repo Redth/MAUI.Sherpa `
-            --pattern "MAUI-Sherpa.win-x64.zip" `
-            --pattern "MAUI-Sherpa.win-arm64.zip" `
+            --pattern "MAUI-Sherpa.Setup.win-x64.exe" `
+            --pattern "MAUI-Sherpa.Setup.win-arm64.exe" `
             --dir packages
 
-          if (-not (Test-Path "packages/MAUI-Sherpa.win-x64.zip")) {
-            throw "Missing win-x64 asset for release $env:RELEASE_TAG."
+          if (-not (Test-Path "packages/MAUI-Sherpa.Setup.win-x64.exe")) {
+            throw "Missing win-x64 installer for release $env:RELEASE_TAG."
           }
-          if (-not (Test-Path "packages/MAUI-Sherpa.win-arm64.zip")) {
-            throw "Missing win-arm64 asset for release $env:RELEASE_TAG."
+          if (-not (Test-Path "packages/MAUI-Sherpa.Setup.win-arm64.exe")) {
+            throw "Missing win-arm64 installer for release $env:RELEASE_TAG."
           }
           Get-ChildItem packages | Format-Table Name, Length
 
@@ -78,8 +78,8 @@ jobs:
           $replacements = @{
             "__VERSION__" = $env:PACKAGE_VERSION
             "__RELEASE_TAG__" = $env:RELEASE_TAG
-            "__X64_SHA256__" = (Get-FileHash "packages/MAUI-Sherpa.win-x64.zip" -Algorithm SHA256).Hash.ToLowerInvariant()
-            "__ARM64_SHA256__" = (Get-FileHash "packages/MAUI-Sherpa.win-arm64.zip" -Algorithm SHA256).Hash.ToLowerInvariant()
+            "__X64_SHA256__" = (Get-FileHash "packages/MAUI-Sherpa.Setup.win-x64.exe" -Algorithm SHA256).Hash.ToLowerInvariant()
+            "__ARM64_SHA256__" = (Get-FileHash "packages/MAUI-Sherpa.Setup.win-arm64.exe" -Algorithm SHA256).Hash.ToLowerInvariant()
           }
 
           $templates = @{
@@ -177,14 +177,22 @@ jobs:
             Remove-Item $keyPath -Force -ErrorAction SilentlyContinue
           }
 
-          $compareUrl = "https://github.com/microsoft/winget-pkgs/compare/master...Redth:winget-pkgs:${branch}?expand=1"
-          "compare_url=$compareUrl" >> $env:GITHUB_OUTPUT
-          Write-Host "::notice title=WinGet pull request ready::$compareUrl"
+          $prTitle = "New version: Maui.Sherpa version $env:PACKAGE_VERSION"
+          $encodedTitle = [Uri]::EscapeDataString($prTitle)
+          $submissionUrl = "https://github.com/microsoft/winget-pkgs/compare/master...Redth:winget-pkgs:${branch}?quick_pull=1&title=$encodedTitle"
+          "submission_url=$submissionUrl" >> $env:GITHUB_OUTPUT
+          Write-Host "::notice title=Manual WinGet submission ready::$submissionUrl"
 
           @"
-          ## WinGet pull request ready
+          # WinGet submission ready
 
-          The validated manifests were published to ``Redth/winget-pkgs:$branch``.
+          ## [Open the prefilled WinGet pull request]($submissionUrl)
 
-          **[Open the pull request against microsoft/winget-pkgs]($compareUrl)**
+          The manifests are validated and already published to:
+
+          - **Branch:** ``Redth/winget-pkgs:$branch``
+          - **Manifest:** ``manifests/m/Maui/Sherpa/$env:PACKAGE_VERSION``
+
+          No GitHub token is needed. Open the link using your browser session, review
+          the generated checklist and manifest diff, then click **Create pull request**.
           "@ >> $env:GITHUB_STEP_SUMMARY

--- a/build/windows/MauiSherpa.iss
+++ b/build/windows/MauiSherpa.iss
@@ -1,0 +1,60 @@
+#ifndef MyAppVersion
+  #error MyAppVersion must be provided
+#endif
+#ifndef MyAppArch
+  #error MyAppArch must be provided
+#endif
+#ifndef MySourceDir
+  #error MySourceDir must be provided
+#endif
+#ifndef MyOutputDir
+  #error MyOutputDir must be provided
+#endif
+
+#define MyAppName "MAUI Sherpa"
+#define MyAppPublisher "Redth"
+#define MyAppExeName "MauiSherpa.exe"
+
+[Setup]
+AppId=codes.redth.mauisherpa
+AppName={#MyAppName}
+AppVersion={#MyAppVersion}
+AppVerName={#MyAppName} {#MyAppVersion}
+AppPublisher={#MyAppPublisher}
+AppPublisherURL=https://github.com/Redth/MAUI.Sherpa
+AppSupportURL=https://github.com/Redth/MAUI.Sherpa/issues
+AppUpdatesURL=https://github.com/Redth/MAUI.Sherpa/releases
+DefaultDirName={localappdata}\Programs\MAUI Sherpa
+DefaultGroupName=MAUI Sherpa
+DisableProgramGroupPage=yes
+PrivilegesRequired=lowest
+OutputDir={#MyOutputDir}
+OutputBaseFilename=MAUI-Sherpa.Setup.win-{#MyAppArch}
+Compression=lzma2/max
+SolidCompression=yes
+WizardStyle=modern
+UninstallDisplayIcon={app}\{#MyAppExeName}
+CloseApplications=yes
+RestartApplications=no
+#if MyAppArch == "x64"
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64
+#elif MyAppArch == "arm64"
+ArchitecturesAllowed=arm64
+ArchitecturesInstallIn64BitMode=arm64
+#else
+  #error MyAppArch must be x64 or arm64
+#endif
+
+[Tasks]
+Name: "desktopicon"; Description: "Create a desktop shortcut"; GroupDescription: "Additional shortcuts:"; Flags: unchecked
+
+[Files]
+Source: "{#MySourceDir}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+
+[Icons]
+Name: "{group}\MAUI Sherpa"; Filename: "{app}\{#MyAppExeName}"; WorkingDir: "{app}"
+Name: "{autodesktop}\MAUI Sherpa"; Filename: "{app}\{#MyAppExeName}"; WorkingDir: "{app}"; Tasks: desktopicon
+
+[Run]
+Filename: "{app}\{#MyAppExeName}"; Description: "Launch MAUI Sherpa"; Flags: nowait postinstall skipifsilent

--- a/src/MauiSherpa/Services/WindowsTitleBarManager.cs
+++ b/src/MauiSherpa/Services/WindowsTitleBarManager.cs
@@ -404,37 +404,77 @@ public class WindowsTitleBarManager
         return btn;
     }
 
-    private Button CreateActionButton(ToolbarAction action)
+    private Border CreateActionButton(ToolbarAction action)
     {
         var fluentIcon = MapSfSymbolToFluentIcon(action.SfSymbol);
-        var glyph = GetEnumDescription(fluentIcon);
+        var isEnabled = _toolbarService.IsItemEnabled(action.Id);
 
-        var btn = new Button
+        var content = new HorizontalStackLayout
         {
-            Text = glyph,
-            FontFamily = "FluentIcons",
-            FontSize = 18,
-            HeightRequest = 32,
-            WidthRequest = 36,
-            MinimumWidthRequest = 36,
-            Padding = new Thickness(0),
-            BackgroundColor = BgControl,
-            TextColor = Colors.White,
-            BorderColor = BorderColor,
-            BorderWidth = 1,
-            CornerRadius = 6,
+            Spacing = 6,
             VerticalOptions = LayoutOptions.Center,
             HorizontalOptions = LayoutOptions.Center,
-            LineBreakMode = LineBreakMode.NoWrap,
         };
-        ApplyVerticalCentering(btn);
-        ToolTipProperties.SetText(btn, action.Label);
-        ApplyHoverEffect(btn, BgControl, BgControlHover, BorderColor, Accent);
+        if (fluentIcon is { } icon)
+        {
+            content.Children.Add(new Label
+            {
+                Text = GetEnumDescription(icon),
+                FontFamily = "FluentIcons",
+                FontSize = 16,
+                TextColor = Colors.White,
+                VerticalOptions = LayoutOptions.Center,
+                VerticalTextAlignment = TextAlignment.Center,
+            });
+        }
+        content.Children.Add(new Label
+        {
+            Text = action.Label,
+            FontSize = 12,
+            TextColor = Colors.White,
+            VerticalOptions = LayoutOptions.Center,
+            VerticalTextAlignment = TextAlignment.Center,
+            LineBreakMode = LineBreakMode.NoWrap,
+        });
 
-        btn.Clicked += (s, e) =>
+        var btn = new Border
+        {
+            Content = content,
+            HeightRequest = 32,
+            MinimumWidthRequest = 36,
+            Padding = new Thickness(10, 0),
+            BackgroundColor = BgControl,
+            Stroke = BorderColor,
+            StrokeThickness = 1,
+            StrokeShape = new Microsoft.Maui.Controls.Shapes.RoundRectangle { CornerRadius = 6 },
+            IsEnabled = isEnabled,
+            Opacity = isEnabled ? 1 : 0.5,
+            VerticalOptions = LayoutOptions.Center,
+            HorizontalOptions = LayoutOptions.Center,
+        };
+        ToolTipProperties.SetText(btn, action.Label);
+
+        var tapGesture = new TapGestureRecognizer();
+        tapGesture.Tapped += (s, e) =>
         {
             _toolbarService.InvokeToolbarItemClicked(action.Id);
         };
+        btn.GestureRecognizers.Add(tapGesture);
+
+        var pointerEnter = new PointerGestureRecognizer();
+        pointerEnter.PointerEntered += (s, e) =>
+        {
+            btn.BackgroundColor = BgControlHover;
+            btn.Stroke = Accent;
+        };
+        var pointerExit = new PointerGestureRecognizer();
+        pointerExit.PointerExited += (s, e) =>
+        {
+            btn.BackgroundColor = BgControl;
+            btn.Stroke = BorderColor;
+        };
+        btn.GestureRecognizers.Add(pointerEnter);
+        btn.GestureRecognizers.Add(pointerExit);
 
         return btn;
     }
@@ -668,13 +708,17 @@ public class WindowsTitleBarManager
         return border;
     }
 
-    private static FluentIcons MapSfSymbolToFluentIcon(string sfSymbol) => sfSymbol switch
+    private static FluentIcons? MapSfSymbolToFluentIcon(string sfSymbol) => sfSymbol switch
     {
         "arrow.clockwise" => FluentIcons.ArrowClockwise20,
         "plus" => FluentIcons.Add20,
         "plus.circle" => FluentIcons.AddCircle20,
+        "folder" => FluentIcons.FolderOpen20,
+        "folder.badge.plus" => FluentIcons.FolderAdd20,
+        "mountain.2" => FluentIcons.BookOpen20,
         "square.and.arrow.down" or "fa-download" => FluentIcons.ArrowDownload20,
         "square.and.arrow.up" => FluentIcons.ArrowUpload20,
+        "arrow.up" => FluentIcons.ArrowUp20,
         "trash" => FluentIcons.Delete20,
         "pencil" => FluentIcons.Edit20,
         "xmark" => FluentIcons.Dismiss20,
@@ -685,20 +729,11 @@ public class WindowsTitleBarManager
         "arrow.triangle.2.circlepath" or "fa-sync-alt" => FluentIcons.ArrowSync20,
         "fa-stethoscope" => FluentIcons.Stethoscope20,
         "wand.and.stars" => FluentIcons.Sparkle20,
-        _ => FluentIcons.Circle20,
+        "record.circle" => FluentIcons.Record20,
+        "doc.badge.plus" => FluentIcons.DocumentAdd20,
+        "archivebox" => FluentIcons.Archive20,
+        _ => null,
     };
-
-    private static FontImageSource GetFluentIcon(FluentIcons icon, Color color, double size)
-    {
-        var glyph = GetEnumDescription(icon);
-        return new FontImageSource
-        {
-            Glyph = glyph,
-            FontFamily = "FluentIcons",
-            Color = color,
-            Size = size,
-        };
-    }
 
     private static string GetEnumDescription(Enum value)
     {
@@ -738,7 +773,6 @@ public class WindowsTitleBarManager
             {
                 platformBtn.VerticalContentAlignment = Microsoft.UI.Xaml.VerticalAlignment.Center;
                 platformBtn.HorizontalContentAlignment = Microsoft.UI.Xaml.HorizontalAlignment.Center;
-                platformBtn.Padding = new Microsoft.UI.Xaml.Thickness(0);
             }
         };
 #endif

--- a/winget/Maui.Sherpa.installer.template.yaml
+++ b/winget/Maui.Sherpa.installer.template.yaml
@@ -1,17 +1,15 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 PackageIdentifier: Maui.Sherpa
 PackageVersion: __VERSION__
-InstallerType: zip
-NestedInstallerType: portable
-NestedInstallerFiles:
-  - RelativeFilePath: MauiSherpa.exe
-    PortableCommandAlias: mauisherpa
+InstallerType: inno
+Scope: user
+UpgradeBehavior: install
 Installers:
   - Architecture: x64
-    InstallerUrl: https://github.com/Redth/MAUI.Sherpa/releases/download/__RELEASE_TAG__/MAUI-Sherpa.win-x64.zip
+    InstallerUrl: https://github.com/Redth/MAUI.Sherpa/releases/download/__RELEASE_TAG__/MAUI-Sherpa.Setup.win-x64.exe
     InstallerSha256: __X64_SHA256__
   - Architecture: arm64
-    InstallerUrl: https://github.com/Redth/MAUI.Sherpa/releases/download/__RELEASE_TAG__/MAUI-Sherpa.win-arm64.zip
+    InstallerUrl: https://github.com/Redth/MAUI.Sherpa/releases/download/__RELEASE_TAG__/MAUI-Sherpa.Setup.win-arm64.exe
     InstallerSha256: __ARM64_SHA256__
 ManifestType: installer
 ManifestVersion: 1.12.0


### PR DESCRIPTION
Windows users currently see generic circle glyphs for unmapped toolbar actions, while the Winget package installs only a portable command with no Start menu entry. Recent Winget manifests also stopped at fork branches because upstream PR creation depended on short-lived Microsoft SSO authorization.

## Changes

- Render Windows toolbar actions as explicitly centered Fluent icon and text layouts, map all current toolbar symbols, and avoid bogus fallback glyphs.
- Preserve action enabled state and add readable labels such as Release Notes, New Folder, and Open Project Folder.
- Build self-contained x64 and ARM64 Inno Setup installers while retaining ZIP release assets for existing download and update flows.
- Register MAUI Sherpa in the Start menu with per-user installation and normal uninstall support.
- Publish Winget manifests against the new installers instead of portable ZIPs.
- Replace PAT-dependent upstream submission with a prominent, prefilled browser link in the Actions summary so the final PR uses the maintainer's browser session.

## Validation

- Built and launched the Windows Release app and visually checked toolbar icon and label alignment.
- Launched the exact self-contained publish output without `DOTNET_ROOT` or a system .NET 10 runtime.
- Compiled x64 and ARM64 installers and confirmed the Start menu shortcut is created and removed through install/uninstall.
- Generated and validated the updated Winget manifests.