### PR TITLE
Add multi-provider secret sync

### DIFF
--- a/build/DedupeNativeReferences.targets
+++ b/build/DedupeNativeReferences.targets
@@ -1,5 +1,36 @@
 <Project>
 
+  <!-- Collapse duplicate package-native references before dependency rewriting so the app
+       executable and the copied dylib are computed from the same source item. -->
+  <Target Name="_CollapseDuplicateFileNativeReferences"
+          BeforeTargets="_ComputeDynamicLibrariesToReidentify"
+          Outputs="%(_FileNativeReference.RelativePath)"
+          Condition="'@(_FileNativeReference)' != ''">
+
+    <ItemGroup>
+      <_NativeReferencesForPath Include="@(_FileNativeReference)" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <_NativeReferencesForPathCount>@(_NativeReferencesForPath->Count())</_NativeReferencesForPathCount>
+      <_NativeReferenceToKeep />
+    </PropertyGroup>
+
+    <PropertyGroup Condition="$(_NativeReferencesForPathCount) &gt; 1">
+      <_NativeReferenceToKeep>%(_NativeReferencesForPath.Identity)</_NativeReferenceToKeep>
+    </PropertyGroup>
+
+    <ItemGroup Condition="$(_NativeReferencesForPathCount) &gt; 1">
+      <_FileNativeReference Remove="@(_NativeReferencesForPath)" MatchOnMetadata="RelativePath" />
+      <_FileNativeReference Include="@(_NativeReferencesForPath)"
+                            Condition="'%(Identity)' == '$(_NativeReferenceToKeep)'" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <_NativeReferencesForPath Remove="@(_NativeReferencesForPath)" />
+    </ItemGroup>
+  </Target>
+
   <!-- InstallNameTool processes these items in parallel and uses ReidentifiedPath for its scratch
        file. Duplicate destinations therefore race on the same file, even when their source
        identities or project metadata differ. Deduplicate the final SDK items by that destination. -->

--- a/src/MauiSherpa.Core/Interfaces.cs
+++ b/src/MauiSherpa.Core/Interfaces.cs
@@ -798,6 +798,7 @@ public interface IAppleIdentityService
 public interface IAppleIdentityStateService
 {
     AppleIdentity? SelectedIdentity { get; }
+    string? LastSelectedIdentityId { get; }
     event Action? OnSelectionChanged;
     void SetSelectedIdentity(AppleIdentity? identity);
 }
@@ -814,8 +815,17 @@ public interface IGoogleIdentityService
 public interface IGoogleIdentityStateService
 {
     GoogleIdentity? SelectedIdentity { get; }
+    string? LastSelectedIdentityId { get; }
     event Action? OnSelectionChanged;
     void SetSelectedIdentity(GoogleIdentity? identity);
+}
+
+public interface IIdentitySelectionStore
+{
+    string? GetLastAppleIdentityId();
+    void SetLastAppleIdentityId(string identityId);
+    string? GetLastGoogleIdentityId();
+    void SetLastGoogleIdentityId(string identityId);
 }
 
 public interface IAppleConnectService
@@ -2992,15 +3002,40 @@ public enum CloudSecretsProviderType
 }
 
 /// <summary>
+/// Logical item categories that can be stored in one or more secrets providers.
+/// </summary>
+public enum SecretItemKind
+{
+    ManagedSecret,
+    AndroidKeystore,
+    Certificate,
+    ProvisioningProfile,
+    PublishProfile
+}
+
+public static class SecretItemKinds
+{
+    public static IReadOnlyList<SecretItemKind> All { get; } =
+        Enum.GetValues<SecretItemKind>();
+}
+
+/// <summary>
 /// Configuration for a cloud secrets provider instance
 /// </summary>
 public record CloudSecretsProviderConfig(
     string Id,
     string Name,
     CloudSecretsProviderType ProviderType,
-    Dictionary<string, string> Settings
+    Dictionary<string, string> Settings,
+    List<SecretItemKind>? DefaultItemKinds = null
 )
 {
+    public IReadOnlyList<SecretItemKind> EffectiveDefaultItemKinds =>
+        DefaultItemKinds ?? SecretItemKinds.All;
+
+    public bool StoresByDefault(SecretItemKind itemKind) =>
+        EffectiveDefaultItemKinds.Contains(itemKind);
+
     /// <summary>
     /// Creates a new config with a generated ID
     /// </summary>
@@ -3008,7 +3043,7 @@ public record CloudSecretsProviderConfig(
         string name,
         CloudSecretsProviderType providerType,
         Dictionary<string, string> settings) =>
-        new(Guid.NewGuid().ToString("N"), name, providerType, settings);
+        new(Guid.NewGuid().ToString("N"), name, providerType, settings, SecretItemKinds.All.ToList());
 }
 
 /// <summary>
@@ -3159,6 +3194,215 @@ public interface ICloudSecretsProviderFactory
     /// Gets the display name for a provider type
     /// </summary>
     string GetProviderDisplayName(CloudSecretsProviderType providerType);
+}
+
+/// <summary>
+/// Registry for explicitly addressing every configured secrets provider.
+/// New multi-provider code should use this instead of changing the legacy active provider.
+/// </summary>
+public interface ISecretsProviderRegistry
+{
+    Task<IReadOnlyList<CloudSecretsProviderConfig>> GetProvidersAsync();
+    Task<CloudSecretsProviderConfig?> GetProviderConfigAsync(string providerId);
+    Task<ICloudSecretsProvider?> GetProviderAsync(string providerId);
+    Task SaveProviderAsync(CloudSecretsProviderConfig provider);
+    Task DeleteProviderAsync(string providerId);
+    Task<bool> TestProviderConnectionAsync(string providerId);
+    event Action? ProvidersChanged;
+}
+
+public record SecretItemRef(
+    SecretItemKind Kind,
+    string Id,
+    string DisplayName
+);
+
+public record SecretArtifact(
+    string Key,
+    byte[] Value,
+    Dictionary<string, string>? Metadata = null
+);
+
+public record SecretItemPayload(
+    SecretItemRef Item,
+    long Revision,
+    string ContentHash,
+    IReadOnlyList<SecretArtifact> Artifacts
+);
+
+public enum SecretPlacementStatus
+{
+    Loading,
+    NotStored,
+    Synced,
+    Pending,
+    Failed,
+    Unavailable,
+    Conflict
+}
+
+public record ProviderPlacementState(
+    string ProviderId,
+    bool Desired,
+    bool Observed,
+    SecretPlacementStatus Status,
+    long? Revision = null,
+    string? ContentHash = null,
+    string? Error = null
+);
+
+public record SecretSyncManifest(
+    int SchemaVersion,
+    SecretItemKind Kind,
+    string ItemId,
+    string DisplayName,
+    long Revision,
+    string ContentHash,
+    List<string> DesiredProviderIds,
+    DateTime UpdatedAtUtc
+)
+{
+    public const int CurrentSchemaVersion = 1;
+}
+
+public record ProviderSyncCatalogEntry(
+    SecretItemKind Kind,
+    string ItemId,
+    string DisplayName,
+    long Revision,
+    string ContentHash,
+    List<string> DesiredProviderIds,
+    DateTime UpdatedAtUtc
+);
+
+public record ProviderSyncCatalog(
+    int SchemaVersion,
+    Dictionary<string, ProviderSyncCatalogEntry> Entries,
+    DateTime UpdatedAtUtc
+)
+{
+    public const int CurrentSchemaVersion = 1;
+}
+
+public record SecretItemSyncState(
+    SecretItemRef Item,
+    IReadOnlyList<ProviderPlacementState> Providers,
+    bool HasConflict,
+    string? PendingTaskId = null
+);
+
+/// <summary>
+/// Maps one user-visible item type to the provider artifacts required to store it.
+/// </summary>
+public interface ISecretItemAdapter
+{
+    SecretItemKind Kind { get; }
+    bool IsProviderOwned { get; }
+    Task<IReadOnlyList<SecretItemRef>> ListLocalItemsAsync(CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<SecretItemRef>> ListProviderItemsAsync(string providerId, CancellationToken cancellationToken = default);
+    Task<IReadOnlySet<string>> ListProviderItemIdsAsync(string providerId, CancellationToken cancellationToken = default);
+    IReadOnlySet<string> ExtractProviderItemIds(IReadOnlyList<string> providerKeys);
+    Task<SecretItemPayload?> ReadLocalAsync(SecretItemRef item, CancellationToken cancellationToken = default);
+    Task<SecretItemPayload?> ReadProviderAsync(SecretItemRef item, string providerId, CancellationToken cancellationToken = default);
+    Task<bool> WriteProviderAsync(SecretItemPayload payload, string providerId, CancellationToken cancellationToken = default);
+    Task<bool> DeleteProviderAsync(SecretItemRef item, string providerId, CancellationToken cancellationToken = default);
+}
+
+public interface ISecretSyncCoordinator
+{
+    Task<IReadOnlyList<SecretItemSyncState>> ListItemsAsync(SecretItemKind kind, CancellationToken cancellationToken = default);
+    Task<SecretItemSyncState> GetStateAsync(SecretItemRef item, CancellationToken cancellationToken = default);
+    Task<SecretItemSyncState> GetStateProgressivelyAsync(SecretItemRef item, IProgress<ProviderPlacementState>? progress = null, CancellationToken cancellationToken = default);
+    Task<string?> SetDefaultProvidersAsync(SecretItemRef item, CancellationToken cancellationToken = default);
+    Task<string?> SetDesiredProvidersAsync(SecretItemRef item, IReadOnlyCollection<string> providerIds, CancellationToken cancellationToken = default);
+    Task<string?> UpdateDesiredProvidersAsync(SecretItemRef item, IReadOnlyDictionary<string, bool> changes, CancellationToken cancellationToken = default);
+    Task<string?> MoveAsync(SecretItemRef previousItem, SecretItemRef item, IReadOnlyCollection<string> providerIds, string sourceProviderId, CancellationToken cancellationToken = default);
+    Task<string?> ResolveConflictAsync(SecretItemRef item, string sourceProviderId, CancellationToken cancellationToken = default);
+    event Action<SecretItemRef>? ItemStateChanged;
+}
+
+public enum BackgroundTaskState
+{
+    Pending,
+    Running,
+    Succeeded,
+    Failed,
+    Cancelled,
+    Interrupted
+}
+
+public enum BackgroundTaskStepState
+{
+    Pending,
+    Running,
+    Succeeded,
+    Failed,
+    Cancelled
+}
+
+public record BackgroundTaskStepInfo(
+    string Id,
+    string Label,
+    BackgroundTaskStepState State,
+    string? Status = null,
+    string? Error = null
+);
+
+public record BackgroundTaskRequest(
+    string Type,
+    string Title,
+    string Description,
+    Dictionary<string, string> Parameters,
+    string? CoalesceKey = null,
+    string? ItemRoute = null
+);
+
+public record BackgroundTaskInfo(
+    string Id,
+    BackgroundTaskRequest Request,
+    BackgroundTaskState State,
+    int? Progress,
+    string? Status,
+    string? Error,
+    DateTime CreatedAtUtc,
+    DateTime? StartedAtUtc,
+    DateTime? CompletedAtUtc,
+    IReadOnlyList<OperationLogEntry> Log,
+    int Attempt,
+    IReadOnlyList<BackgroundTaskStepInfo>? Steps = null
+);
+
+public interface IBackgroundTaskContext
+{
+    CancellationToken CancellationToken { get; }
+    void SetStatus(string status);
+    void SetProgress(int? progress);
+    void SetSteps(IReadOnlyList<BackgroundTaskStepInfo> steps);
+    void UpdateStep(
+        string stepId,
+        BackgroundTaskStepState state,
+        string? status = null,
+        string? error = null);
+    void Log(string message, OperationLogLevel level = OperationLogLevel.Info);
+}
+
+public interface IBackgroundTaskHandler
+{
+    string Type { get; }
+    Task ExecuteAsync(BackgroundTaskRequest request, IBackgroundTaskContext context);
+}
+
+public interface IBackgroundTaskService
+{
+    bool IsPersistent { get; }
+    IReadOnlyList<BackgroundTaskInfo> Tasks { get; }
+    Task InitializeAsync(CancellationToken cancellationToken = default);
+    Task<string> EnqueueAsync(BackgroundTaskRequest request, CancellationToken cancellationToken = default);
+    Task RetryAsync(string taskId, CancellationToken cancellationToken = default);
+    Task CancelAsync(string taskId);
+    Task DismissAsync(string taskId, CancellationToken cancellationToken = default);
+    Task ClearCompletedAsync(CancellationToken cancellationToken = default);
+    event Action? TasksChanged;
 }
 
 /// <summary>
@@ -3810,7 +4054,8 @@ public record CloudProviderData(
     string Name,
     CloudSecretsProviderType ProviderType,
     Dictionary<string, string> Settings,
-    bool IsActive = false
+    bool IsActive = false,
+    List<SecretItemKind>? DefaultItemKinds = null
 );
 
 public record SecretsPublisherData(

--- a/src/MauiSherpa.Core/Requests/SecretProviderPlacementChangedEvent.cs
+++ b/src/MauiSherpa.Core/Requests/SecretProviderPlacementChangedEvent.cs
@@ -1,0 +1,8 @@
+using MauiSherpa.Core.Interfaces;
+using Shiny.Mediator;
+
+namespace MauiSherpa.Core.Requests;
+
+public sealed record SecretProviderPlacementChangedEvent(
+    SecretItemRef Item,
+    ProviderPlacementState Placement) : IEvent;

--- a/src/MauiSherpa.Core/Services/AndroidKeystoreItemAdapter.cs
+++ b/src/MauiSherpa.Core/Services/AndroidKeystoreItemAdapter.cs
@@ -1,0 +1,265 @@
+using System.Text;
+using System.Text.Json;
+using MauiSherpa.Core.Interfaces;
+
+namespace MauiSherpa.Core.Services;
+
+public sealed class AndroidKeystoreItemAdapter : ISecretItemAdapter
+{
+    private const string KeyPrefix = "KEYSTORE_";
+    private const string PasswordStoragePrefix = "android_keystore_pwd_";
+    private readonly ISecretsProviderRegistry _providerRegistry;
+    private readonly IKeystoreService _keystoreService;
+    private readonly ISecureStorageService _secureStorage;
+
+    public AndroidKeystoreItemAdapter(
+        ISecretsProviderRegistry providerRegistry,
+        IKeystoreService keystoreService,
+        ISecureStorageService secureStorage)
+    {
+        _providerRegistry = providerRegistry;
+        _keystoreService = keystoreService;
+        _secureStorage = secureStorage;
+    }
+
+    public SecretItemKind Kind => SecretItemKind.AndroidKeystore;
+    public bool IsProviderOwned => false;
+
+    public async Task<IReadOnlyList<SecretItemRef>> ListLocalItemsAsync(
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var keystores = await _keystoreService.ListKeystoresAsync();
+        return keystores
+            .Where(x => !string.IsNullOrWhiteSpace(x.Alias))
+            .GroupBy(x => x.Alias, StringComparer.OrdinalIgnoreCase)
+            .Select(x => new SecretItemRef(Kind, x.Key, x.First().Alias))
+            .OrderBy(x => x.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    public async Task<IReadOnlyList<SecretItemRef>> ListProviderItemsAsync(
+        string providerId,
+        CancellationToken cancellationToken = default)
+    {
+        var provider = await SecretItemAdapterHelper.GetProviderAsync(_providerRegistry, providerId);
+        if (provider is null)
+            return Array.Empty<SecretItemRef>();
+
+        var items = new Dictionary<string, SecretItemRef>(StringComparer.OrdinalIgnoreCase);
+        var keys = await provider.ListSecretsAsync(KeyPrefix, cancellationToken);
+
+        foreach (var key in keys)
+        {
+            if (SecretItemAdapterHelper.TryExtractAffixedId(key, KeyPrefix, "_JKS", out var alias))
+                items[alias] = new SecretItemRef(Kind, alias, alias);
+        }
+
+        foreach (var key in keys)
+        {
+            if (!SecretItemAdapterHelper.TryExtractAffixedId(key, KeyPrefix, "_META", out var fallbackAlias))
+                continue;
+
+            var metadata = DeserializeMetadata(await provider.GetSecretAsync(key, cancellationToken));
+            var alias = string.IsNullOrWhiteSpace(metadata?.Alias) ? fallbackAlias : metadata.Alias;
+            items[alias] = new SecretItemRef(Kind, alias, alias);
+        }
+
+        return items.Values
+            .OrderBy(x => x.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    public async Task<IReadOnlySet<string>> ListProviderItemIdsAsync(
+        string providerId,
+        CancellationToken cancellationToken = default)
+    {
+        var itemIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var provider = await SecretItemAdapterHelper.GetProviderAsync(_providerRegistry, providerId);
+        if (provider is null)
+            return itemIds;
+
+        var keys = await provider.ListSecretsAsync(
+            prefix: null,
+            cancellationToken: cancellationToken);
+        return ExtractProviderItemIds(keys);
+    }
+
+    public IReadOnlySet<string> ExtractProviderItemIds(IReadOnlyList<string> providerKeys)
+    {
+        var itemIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var key in providerKeys)
+        {
+            if (SecretItemAdapterHelper.TryExtractAffixedId(
+                    key,
+                    KeyPrefix,
+                    "_JKS",
+                    out var alias))
+            {
+                itemIds.Add(alias);
+            }
+        }
+
+        return itemIds;
+    }
+
+    public async Task<SecretItemPayload?> ReadLocalAsync(
+        SecretItemRef item,
+        CancellationToken cancellationToken = default)
+    {
+        if (item.Kind != Kind)
+            return null;
+
+        var keystores = await _keystoreService.ListKeystoresAsync();
+        var keystore = keystores.FirstOrDefault(x =>
+            string.Equals(x.Alias, item.Id, StringComparison.OrdinalIgnoreCase));
+        if (keystore is null || !File.Exists(keystore.FilePath))
+            return null;
+
+        var password = await _secureStorage.GetAsync(PasswordStoragePrefix + keystore.Id);
+        if (password is null)
+            return null;
+
+        var fileBytes = await File.ReadAllBytesAsync(keystore.FilePath, cancellationToken);
+        var lastWriteTime = File.GetLastWriteTimeUtc(keystore.FilePath);
+        var metadata = new KeystoreArtifactMetadata(
+            keystore.Alias,
+            keystore.KeystoreType,
+            keystore.CreatedDate,
+            keystore.Notes,
+            lastWriteTime);
+        var artifacts = new[]
+        {
+            new SecretArtifact(GetKey(keystore.Alias, "JKS"), fileBytes),
+            new SecretArtifact(
+                GetKey(keystore.Alias, "PWD"),
+                Encoding.UTF8.GetBytes(password)),
+            new SecretArtifact(
+                GetKey(keystore.Alias, "META"),
+                Encoding.UTF8.GetBytes(JsonSerializer.Serialize(metadata)))
+        };
+
+        return SecretItemAdapterHelper.CreatePayload(
+            new SecretItemRef(Kind, keystore.Alias, keystore.Alias),
+            SecretItemAdapterHelper.GetUtcRevision(lastWriteTime),
+            artifacts);
+    }
+
+    public async Task<SecretItemPayload?> ReadProviderAsync(
+        SecretItemRef item,
+        string providerId,
+        CancellationToken cancellationToken = default)
+    {
+        if (item.Kind != Kind)
+            return null;
+
+        var provider = await SecretItemAdapterHelper.GetProviderAsync(_providerRegistry, providerId);
+        if (provider is null)
+            return null;
+
+        var jksArtifact = await SecretItemAdapterHelper.ReadArtifactAsync(
+            provider,
+            GetKey(item.Id, "JKS"),
+            cancellationToken);
+        if (jksArtifact is null)
+            return null;
+
+        var artifacts = new List<SecretArtifact> { jksArtifact };
+        var passwordArtifact = await SecretItemAdapterHelper.ReadArtifactAsync(
+            provider,
+            GetKey(item.Id, "PWD"),
+            cancellationToken);
+        if (passwordArtifact is not null)
+            artifacts.Add(passwordArtifact);
+
+        var metadataKey = GetKey(item.Id, "META");
+        var metadataArtifact = await SecretItemAdapterHelper.ReadArtifactAsync(
+            provider,
+            metadataKey,
+            cancellationToken);
+        var metadata = DeserializeMetadata(metadataArtifact?.Value);
+        if (metadataArtifact is null)
+        {
+            metadata = new KeystoreArtifactMetadata(
+                item.Id,
+                "PKCS12",
+                DateTime.UnixEpoch,
+                null,
+                DateTime.UnixEpoch);
+            metadataArtifact = new SecretArtifact(
+                metadataKey,
+                Encoding.UTF8.GetBytes(JsonSerializer.Serialize(metadata)));
+        }
+        artifacts.Add(metadataArtifact);
+
+        var alias = string.IsNullOrWhiteSpace(metadata?.Alias) ? item.Id : metadata.Alias;
+        return SecretItemAdapterHelper.CreatePayload(
+            new SecretItemRef(Kind, alias, alias),
+            SecretItemAdapterHelper.GetUtcRevision(metadata?.UploadedAt ?? default),
+            artifacts);
+    }
+
+    public async Task<bool> WriteProviderAsync(
+        SecretItemPayload payload,
+        string providerId,
+        CancellationToken cancellationToken = default)
+    {
+        if (payload.Item.Kind != Kind)
+            return false;
+
+        var provider = await SecretItemAdapterHelper.GetProviderAsync(_providerRegistry, providerId);
+        return provider is not null &&
+            await SecretItemAdapterHelper.WriteArtifactsAsync(
+                provider,
+                payload.Artifacts,
+                cancellationToken);
+    }
+
+    public async Task<bool> DeleteProviderAsync(
+        SecretItemRef item,
+        string providerId,
+        CancellationToken cancellationToken = default)
+    {
+        if (item.Kind != Kind)
+            return false;
+
+        var provider = await SecretItemAdapterHelper.GetProviderAsync(_providerRegistry, providerId);
+        return provider is not null &&
+            await SecretItemAdapterHelper.DeleteArtifactsAsync(
+                provider,
+                new[]
+                {
+                    GetKey(item.Id, "JKS"),
+                    GetKey(item.Id, "PWD"),
+                    GetKey(item.Id, "META")
+                },
+                cancellationToken);
+    }
+
+    private static string GetKey(string alias, string suffix) =>
+        $"{KeyPrefix}{alias}_{suffix}";
+
+    private static KeystoreArtifactMetadata? DeserializeMetadata(byte[]? bytes)
+    {
+        if (bytes is null)
+            return null;
+
+        try
+        {
+            return JsonSerializer.Deserialize<KeystoreArtifactMetadata>(
+                bytes,
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private sealed record KeystoreArtifactMetadata(
+        string Alias,
+        string KeystoreType,
+        DateTime CreatedDate,
+        string? Notes,
+        DateTime UploadedAt);
+}

--- a/src/MauiSherpa.Core/Services/AppleIdentityStateService.cs
+++ b/src/MauiSherpa.Core/Services/AppleIdentityStateService.cs
@@ -4,14 +4,28 @@ namespace MauiSherpa.Core.Services;
 
 public class AppleIdentityStateService : IAppleIdentityStateService
 {
+    private readonly IIdentitySelectionStore? _selectionStore;
     private AppleIdentity? _selectedIdentity;
 
+    public AppleIdentityStateService(IIdentitySelectionStore? selectionStore = null)
+    {
+        _selectionStore = selectionStore;
+        LastSelectedIdentityId = selectionStore?.GetLastAppleIdentityId();
+    }
+
     public AppleIdentity? SelectedIdentity => _selectedIdentity;
+    public string? LastSelectedIdentityId { get; private set; }
 
     public event Action? OnSelectionChanged;
 
     public void SetSelectedIdentity(AppleIdentity? identity)
     {
+        if (identity is not null && !string.Equals(LastSelectedIdentityId, identity.Id, StringComparison.Ordinal))
+        {
+            LastSelectedIdentityId = identity.Id;
+            _selectionStore?.SetLastAppleIdentityId(identity.Id);
+        }
+
         if (!EqualityComparer<AppleIdentity?>.Default.Equals(_selectedIdentity, identity))
         {
             _selectedIdentity = identity;

--- a/src/MauiSherpa.Core/Services/AwsSecretsManagerProvider.cs
+++ b/src/MauiSherpa.Core/Services/AwsSecretsManagerProvider.cs
@@ -161,12 +161,12 @@ public class AwsSecretsManagerProvider : ICloudSecretsProvider
         catch (AmazonSecretsManagerException ex)
         {
             _logger.LogError($"AWS Secrets Manager get secret failed: {ex.StatusCode} - {ex.Message}", ex);
-            return null;
+            throw;
         }
         catch (Exception ex)
         {
             _logger.LogError($"AWS Secrets Manager get secret error: {ex.Message}", ex);
-            return null;
+            throw;
         }
     }
 
@@ -262,7 +262,7 @@ public class AwsSecretsManagerProvider : ICloudSecretsProvider
         catch (Exception ex)
         {
             _logger.LogError($"AWS Secrets Manager secret exists check error: {ex.Message}", ex);
-            return false;
+            throw;
         }
     }
 

--- a/src/MauiSherpa.Core/Services/AzureDevOpsProvider.cs
+++ b/src/MauiSherpa.Core/Services/AzureDevOpsProvider.cs
@@ -173,20 +173,23 @@ public class AzureDevOpsProvider : ICloudSecretsProvider
 
             var sanitizedKey = SanitizeKey(key);
 
-            if (!group.Variables.TryGetValue(sanitizedKey, out var variable) || variable.Value == null)
+            if (!group.Variables.TryGetValue(sanitizedKey, out var variable))
                 return null;
+            if (variable.Value == null)
+                throw new InvalidOperationException(
+                    $"Azure DevOps redacted secret '{key}' and cannot return its value.");
 
             return Convert.FromBase64String(variable.Value);
         }
         catch (FormatException ex)
         {
             _logger.LogError($"Azure DevOps secret not base64 encoded: {key} - {ex.Message}");
-            return null;
+            throw;
         }
         catch (Exception ex)
         {
             _logger.LogError($"Azure DevOps get secret error: {ex.Message}", ex);
-            return null;
+            throw;
         }
     }
 
@@ -314,7 +317,7 @@ public class AzureDevOpsProvider : ICloudSecretsProvider
         catch (Exception ex)
         {
             _logger.LogError($"Azure DevOps secret exists check error: {ex.Message}", ex);
-            return false;
+            throw;
         }
     }
 

--- a/src/MauiSherpa.Core/Services/AzureKeyVaultProvider.cs
+++ b/src/MauiSherpa.Core/Services/AzureKeyVaultProvider.cs
@@ -134,12 +134,12 @@ public class AzureKeyVaultProvider : ICloudSecretsProvider
         catch (FormatException ex)
         {
             _logger.LogError($"Azure Key Vault secret not base64 encoded: {key} - {ex.Message}");
-            return null;
+            throw;
         }
         catch (Exception ex)
         {
             _logger.LogError($"Azure Key Vault get secret error: {ex.Message}", ex);
-            return null;
+            throw;
         }
     }
 
@@ -239,7 +239,7 @@ public class AzureKeyVaultProvider : ICloudSecretsProvider
         catch (Exception ex)
         {
             _logger.LogError($"Azure Key Vault secret exists check error: {ex.Message}", ex);
-            return false;
+            throw;
         }
     }
 

--- a/src/MauiSherpa.Core/Services/BackgroundTaskService.cs
+++ b/src/MauiSherpa.Core/Services/BackgroundTaskService.cs
@@ -1,0 +1,710 @@
+using System.Text;
+using System.Text.Json;
+using System.Threading.Channels;
+using MauiSherpa.Core.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MauiSherpa.Core.Services;
+
+public sealed class BackgroundTaskService : IBackgroundTaskService
+{
+    private const string VaultPath = "/tasks";
+    private const string VaultKey = "background-task-queue";
+    private const int MaxHistory = 100;
+    private const int MaxAttempts = 3;
+
+    private readonly ILocalVaultStore? _vaultStore;
+    private readonly ILocalVaultAccessService? _vaultAccess;
+    private readonly ILoggingService _logger;
+    private readonly IServiceProvider _serviceProvider;
+    private Dictionary<string, IBackgroundTaskHandler> _handlers = new(StringComparer.Ordinal);
+    private readonly Channel<string> _queue = Channel.CreateUnbounded<string>(
+        new UnboundedChannelOptions { SingleReader = true, SingleWriter = false });
+    private readonly List<StoredBackgroundTask> _tasks = [];
+    private readonly Dictionary<string, CancellationTokenSource> _runningTasks = new(StringComparer.Ordinal);
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private readonly JsonSerializerOptions _jsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = false
+    };
+
+    private bool _initialized;
+    private Task? _worker;
+
+    public BackgroundTaskService(
+        IServiceProvider serviceProvider,
+        ILoggingService logger,
+        ILocalVaultStore? vaultStore = null,
+        ILocalVaultAccessService? vaultAccess = null)
+    {
+        _serviceProvider = serviceProvider;
+        _logger = logger;
+        _vaultStore = vaultStore;
+        _vaultAccess = vaultAccess;
+        if (_vaultAccess is not null)
+            _vaultAccess.StateChanged += OnVaultAccessChanged;
+    }
+
+    public bool IsPersistent { get; private set; }
+
+    public IReadOnlyList<BackgroundTaskInfo> Tasks
+    {
+        get
+        {
+            lock (_tasks)
+                return _tasks
+                    .OrderByDescending(task => task.CreatedAtUtc)
+                    .Select(task => task.ToInfo())
+                    .ToList();
+        }
+    }
+
+    public event Action? TasksChanged;
+
+    public async Task InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken);
+        try
+        {
+            if (_initialized)
+                return;
+
+            var canPersist = _vaultStore is not null &&
+                _vaultAccess?.GetState().RequiresUserAction != true;
+            _handlers = _serviceProvider
+                .GetServices<IBackgroundTaskHandler>()
+                .ToDictionary(handler => handler.Type, StringComparer.Ordinal);
+
+            if (canPersist)
+            {
+                var loadedTaskIds = await LoadAsync(mergeWithExisting: false, cancellationToken);
+                IsPersistent = loadedTaskIds is not null;
+            }
+
+            _initialized = true;
+            _worker = Task.Run(ProcessQueueAsync);
+
+            List<string> pendingIds;
+            lock (_tasks)
+            {
+                pendingIds = _tasks
+                    .Where(task => task.State == BackgroundTaskState.Pending)
+                    .Select(task => task.Id)
+                    .ToList();
+            }
+
+            foreach (var taskId in pendingIds)
+                await _queue.Writer.WriteAsync(taskId, cancellationToken);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+
+        NotifyChanged();
+    }
+
+    public async Task<string> EnqueueAsync(
+        BackgroundTaskRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        await InitializeAsync(cancellationToken);
+
+        StoredBackgroundTask task;
+        lock (_tasks)
+        {
+            var existingTask = !string.IsNullOrWhiteSpace(request.CoalesceKey)
+                ? _tasks.FirstOrDefault(existing =>
+                    existing.State == BackgroundTaskState.Pending &&
+                    string.Equals(existing.Request.CoalesceKey, request.CoalesceKey, StringComparison.Ordinal))
+                : null;
+
+            if (existingTask is not null)
+            {
+                task = existingTask;
+                task.Request = request;
+                task.Status = "Updated with the latest requested state";
+                task.Error = null;
+            }
+            else
+            {
+                task = new StoredBackgroundTask
+                {
+                    Id = Guid.NewGuid().ToString("N"),
+                    Request = request,
+                    State = BackgroundTaskState.Pending,
+                    CreatedAtUtc = DateTime.UtcNow
+                };
+                _tasks.Add(task);
+            }
+        }
+
+        await PersistAsync(cancellationToken);
+        NotifyChanged();
+        await _queue.Writer.WriteAsync(task.Id, cancellationToken);
+        return task.Id;
+    }
+
+    public async Task RetryAsync(string taskId, CancellationToken cancellationToken = default)
+    {
+        await InitializeAsync(cancellationToken);
+        var shouldQueue = false;
+
+        lock (_tasks)
+        {
+            var task = FindTask(taskId);
+            if (task is null || task.State is BackgroundTaskState.Running or BackgroundTaskState.Pending)
+                return;
+            var taskIndex = _tasks.IndexOf(task);
+            if (!string.IsNullOrWhiteSpace(task.Request.CoalesceKey) &&
+                _tasks.Skip(taskIndex + 1).Any(newer =>
+                    string.Equals(
+                        newer.Request.CoalesceKey,
+                        task.Request.CoalesceKey,
+                        StringComparison.Ordinal)))
+            {
+                throw new InvalidOperationException(
+                    "This task was superseded by a newer sync decision and cannot be retried.");
+            }
+
+            task.State = BackgroundTaskState.Pending;
+            task.Progress = null;
+            task.Status = "Queued for retry";
+            task.Error = null;
+            task.StartedAtUtc = null;
+            task.CompletedAtUtc = null;
+            task.Steps.Clear();
+            shouldQueue = true;
+        }
+
+        if (!shouldQueue)
+            return;
+
+        await PersistAsync(cancellationToken);
+        NotifyChanged();
+        await _queue.Writer.WriteAsync(taskId, cancellationToken);
+    }
+
+    public async Task CancelAsync(string taskId)
+    {
+        CancellationTokenSource? runningCts;
+        lock (_tasks)
+        {
+            var task = FindTask(taskId);
+            if (task is null)
+                return;
+
+            _runningTasks.TryGetValue(taskId, out runningCts);
+            if (task.State == BackgroundTaskState.Pending)
+            {
+                task.State = BackgroundTaskState.Cancelled;
+                task.Status = "Cancelled";
+                task.CompletedAtUtc = DateTime.UtcNow;
+            }
+        }
+
+        runningCts?.Cancel();
+        await PersistAsync(CancellationToken.None);
+        NotifyChanged();
+    }
+
+    public async Task DismissAsync(string taskId, CancellationToken cancellationToken = default)
+    {
+        lock (_tasks)
+        {
+            var task = FindTask(taskId);
+            if (task is null || task.State is BackgroundTaskState.Pending or BackgroundTaskState.Running)
+                return;
+
+            _tasks.Remove(task);
+        }
+
+        await PersistAsync(cancellationToken);
+        NotifyChanged();
+    }
+
+    public async Task ClearCompletedAsync(CancellationToken cancellationToken = default)
+    {
+        var removed = false;
+        lock (_tasks)
+        {
+            removed = _tasks.RemoveAll(task =>
+                task.State is BackgroundTaskState.Succeeded or BackgroundTaskState.Cancelled) > 0;
+        }
+
+        if (!removed)
+            return;
+
+        await PersistAsync(cancellationToken);
+        NotifyChanged();
+    }
+
+    private async Task ProcessQueueAsync()
+    {
+        await foreach (var taskId in _queue.Reader.ReadAllAsync())
+        {
+            StoredBackgroundTask? task;
+            var cts = new CancellationTokenSource();
+            lock (_tasks)
+            {
+                task = FindTask(taskId);
+                if (task is null || task.State != BackgroundTaskState.Pending)
+                {
+                    cts.Dispose();
+                    continue;
+                }
+
+                _runningTasks[task.Id] = cts;
+                task.State = BackgroundTaskState.Running;
+                task.Attempt++;
+                task.StartedAtUtc = DateTime.UtcNow;
+                task.CompletedAtUtc = null;
+                task.Status = "Starting";
+                task.Error = null;
+                task.Progress = null;
+                task.Steps.Clear();
+                task.Log.Add(new OperationLogEntry(DateTime.UtcNow, "Task started"));
+            }
+
+            try
+            {
+                await PersistAndNotifyAsync();
+                if (!_handlers.TryGetValue(task.Request.Type, out var handler))
+                {
+                    await CompleteWithErrorAsync(task, $"No handler is registered for task type '{task.Request.Type}'.");
+                    continue;
+                }
+
+                await RunTaskAsync(task, handler, cts.Token);
+            }
+            finally
+            {
+                lock (_tasks)
+                    _runningTasks.Remove(task.Id);
+                cts.Dispose();
+            }
+        }
+    }
+
+    private async Task RunTaskAsync(
+        StoredBackgroundTask task,
+        IBackgroundTaskHandler handler,
+        CancellationToken cancellationToken)
+    {
+        var context = new BackgroundTaskContext(this, task, cancellationToken);
+        try
+        {
+            await handler.ExecuteAsync(task.Request, context);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            lock (_tasks)
+            {
+                task.State = BackgroundTaskState.Succeeded;
+                task.Progress = 100;
+                task.Status = "Completed";
+                task.CompletedAtUtc = DateTime.UtcNow;
+                task.Log.Add(new OperationLogEntry(DateTime.UtcNow, "Task completed", OperationLogLevel.Success));
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            lock (_tasks)
+            {
+                task.State = BackgroundTaskState.Cancelled;
+                task.Status = "Cancelled";
+                task.CompletedAtUtc = DateTime.UtcNow;
+                task.Log.Add(new OperationLogEntry(DateTime.UtcNow, "Task cancelled", OperationLogLevel.Warning));
+            }
+        }
+        catch (BackgroundTaskTransientException ex) when (task.Attempt < MaxAttempts)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                lock (_tasks)
+                {
+                    task.State = BackgroundTaskState.Cancelled;
+                    task.Status = "Cancelled";
+                    task.CompletedAtUtc = DateTime.UtcNow;
+                    task.Log.Add(new OperationLogEntry(
+                        DateTime.UtcNow,
+                        "Task cancelled while handling a transient failure.",
+                        OperationLogLevel.Warning));
+                }
+                await PersistAndNotifyAsync();
+                return;
+            }
+
+            lock (_tasks)
+            {
+                task.State = BackgroundTaskState.Pending;
+                task.Status = $"Retrying after transient failure ({task.Attempt}/{MaxAttempts})";
+                task.Error = SanitizeError(ex.Message);
+                task.Log.Add(new OperationLogEntry(DateTime.UtcNow, task.Error, OperationLogLevel.Warning));
+            }
+            await PersistAndNotifyAsync();
+            _ = RequeueAfterDelayAsync(
+                task.Id,
+                TimeSpan.FromSeconds(Math.Pow(2, task.Attempt - 1)));
+            return;
+        }
+        catch (Exception ex)
+        {
+            lock (_tasks)
+            {
+                task.State = BackgroundTaskState.Failed;
+                task.Status = "Needs attention";
+                task.Error = SanitizeError(ex.Message);
+                task.CompletedAtUtc = DateTime.UtcNow;
+                task.Log.Add(new OperationLogEntry(DateTime.UtcNow, task.Error, OperationLogLevel.Error));
+            }
+            _logger.LogError($"Background task '{task.Request.Type}' failed: {ex.Message}", ex);
+        }
+
+        TrimHistory();
+        await PersistAndNotifyAsync();
+    }
+
+    private async Task CompleteWithErrorAsync(StoredBackgroundTask task, string error)
+    {
+        lock (_tasks)
+        {
+            task.State = BackgroundTaskState.Failed;
+            task.Status = "Needs attention";
+            task.Error = error;
+            task.CompletedAtUtc = DateTime.UtcNow;
+            task.Log.Add(new OperationLogEntry(DateTime.UtcNow, error, OperationLogLevel.Error));
+        }
+        await PersistAndNotifyAsync();
+    }
+
+    private async Task<IReadOnlyList<string>?> LoadAsync(
+        bool mergeWithExisting,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var item = await _vaultStore!.GetAsync(
+                LocalVaultScopes.BackgroundTask,
+                VaultPath,
+                VaultKey,
+                cancellationToken);
+            if (item is null)
+                return Array.Empty<string>();
+
+            var stored = JsonSerializer.Deserialize<List<StoredBackgroundTask>>(item.Value, _jsonOptions) ?? [];
+            foreach (var task in stored)
+            {
+                if (task.State == BackgroundTaskState.Running)
+                {
+                    task.State = BackgroundTaskState.Pending;
+                    task.Status = "Resuming after app restart";
+                    task.Log.Add(new OperationLogEntry(
+                        DateTime.UtcNow,
+                        "The app exited while this task was running; it was queued again.",
+                        OperationLogLevel.Warning));
+                }
+            }
+
+            var pendingTaskIds = new List<string>();
+            lock (_tasks)
+            {
+                if (!mergeWithExisting)
+                {
+                    _tasks.Clear();
+                    _tasks.AddRange(stored);
+                    pendingTaskIds.AddRange(stored
+                        .Where(task => task.State == BackgroundTaskState.Pending)
+                        .Select(task => task.Id));
+                }
+                else
+                {
+                    var existingIds = _tasks
+                        .Select(task => task.Id)
+                        .ToHashSet(StringComparer.Ordinal);
+                    foreach (var task in stored)
+                    {
+                        if (existingIds.Contains(task.Id))
+                            continue;
+                        if (task.State == BackgroundTaskState.Pending &&
+                            !string.IsNullOrWhiteSpace(task.Request.CoalesceKey) &&
+                            _tasks.Any(existing =>
+                                (existing.State is BackgroundTaskState.Pending or BackgroundTaskState.Running) &&
+                                string.Equals(
+                                    existing.Request.CoalesceKey,
+                                    task.Request.CoalesceKey,
+                                    StringComparison.Ordinal)))
+                        {
+                            continue;
+                        }
+
+                        _tasks.Add(task);
+                        if (task.State == BackgroundTaskState.Pending)
+                            pendingTaskIds.Add(task.Id);
+                    }
+                }
+            }
+
+            return pendingTaskIds;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning($"Background task persistence is unavailable: {ex.Message}");
+            return null;
+        }
+    }
+
+    private async Task PersistAsync(CancellationToken cancellationToken)
+    {
+        if (!IsPersistent || _vaultStore is null)
+            return;
+
+        try
+        {
+            List<StoredBackgroundTask> snapshot;
+            lock (_tasks)
+                snapshot = _tasks.ToList();
+
+            var json = JsonSerializer.SerializeToUtf8Bytes(snapshot, _jsonOptions);
+            await _vaultStore.PutAsync(
+                LocalVaultScopes.BackgroundTask,
+                VaultPath,
+                VaultKey,
+                json,
+                LocalVaultContentTypes.Json,
+                cancellationToken: cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            IsPersistent = false;
+            _logger.LogWarning($"Failed to persist background tasks: {ex.Message}");
+        }
+    }
+
+    private async Task PersistAndNotifyAsync()
+    {
+        await PersistAsync(CancellationToken.None);
+        NotifyChanged();
+    }
+
+    private void TrimHistory()
+    {
+        lock (_tasks)
+        {
+            var completed = _tasks
+                .Where(task => task.State is not BackgroundTaskState.Pending and not BackgroundTaskState.Running)
+                .OrderByDescending(task => task.CompletedAtUtc ?? task.CreatedAtUtc)
+                .Skip(MaxHistory)
+                .ToList();
+
+            foreach (var task in completed)
+                _tasks.Remove(task);
+        }
+    }
+
+    private StoredBackgroundTask? FindTask(string taskId) =>
+        _tasks.FirstOrDefault(task => string.Equals(task.Id, taskId, StringComparison.Ordinal));
+
+    private void NotifyChanged()
+    {
+        if (TasksChanged is null)
+            return;
+
+        foreach (Action subscriber in TasksChanged.GetInvocationList())
+        {
+            try
+            {
+                subscriber();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning($"A background task notification subscriber failed: {ex.Message}");
+            }
+        }
+    }
+
+    private void OnVaultAccessChanged()
+    {
+        if (!_initialized || IsPersistent || _vaultStore is null ||
+            _vaultAccess?.GetState().RequiresUserAction == true)
+        {
+            return;
+        }
+
+        _ = EnablePersistenceAsync();
+    }
+
+    private async Task EnablePersistenceAsync()
+    {
+        await _gate.WaitAsync();
+        try
+        {
+            if (IsPersistent || _vaultStore is null ||
+                _vaultAccess?.GetState().RequiresUserAction == true)
+            {
+                return;
+            }
+
+            var loadedTaskIds = await LoadAsync(
+                mergeWithExisting: true,
+                CancellationToken.None);
+            if (loadedTaskIds is null)
+                return;
+
+            IsPersistent = true;
+            await PersistAsync(CancellationToken.None);
+            foreach (var taskId in loadedTaskIds)
+                await _queue.Writer.WriteAsync(taskId);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+
+        NotifyChanged();
+    }
+
+    private async Task RequeueAfterDelayAsync(string taskId, TimeSpan delay)
+    {
+        await Task.Delay(delay);
+        await _queue.Writer.WriteAsync(taskId);
+    }
+
+    private static string SanitizeError(string message)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+            return "The task failed.";
+
+        var sanitized = message.ReplaceLineEndings(" ").Trim();
+        return sanitized.Length <= 500 ? sanitized : sanitized[..500];
+    }
+
+    private sealed class BackgroundTaskContext : IBackgroundTaskContext
+    {
+        private readonly BackgroundTaskService _service;
+        private readonly StoredBackgroundTask _task;
+
+        public BackgroundTaskContext(
+            BackgroundTaskService service,
+            StoredBackgroundTask task,
+            CancellationToken cancellationToken)
+        {
+            _service = service;
+            _task = task;
+            CancellationToken = cancellationToken;
+        }
+
+        public CancellationToken CancellationToken { get; }
+
+        public void SetStatus(string status)
+        {
+            lock (_service._tasks)
+                _task.Status = status;
+            _ = _service.PersistAndNotifyAsync();
+        }
+
+        public void SetProgress(int? progress)
+        {
+            lock (_service._tasks)
+                _task.Progress = progress is null ? null : Math.Clamp(progress.Value, 0, 100);
+            _ = _service.PersistAndNotifyAsync();
+        }
+
+        public void SetSteps(IReadOnlyList<BackgroundTaskStepInfo> steps)
+        {
+            lock (_service._tasks)
+            {
+                _task.Steps = steps
+                    .Select(step => step with
+                    {
+                        Label = SanitizeError(step.Label),
+                        Status = string.IsNullOrWhiteSpace(step.Status)
+                            ? null
+                            : SanitizeError(step.Status),
+                        Error = string.IsNullOrWhiteSpace(step.Error)
+                            ? null
+                            : SanitizeError(step.Error)
+                    })
+                    .ToList();
+            }
+            _ = _service.PersistAndNotifyAsync();
+        }
+
+        public void UpdateStep(
+            string stepId,
+            BackgroundTaskStepState state,
+            string? status = null,
+            string? error = null)
+        {
+            lock (_service._tasks)
+            {
+                var index = _task.Steps.FindIndex(step =>
+                    string.Equals(step.Id, stepId, StringComparison.Ordinal));
+                if (index < 0)
+                    throw new InvalidOperationException($"Background task step '{stepId}' is not registered.");
+
+                var current = _task.Steps[index];
+                _task.Steps[index] = current with
+                {
+                    State = state,
+                    Status = string.IsNullOrWhiteSpace(status) ? current.Status : SanitizeError(status),
+                    Error = string.IsNullOrWhiteSpace(error) ? null : SanitizeError(error)
+                };
+            }
+            _ = _service.PersistAndNotifyAsync();
+        }
+
+        public void Log(string message, OperationLogLevel level = OperationLogLevel.Info)
+        {
+            lock (_service._tasks)
+                _task.Log.Add(new OperationLogEntry(DateTime.UtcNow, SanitizeError(message), level));
+            _ = _service.PersistAndNotifyAsync();
+        }
+    }
+
+    private sealed class StoredBackgroundTask
+    {
+        public StoredBackgroundTask()
+        {
+        }
+
+        public string Id { get; set; } = "";
+        public BackgroundTaskRequest Request { get; set; } = new("", "", "", []);
+        public BackgroundTaskState State { get; set; }
+        public int? Progress { get; set; }
+        public string? Status { get; set; }
+        public string? Error { get; set; }
+        public DateTime CreatedAtUtc { get; set; }
+        public DateTime? StartedAtUtc { get; set; }
+        public DateTime? CompletedAtUtc { get; set; }
+        public List<OperationLogEntry> Log { get; set; } = [];
+        public List<BackgroundTaskStepInfo> Steps { get; set; } = [];
+        public int Attempt { get; set; }
+
+        public BackgroundTaskInfo ToInfo() => new(
+            Id,
+            Request,
+            State,
+            Progress,
+            Status,
+            Error,
+            CreatedAtUtc,
+            StartedAtUtc,
+            CompletedAtUtc,
+            Log.ToList(),
+            Attempt,
+            Steps.ToList());
+    }
+}
+
+public sealed class BackgroundTaskTransientException : Exception
+{
+    public BackgroundTaskTransientException(string message)
+        : base(message)
+    {
+    }
+
+    public BackgroundTaskTransientException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/MauiSherpa.Core/Services/BackupService.cs
+++ b/src/MauiSherpa.Core/Services/BackupService.cs
@@ -292,7 +292,8 @@ public class BackupService : IBackupService
                     Name: provider.Name,
                     ProviderType: provider.ProviderType,
                     Settings: new Dictionary<string, string>(provider.Settings),
-                    IsActive: provider.Id == activeProviderId))
+                    IsActive: provider.Id == activeProviderId,
+                    DefaultItemKinds: provider.EffectiveDefaultItemKinds.ToList()))
                 .ToList(),
             ActiveCloudProviderId = activeProviderId
         };

--- a/src/MauiSherpa.Core/Services/CertificateItemAdapter.cs
+++ b/src/MauiSherpa.Core/Services/CertificateItemAdapter.cs
@@ -1,0 +1,286 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using MauiSherpa.Core.Interfaces;
+
+namespace MauiSherpa.Core.Services;
+
+public sealed class CertificateItemAdapter : ISecretItemAdapter
+{
+    private const string KeyPrefix = "CERT_";
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+    private readonly ISecretsProviderRegistry _providerRegistry;
+    private readonly ILocalCertificateService _localCertificateService;
+
+    public CertificateItemAdapter(
+        ISecretsProviderRegistry providerRegistry,
+        ILocalCertificateService localCertificateService)
+    {
+        _providerRegistry = providerRegistry;
+        _localCertificateService = localCertificateService;
+    }
+
+    public SecretItemKind Kind => SecretItemKind.Certificate;
+    public bool IsProviderOwned => false;
+
+    public async Task<IReadOnlyList<SecretItemRef>> ListLocalItemsAsync(
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var identities = await _localCertificateService.GetSigningIdentitiesAsync();
+        return identities
+            .Where(x => x.IsValid && !string.IsNullOrWhiteSpace(x.SerialNumber))
+            .Select(x => (
+                Identity: x,
+                Id: SecretItemAdapterHelper.SanitizeSerialNumber(x.SerialNumber!)))
+            .Where(x => x.Id.Length > 0)
+            .GroupBy(x => x.Id, StringComparer.Ordinal)
+            .Select(x => new SecretItemRef(Kind, x.Key, x.First().Identity.CommonName))
+            .OrderBy(x => x.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    public async Task<IReadOnlyList<SecretItemRef>> ListProviderItemsAsync(
+        string providerId,
+        CancellationToken cancellationToken = default)
+    {
+        var provider = await SecretItemAdapterHelper.GetProviderAsync(_providerRegistry, providerId);
+        if (provider is null)
+            return Array.Empty<SecretItemRef>();
+
+        var items = new Dictionary<string, SecretItemRef>(StringComparer.Ordinal);
+        var keys = await provider.ListSecretsAsync(KeyPrefix, cancellationToken);
+        foreach (var key in keys)
+        {
+            if (!SecretItemAdapterHelper.TryExtractAffixedId(key, KeyPrefix, "_P12", out var serial))
+                continue;
+
+            var itemId = SecretItemAdapterHelper.SanitizeSerialNumber(serial);
+            if (itemId.Length > 0)
+                items[itemId] = new SecretItemRef(Kind, itemId, serial);
+        }
+
+        foreach (var key in keys)
+        {
+            if (!SecretItemAdapterHelper.TryExtractAffixedId(key, KeyPrefix, "_META", out _))
+                continue;
+
+            var metadata = DeserializeMetadata(await provider.GetSecretAsync(key, cancellationToken));
+            if (metadata is null)
+                continue;
+
+            var itemId = SecretItemAdapterHelper.SanitizeSerialNumber(metadata.SerialNumber);
+            if (itemId.Length > 0)
+                items[itemId] = new SecretItemRef(Kind, itemId, metadata.CommonName);
+        }
+
+        return items.Values
+            .OrderBy(x => x.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    public async Task<IReadOnlySet<string>> ListProviderItemIdsAsync(
+        string providerId,
+        CancellationToken cancellationToken = default)
+    {
+        var itemIds = new HashSet<string>(StringComparer.Ordinal);
+        var provider = await SecretItemAdapterHelper.GetProviderAsync(_providerRegistry, providerId);
+        if (provider is null)
+            return itemIds;
+
+        var keys = await provider.ListSecretsAsync(
+            prefix: null,
+            cancellationToken: cancellationToken);
+        return ExtractProviderItemIds(keys);
+    }
+
+    public IReadOnlySet<string> ExtractProviderItemIds(IReadOnlyList<string> providerKeys)
+    {
+        var itemIds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var key in providerKeys)
+        {
+            if (!SecretItemAdapterHelper.TryExtractAffixedId(
+                    key,
+                    KeyPrefix,
+                    "_P12",
+                    out var serial))
+            {
+                continue;
+            }
+
+            var itemId = SecretItemAdapterHelper.SanitizeSerialNumber(serial);
+            if (itemId.Length > 0)
+                itemIds.Add(itemId);
+        }
+
+        return itemIds;
+    }
+
+    public async Task<SecretItemPayload?> ReadLocalAsync(
+        SecretItemRef item,
+        CancellationToken cancellationToken = default)
+    {
+        if (item.Kind != Kind)
+            return null;
+
+        var identities = await _localCertificateService.GetSigningIdentitiesAsync();
+        var identity = identities.FirstOrDefault(x =>
+            x.IsValid &&
+            SecretItemAdapterHelper.SanitizeSerialNumber(x.SerialNumber ?? string.Empty) == item.Id);
+        if (identity is null || string.IsNullOrWhiteSpace(identity.SerialNumber))
+            return null;
+
+        cancellationToken.ThrowIfCancellationRequested();
+        var password = Convert.ToBase64String(RandomNumberGenerator.GetBytes(18));
+        var p12 = await _localCertificateService.ExportP12Async(identity.Identity, password);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var metadata = new CertificateSecretMetadata(
+            string.Empty,
+            identity.SerialNumber,
+            identity.CommonName,
+            GetCertificateType(identity.CommonName),
+            identity.ExpirationDate ?? DateTime.MinValue,
+            Environment.MachineName,
+            DateTime.UnixEpoch);
+        var artifacts = new[]
+        {
+            new SecretArtifact(GetKey(item.Id, "P12"), p12),
+            new SecretArtifact(GetKey(item.Id, "PWD"), Encoding.UTF8.GetBytes(password)),
+            new SecretArtifact(
+                GetKey(item.Id, "META"),
+                Encoding.UTF8.GetBytes(JsonSerializer.Serialize(metadata)))
+        };
+
+        return SecretItemAdapterHelper.CreatePayload(
+            new SecretItemRef(Kind, item.Id, identity.CommonName),
+            0,
+            artifacts);
+    }
+
+    public async Task<SecretItemPayload?> ReadProviderAsync(
+        SecretItemRef item,
+        string providerId,
+        CancellationToken cancellationToken = default)
+    {
+        if (item.Kind != Kind)
+            return null;
+
+        var provider = await SecretItemAdapterHelper.GetProviderAsync(_providerRegistry, providerId);
+        if (provider is null)
+            return null;
+
+        var p12Artifact = await SecretItemAdapterHelper.ReadArtifactAsync(
+            provider,
+            GetKey(item.Id, "P12"),
+            cancellationToken);
+        if (p12Artifact is null)
+            return null;
+
+        var artifacts = new List<SecretArtifact> { p12Artifact };
+        var passwordArtifact = await SecretItemAdapterHelper.ReadArtifactAsync(
+            provider,
+            GetKey(item.Id, "PWD"),
+            cancellationToken);
+        if (passwordArtifact is not null)
+            artifacts.Add(passwordArtifact);
+
+        var metadataKey = GetKey(item.Id, "META");
+        var metadataArtifact = await SecretItemAdapterHelper.ReadArtifactAsync(
+            provider,
+            metadataKey,
+            cancellationToken);
+        var metadata = DeserializeMetadata(metadataArtifact?.Value);
+        if (metadataArtifact is null)
+        {
+            metadata = new CertificateSecretMetadata(
+                string.Empty,
+                item.Id,
+                item.DisplayName,
+                string.Empty,
+                DateTime.MinValue,
+                string.Empty,
+                DateTime.UnixEpoch);
+            metadataArtifact = new SecretArtifact(
+                metadataKey,
+                Encoding.UTF8.GetBytes(JsonSerializer.Serialize(metadata)));
+        }
+        artifacts.Add(metadataArtifact);
+
+        var itemId = SecretItemAdapterHelper.SanitizeSerialNumber(
+            metadata?.SerialNumber ?? item.Id);
+        return SecretItemAdapterHelper.CreatePayload(
+            new SecretItemRef(
+                Kind,
+                itemId,
+                string.IsNullOrWhiteSpace(metadata?.CommonName)
+                    ? item.DisplayName
+                    : metadata.CommonName),
+            SecretItemAdapterHelper.GetUtcRevision(metadata?.CreatedAt ?? default),
+            artifacts);
+    }
+
+    public async Task<bool> WriteProviderAsync(
+        SecretItemPayload payload,
+        string providerId,
+        CancellationToken cancellationToken = default)
+    {
+        if (payload.Item.Kind != Kind)
+            return false;
+
+        var provider = await SecretItemAdapterHelper.GetProviderAsync(_providerRegistry, providerId);
+        return provider is not null &&
+            await SecretItemAdapterHelper.WriteArtifactsAsync(
+                provider,
+                payload.Artifacts,
+                cancellationToken);
+    }
+
+    public async Task<bool> DeleteProviderAsync(
+        SecretItemRef item,
+        string providerId,
+        CancellationToken cancellationToken = default)
+    {
+        if (item.Kind != Kind)
+            return false;
+
+        var provider = await SecretItemAdapterHelper.GetProviderAsync(_providerRegistry, providerId);
+        return provider is not null &&
+            await SecretItemAdapterHelper.DeleteArtifactsAsync(
+                provider,
+                new[]
+                {
+                    GetKey(item.Id, "P12"),
+                    GetKey(item.Id, "PWD"),
+                    GetKey(item.Id, "META")
+                },
+                cancellationToken);
+    }
+
+    private static string GetKey(string serialNumber, string suffix) =>
+        $"{KeyPrefix}{SecretItemAdapterHelper.SanitizeSerialNumber(serialNumber)}_{suffix}";
+
+    private static CertificateSecretMetadata? DeserializeMetadata(byte[]? bytes)
+    {
+        if (bytes is null)
+            return null;
+
+        try
+        {
+            return JsonSerializer.Deserialize<CertificateSecretMetadata>(bytes, JsonOptions);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static string GetCertificateType(string commonName)
+    {
+        var separator = commonName.IndexOf(':');
+        return separator > 0 ? commonName[..separator].Trim() : string.Empty;
+    }
+}

--- a/src/MauiSherpa.Core/Services/CloudSecretsService.cs
+++ b/src/MauiSherpa.Core/Services/CloudSecretsService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Text.Json;
 using MauiSherpa.Core.Interfaces;
 
@@ -7,7 +8,7 @@ namespace MauiSherpa.Core.Services;
 /// Service for managing cloud secrets storage providers and operations.
 /// Stores provider configurations in secure storage, with metadata in JSON.
 /// </summary>
-public class CloudSecretsService : ICloudSecretsService
+public class CloudSecretsService : ICloudSecretsService, ISecretsProviderRegistry
 {
     private readonly ISecureStorageService _secureStorage;
     private readonly IFileSystemService _fileSystem;
@@ -17,10 +18,16 @@ public class CloudSecretsService : ICloudSecretsService
     private readonly ILocalVaultAccessService? _localVaultAccess;
     private readonly ILocalVaultIntroductionService? _localVaultIntroduction;
     private readonly string _settingsPath;
+    private readonly object _metadataLock = new();
+    private readonly SemaphoreSlim _metadataLoadGate = new(1, 1);
+    private readonly SemaphoreSlim _metadataPersistGate = new(1, 1);
     
     private List<CloudSecretsProviderMetadata> _providerMetadata = new();
+    private volatile bool _metadataLoaded;
     private string? _activeProviderId;
     private ICloudSecretsProvider? _activeProviderInstance;
+    private readonly ConcurrentDictionary<string, ICloudSecretsProvider> _providerInstances =
+        new(StringComparer.Ordinal);
     
     // Internal record for storing non-sensitive data in JSON
     private record CloudSecretsProviderMetadata(
@@ -28,7 +35,8 @@ public class CloudSecretsService : ICloudSecretsService
         string Name,
         CloudSecretsProviderType ProviderType,
         // Only store non-secret setting keys here; secrets go in secure storage
-        List<string> NonSecretSettingKeys
+        List<string> NonSecretSettingKeys,
+        List<SecretItemKind>? DefaultItemKinds = null
     );
 
     private const string SecureKeyPrefix = "cloud_secrets_provider_";
@@ -62,6 +70,7 @@ public class CloudSecretsService : ICloudSecretsService
     public CloudSecretsProviderConfig? ActiveProvider { get; private set; }
 
     public event Action? OnActiveProviderChanged;
+    public event Action? ProvidersChanged;
 
     #region Provider Management
 
@@ -69,13 +78,17 @@ public class CloudSecretsService : ICloudSecretsService
     {
         await LoadMetadataAsync();
 
-        var metadata = _providerMetadata;
-        if (_providerMetadata.All(p => p.Id != DefaultLocalProviderId))
+        List<CloudSecretsProviderMetadata> metadata;
+        lock (_metadataLock)
+            metadata = _providerMetadata.ToList();
+
+        if (metadata.All(p => p.Id != DefaultLocalProviderId))
         {
             if (CanUseLocalVault())
             {
                 await EnsureDefaultLocalProviderMetadataAsync();
-                metadata = _providerMetadata;
+                lock (_metadataLock)
+                    metadata = _providerMetadata.ToList();
             }
             else
             {
@@ -83,14 +96,15 @@ public class CloudSecretsService : ICloudSecretsService
                 {
                     CreateDefaultLocalProviderMetadata()
                 };
-                withDefaultLocal.AddRange(_providerMetadata);
+                withDefaultLocal.AddRange(metadata);
                 metadata = withDefaultLocal;
             }
         }
         else if (CanUseLocalVault())
         {
             await EnsureDefaultLocalProviderMetadataAsync();
-            metadata = _providerMetadata;
+            lock (_metadataLock)
+                metadata = _providerMetadata.ToList();
         }
 
         var result = new List<CloudSecretsProviderConfig>();
@@ -131,14 +145,18 @@ public class CloudSecretsService : ICloudSecretsService
             provider.Id,
             provider.Name,
             provider.ProviderType,
-            nonSecretKeys
+            nonSecretKeys,
+            provider.EffectiveDefaultItemKinds.ToList()
         );
 
-        var existing = _providerMetadata.FindIndex(m => m.Id == provider.Id);
-        if (existing >= 0)
-            _providerMetadata[existing] = metadata;
-        else
-            _providerMetadata.Add(metadata);
+        lock (_metadataLock)
+        {
+            var existing = _providerMetadata.FindIndex(m => m.Id == provider.Id);
+            if (existing >= 0)
+                _providerMetadata[existing] = metadata;
+            else
+                _providerMetadata.Add(metadata);
+        }
 
         await PersistMetadataAsync();
         
@@ -149,6 +167,7 @@ public class CloudSecretsService : ICloudSecretsService
         await PersistNonSecretSettingsAsync(provider.Id, nonSecretSettings);
         
         _logger.LogInformation($"Saved cloud secrets provider: {provider.Name}");
+        _providerInstances.TryRemove(provider.Id, out _);
         
         // Update active provider if it's the one we just saved
         if (_activeProviderId == provider.Id)
@@ -157,6 +176,8 @@ public class CloudSecretsService : ICloudSecretsService
             _activeProviderInstance = null; // Force re-creation
             OnActiveProviderChanged?.Invoke();
         }
+
+        ProvidersChanged?.Invoke();
     }
 
     public async Task EnableDefaultLocalProviderAsync(bool setActiveProvider = true)
@@ -187,11 +208,14 @@ public class CloudSecretsService : ICloudSecretsService
         if (await _fileSystem.FileExistsAsync(nonSecretPath))
             await _fileSystem.DeleteFileAsync(nonSecretPath);
         if (CanUseLocalVault())
-            await _vaultStore.RemoveAsync(LocalVaultScopes.CloudProvider, ProviderSettingsVaultPath, GetProviderSettingsVaultKey(providerId));
+            await _vaultStore!.RemoveAsync(LocalVaultScopes.CloudProvider, ProviderSettingsVaultPath, GetProviderSettingsVaultKey(providerId));
 
-        var removed = _providerMetadata.RemoveAll(m => m.Id == providerId);
+        int removed;
+        lock (_metadataLock)
+            removed = _providerMetadata.RemoveAll(m => m.Id == providerId);
         if (removed > 0)
         {
+            _providerInstances.TryRemove(providerId, out _);
             await PersistMetadataAsync();
             _logger.LogInformation($"Deleted cloud secrets provider: {providerId}");
             
@@ -200,7 +224,30 @@ public class CloudSecretsService : ICloudSecretsService
             {
                 await SetActiveProviderAsync(null);
             }
+
+            ProvidersChanged?.Invoke();
         }
+    }
+
+    public async Task<CloudSecretsProviderConfig?> GetProviderConfigAsync(string providerId)
+    {
+        var providers = await GetProvidersAsync();
+        return providers.FirstOrDefault(provider =>
+            string.Equals(provider.Id, providerId, StringComparison.Ordinal));
+    }
+
+    public async Task<ICloudSecretsProvider?> GetProviderAsync(string providerId)
+    {
+        if (_providerInstances.TryGetValue(providerId, out var existing))
+            return existing;
+
+        var config = await GetProviderConfigAsync(providerId);
+        if (config is null)
+            return null;
+
+        return _providerInstances.GetOrAdd(
+            providerId,
+            _ => _providerFactory.CreateProvider(config));
     }
 
     public async Task<bool> TestProviderConnectionAsync(string providerId)
@@ -388,7 +435,7 @@ public class CloudSecretsService : ICloudSecretsService
         if (ActiveProvider == null)
             return null;
         
-        _activeProviderInstance = _providerFactory.CreateProvider(ActiveProvider);
+        _activeProviderInstance = await GetProviderAsync(ActiveProvider.Id);
         return _activeProviderInstance;
     }
 
@@ -423,7 +470,8 @@ public class CloudSecretsService : ICloudSecretsService
                 metadata.Id,
                 metadata.Name,
                 metadata.ProviderType,
-                settings
+                settings,
+                metadata.DefaultItemKinds ?? SecretItemKinds.All.ToList()
             );
         }
         catch (Exception ex)
@@ -435,43 +483,74 @@ public class CloudSecretsService : ICloudSecretsService
 
     private async Task LoadMetadataAsync()
     {
-        if (CanUseLocalVault())
-        {
-            try
-            {
-                var item = await _vaultStore.GetAsync(LocalVaultScopes.CloudProvider, "/", ProviderMetadataVaultKey);
-                if (item is not null)
-                {
-                    var json = System.Text.Encoding.UTF8.GetString(item.Value);
-                    _providerMetadata = JsonSerializer.Deserialize<List<CloudSecretsProviderMetadata>>(json) ?? new();
-                    return;
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning($"Failed to read cloud secrets metadata from local vault: {ex.Message}");
-            }
-        }
+        if (_metadataLoaded)
+            return;
 
+        await _metadataLoadGate.WaitAsync();
         try
         {
-            if (await _fileSystem.FileExistsAsync(_settingsPath))
+            if (_metadataLoaded)
+                return;
+
+            List<CloudSecretsProviderMetadata>? loaded = null;
+            Exception? vaultReadError = null;
+            if (CanUseLocalVault())
             {
-                var json = await _fileSystem.ReadFileAsync(_settingsPath);
-                if (!string.IsNullOrEmpty(json))
+                try
                 {
-                    _providerMetadata = JsonSerializer.Deserialize<List<CloudSecretsProviderMetadata>>(json) ?? new();
-                    if (CanUseLocalVault() && await TryPersistMetadataToVaultAsync(json))
-                        await _fileSystem.DeleteFileAsync(_settingsPath);
-                    return;
+                    var item = await _vaultStore!.GetAsync(
+                        LocalVaultScopes.CloudProvider,
+                        "/",
+                        ProviderMetadataVaultKey);
+                    if (item is not null)
+                    {
+                        var json = System.Text.Encoding.UTF8.GetString(item.Value);
+                        loaded = JsonSerializer.Deserialize<List<CloudSecretsProviderMetadata>>(json) ?? new();
+                    }
+                }
+                catch (Exception ex)
+                {
+                    vaultReadError = ex;
+                    _logger.LogWarning($"Failed to read cloud secrets metadata from local vault: {ex.Message}");
                 }
             }
+
+            if (loaded is null)
+            {
+                try
+                {
+                    if (await _fileSystem.FileExistsAsync(_settingsPath))
+                    {
+                        var json = await _fileSystem.ReadFileAsync(_settingsPath);
+                        if (!string.IsNullOrEmpty(json))
+                        {
+                            loaded = JsonSerializer.Deserialize<List<CloudSecretsProviderMetadata>>(json) ?? new();
+                            if (CanUseLocalVault() && await TryPersistMetadataToVaultAsync(json))
+                                await _fileSystem.DeleteFileAsync(_settingsPath);
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning($"Failed to load cloud secrets metadata: {ex.Message}");
+                }
+            }
+
+            if (loaded is null && vaultReadError is not null)
+            {
+                throw new LocalVaultUnavailableException(
+                    "Cloud provider metadata could not be read from Local Vault. Unlock or repair Local Vault before changing providers.",
+                    vaultReadError);
+            }
+
+            lock (_metadataLock)
+                _providerMetadata = loaded ?? new();
+            _metadataLoaded = true;
         }
-        catch (Exception ex)
+        finally
         {
-            _logger.LogWarning($"Failed to load cloud secrets metadata: {ex.Message}");
+            _metadataLoadGate.Release();
         }
-        _providerMetadata = new();
     }
 
     private async Task EnsureDefaultLocalProviderAsync()
@@ -482,11 +561,21 @@ public class CloudSecretsService : ICloudSecretsService
 
     private async Task EnsureDefaultLocalProviderMetadataAsync()
     {
-        if (_providerMetadata.Any(p => p.Id == DefaultLocalProviderId))
+        var added = false;
+        lock (_metadataLock)
+        {
+            if (_providerMetadata.All(p => p.Id != DefaultLocalProviderId))
+            {
+                _providerMetadata.Insert(0, CreateDefaultLocalProviderMetadata());
+                added = true;
+            }
+        }
+
+        if (!added)
             return;
 
-        _providerMetadata.Insert(0, CreateDefaultLocalProviderMetadata());
         await PersistMetadataAsync();
+        ProvidersChanged?.Invoke();
     }
 
     private static CloudSecretsProviderMetadata CreateDefaultLocalProviderMetadata() =>
@@ -494,33 +583,46 @@ public class CloudSecretsService : ICloudSecretsService
             DefaultLocalProviderId,
             "Local",
             CloudSecretsProviderType.Local,
-            new List<string>());
+            new List<string>(),
+            SecretItemKinds.All.ToList());
 
     private async Task PersistMetadataAsync()
     {
-        var json = JsonSerializer.Serialize(_providerMetadata, new JsonSerializerOptions
-        {
-            WriteIndented = true
-        });
-
-        if (CanUseLocalVault() && await TryPersistMetadataToVaultAsync(json))
-        {
-            if (await _fileSystem.FileExistsAsync(_settingsPath))
-                await _fileSystem.DeleteFileAsync(_settingsPath);
-            return;
-        }
-
+        await _metadataPersistGate.WaitAsync();
         try
         {
-            var directory = Path.GetDirectoryName(_settingsPath);
-            if (!string.IsNullOrEmpty(directory))
-                await _fileSystem.CreateDirectoryAsync(directory);
+            List<CloudSecretsProviderMetadata> snapshot;
+            lock (_metadataLock)
+                snapshot = _providerMetadata.ToList();
 
-            await _fileSystem.WriteFileAsync(_settingsPath, json);
+            var json = JsonSerializer.Serialize(snapshot, new JsonSerializerOptions
+            {
+                WriteIndented = true
+            });
+
+            if (CanUseLocalVault() && await TryPersistMetadataToVaultAsync(json))
+            {
+                if (await _fileSystem.FileExistsAsync(_settingsPath))
+                    await _fileSystem.DeleteFileAsync(_settingsPath);
+                return;
+            }
+
+            try
+            {
+                var directory = Path.GetDirectoryName(_settingsPath);
+                if (!string.IsNullOrEmpty(directory))
+                    await _fileSystem.CreateDirectoryAsync(directory);
+
+                await _fileSystem.WriteFileAsync(_settingsPath, json);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Failed to persist cloud secrets metadata: {ex.Message}", ex);
+            }
         }
-        catch (Exception ex)
+        finally
         {
-            _logger.LogError($"Failed to persist cloud secrets metadata: {ex.Message}", ex);
+            _metadataPersistGate.Release();
         }
     }
 
@@ -552,7 +654,7 @@ public class CloudSecretsService : ICloudSecretsService
         {
             try
             {
-                var item = await _vaultStore.GetAsync(
+                var item = await _vaultStore!.GetAsync(
                     LocalVaultScopes.CloudProvider,
                     ProviderSettingsVaultPath,
                     GetProviderSettingsVaultKey(providerId));

--- a/src/MauiSherpa.Core/Services/GoogleIdentityStateService.cs
+++ b/src/MauiSherpa.Core/Services/GoogleIdentityStateService.cs
@@ -4,14 +4,28 @@ namespace MauiSherpa.Core.Services;
 
 public class GoogleIdentityStateService : IGoogleIdentityStateService
 {
+    private readonly IIdentitySelectionStore? _selectionStore;
     private GoogleIdentity? _selectedIdentity;
 
+    public GoogleIdentityStateService(IIdentitySelectionStore? selectionStore = null)
+    {
+        _selectionStore = selectionStore;
+        LastSelectedIdentityId = selectionStore?.GetLastGoogleIdentityId();
+    }
+
     public GoogleIdentity? SelectedIdentity => _selectedIdentity;
+    public string? LastSelectedIdentityId { get; private set; }
 
     public event Action? OnSelectionChanged;
 
     public void SetSelectedIdentity(GoogleIdentity? identity)
     {
+        if (identity is not null && !string.Equals(LastSelectedIdentityId, identity.Id, StringComparison.Ordinal))
+        {
+            LastSelectedIdentityId = identity.Id;
+            _selectionStore?.SetLastGoogleIdentityId(identity.Id);
+        }
+
         if (_selectedIdentity != identity)
         {
             _selectedIdentity = identity;

--- a/src/MauiSherpa.Core/Services/GoogleSecretManagerProvider.cs
+++ b/src/MauiSherpa.Core/Services/GoogleSecretManagerProvider.cs
@@ -170,12 +170,12 @@ public class GoogleSecretManagerProvider : ICloudSecretsProvider
         catch (Grpc.Core.RpcException ex)
         {
             _logger.LogError($"Google Secret Manager get secret failed: {ex.StatusCode} - {ex.Message}", ex);
-            return null;
+            throw;
         }
         catch (Exception ex)
         {
             _logger.LogError($"Google Secret Manager get secret error: {ex.Message}", ex);
-            return null;
+            throw;
         }
     }
 
@@ -267,7 +267,7 @@ public class GoogleSecretManagerProvider : ICloudSecretsProvider
         catch (Exception ex)
         {
             _logger.LogError($"Google Secret Manager secret exists check error: {ex.Message}", ex);
-            return false;
+            throw;
         }
     }
 

--- a/src/MauiSherpa.Core/Services/InfisicalProvider.cs
+++ b/src/MauiSherpa.Core/Services/InfisicalProvider.cs
@@ -167,7 +167,7 @@ public class InfisicalProvider : ICloudSecretsProvider
         {
             var client = await GetClientAsync(cancellationToken);
             if (client == null)
-                return null;
+                throw new InvalidOperationException("Infisical client is unavailable.");
 
             var secretName = SanitizeSecretName(key);
             
@@ -194,12 +194,12 @@ public class InfisicalProvider : ICloudSecretsProvider
         catch (FormatException ex)
         {
             _logger.LogError($"Infisical secret not base64 encoded: {key} - {ex.Message}");
-            return null;
+            throw;
         }
         catch (Exception ex)
         {
             _logger.LogError($"Infisical get secret error: {ex.Message}", ex);
-            return null;
+            throw;
         }
     }
 
@@ -313,7 +313,7 @@ public class InfisicalProvider : ICloudSecretsProvider
         catch (Exception ex)
         {
             _logger.LogError($"Infisical secret exists check error: {ex.Message}", ex);
-            return false;
+            throw;
         }
     }
 
@@ -389,7 +389,7 @@ public class InfisicalProvider : ICloudSecretsProvider
         catch (Exception ex)
         {
             _logger.LogError($"Infisical list secrets error: {ex.Message}", ex);
-            return Array.Empty<string>();
+            throw;
         }
     }
 

--- a/src/MauiSherpa.Core/Services/LocalSqlCipherSecretsProvider.cs
+++ b/src/MauiSherpa.Core/Services/LocalSqlCipherSecretsProvider.cs
@@ -114,7 +114,7 @@ public class LocalSqlCipherSecretsProvider : ICloudSecretsProvider
         catch (Exception ex)
         {
             _logger.LogError($"Local secrets provider get error: {ex.Message}", ex);
-            return null;
+            throw;
         }
     }
 
@@ -209,7 +209,7 @@ public class LocalSqlCipherSecretsProvider : ICloudSecretsProvider
         catch (Exception ex)
         {
             _logger.LogError($"Local secrets provider exists check error: {ex.Message}", ex);
-            return false;
+            throw;
         }
     }
 

--- a/src/MauiSherpa.Core/Services/LocalVaultItem.cs
+++ b/src/MauiSherpa.Core/Services/LocalVaultItem.cs
@@ -41,6 +41,8 @@ public static class LocalVaultScopes
     public const string SecureStorage = "secure";
     public const string CloudProvider = "cloud-provider";
     public const string Migration = "migration";
+    public const string BackgroundTask = "background-task";
+    public const string SecretSync = "secret-sync";
 }
 
 public static class LocalVaultNames

--- a/src/MauiSherpa.Core/Services/ManagedSecretItemAdapter.cs
+++ b/src/MauiSherpa.Core/Services/ManagedSecretItemAdapter.cs
@@ -1,0 +1,307 @@
+using System.Text;
+using System.Text.Json;
+using MauiSherpa.Core.Interfaces;
+
+namespace MauiSherpa.Core.Services;
+
+public sealed class ManagedSecretItemAdapter : ISecretItemAdapter
+{
+    public const string FolderItemIdPrefix = "$folder$:";
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+    private readonly ISecretsProviderRegistry _providerRegistry;
+
+    public ManagedSecretItemAdapter(ISecretsProviderRegistry providerRegistry)
+    {
+        _providerRegistry = providerRegistry;
+    }
+
+    public SecretItemKind Kind => SecretItemKind.ManagedSecret;
+    public bool IsProviderOwned => true;
+
+    public Task<IReadOnlyList<SecretItemRef>> ListLocalItemsAsync(
+        CancellationToken cancellationToken = default) =>
+        Task.FromResult<IReadOnlyList<SecretItemRef>>(Array.Empty<SecretItemRef>());
+
+    public async Task<IReadOnlyList<SecretItemRef>> ListProviderItemsAsync(
+        string providerId,
+        CancellationToken cancellationToken = default)
+    {
+        var provider = await SecretItemAdapterHelper.GetProviderAsync(_providerRegistry, providerId);
+        if (provider is null)
+            return Array.Empty<SecretItemRef>();
+
+        var items = new Dictionary<string, SecretItemRef>(StringComparer.Ordinal);
+        var valueKeys = await provider.ListSecretsAsync(
+            IManagedSecretsService.SecretPrefix,
+            cancellationToken);
+        foreach (var key in valueKeys)
+        {
+            if (SecretItemAdapterHelper.KeyMatchesPrefix(key, IManagedSecretsService.MetadataPrefix) ||
+                !SecretItemAdapterHelper.TryGetRelativeKey(
+                    key,
+                    IManagedSecretsService.SecretPrefix,
+                    out var itemId) ||
+                itemId.EndsWith(ManagedSecretsService.FolderPlaceholderKey, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            items[itemId] = CreateItem(itemId);
+        }
+
+        var metadataKeys = await provider.ListSecretsAsync(
+            IManagedSecretsService.MetadataPrefix,
+            cancellationToken);
+        foreach (var key in metadataKeys)
+        {
+            var metadataBytes = await provider.GetSecretAsync(key, cancellationToken);
+            var metadata = DeserializeMetadata(metadataBytes);
+            if (metadata is not null)
+            {
+                items[metadata.Key] = CreateItem(metadata.Key);
+            }
+            else if (SecretItemAdapterHelper.TryGetRelativeKey(
+                key,
+                IManagedSecretsService.MetadataPrefix,
+                out var itemId))
+            {
+                items.TryAdd(itemId, CreateItem(itemId));
+            }
+        }
+
+        return items.Values
+            .OrderBy(x => x.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    public async Task<IReadOnlySet<string>> ListProviderItemIdsAsync(
+        string providerId,
+        CancellationToken cancellationToken = default)
+    {
+        var itemIds = new HashSet<string>(StringComparer.Ordinal);
+        var provider = await SecretItemAdapterHelper.GetProviderAsync(_providerRegistry, providerId);
+        if (provider is null)
+            return itemIds;
+
+        // Providers currently enumerate their complete key collection before applying a prefix,
+        // so take one snapshot and partition all managed-secret key families in memory.
+        var keys = await provider.ListSecretsAsync(
+            prefix: null,
+            cancellationToken: cancellationToken);
+        return ExtractProviderItemIds(keys);
+    }
+
+    public IReadOnlySet<string> ExtractProviderItemIds(IReadOnlyList<string> providerKeys)
+    {
+        var itemIds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var key in providerKeys)
+        {
+            if (SecretItemAdapterHelper.TryGetRelativeKey(
+                    key,
+                    IManagedSecretsService.FolderPrefix,
+                    out var folderPath))
+            {
+                itemIds.Add(CreateFolderItem(folderPath).Id);
+            }
+            else if (SecretItemAdapterHelper.TryGetRelativeKey(
+                    key,
+                    IManagedSecretsService.MetadataPrefix,
+                    out var metadataItemId) &&
+                !IsFolderPlaceholderItemId(metadataItemId))
+            {
+                itemIds.Add(metadataItemId);
+            }
+            else if (SecretItemAdapterHelper.TryGetRelativeKey(
+                    key,
+                    IManagedSecretsService.SecretPrefix,
+                    out var itemId) &&
+                !IsFolderPlaceholderItemId(itemId))
+            {
+                itemIds.Add(itemId);
+            }
+        }
+
+        return itemIds;
+    }
+
+    public Task<SecretItemPayload?> ReadLocalAsync(
+        SecretItemRef item,
+        CancellationToken cancellationToken = default) =>
+        Task.FromResult<SecretItemPayload?>(null);
+
+    public async Task<SecretItemPayload?> ReadProviderAsync(
+        SecretItemRef item,
+        string providerId,
+        CancellationToken cancellationToken = default)
+    {
+        if (item.Kind != Kind)
+            return null;
+
+        var provider = await SecretItemAdapterHelper.GetProviderAsync(_providerRegistry, providerId);
+        if (provider is null)
+            return null;
+
+        if (TryGetFolderPath(item.Id, out var folderPath))
+        {
+            var folderMetadata = await SecretItemAdapterHelper.ReadArtifactAsync(
+                provider,
+                GetFolderMetadataKey(folderPath),
+                cancellationToken);
+            if (folderMetadata is null)
+                return null;
+
+            var artifacts = new List<SecretArtifact> { folderMetadata };
+            var placeholder = await SecretItemAdapterHelper.ReadArtifactAsync(
+                provider,
+                GetFolderPlaceholderKey(folderPath),
+                cancellationToken);
+            if (placeholder is not null)
+                artifacts.Add(placeholder);
+
+            return SecretItemAdapterHelper.CreatePayload(item, 0, artifacts);
+        }
+
+        var valueKey = IManagedSecretsService.SecretPrefix + item.Id;
+        var valueArtifact = await SecretItemAdapterHelper.ReadArtifactAsync(
+            provider,
+            valueKey,
+            cancellationToken);
+        if (valueArtifact is null)
+            return null;
+
+        var metadataKey = IManagedSecretsService.MetadataPrefix + item.Id;
+        var metadataArtifact = await SecretItemAdapterHelper.ReadArtifactAsync(
+            provider,
+            metadataKey,
+            cancellationToken);
+        var metadata = DeserializeMetadata(metadataArtifact?.Value);
+        metadata ??= new ManagedSecret(
+            item.Id,
+            ManagedSecretType.String,
+            null,
+            null,
+            DateTime.UnixEpoch,
+            DateTime.UnixEpoch);
+        metadataArtifact ??= new SecretArtifact(
+            metadataKey,
+            Encoding.UTF8.GetBytes(JsonSerializer.Serialize(metadata, JsonOptions)));
+
+        return SecretItemAdapterHelper.CreatePayload(
+            new SecretItemRef(Kind, metadata.Key, GetDisplayName(metadata.Key)),
+            SecretItemAdapterHelper.GetUtcRevision(metadata.UpdatedAt),
+            new[] { valueArtifact, metadataArtifact });
+    }
+
+    public async Task<bool> WriteProviderAsync(
+        SecretItemPayload payload,
+        string providerId,
+        CancellationToken cancellationToken = default)
+    {
+        if (payload.Item.Kind != Kind)
+            return false;
+
+        var provider = await SecretItemAdapterHelper.GetProviderAsync(_providerRegistry, providerId);
+        return provider is not null &&
+            await SecretItemAdapterHelper.WriteArtifactsAsync(
+                provider,
+                payload.Artifacts,
+                cancellationToken);
+    }
+
+    public async Task<bool> DeleteProviderAsync(
+        SecretItemRef item,
+        string providerId,
+        CancellationToken cancellationToken = default)
+    {
+        if (item.Kind != Kind)
+            return false;
+
+        var provider = await SecretItemAdapterHelper.GetProviderAsync(_providerRegistry, providerId);
+        if (provider is null)
+            return false;
+
+        if (TryGetFolderPath(item.Id, out var folderPath))
+        {
+            return await SecretItemAdapterHelper.DeleteArtifactsAsync(
+                provider,
+                new[]
+                {
+                    GetFolderMetadataKey(folderPath),
+                    GetFolderPlaceholderKey(folderPath)
+                },
+                cancellationToken);
+        }
+
+        return provider is not null &&
+            await SecretItemAdapterHelper.DeleteArtifactsAsync(
+                provider,
+                new[]
+                {
+                    IManagedSecretsService.SecretPrefix + item.Id,
+                    IManagedSecretsService.MetadataPrefix + item.Id
+                },
+                cancellationToken);
+    }
+
+    public static SecretItemRef CreateFolderItem(string folderPath)
+    {
+        var normalized = SecretPath.NormalizeFolderPath(folderPath);
+        return new SecretItemRef(
+            SecretItemKind.ManagedSecret,
+            FolderItemIdPrefix + normalized,
+            normalized);
+    }
+
+    private static bool TryGetFolderPath(string itemId, out string folderPath)
+    {
+        folderPath = "/";
+        if (!itemId.StartsWith(FolderItemIdPrefix, StringComparison.Ordinal))
+            return false;
+
+        folderPath = SecretPath.NormalizeFolderPath(itemId[FolderItemIdPrefix.Length..]);
+        return folderPath != "/";
+    }
+
+    private static string GetFolderMetadataKey(string folderPath) =>
+        IManagedSecretsService.FolderPrefix +
+        SecretPath.NormalizeFolderPath(folderPath).TrimStart('/');
+
+    private static string GetFolderPlaceholderKey(string folderPath) =>
+        IManagedSecretsService.SecretPrefix +
+        new SecretPath(folderPath, ManagedSecretsService.FolderPlaceholderKey).ToFlatKey();
+
+    private static bool IsFolderPlaceholderItemId(string itemId) =>
+        (itemId.Length == ManagedSecretsService.FolderPlaceholderKey.Length &&
+            SecretItemAdapterHelper.KeyMatchesPrefix(
+                itemId,
+                ManagedSecretsService.FolderPlaceholderKey)) ||
+        SecretItemAdapterHelper.TryExtractAffixedId(
+            itemId,
+            string.Empty,
+            "/" + ManagedSecretsService.FolderPlaceholderKey,
+            out _);
+
+    private static SecretItemRef CreateItem(string itemId) =>
+        new(SecretItemKind.ManagedSecret, itemId, GetDisplayName(itemId));
+
+    private static string GetDisplayName(string key)
+    {
+        var separator = key.LastIndexOf('/');
+        return separator >= 0 ? key[(separator + 1)..] : key;
+    }
+
+    private static ManagedSecret? DeserializeMetadata(byte[]? bytes)
+    {
+        if (bytes is null)
+            return null;
+
+        try
+        {
+            return JsonSerializer.Deserialize<ManagedSecret>(bytes, JsonOptions);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/MauiSherpa.Core/Services/ManagedSecretsService.cs
+++ b/src/MauiSherpa.Core/Services/ManagedSecretsService.cs
@@ -10,6 +10,7 @@ public class ManagedSecretsService : IManagedSecretsService
 
     readonly ICloudSecretsService _cloudService;
     readonly ILoggingService _logger;
+    readonly ISecretsProviderRegistry? _providerRegistry;
     static readonly byte[] FolderPlaceholderValue = Encoding.UTF8.GetBytes("""{"kind":"maui-sherpa-folder"}""");
 
     static readonly JsonSerializerOptions JsonOptions = new()
@@ -18,67 +19,75 @@ public class ManagedSecretsService : IManagedSecretsService
         WriteIndented = false
     };
 
-    public ManagedSecretsService(ICloudSecretsService cloudService, ILoggingService logger)
+    public ManagedSecretsService(
+        ICloudSecretsService cloudService,
+        ILoggingService logger,
+        ISecretsProviderRegistry? providerRegistry = null)
     {
         _cloudService = cloudService;
         _logger = logger;
+        _providerRegistry = providerRegistry;
     }
 
     public async Task<IReadOnlyList<ManagedSecret>> ListAsync(CancellationToken cancellationToken = default)
     {
-        if (_cloudService.ActiveProvider is null)
-            return Array.Empty<ManagedSecret>();
-
-        // List metadata keys as the source of truth (value keys may be sanitized by provider)
-        var metaKeys = await _cloudService.ListSecretsAsync(IManagedSecretsService.MetadataPrefix, cancellationToken);
-        var secrets = new List<ManagedSecret>();
-
-        foreach (var fullMetaKey in metaKeys)
+        var secrets = new Dictionary<string, ManagedSecret>(StringComparer.Ordinal);
+        foreach (var provider in await GetReadProvidersAsync(cancellationToken))
         {
             try
             {
-                var metaBytes = await _cloudService.GetSecretAsync(fullMetaKey, cancellationToken);
-                if (metaBytes is null)
-                    continue;
+                // Metadata keys are the source of truth because providers may sanitize value keys.
+                var metaKeys = await provider.ListSecretsAsync(
+                    IManagedSecretsService.MetadataPrefix,
+                    cancellationToken);
+                foreach (var fullMetaKey in metaKeys)
+                {
+                    var metaBytes = await provider.GetSecretAsync(fullMetaKey, cancellationToken);
+                    if (metaBytes is null)
+                        continue;
 
-                var json = System.Text.Encoding.UTF8.GetString(metaBytes);
-                var meta = JsonSerializer.Deserialize<ManagedSecret>(json, JsonOptions);
-                if (meta is not null)
-                    secrets.Add(meta);
+                    var json = Encoding.UTF8.GetString(metaBytes);
+                    var meta = JsonSerializer.Deserialize<ManagedSecret>(json, JsonOptions);
+                    if (meta is not null)
+                        secrets.TryAdd(meta.Key, meta);
+                }
             }
             catch (Exception ex)
             {
-                _logger.LogWarning($"Failed to load metadata for '{fullMetaKey}': {ex.Message}");
+                _logger.LogWarning($"Failed to enumerate managed secrets from {provider.DisplayName}: {ex.Message}");
             }
         }
 
-        return secrets;
+        return secrets.Values
+            .OrderBy(secret => secret.Key, StringComparer.OrdinalIgnoreCase)
+            .ToList();
     }
 
     public async Task<IReadOnlyList<ManagedSecretFolder>> ListFoldersAsync(CancellationToken cancellationToken = default)
     {
-        if (_cloudService.ActiveProvider is null)
-            return Array.Empty<ManagedSecretFolder>();
-
-        var folderKeys = await _cloudService.ListSecretsAsync(IManagedSecretsService.FolderPrefix, cancellationToken);
         var folders = new List<ManagedSecretFolder>();
-
-        foreach (var fullFolderKey in folderKeys)
+        foreach (var provider in await GetReadProvidersAsync(cancellationToken))
         {
             try
             {
-                var folderBytes = await _cloudService.GetSecretAsync(fullFolderKey, cancellationToken);
-                if (folderBytes is null)
-                    continue;
+                var folderKeys = await provider.ListSecretsAsync(
+                    IManagedSecretsService.FolderPrefix,
+                    cancellationToken);
+                foreach (var fullFolderKey in folderKeys)
+                {
+                    var folderBytes = await provider.GetSecretAsync(fullFolderKey, cancellationToken);
+                    if (folderBytes is null)
+                        continue;
 
-                var json = System.Text.Encoding.UTF8.GetString(folderBytes);
-                var folder = JsonSerializer.Deserialize<ManagedSecretFolder>(json, JsonOptions);
-                if (folder is not null)
-                    folders.Add(folder);
+                    var json = Encoding.UTF8.GetString(folderBytes);
+                    var folder = JsonSerializer.Deserialize<ManagedSecretFolder>(json, JsonOptions);
+                    if (folder is not null)
+                        folders.Add(folder);
+                }
             }
             catch (Exception ex)
             {
-                _logger.LogWarning($"Failed to load folder metadata for '{fullFolderKey}': {ex.Message}");
+                _logger.LogWarning($"Failed to enumerate managed secret folders from {provider.DisplayName}: {ex.Message}");
             }
         }
 
@@ -164,6 +173,8 @@ public class ManagedSecretsService : IManagedSecretsService
             })
             .ToList();
 
+        var stagedSecretKeys = new List<string>();
+        var stagedFolderPaths = new List<string>();
         foreach (var (_, moved, value) in secretMoves)
         {
             var stored = await _cloudService.StoreSecretAsync(
@@ -171,16 +182,37 @@ public class ManagedSecretsService : IManagedSecretsService
                 value,
                 cancellationToken: cancellationToken);
             if (!stored)
+            {
+                await RollbackFolderRenameStagingAsync(
+                    stagedSecretKeys,
+                    stagedFolderPaths,
+                    cancellationToken);
                 return false;
+            }
 
-            await SaveMetadataAsync(moved, cancellationToken);
+            stagedSecretKeys.Add(moved.Key);
+            if (!await SaveMetadataAsync(moved, cancellationToken))
+            {
+                await RollbackFolderRenameStagingAsync(
+                    stagedSecretKeys,
+                    stagedFolderPaths,
+                    cancellationToken);
+                return false;
+            }
         }
 
         foreach (var (_, moved) in folderMoves)
         {
             var stored = await StoreFolderAsync(moved, cancellationToken);
             if (!stored)
+            {
+                await RollbackFolderRenameStagingAsync(
+                    stagedSecretKeys,
+                    stagedFolderPaths,
+                    cancellationToken);
                 return false;
+            }
+            stagedFolderPaths.Add(moved.Path);
         }
 
         foreach (var (existing, _, _) in secretMoves)
@@ -194,6 +226,32 @@ public class ManagedSecretsService : IManagedSecretsService
 
         _logger.LogInformation($"Renamed managed secrets folder: {oldPath} -> {normalizedNewPath}");
         return true;
+    }
+
+    async Task RollbackFolderRenameStagingAsync(
+        IEnumerable<string> secretKeys,
+        IEnumerable<string> folderPaths,
+        CancellationToken cancellationToken)
+    {
+        foreach (var key in secretKeys.Reverse())
+        {
+            await _cloudService.DeleteSecretAsync(
+                IManagedSecretsService.SecretPrefix + key,
+                cancellationToken);
+            await _cloudService.DeleteSecretAsync(
+                IManagedSecretsService.MetadataPrefix + key,
+                cancellationToken);
+        }
+
+        foreach (var path in folderPaths.Reverse())
+        {
+            await _cloudService.DeleteSecretAsync(
+                GetFolderMetadataKey(path),
+                cancellationToken);
+            await _cloudService.DeleteSecretAsync(
+                GetFolderPlaceholderKey(path),
+                cancellationToken);
+        }
     }
 
     public async Task<bool> DeleteFolderAsync(string folderPath, CancellationToken cancellationToken = default)
@@ -224,19 +282,27 @@ public class ManagedSecretsService : IManagedSecretsService
 
     public async Task<ManagedSecret?> GetAsync(string key, CancellationToken cancellationToken = default)
     {
-        if (_cloudService.ActiveProvider is null)
-            return null;
-
         return await LoadMetadataAsync(key, cancellationToken);
     }
 
     public async Task<byte[]?> GetValueAsync(string key, CancellationToken cancellationToken = default)
     {
-        if (_cloudService.ActiveProvider is null)
-            return null;
-
         var fullKey = IManagedSecretsService.SecretPrefix + key;
-        return await _cloudService.GetSecretAsync(fullKey, cancellationToken);
+        foreach (var provider in await GetReadProvidersAsync(cancellationToken))
+        {
+            try
+            {
+                var value = await provider.GetSecretAsync(fullKey, cancellationToken);
+                if (value is not null)
+                    return value;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning($"Failed to read managed secret '{key}' from {provider.DisplayName}: {ex.Message}");
+            }
+        }
+
+        return null;
     }
 
     public async Task<bool> CreateAsync(string key, byte[] value, ManagedSecretType type,
@@ -395,21 +461,25 @@ public class ManagedSecretsService : IManagedSecretsService
 
     async Task<ManagedSecret?> LoadMetadataAsync(string key, CancellationToken cancellationToken)
     {
-        try
+        foreach (var provider in await GetReadProvidersAsync(cancellationToken))
         {
-            var metaKey = IManagedSecretsService.MetadataPrefix + key;
-            var metaBytes = await _cloudService.GetSecretAsync(metaKey, cancellationToken);
-            if (metaBytes is null)
-                return null;
+            try
+            {
+                var metaKey = IManagedSecretsService.MetadataPrefix + key;
+                var metaBytes = await provider.GetSecretAsync(metaKey, cancellationToken);
+                if (metaBytes is null)
+                    continue;
 
-            var json = System.Text.Encoding.UTF8.GetString(metaBytes);
-            return JsonSerializer.Deserialize<ManagedSecret>(json, JsonOptions);
+                var json = Encoding.UTF8.GetString(metaBytes);
+                return JsonSerializer.Deserialize<ManagedSecret>(json, JsonOptions);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning($"Failed to load metadata for secret '{key}' from {provider.DisplayName}: {ex.Message}");
+            }
         }
-        catch (Exception ex)
-        {
-            _logger.LogWarning($"Failed to load metadata for secret '{key}': {ex.Message}");
-            return null;
-        }
+
+        return null;
     }
 
     async Task<bool> SaveMetadataAsync(ManagedSecret meta, CancellationToken cancellationToken)
@@ -446,6 +516,32 @@ public class ManagedSecretsService : IManagedSecretsService
         }
 
         return true;
+    }
+
+    async Task<IReadOnlyList<ICloudSecretsProvider>> GetReadProvidersAsync(
+        CancellationToken cancellationToken)
+    {
+        if (_providerRegistry is null)
+        {
+            if (_cloudService.ActiveProvider is null)
+                return Array.Empty<ICloudSecretsProvider>();
+
+            return [new ActiveCloudProviderAdapter(_cloudService)];
+        }
+
+        var providers = new List<ICloudSecretsProvider>();
+        var configs = await _providerRegistry.GetProvidersAsync();
+        foreach (var config in configs
+            .OrderBy(provider => provider.ProviderType == CloudSecretsProviderType.Local ? 0 : 1)
+            .ThenBy(provider => provider.Name, StringComparer.OrdinalIgnoreCase))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var provider = await _providerRegistry.GetProviderAsync(config.Id);
+            if (provider is not null)
+                providers.Add(provider);
+        }
+
+        return providers;
     }
 
     static string GetFolderMetadataKey(string folderPath) =>
@@ -487,5 +583,55 @@ public class ManagedSecretsService : IManagedSecretsService
         return SecretPath.NormalizeFolderPath(string.IsNullOrEmpty(relativePath)
             ? newFolderPath
             : newFolderPath + "/" + relativePath);
+    }
+
+    private sealed class ActiveCloudProviderAdapter : ICloudSecretsProvider
+    {
+        private readonly ICloudSecretsService _cloudService;
+
+        public ActiveCloudProviderAdapter(ICloudSecretsService cloudService)
+        {
+            _cloudService = cloudService;
+        }
+
+        public CloudSecretsProviderType ProviderType =>
+            _cloudService.ActiveProvider?.ProviderType ?? CloudSecretsProviderType.None;
+
+        public string DisplayName => _cloudService.ActiveProvider?.Name ?? "Active provider";
+
+        public Task<bool> TestConnectionAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(_cloudService.ActiveProvider is not null);
+
+        public Task<bool> StoreSecretAsync(
+            string key,
+            byte[] value,
+            Dictionary<string, string>? metadata = null,
+            CancellationToken cancellationToken = default) =>
+            _cloudService.StoreSecretAsync(key, value, metadata, cancellationToken);
+
+        public Task<byte[]?> GetSecretAsync(string key, CancellationToken cancellationToken = default) =>
+            _cloudService.GetSecretAsync(key, cancellationToken);
+
+        public Task<Dictionary<string, string>?> GetSecretMetadataAsync(
+            string key,
+            CancellationToken cancellationToken = default) =>
+            _cloudService.GetSecretMetadataAsync(key, cancellationToken);
+
+        public Task<bool> SetSecretMetadataAsync(
+            string key,
+            Dictionary<string, string> metadata,
+            CancellationToken cancellationToken = default) =>
+            _cloudService.SetSecretMetadataAsync(key, metadata, cancellationToken);
+
+        public Task<bool> DeleteSecretAsync(string key, CancellationToken cancellationToken = default) =>
+            _cloudService.DeleteSecretAsync(key, cancellationToken);
+
+        public Task<bool> SecretExistsAsync(string key, CancellationToken cancellationToken = default) =>
+            _cloudService.SecretExistsAsync(key, cancellationToken);
+
+        public Task<IReadOnlyList<string>> ListSecretsAsync(
+            string? prefix = null,
+            CancellationToken cancellationToken = default) =>
+            _cloudService.ListSecretsAsync(prefix, cancellationToken);
     }
 }

--- a/src/MauiSherpa.Core/Services/OnePasswordProvider.cs
+++ b/src/MauiSherpa.Core/Services/OnePasswordProvider.cs
@@ -133,12 +133,12 @@ public class OnePasswordProvider : ICloudSecretsProvider
         catch (FormatException ex)
         {
             _logger.LogError($"1Password secret not base64 encoded: {key} - {ex.Message}");
-            return null;
+            throw;
         }
         catch (Exception ex)
         {
             _logger.LogError($"1Password get secret error: {ex.Message}", ex);
-            return null;
+            throw;
         }
     }
 
@@ -233,7 +233,7 @@ public class OnePasswordProvider : ICloudSecretsProvider
         catch (Exception ex)
         {
             _logger.LogError($"1Password secret exists check error: {ex.Message}", ex);
-            return false;
+            throw;
         }
     }
 
@@ -389,7 +389,15 @@ public class OnePasswordProvider : ICloudSecretsProvider
             new[] { "item", "get", ItemTitle, "--vault", Vault, "--format", "json" }, cancellationToken);
 
         if (exitCode != 0)
-            return null;
+        {
+            if (output.Contains("not found", StringComparison.OrdinalIgnoreCase) ||
+                output.Contains("isn't an item", StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            throw new InvalidOperationException($"Failed to read 1Password item: {output}");
+        }
 
         if (string.IsNullOrWhiteSpace(output))
             return null;

--- a/src/MauiSherpa.Core/Services/ProvisioningProfileItemAdapter.cs
+++ b/src/MauiSherpa.Core/Services/ProvisioningProfileItemAdapter.cs
@@ -1,0 +1,245 @@
+using System.Text;
+using System.Text.Json;
+using MauiSherpa.Core.Interfaces;
+
+namespace MauiSherpa.Core.Services;
+
+public sealed class ProvisioningProfileItemAdapter : ISecretItemAdapter
+{
+    internal const string KeyPrefix = "sherpa-provisioning-profiles/";
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+    private readonly ISecretsProviderRegistry _providerRegistry;
+    private readonly IAppleConnectService _appleConnectService;
+
+    public ProvisioningProfileItemAdapter(
+        ISecretsProviderRegistry providerRegistry,
+        IAppleConnectService appleConnectService)
+    {
+        _providerRegistry = providerRegistry;
+        _appleConnectService = appleConnectService;
+    }
+
+    public SecretItemKind Kind => SecretItemKind.ProvisioningProfile;
+    public bool IsProviderOwned => false;
+
+    public async Task<IReadOnlyList<SecretItemRef>> ListLocalItemsAsync(
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var profiles = await _appleConnectService.GetProfilesAsync();
+        return profiles
+            .Where(x => !string.IsNullOrWhiteSpace(x.Id))
+            .GroupBy(x => x.Id, StringComparer.Ordinal)
+            .Select(x => new SecretItemRef(Kind, x.Key, x.First().Name))
+            .OrderBy(x => x.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    public async Task<IReadOnlyList<SecretItemRef>> ListProviderItemsAsync(
+        string providerId,
+        CancellationToken cancellationToken = default)
+    {
+        var provider = await SecretItemAdapterHelper.GetProviderAsync(_providerRegistry, providerId);
+        if (provider is null)
+            return Array.Empty<SecretItemRef>();
+
+        var items = new Dictionary<string, SecretItemRef>(StringComparer.Ordinal);
+        var keys = await provider.ListSecretsAsync(KeyPrefix, cancellationToken);
+        foreach (var key in keys)
+        {
+            if (TryExtractProfileId(key, "data", out var profileId))
+                items[profileId] = new SecretItemRef(Kind, profileId, profileId);
+        }
+
+        foreach (var key in keys)
+        {
+            if (!TryExtractProfileId(key, "meta", out var fallbackId))
+                continue;
+
+            var profile = DeserializeProfile(await provider.GetSecretAsync(key, cancellationToken));
+            var profileId = string.IsNullOrWhiteSpace(profile?.Id) ? fallbackId : profile.Id;
+            var displayName = string.IsNullOrWhiteSpace(profile?.Name) ? profileId : profile.Name;
+            items[profileId] = new SecretItemRef(Kind, profileId, displayName);
+        }
+
+        return items.Values
+            .OrderBy(x => x.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    public async Task<IReadOnlySet<string>> ListProviderItemIdsAsync(
+        string providerId,
+        CancellationToken cancellationToken = default)
+    {
+        var itemIds = new HashSet<string>(StringComparer.Ordinal);
+        var provider = await SecretItemAdapterHelper.GetProviderAsync(_providerRegistry, providerId);
+        if (provider is null)
+            return itemIds;
+
+        var keys = await provider.ListSecretsAsync(
+            prefix: null,
+            cancellationToken: cancellationToken);
+        return ExtractProviderItemIds(keys);
+    }
+
+    public IReadOnlySet<string> ExtractProviderItemIds(IReadOnlyList<string> providerKeys)
+    {
+        var itemIds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var key in providerKeys)
+        {
+            if (TryExtractProfileId(key, "data", out var profileId))
+                itemIds.Add(profileId);
+        }
+
+        return itemIds;
+    }
+
+    public async Task<SecretItemPayload?> ReadLocalAsync(
+        SecretItemRef item,
+        CancellationToken cancellationToken = default)
+    {
+        if (item.Kind != Kind)
+            return null;
+
+        cancellationToken.ThrowIfCancellationRequested();
+        var profiles = await _appleConnectService.GetProfilesAsync();
+        var profile = profiles.FirstOrDefault(x =>
+            string.Equals(x.Id, item.Id, StringComparison.Ordinal));
+        if (profile is null)
+            return null;
+
+        cancellationToken.ThrowIfCancellationRequested();
+        var data = await _appleConnectService.DownloadProfileAsync(profile.Id);
+        cancellationToken.ThrowIfCancellationRequested();
+        var artifacts = new[]
+        {
+            new SecretArtifact(GetDataKey(profile.Id), data),
+            new SecretArtifact(
+                GetMetadataKey(profile.Id),
+                Encoding.UTF8.GetBytes(JsonSerializer.Serialize(profile, JsonOptions)))
+        };
+
+        return SecretItemAdapterHelper.CreatePayload(
+            new SecretItemRef(Kind, profile.Id, profile.Name),
+            0,
+            artifacts);
+    }
+
+    public async Task<SecretItemPayload?> ReadProviderAsync(
+        SecretItemRef item,
+        string providerId,
+        CancellationToken cancellationToken = default)
+    {
+        if (item.Kind != Kind)
+            return null;
+
+        var provider = await SecretItemAdapterHelper.GetProviderAsync(_providerRegistry, providerId);
+        if (provider is null)
+            return null;
+
+        var dataArtifact = await SecretItemAdapterHelper.ReadArtifactAsync(
+            provider,
+            GetDataKey(item.Id),
+            cancellationToken);
+        if (dataArtifact is null)
+            return null;
+
+        var metadataKey = GetMetadataKey(item.Id);
+        var metadataArtifact = await SecretItemAdapterHelper.ReadArtifactAsync(
+            provider,
+            metadataKey,
+            cancellationToken);
+        var profile = DeserializeProfile(metadataArtifact?.Value);
+        if (metadataArtifact is null)
+        {
+            profile = new AppleProfile(
+                item.Id,
+                item.DisplayName,
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                DateTime.MinValue,
+                null,
+                string.Empty);
+            metadataArtifact = new SecretArtifact(
+                metadataKey,
+                Encoding.UTF8.GetBytes(JsonSerializer.Serialize(profile, JsonOptions)));
+        }
+
+        var profileId = string.IsNullOrWhiteSpace(profile?.Id) ? item.Id : profile.Id;
+        var displayName = string.IsNullOrWhiteSpace(profile?.Name)
+            ? item.DisplayName
+            : profile.Name;
+        return SecretItemAdapterHelper.CreatePayload(
+            new SecretItemRef(Kind, profileId, displayName),
+            0,
+            new[] { dataArtifact, metadataArtifact });
+    }
+
+    public async Task<bool> WriteProviderAsync(
+        SecretItemPayload payload,
+        string providerId,
+        CancellationToken cancellationToken = default)
+    {
+        if (payload.Item.Kind != Kind)
+            return false;
+
+        var provider = await SecretItemAdapterHelper.GetProviderAsync(_providerRegistry, providerId);
+        return provider is not null &&
+            await SecretItemAdapterHelper.WriteArtifactsAsync(
+                provider,
+                payload.Artifacts,
+                cancellationToken);
+    }
+
+    public async Task<bool> DeleteProviderAsync(
+        SecretItemRef item,
+        string providerId,
+        CancellationToken cancellationToken = default)
+    {
+        if (item.Kind != Kind)
+            return false;
+
+        var provider = await SecretItemAdapterHelper.GetProviderAsync(_providerRegistry, providerId);
+        return provider is not null &&
+            await SecretItemAdapterHelper.DeleteArtifactsAsync(
+                provider,
+                new[] { GetDataKey(item.Id), GetMetadataKey(item.Id) },
+                cancellationToken);
+    }
+
+    private static string GetDataKey(string profileId) =>
+        $"{KeyPrefix}{profileId}/data";
+
+    private static string GetMetadataKey(string profileId) =>
+        $"{KeyPrefix}{profileId}/meta";
+
+    private static bool TryExtractProfileId(string key, string artifactName, out string profileId)
+    {
+        profileId = string.Empty;
+        if (!SecretItemAdapterHelper.TryGetRelativeKey(key, KeyPrefix, out var relativeKey))
+            return false;
+
+        var suffix = "/" + artifactName;
+        return SecretItemAdapterHelper.TryExtractAffixedId(
+            relativeKey,
+            string.Empty,
+            suffix,
+            out profileId);
+    }
+
+    private static AppleProfile? DeserializeProfile(byte[]? bytes)
+    {
+        if (bytes is null)
+            return null;
+
+        try
+        {
+            return JsonSerializer.Deserialize<AppleProfile>(bytes, JsonOptions);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/MauiSherpa.Core/Services/PublishProfileItemAdapter.cs
+++ b/src/MauiSherpa.Core/Services/PublishProfileItemAdapter.cs
@@ -1,0 +1,159 @@
+using System.Text.Json;
+using MauiSherpa.Core.Interfaces;
+
+namespace MauiSherpa.Core.Services;
+
+public sealed class PublishProfileItemAdapter : ISecretItemAdapter
+{
+    internal const string KeyPrefix = "sherpa-publish-profiles/";
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+    private readonly ISecretsProviderRegistry _providerRegistry;
+
+    public PublishProfileItemAdapter(ISecretsProviderRegistry providerRegistry)
+    {
+        _providerRegistry = providerRegistry;
+    }
+
+    public SecretItemKind Kind => SecretItemKind.PublishProfile;
+    public bool IsProviderOwned => true;
+
+    public Task<IReadOnlyList<SecretItemRef>> ListLocalItemsAsync(
+        CancellationToken cancellationToken = default) =>
+        Task.FromResult<IReadOnlyList<SecretItemRef>>(Array.Empty<SecretItemRef>());
+
+    public async Task<IReadOnlyList<SecretItemRef>> ListProviderItemsAsync(
+        string providerId,
+        CancellationToken cancellationToken = default)
+    {
+        var provider = await SecretItemAdapterHelper.GetProviderAsync(_providerRegistry, providerId);
+        if (provider is null)
+            return Array.Empty<SecretItemRef>();
+
+        var items = new Dictionary<string, SecretItemRef>(StringComparer.Ordinal);
+        var keys = await provider.ListSecretsAsync(KeyPrefix, cancellationToken);
+        foreach (var key in keys)
+        {
+            if (!SecretItemAdapterHelper.TryGetRelativeKey(key, KeyPrefix, out var fallbackId))
+                continue;
+
+            var profile = DeserializeProfile(await provider.GetSecretAsync(key, cancellationToken));
+            var profileId = string.IsNullOrWhiteSpace(profile?.Id) ? fallbackId : profile.Id;
+            var displayName = string.IsNullOrWhiteSpace(profile?.Name) ? profileId : profile.Name;
+            items[profileId] = new SecretItemRef(Kind, profileId, displayName);
+        }
+
+        return items.Values
+            .OrderBy(x => x.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    public async Task<IReadOnlySet<string>> ListProviderItemIdsAsync(
+        string providerId,
+        CancellationToken cancellationToken = default)
+    {
+        var itemIds = new HashSet<string>(StringComparer.Ordinal);
+        var provider = await SecretItemAdapterHelper.GetProviderAsync(_providerRegistry, providerId);
+        if (provider is null)
+            return itemIds;
+
+        var keys = await provider.ListSecretsAsync(
+            prefix: null,
+            cancellationToken: cancellationToken);
+        return ExtractProviderItemIds(keys);
+    }
+
+    public IReadOnlySet<string> ExtractProviderItemIds(IReadOnlyList<string> providerKeys)
+    {
+        var itemIds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var key in providerKeys)
+        {
+            if (SecretItemAdapterHelper.TryGetRelativeKey(key, KeyPrefix, out var itemId))
+                itemIds.Add(itemId);
+        }
+
+        return itemIds;
+    }
+
+    public Task<SecretItemPayload?> ReadLocalAsync(
+        SecretItemRef item,
+        CancellationToken cancellationToken = default) =>
+        Task.FromResult<SecretItemPayload?>(null);
+
+    public async Task<SecretItemPayload?> ReadProviderAsync(
+        SecretItemRef item,
+        string providerId,
+        CancellationToken cancellationToken = default)
+    {
+        if (item.Kind != Kind)
+            return null;
+
+        var provider = await SecretItemAdapterHelper.GetProviderAsync(_providerRegistry, providerId);
+        if (provider is null)
+            return null;
+
+        var key = KeyPrefix + item.Id;
+        var artifact = await SecretItemAdapterHelper.ReadArtifactAsync(
+            provider,
+            key,
+            cancellationToken);
+        if (artifact is null)
+            return null;
+
+        var profile = DeserializeProfile(artifact.Value);
+        var profileId = string.IsNullOrWhiteSpace(profile?.Id) ? item.Id : profile.Id;
+        var displayName = string.IsNullOrWhiteSpace(profile?.Name)
+            ? item.DisplayName
+            : profile.Name;
+        return SecretItemAdapterHelper.CreatePayload(
+            new SecretItemRef(Kind, profileId, displayName),
+            SecretItemAdapterHelper.GetUtcRevision(profile?.UpdatedAt ?? default),
+            new[] { artifact });
+    }
+
+    public async Task<bool> WriteProviderAsync(
+        SecretItemPayload payload,
+        string providerId,
+        CancellationToken cancellationToken = default)
+    {
+        if (payload.Item.Kind != Kind)
+            return false;
+
+        var provider = await SecretItemAdapterHelper.GetProviderAsync(_providerRegistry, providerId);
+        return provider is not null &&
+            await SecretItemAdapterHelper.WriteArtifactsAsync(
+                provider,
+                payload.Artifacts,
+                cancellationToken);
+    }
+
+    public async Task<bool> DeleteProviderAsync(
+        SecretItemRef item,
+        string providerId,
+        CancellationToken cancellationToken = default)
+    {
+        if (item.Kind != Kind)
+            return false;
+
+        var provider = await SecretItemAdapterHelper.GetProviderAsync(_providerRegistry, providerId);
+        return provider is not null &&
+            await SecretItemAdapterHelper.DeleteArtifactsAsync(
+                provider,
+                new[] { KeyPrefix + item.Id },
+                cancellationToken);
+    }
+
+    private static PublishProfile? DeserializeProfile(byte[]? bytes)
+    {
+        if (bytes is null)
+            return null;
+
+        try
+        {
+            return JsonSerializer.Deserialize<PublishProfile>(bytes, JsonOptions);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/MauiSherpa.Core/Services/PublishProfileService.cs
+++ b/src/MauiSherpa.Core/Services/PublishProfileService.cs
@@ -18,6 +18,8 @@ public class PublishProfileService : IPublishProfileService
     readonly IAppleIdentityStateService _identityState;
     readonly IGoogleIdentityService _googleIdentity;
     readonly ILoggingService _logger;
+    readonly ISecretsProviderRegistry? _providerRegistry;
+    readonly ISecretSyncCoordinator? _syncCoordinator;
 
     static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -26,6 +28,9 @@ public class PublishProfileService : IPublishProfileService
     };
 
     List<PublishProfile>? _cache;
+    readonly object _cacheLock = new();
+    readonly SemaphoreSlim _cacheLoadGate = new(1, 1);
+    long _cacheGeneration;
 
     public event Action? OnProfilesChanged;
 
@@ -39,7 +44,9 @@ public class PublishProfileService : IPublishProfileService
         IAppleIdentityService appleIdentity,
         IAppleIdentityStateService identityState,
         IGoogleIdentityService googleIdentity,
-        ILoggingService logger)
+        ILoggingService logger,
+        ISecretsProviderRegistry? providerRegistry = null,
+        ISecretSyncCoordinator? syncCoordinator = null)
     {
         _cloudService = cloudService;
         _certSync = certSync;
@@ -51,39 +58,102 @@ public class PublishProfileService : IPublishProfileService
         _identityState = identityState;
         _googleIdentity = googleIdentity;
         _logger = logger;
+        _providerRegistry = providerRegistry;
+        _syncCoordinator = syncCoordinator;
+        if (_syncCoordinator is not null)
+            _syncCoordinator.ItemStateChanged += OnSyncItemStateChanged;
     }
 
     public async Task<IReadOnlyList<PublishProfile>> GetProfilesAsync()
     {
-        if (_cache is not null)
-            return _cache;
-
-        if (_cloudService.ActiveProvider is null)
-            return Array.Empty<PublishProfile>();
-
-        var keys = await _cloudService.ListSecretsAsync(CloudKeyPrefix);
-        var profiles = new List<PublishProfile>();
-
-        foreach (var key in keys)
+        lock (_cacheLock)
         {
-            try
-            {
-                var bytes = await _cloudService.GetSecretAsync(key);
-                if (bytes is null) continue;
-
-                var json = Encoding.UTF8.GetString(bytes);
-                var profile = JsonSerializer.Deserialize<PublishProfile>(json, JsonOptions);
-                if (profile is not null)
-                    profiles.Add(profile);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning($"Failed to load publish profile '{key}': {ex.Message}");
-            }
+            if (_cache is not null)
+                return _cache;
         }
 
-        _cache = profiles.OrderBy(p => p.Name).ToList();
-        return _cache;
+        await _cacheLoadGate.WaitAsync();
+        try
+        {
+            lock (_cacheLock)
+            {
+                if (_cache is not null)
+                    return _cache;
+            }
+
+            var generation = Interlocked.Read(ref _cacheGeneration);
+            var profiles = new Dictionary<string, PublishProfile>(StringComparer.Ordinal);
+            if (_providerRegistry is not null)
+            {
+                var providerConfigs = await _providerRegistry.GetProvidersAsync();
+                foreach (var config in providerConfigs
+                    .OrderBy(provider => provider.ProviderType == CloudSecretsProviderType.Local ? 0 : 1)
+                    .ThenBy(provider => provider.Name, StringComparer.OrdinalIgnoreCase))
+                {
+                    try
+                    {
+                        var provider = await _providerRegistry.GetProviderAsync(config.Id);
+                        if (provider is null)
+                            continue;
+
+                        var keys = await provider.ListSecretsAsync(CloudKeyPrefix);
+                        foreach (var key in keys)
+                        {
+                            var bytes = await provider.GetSecretAsync(key);
+                            if (bytes is null)
+                                continue;
+
+                            var profile = JsonSerializer.Deserialize<PublishProfile>(
+                                Encoding.UTF8.GetString(bytes),
+                                JsonOptions);
+                            if (profile is not null)
+                                profiles.TryAdd(profile.Id, profile);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning($"Failed to load publish profiles from '{config.Name}': {ex.Message}");
+                    }
+                }
+            }
+            else if (_cloudService.ActiveProvider is not null)
+            {
+                var keys = await _cloudService.ListSecretsAsync(CloudKeyPrefix);
+                foreach (var key in keys)
+                {
+                    try
+                    {
+                        var bytes = await _cloudService.GetSecretAsync(key);
+                        if (bytes is null)
+                            continue;
+
+                        var profile = JsonSerializer.Deserialize<PublishProfile>(
+                            Encoding.UTF8.GetString(bytes),
+                            JsonOptions);
+                        if (profile is not null)
+                            profiles.TryAdd(profile.Id, profile);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning($"Failed to load publish profile '{key}': {ex.Message}");
+                    }
+                }
+            }
+
+            var loaded = profiles.Values.OrderBy(p => p.Name).ToList();
+            lock (_cacheLock)
+            {
+                if (generation == Interlocked.Read(ref _cacheGeneration))
+                    _cache = loaded;
+                return _cache is not null
+                    ? _cache
+                    : Array.Empty<PublishProfile>();
+            }
+        }
+        finally
+        {
+            _cacheLoadGate.Release();
+        }
     }
 
     public async Task<PublishProfile?> GetProfileAsync(string id)
@@ -104,15 +174,17 @@ public class PublishProfileService : IPublishProfileService
         await _cloudService.StoreSecretAsync(key, bytes);
 
         // Update cache directly instead of invalidating — cloud list may lag
-        if (_cache is null)
-            _cache = new List<PublishProfile>();
-
-        var existing = _cache.FindIndex(p => p.Id == profile.Id);
-        if (existing >= 0)
-            _cache[existing] = profile;
-        else
-            _cache.Add(profile);
-        _cache = _cache.OrderBy(p => p.Name).ToList();
+        Interlocked.Increment(ref _cacheGeneration);
+        lock (_cacheLock)
+        {
+            _cache ??= [];
+            var existing = _cache.FindIndex(p => p.Id == profile.Id);
+            if (existing >= 0)
+                _cache[existing] = profile;
+            else
+                _cache.Add(profile);
+            _cache = _cache.OrderBy(p => p.Name).ToList();
+        }
 
         OnProfilesChanged?.Invoke();
     }
@@ -126,7 +198,20 @@ public class PublishProfileService : IPublishProfileService
         await _cloudService.DeleteSecretAsync(key);
 
         // Update cache directly instead of invalidating
-        _cache?.RemoveAll(p => p.Id == id);
+        Interlocked.Increment(ref _cacheGeneration);
+        lock (_cacheLock)
+            _cache?.RemoveAll(p => p.Id == id);
+        OnProfilesChanged?.Invoke();
+    }
+
+    void OnSyncItemStateChanged(SecretItemRef item)
+    {
+        if (item.Kind != SecretItemKind.PublishProfile)
+            return;
+
+        Interlocked.Increment(ref _cacheGeneration);
+        lock (_cacheLock)
+            _cache = null;
         OnProfilesChanged?.Invoke();
     }
 

--- a/src/MauiSherpa.Core/Services/SecretItemAdapterHelper.cs
+++ b/src/MauiSherpa.Core/Services/SecretItemAdapterHelper.cs
@@ -1,0 +1,267 @@
+using System.Security.Cryptography;
+using System.Text;
+using MauiSherpa.Core.Interfaces;
+
+namespace MauiSherpa.Core.Services;
+
+internal static class SecretItemAdapterHelper
+{
+    public static string ComputeContentHash(IEnumerable<SecretArtifact> artifacts)
+    {
+        using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+
+        foreach (var artifact in artifacts.OrderBy(x => x.Key, StringComparer.Ordinal))
+        {
+            hash.AppendData(Encoding.UTF8.GetBytes(artifact.Key));
+            hash.AppendData(artifact.Value);
+        }
+
+        return Convert.ToHexString(hash.GetHashAndReset()).ToLowerInvariant();
+    }
+
+    public static SecretItemPayload CreatePayload(
+        SecretItemRef item,
+        long revision,
+        IEnumerable<SecretArtifact> artifacts)
+    {
+        var artifactList = artifacts
+            .OrderBy(x => x.Key, StringComparer.Ordinal)
+            .ToList();
+        return new SecretItemPayload(item, revision, ComputeContentHash(artifactList), artifactList);
+    }
+
+    public static async Task<ICloudSecretsProvider?> GetProviderAsync(
+        ISecretsProviderRegistry registry,
+        string providerId)
+    {
+        if (string.IsNullOrWhiteSpace(providerId))
+            return null;
+
+        return await registry.GetProviderAsync(providerId);
+    }
+
+    public static async Task<SecretArtifact?> ReadArtifactAsync(
+        ICloudSecretsProvider provider,
+        string key,
+        CancellationToken cancellationToken)
+    {
+        var value = await provider.GetSecretAsync(key, cancellationToken);
+        if (value is null)
+            return null;
+
+        var metadata = await provider.GetSecretMetadataAsync(key, cancellationToken);
+        return new SecretArtifact(key, value, metadata);
+    }
+
+    public static async Task<bool> WriteArtifactsAsync(
+        ICloudSecretsProvider provider,
+        IReadOnlyList<SecretArtifact> artifacts,
+        CancellationToken cancellationToken)
+    {
+        var ordered = artifacts
+            .OrderBy(x => x.Key, StringComparer.Ordinal)
+            .ToList();
+        var snapshots = new Dictionary<string, ArtifactSnapshot>(StringComparer.Ordinal);
+
+        foreach (var artifact in ordered)
+        {
+            var exists = await provider.SecretExistsAsync(artifact.Key, cancellationToken);
+            var value = exists
+                ? await provider.GetSecretAsync(artifact.Key, cancellationToken)
+                : null;
+            var metadata = value is null
+                ? null
+                : await provider.GetSecretMetadataAsync(artifact.Key, cancellationToken);
+            snapshots[artifact.Key] = new ArtifactSnapshot(value, metadata);
+        }
+
+        var attemptedKeys = new List<string>();
+        foreach (var artifact in ordered)
+        {
+            attemptedKeys.Add(artifact.Key);
+            bool stored;
+            try
+            {
+                stored = await provider.StoreSecretAsync(
+                    artifact.Key,
+                    artifact.Value,
+                    artifact.Metadata,
+                    cancellationToken);
+            }
+            catch (Exception writeError)
+            {
+                var cleanupErrors = await RollbackAsync(
+                    provider,
+                    attemptedKeys,
+                    snapshots,
+                    CancellationToken.None);
+                if (cleanupErrors.Count > 0)
+                    throw new AggregateException(
+                        "Artifact write failed and rollback was incomplete.",
+                        new[] { writeError }.Concat(cleanupErrors));
+
+                throw;
+            }
+
+            if (stored)
+                continue;
+
+            var errors = await RollbackAsync(
+                provider,
+                attemptedKeys,
+                snapshots,
+                CancellationToken.None);
+            if (errors.Count > 0)
+                throw new AggregateException("Artifact write failed and rollback was incomplete.", errors);
+
+            return false;
+        }
+
+        return true;
+    }
+
+    public static async Task<bool> DeleteArtifactsAsync(
+        ICloudSecretsProvider provider,
+        IEnumerable<string> keys,
+        CancellationToken cancellationToken)
+    {
+        var succeeded = true;
+        var errors = new List<Exception>();
+
+        foreach (var key in keys.Distinct(StringComparer.Ordinal).OrderBy(x => x, StringComparer.Ordinal))
+        {
+            try
+            {
+                if (!await provider.SecretExistsAsync(key, cancellationToken))
+                    continue;
+
+                if (!await provider.DeleteSecretAsync(key, cancellationToken))
+                    succeeded = false;
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                errors.Add(ex);
+            }
+        }
+
+        if (errors.Count > 0)
+            throw new AggregateException("One or more artifacts could not be deleted.", errors);
+
+        return succeeded;
+    }
+
+    public static bool KeyMatchesPrefix(string key, string prefix) =>
+        NormalizeStorageKey(key).StartsWith(NormalizeStorageKey(prefix), StringComparison.Ordinal);
+
+    public static bool StorageKeysEqual(string left, string right) =>
+        string.Equals(
+            NormalizeStorageKey(left),
+            NormalizeStorageKey(right),
+            StringComparison.Ordinal);
+
+    public static bool TryGetRelativeKey(string key, string prefix, out string relativeKey)
+    {
+        relativeKey = string.Empty;
+        if (!KeyMatchesPrefix(key, prefix) || key.Length < prefix.Length)
+            return false;
+
+        relativeKey = key[prefix.Length..];
+        return relativeKey.Length > 0;
+    }
+
+    public static bool TryExtractAffixedId(
+        string key,
+        string prefix,
+        string suffix,
+        out string id)
+    {
+        id = string.Empty;
+        var normalizedKey = NormalizeStorageKey(key);
+        var normalizedPrefix = NormalizeStorageKey(prefix);
+        var normalizedSuffix = NormalizeStorageKey(suffix);
+
+        if (!normalizedKey.StartsWith(normalizedPrefix, StringComparison.Ordinal) ||
+            !normalizedKey.EndsWith(normalizedSuffix, StringComparison.Ordinal) ||
+            key.Length <= prefix.Length + suffix.Length)
+        {
+            return false;
+        }
+
+        id = key.Substring(prefix.Length, key.Length - prefix.Length - suffix.Length);
+        return id.Length > 0;
+    }
+
+    public static string SanitizeSerialNumber(string serialNumber)
+    {
+        var sanitized = new string(serialNumber
+            .Where(char.IsLetterOrDigit)
+            .Select(char.ToUpperInvariant)
+            .ToArray());
+        return sanitized.TrimStart('0');
+    }
+
+    public static long GetUtcRevision(DateTime value)
+    {
+        if (value == default)
+            return 0;
+
+        return value.Kind == DateTimeKind.Utc
+            ? value.Ticks
+            : value.ToUniversalTime().Ticks;
+    }
+
+    private static string NormalizeStorageKey(string key)
+    {
+        var builder = new StringBuilder(key.Length);
+        foreach (var character in key)
+        {
+            builder.Append(char.IsLetterOrDigit(character)
+                ? char.ToUpperInvariant(character)
+                : '_');
+        }
+
+        return builder.ToString();
+    }
+
+    private static async Task<List<Exception>> RollbackAsync(
+        ICloudSecretsProvider provider,
+        IEnumerable<string> attemptedKeys,
+        IReadOnlyDictionary<string, ArtifactSnapshot> snapshots,
+        CancellationToken cancellationToken)
+    {
+        var errors = new List<Exception>();
+        foreach (var key in attemptedKeys.Reverse())
+        {
+            try
+            {
+                var snapshot = snapshots[key];
+                if (snapshot.Value is null)
+                {
+                    await provider.DeleteSecretAsync(key, cancellationToken);
+                }
+                else
+                {
+                    await provider.StoreSecretAsync(
+                        key,
+                        snapshot.Value,
+                        snapshot.Metadata,
+                        cancellationToken);
+                }
+            }
+            catch (Exception ex)
+            {
+                errors.Add(ex);
+            }
+        }
+
+        return errors;
+    }
+
+    private sealed record ArtifactSnapshot(
+        byte[]? Value,
+        Dictionary<string, string>? Metadata);
+}

--- a/src/MauiSherpa.Core/Services/SecretSyncCoordinator.cs
+++ b/src/MauiSherpa.Core/Services/SecretSyncCoordinator.cs
@@ -1,0 +1,1470 @@
+using System.Collections.Concurrent;
+using System.Text;
+using System.Text.Json;
+using MauiSherpa.Core.Interfaces;
+using MauiSherpa.Core.Requests;
+using Shiny.Mediator;
+
+namespace MauiSherpa.Core.Services;
+
+public sealed class SecretSyncCoordinator : ISecretSyncCoordinator, IBackgroundTaskHandler
+{
+    public const string TaskType = "secret-sync";
+    private const string ManifestPrefix = "sherpa-sync-manifests/";
+    private const string CatalogKey = "sherpa-sync-catalog-v1";
+    private const string PlatformSourceId = "$platform";
+    private static readonly TimeSpan StatusSnapshotLifetime = TimeSpan.FromSeconds(15);
+
+    private readonly ISecretsProviderRegistry _providerRegistry;
+    private readonly IBackgroundTaskService _backgroundTasks;
+    private readonly IMediator _mediator;
+    private readonly ILoggingService _logger;
+    private readonly Dictionary<SecretItemKind, ISecretItemAdapter> _adapters;
+    private readonly JsonSerializerOptions _jsonOptions = new(JsonSerializerDefaults.Web);
+    private readonly ConcurrentDictionary<string, TimedSnapshot<ProviderSyncCatalog?>> _catalogSnapshots =
+        new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, TimedSnapshot<IReadOnlyList<string>>> _providerKeySnapshots =
+        new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, TimedSnapshot<IReadOnlySet<string>>> _presenceSnapshots =
+        new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> _catalogWriteLocks =
+        new(StringComparer.Ordinal);
+
+    public SecretSyncCoordinator(
+        ISecretsProviderRegistry providerRegistry,
+        IBackgroundTaskService backgroundTasks,
+        IMediator mediator,
+        IEnumerable<ISecretItemAdapter> adapters,
+        ILoggingService logger)
+    {
+        _providerRegistry = providerRegistry;
+        _backgroundTasks = backgroundTasks;
+        _mediator = mediator;
+        _logger = logger;
+        _adapters = adapters.ToDictionary(adapter => adapter.Kind);
+        _providerRegistry.ProvidersChanged += InvalidateAllStatusSnapshots;
+    }
+
+    public string Type => TaskType;
+
+    public event Action<SecretItemRef>? ItemStateChanged;
+
+    public async Task<IReadOnlyList<SecretItemSyncState>> ListItemsAsync(
+        SecretItemKind kind,
+        CancellationToken cancellationToken = default)
+    {
+        var adapter = GetAdapter(kind);
+        var items = new Dictionary<string, SecretItemRef>(StringComparer.Ordinal);
+
+        foreach (var item in await adapter.ListLocalItemsAsync(cancellationToken))
+            items[item.Id] = item;
+
+        var providers = (await _providerRegistry.GetProvidersAsync())
+            .OrderBy(provider =>
+                string.Equals(
+                    provider.Id,
+                    CloudSecretsService.DefaultLocalProviderId,
+                    StringComparison.Ordinal) ? 0 : 1)
+            .ThenBy(provider => provider.Id, StringComparer.Ordinal)
+            .ToList();
+        foreach (var provider in providers)
+        {
+            try
+            {
+                foreach (var item in await adapter.ListProviderItemsAsync(provider.Id, cancellationToken))
+                    items.TryAdd(item.Id, item);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(
+                    $"Could not enumerate {kind} items from provider '{provider.Name}': {ex.Message}");
+            }
+        }
+
+        var states = new List<SecretItemSyncState>();
+        foreach (var item in items.Values.OrderBy(item => item.DisplayName, StringComparer.OrdinalIgnoreCase))
+            states.Add(await GetStateAsync(item, cancellationToken));
+
+        return states;
+    }
+
+    public async Task<SecretItemSyncState> GetStateAsync(
+        SecretItemRef item,
+        CancellationToken cancellationToken = default)
+    {
+        var adapter = GetAdapter(item.Kind);
+        var providers = await _providerRegistry.GetProvidersAsync();
+        var observations = new Dictionary<string, ProviderObservation>(StringComparer.Ordinal);
+        var manifests = new List<(string ProviderId, SecretSyncManifest Manifest)>();
+
+        foreach (var provider in providers)
+        {
+            try
+            {
+                var payload = await adapter.ReadProviderAsync(item, provider.Id, cancellationToken);
+                var manifest = await ReadManifestAsync(provider.Id, item, cancellationToken);
+                observations[provider.Id] = new ProviderObservation(
+                    payload is not null,
+                    payload?.ContentHash,
+                    manifest?.Revision ?? payload?.Revision,
+                    manifest?.DesiredProviderIds,
+                    Error: null);
+                if (manifest is not null)
+                    manifests.Add((provider.Id, manifest));
+            }
+            catch (Exception ex)
+            {
+                observations[provider.Id] = new ProviderObservation(
+                    Observed: false,
+                    ContentHash: null,
+                    Revision: null,
+                    DesiredProviderIds: null,
+                    ex.Message);
+            }
+        }
+
+        var task = GetLatestTask(item);
+        var desiredProviderIds = task is not null
+            ? TryParseDesiredProviders(task.Request.Parameters)
+            : null;
+        var selectionChanges = task is not null
+            ? ParseProviderSelectionChanges(task.Request.Parameters)
+            : new Dictionary<string, bool>(StringComparer.Ordinal);
+        desiredProviderIds ??= SelectManifest(manifests)?
+            .DesiredProviderIds
+            .ToHashSet(StringComparer.Ordinal)
+            ?? observations
+                .Where(pair => pair.Value.Observed)
+                .Select(pair => pair.Key)
+                .ToHashSet(StringComparer.Ordinal);
+        ApplyProviderSelectionChanges(desiredProviderIds, selectionChanges);
+
+        var hasConflict = observations.Values
+            .Where(observation => observation.Observed &&
+                !string.IsNullOrEmpty(observation.ContentHash))
+            .Select(observation => observation.ContentHash)
+            .Distinct(StringComparer.Ordinal)
+            .Skip(1)
+            .Any();
+        var selectedManifest = SelectManifest(manifests);
+        var selectedEntry = selectedManifest is null
+            ? null
+            : new ProviderSyncCatalogEntry(
+                selectedManifest.Kind,
+                selectedManifest.ItemId,
+                selectedManifest.DisplayName,
+                selectedManifest.Revision,
+                selectedManifest.ContentHash,
+                selectedManifest.DesiredProviderIds,
+                selectedManifest.UpdatedAtUtc);
+        var placements = providers.Select(provider =>
+        {
+            var observation = observations[provider.Id];
+            var desired = desiredProviderIds.Contains(provider.Id);
+            return new ProviderPlacementState(
+                provider.Id,
+                desired,
+                observation.Observed,
+                GetPlacementStatus(
+                    desired,
+                    observation.Observed,
+                    observation,
+                    selectedEntry,
+                    hasConflict,
+                    task),
+                observation.Revision,
+                observation.ContentHash,
+                observation.Error);
+        }).ToList();
+
+        return new SecretItemSyncState(
+            item,
+            placements,
+            hasConflict,
+            task is { State: BackgroundTaskState.Pending or BackgroundTaskState.Running or BackgroundTaskState.Failed }
+                ? task.Id
+                : null);
+    }
+
+    public async Task<SecretItemSyncState> GetStateProgressivelyAsync(
+        SecretItemRef item,
+        IProgress<ProviderPlacementState>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        var adapter = GetAdapter(item.Kind);
+        var providers = await _providerRegistry.GetProvidersAsync();
+        var observations = new Dictionary<string, ProviderObservation>(StringComparer.Ordinal);
+        var task = GetLatestTask(item);
+        var requestedProviderIds = task is not null
+            ? TryParseDesiredProviders(task.Request.Parameters)
+            : null;
+        var selectionChanges = task is not null
+            ? ParseProviderSelectionChanges(task.Request.Parameters)
+            : new Dictionary<string, bool>(StringComparer.Ordinal);
+        var pending = providers
+            .Select(provider => ObserveProviderAsync(adapter, item, provider, cancellationToken))
+            .ToList();
+
+        while (pending.Count > 0)
+        {
+            var completedTask = await Task.WhenAny(pending);
+            pending.Remove(completedTask);
+            var completed = await completedTask;
+            observations[completed.Provider.Id] = completed.Observation;
+
+            progress?.Report(CreateProgressPlacement(
+                completed.Provider,
+                completed.Observation,
+                requestedProviderIds,
+                selectionChanges,
+                task));
+        }
+
+        var desiredProviderIds = requestedProviderIds is not null
+            ? requestedProviderIds
+            : SelectCatalogEntry(observations)?.DesiredProviderIds.ToHashSet(StringComparer.Ordinal)
+                ?? observations
+                    .Where(pair => pair.Value.Observed)
+                    .Select(pair => pair.Key)
+                    .ToHashSet(StringComparer.Ordinal);
+        ApplyProviderSelectionChanges(desiredProviderIds, selectionChanges);
+
+        var observedHashes = observations.Values
+            .Where(observation => observation.Observed &&
+                !string.IsNullOrEmpty(observation.ContentHash))
+            .Select(observation => observation.ContentHash!)
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+        var hasConflict = observedHashes.Count > 1;
+        var selectedEntry = SelectCatalogEntry(observations);
+
+        var placementStates = providers.Select(provider =>
+        {
+            var observation = observations[provider.Id];
+            var desired = desiredProviderIds.Contains(provider.Id);
+            var observed = observation.Observed;
+            var status = GetPlacementStatus(
+                desired,
+                observed,
+                observation,
+                selectedEntry,
+                hasConflict,
+                task);
+
+            return new ProviderPlacementState(
+                provider.Id,
+                desired,
+                observed,
+                status,
+                observation.Revision,
+                observation.ContentHash,
+                observation.Error ?? (status == SecretPlacementStatus.Failed ? task?.Error : null));
+        }).ToList();
+        foreach (var missingProviderId in desiredProviderIds
+            .Where(providerId => !observations.ContainsKey(providerId))
+            .Order(StringComparer.Ordinal))
+        {
+            placementStates.Add(new ProviderPlacementState(
+                missingProviderId,
+                Desired: true,
+                Observed: false,
+                SecretPlacementStatus.Unavailable,
+                Error: "This provider is no longer configured."));
+        }
+
+        return new SecretItemSyncState(
+            item,
+            placementStates,
+            hasConflict,
+            task is { State: BackgroundTaskState.Pending or BackgroundTaskState.Running or BackgroundTaskState.Failed }
+                ? task.Id
+                : null);
+    }
+
+    private async Task<CompletedProviderObservation> ObserveProviderAsync(
+        ISecretItemAdapter adapter,
+        SecretItemRef item,
+        CloudSecretsProviderConfig provider,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var catalogTask = GetProviderCatalogSnapshotAsync(
+                provider.Id,
+                cancellationToken);
+            var presenceTask = GetProviderPresenceSnapshotAsync(
+                adapter,
+                provider.Id,
+                cancellationToken);
+            await Task.WhenAll(catalogTask, presenceTask);
+            var catalog = await catalogTask;
+            var presentItemIds = await presenceTask;
+            var observed = presentItemIds.Contains(item.Id) ||
+                presentItemIds.Any(candidate =>
+                    SecretItemAdapterHelper.StorageKeysEqual(candidate, item.Id));
+            ProviderSyncCatalogEntry? entry = null;
+            catalog?.Entries.TryGetValue(GetCatalogEntryKey(item), out entry);
+            return new CompletedProviderObservation(
+                provider,
+                new ProviderObservation(
+                    observed,
+                    observed ? entry?.ContentHash : null,
+                    observed ? entry?.Revision : null,
+                    entry?.DesiredProviderIds,
+                    Error: null));
+        }
+        catch (Exception ex)
+        {
+            return new CompletedProviderObservation(
+                provider,
+                new ProviderObservation(
+                    Observed: false,
+                    ContentHash: null,
+                    Revision: null,
+                    DesiredProviderIds: null,
+                    ex.Message));
+        }
+    }
+
+    private static ProviderPlacementState CreateProgressPlacement(
+        CloudSecretsProviderConfig provider,
+        ProviderObservation observation,
+        HashSet<string>? requestedProviderIds,
+        IReadOnlyDictionary<string, bool> selectionChanges,
+        BackgroundTaskInfo? task)
+    {
+        var desired = requestedProviderIds?.Contains(provider.Id)
+            ?? observation.DesiredProviderIds?.Contains(provider.Id)
+            ?? observation.Observed;
+        if (selectionChanges.TryGetValue(provider.Id, out var changedDesired))
+            desired = changedDesired;
+        var observed = observation.Observed;
+        var status = observation.Error is not null
+            ? SecretPlacementStatus.Unavailable
+            : (task?.State is BackgroundTaskState.Pending or BackgroundTaskState.Running) &&
+                desired != observed
+                ? SecretPlacementStatus.Pending
+                : desired == observed
+                    ? observed
+                        ? SecretPlacementStatus.Synced
+                        : SecretPlacementStatus.NotStored
+                    : SecretPlacementStatus.Failed;
+
+        return new ProviderPlacementState(
+            provider.Id,
+            desired,
+            observed,
+            status,
+            observation.Revision,
+            observation.ContentHash,
+            observation.Error ?? (status == SecretPlacementStatus.Failed ? task?.Error : null));
+    }
+
+    public async Task<string?> SetDesiredProvidersAsync(
+        SecretItemRef item,
+        IReadOnlyCollection<string> providerIds,
+        CancellationToken cancellationToken = default)
+    {
+        var configured = (await _providerRegistry.GetProvidersAsync())
+            .Select(provider => provider.Id)
+            .ToHashSet(StringComparer.Ordinal);
+        var desired = providerIds
+            .Where(configured.Contains)
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)
+            .ToList();
+
+        var request = CreateRequest(item, desired, sourceProviderId: null, previousItem: null);
+        var taskId = await _backgroundTasks.EnqueueAsync(request, cancellationToken);
+        NotifyItemStateChanged(item);
+        return taskId;
+    }
+
+    public async Task<string?> UpdateDesiredProvidersAsync(
+        SecretItemRef item,
+        IReadOnlyDictionary<string, bool> changes,
+        CancellationToken cancellationToken = default)
+    {
+        var configured = (await _providerRegistry.GetProvidersAsync())
+            .Select(provider => provider.Id)
+            .ToHashSet(StringComparer.Ordinal);
+        var normalizedChanges = changes
+            .Where(change => configured.Contains(change.Key) || !change.Value)
+            .ToDictionary(change => change.Key, change => change.Value, StringComparer.Ordinal);
+        if (normalizedChanges.Count == 0)
+            return null;
+
+        var latestPending = _backgroundTasks.Tasks
+            .Where(task =>
+                task.State == BackgroundTaskState.Pending &&
+                string.Equals(task.Request.CoalesceKey, GetCoalesceKey(item), StringComparison.Ordinal))
+            .OrderByDescending(task => task.CreatedAtUtc)
+            .FirstOrDefault();
+        if (latestPending is not null)
+        {
+            var previousChanges = ParseProviderSelectionChanges(latestPending.Request.Parameters);
+            foreach (var (providerId, desired) in previousChanges)
+                normalizedChanges.TryAdd(providerId, desired);
+
+            var previousDesired = TryParseDesiredProviders(latestPending.Request.Parameters);
+            if (previousDesired is not null)
+            {
+                ApplyProviderSelectionChanges(previousDesired, normalizedChanges);
+                return await SetDesiredProvidersAsync(item, previousDesired, cancellationToken);
+            }
+        }
+
+        var request = CreateSelectionChangeRequest(item, normalizedChanges);
+        var taskId = await _backgroundTasks.EnqueueAsync(request, cancellationToken);
+        NotifyItemStateChanged(item);
+        return taskId;
+    }
+
+    public async Task<string?> SetDefaultProvidersAsync(
+        SecretItemRef item,
+        CancellationToken cancellationToken = default)
+    {
+        var providerIds = (await _providerRegistry.GetProvidersAsync())
+            .Where(provider => provider.StoresByDefault(item.Kind))
+            .Select(provider => provider.Id)
+            .ToList();
+        if (providerIds.Count == 0 && GetAdapter(item.Kind).IsProviderOwned)
+        {
+            var current = await GetStateAsync(item, cancellationToken);
+            providerIds = current.Providers
+                .Where(provider => provider.Observed)
+                .Select(provider => provider.ProviderId)
+                .ToList();
+        }
+        return await SetDesiredProvidersAsync(item, providerIds, cancellationToken);
+    }
+
+    public async Task<string?> ResolveConflictAsync(
+        SecretItemRef item,
+        string sourceProviderId,
+        CancellationToken cancellationToken = default)
+    {
+        var state = await GetStateAsync(item, cancellationToken);
+        var desired = state.Providers
+            .Where(provider => provider.Desired)
+            .Select(provider => provider.ProviderId)
+            .ToList();
+
+        var request = CreateRequest(item, desired, sourceProviderId, previousItem: null);
+        var taskId = await _backgroundTasks.EnqueueAsync(request, cancellationToken);
+        NotifyItemStateChanged(item);
+        return taskId;
+    }
+
+    public async Task<string?> MoveAsync(
+        SecretItemRef previousItem,
+        SecretItemRef item,
+        IReadOnlyCollection<string> providerIds,
+        string sourceProviderId,
+        CancellationToken cancellationToken = default)
+    {
+        if (previousItem.Kind != item.Kind)
+            throw new ArgumentException("A synced item cannot change kind while moving.", nameof(item));
+
+        var configured = (await _providerRegistry.GetProvidersAsync())
+            .Select(provider => provider.Id)
+            .ToHashSet(StringComparer.Ordinal);
+        var desired = providerIds
+            .Where(configured.Contains)
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)
+            .ToList();
+        var request = CreateRequest(item, desired, sourceProviderId, previousItem);
+        var taskId = await _backgroundTasks.EnqueueAsync(request, cancellationToken);
+        NotifyItemStateChanged(previousItem);
+        NotifyItemStateChanged(item);
+        return taskId;
+    }
+
+    public async Task ExecuteAsync(
+        BackgroundTaskRequest request,
+        IBackgroundTaskContext context)
+    {
+        var item = ParseItem(request.Parameters);
+        var desiredProviderIds = TryParseDesiredProviders(request.Parameters);
+        var selectionChanges = ParseProviderSelectionChanges(request.Parameters);
+        request.Parameters.TryGetValue("sourceProviderId", out var sourceProviderId);
+        var adapter = GetAdapter(item.Kind);
+
+        try
+        {
+            context.SetStatus("Inspecting provider copies");
+            context.SetProgress(5);
+
+            var providers = (await _providerRegistry.GetProvidersAsync())
+                .OrderBy(provider =>
+                    string.Equals(
+                        provider.Id,
+                        CloudSecretsService.DefaultLocalProviderId,
+                        StringComparison.Ordinal) ? 0 : 1)
+                .ThenBy(provider => provider.Id, StringComparer.Ordinal)
+                .ToList();
+            var providerById = providers.ToDictionary(provider => provider.Id, StringComparer.Ordinal);
+            var payloads = new Dictionary<string, SecretItemPayload>(StringComparer.Ordinal);
+            var manifests = new List<SecretSyncManifest>();
+            var unreadableProviderIds = new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (var provider in providers)
+            {
+                context.CancellationToken.ThrowIfCancellationRequested();
+                try
+                {
+                    var providerInstance = await _providerRegistry.GetProviderAsync(provider.Id);
+                    if (providerInstance is null)
+                        throw new InvalidOperationException($"Provider '{provider.Id}' is not configured.");
+
+                    var providerKeys = await providerInstance.ListSecretsAsync(
+                        prefix: null,
+                        cancellationToken: context.CancellationToken);
+                    var presentIds = adapter.ExtractProviderItemIds(providerKeys);
+                    var itemExists = presentIds.Contains(item.Id) ||
+                        presentIds.Any(candidate =>
+                            SecretItemAdapterHelper.StorageKeysEqual(candidate, item.Id));
+                    if (itemExists)
+                    {
+                        var payload = await adapter.ReadProviderAsync(
+                            item,
+                            provider.Id,
+                            context.CancellationToken);
+                        if (payload is not null)
+                            payloads[provider.Id] = payload;
+                    }
+
+                    var manifestKey = GetManifestKey(item);
+                    if (providerKeys.Any(key =>
+                        SecretItemAdapterHelper.StorageKeysEqual(key, manifestKey)))
+                    {
+                        var manifest = await ReadManifestAsync(
+                            provider.Id,
+                            item,
+                            context.CancellationToken);
+                        if (manifest is not null)
+                            manifests.Add(manifest);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    unreadableProviderIds.Add(provider.Id);
+                    if (desiredProviderIds?.Contains(provider.Id) == true ||
+                        selectionChanges.GetValueOrDefault(provider.Id))
+                    {
+                        throw new BackgroundTaskTransientException(
+                            $"Could not read provider '{provider.Name}': {ex.Message}",
+                            ex);
+                    }
+                }
+
+            }
+
+            desiredProviderIds ??= SelectManifest(manifests
+                    .Select(manifest => (ProviderId: string.Empty, Manifest: manifest)))?
+                .DesiredProviderIds
+                .ToHashSet(StringComparer.Ordinal)
+                ?? payloads.Keys.ToHashSet(StringComparer.Ordinal);
+            if (TryParseDesiredProviders(request.Parameters) is null)
+            {
+                foreach (var providerId in unreadableProviderIds.Where(providerId =>
+                    !selectionChanges.TryGetValue(providerId, out var desired) || desired))
+                {
+                    desiredProviderIds.Add(providerId);
+                }
+            }
+            ApplyProviderSelectionChanges(desiredProviderIds, selectionChanges);
+
+            SecretItemPayload? sourcePayload = null;
+            if (desiredProviderIds.Count > 0)
+            {
+                var distinctHashes = payloads.Values
+                    .Select(payload => payload.ContentHash)
+                    .Distinct(StringComparer.Ordinal)
+                    .ToList();
+                if (distinctHashes.Count > 1 && string.IsNullOrWhiteSpace(sourceProviderId))
+                    throw new InvalidOperationException(
+                        "Provider copies contain different values. Choose the source copy before retrying.");
+
+                if (string.Equals(sourceProviderId, PlatformSourceId, StringComparison.Ordinal))
+                {
+                    sourcePayload = await adapter.ReadLocalAsync(item, context.CancellationToken);
+                }
+                else if (!string.IsNullOrWhiteSpace(sourceProviderId))
+                {
+                    payloads.TryGetValue(sourceProviderId, out sourcePayload);
+                    sourcePayload ??= await adapter.ReadProviderAsync(
+                        item,
+                        sourceProviderId,
+                        context.CancellationToken);
+                }
+                else
+                {
+                    if (item.Kind == SecretItemKind.Certificate && payloads.Count > 0)
+                    {
+                        if (payloads.TryGetValue(CloudSecretsService.DefaultLocalProviderId, out var localVaultPayload))
+                            sourcePayload = localVaultPayload;
+                        sourcePayload ??= payloads.Values.FirstOrDefault();
+                    }
+
+                    sourcePayload ??= await adapter.ReadLocalAsync(item, context.CancellationToken);
+                    if (sourcePayload is null &&
+                        payloads.TryGetValue(CloudSecretsService.DefaultLocalProviderId, out var localProviderPayload))
+                    {
+                        sourcePayload = localProviderPayload;
+                    }
+                    sourcePayload ??= payloads.Values.FirstOrDefault();
+                }
+
+                if (sourcePayload is null)
+                {
+                    throw new InvalidOperationException(item.Kind == SecretItemKind.Certificate
+                        ? "No certificate private key source is available. Import it into Keychain or install it from another provider before syncing."
+                        : "No readable source copy is available for this item.");
+                }
+            }
+
+            var nextRevision = Math.Max(
+                sourcePayload?.Revision ?? 0,
+                manifests.Count == 0 ? 0 : manifests.Max(manifest => manifest.Revision)) + 1;
+            SecretSyncManifest? nextManifest = sourcePayload is null
+                ? null
+                : new SecretSyncManifest(
+                    SecretSyncManifest.CurrentSchemaVersion,
+                    item.Kind,
+                    item.Id,
+                    item.DisplayName,
+                    nextRevision,
+                    sourcePayload.ContentHash,
+                    desiredProviderIds.Order(StringComparer.Ordinal).ToList(),
+                    DateTime.UtcNow);
+            var nextPayload = sourcePayload is null
+                ? null
+                : sourcePayload with { Revision = nextRevision };
+
+            var orderedDesired = desiredProviderIds
+                .OrderBy(providerId =>
+                    string.Equals(providerId, CloudSecretsService.DefaultLocalProviderId, StringComparison.Ordinal) ? 0 : 1)
+                .ThenBy(providerId => providerId, StringComparer.Ordinal)
+                .ToList();
+            var orderedRemovals = providers
+                .Where(provider => !desiredProviderIds.Contains(provider.Id))
+                .ToList();
+            SecretItemRef? previousItemToRemove = null;
+            if (TryParsePreviousItem(request.Parameters, out var previousItem) &&
+                !string.Equals(previousItem.Id, item.Id, StringComparison.Ordinal))
+            {
+                previousItemToRemove = previousItem;
+            }
+
+            var steps = new List<BackgroundTaskStepInfo>();
+            foreach (var providerId in orderedDesired)
+            {
+                if (!providerById.TryGetValue(providerId, out var config))
+                    throw new InvalidOperationException($"Provider '{providerId}' is no longer configured.");
+
+                steps.Add(new BackgroundTaskStepInfo(
+                    $"sync:{providerId}",
+                    config.Name,
+                    BackgroundTaskStepState.Pending,
+                    "Waiting to sync"));
+            }
+            steps.AddRange(orderedRemovals.Select(provider =>
+                new BackgroundTaskStepInfo(
+                    $"remove:{provider.Id}",
+                    provider.Name,
+                    BackgroundTaskStepState.Pending,
+                    "Waiting to remove")));
+            if (previousItemToRemove is not null)
+            {
+                steps.AddRange(providers.Select(provider =>
+                    new BackgroundTaskStepInfo(
+                        $"cleanup:{provider.Id}",
+                        provider.Name,
+                        BackgroundTaskStepState.Pending,
+                        $"Waiting to remove old copy of {previousItemToRemove.DisplayName}")));
+            }
+            context.SetSteps(steps);
+
+            async Task RunProviderStepAsync(
+                string stepId,
+                string runningStatus,
+                string successStatus,
+                Func<Task> operation)
+            {
+                context.SetStatus(runningStatus);
+                context.UpdateStep(stepId, BackgroundTaskStepState.Running, runningStatus);
+                try
+                {
+                    await operation();
+                    context.UpdateStep(stepId, BackgroundTaskStepState.Succeeded, successStatus);
+                }
+                catch (OperationCanceledException)
+                {
+                    context.UpdateStep(stepId, BackgroundTaskStepState.Cancelled, "Cancelled");
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    context.UpdateStep(stepId, BackgroundTaskStepState.Failed, "Failed", ex.Message);
+                    throw;
+                }
+            }
+
+            async Task PublishCurrentPlacementAsync(
+                string providerId,
+                bool desired,
+                SecretPlacementStatus status,
+                string? error = null)
+            {
+                payloads.TryGetValue(providerId, out var existingPayload);
+                var observed = status switch
+                {
+                    SecretPlacementStatus.Synced => true,
+                    SecretPlacementStatus.NotStored => false,
+                    _ => existingPayload is not null
+                };
+                var placement = new ProviderPlacementState(
+                    providerId,
+                    desired,
+                    observed,
+                    status,
+                    status == SecretPlacementStatus.Synced
+                        ? nextPayload?.Revision
+                        : existingPayload?.Revision,
+                    status == SecretPlacementStatus.Synced
+                        ? nextPayload?.ContentHash
+                        : existingPayload?.ContentHash,
+                    error);
+                await PublishPlacementChangedAsync(item, placement, context.CancellationToken);
+            }
+
+            var totalSteps = Math.Max(1, steps.Count);
+            var completedSteps = 0;
+
+            foreach (var providerId in orderedDesired)
+            {
+                context.CancellationToken.ThrowIfCancellationRequested();
+                if (!providerById.TryGetValue(providerId, out var config))
+                    throw new InvalidOperationException($"Provider '{providerId}' is no longer configured.");
+
+                await PublishCurrentPlacementAsync(
+                    providerId,
+                    desired: true,
+                    SecretPlacementStatus.Pending);
+                try
+                {
+                    await RunProviderStepAsync(
+                        $"sync:{providerId}",
+                        $"Syncing to {config.Name}",
+                        "Synced",
+                        async () =>
+                        {
+                            var existingMatches = payloads.TryGetValue(providerId, out var existing) &&
+                                string.Equals(existing.ContentHash, nextPayload!.ContentHash, StringComparison.Ordinal);
+                            if (!existingMatches &&
+                                !await adapter.WriteProviderAsync(nextPayload!, providerId, context.CancellationToken))
+                            {
+                                throw new BackgroundTaskTransientException(
+                                    $"Failed to write item to provider '{config.Name}'.");
+                            }
+
+                            if (!await WriteManifestAsync(providerId, nextManifest!, context.CancellationToken))
+                            {
+                                throw new BackgroundTaskTransientException(
+                                    $"Failed to write sync metadata to provider '{config.Name}'.");
+                            }
+                            await TryUpdateProviderCatalogAsync(
+                                providerId,
+                                nextManifest,
+                                removeItem: null,
+                                context.CancellationToken);
+
+                            context.Log(
+                                $"Synced {item.DisplayName} to {config.Name}",
+                                OperationLogLevel.Success);
+                        });
+                    await PublishCurrentPlacementAsync(
+                        providerId,
+                        desired: true,
+                        SecretPlacementStatus.Synced);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    await PublishCurrentPlacementAsync(
+                        providerId,
+                        desired: true,
+                        SecretPlacementStatus.Failed,
+                        ex.Message);
+                    throw;
+                }
+                completedSteps++;
+                context.SetProgress(completedSteps * 100 / totalSteps);
+            }
+
+            foreach (var provider in orderedRemovals)
+            {
+                context.CancellationToken.ThrowIfCancellationRequested();
+                await PublishCurrentPlacementAsync(
+                    provider.Id,
+                    desired: false,
+                    SecretPlacementStatus.Pending);
+                try
+                {
+                    await RunProviderStepAsync(
+                        $"remove:{provider.Id}",
+                        $"Removing from {provider.Name}",
+                        "Removed",
+                        async () =>
+                        {
+                            var providerInstance = await _providerRegistry.GetProviderAsync(provider.Id);
+                            if (providerInstance is null ||
+                                !await providerInstance.TestConnectionAsync(context.CancellationToken))
+                            {
+                                throw new BackgroundTaskTransientException(
+                                    $"Provider '{provider.Name}' is unavailable; removal was not confirmed.");
+                            }
+
+                            if (!await adapter.DeleteProviderAsync(item, provider.Id, context.CancellationToken))
+                            {
+                                throw new BackgroundTaskTransientException(
+                                    $"Failed to remove item from provider '{provider.Name}'.");
+                            }
+
+                            if (!await DeleteManifestAsync(provider.Id, item, context.CancellationToken))
+                            {
+                                throw new BackgroundTaskTransientException(
+                                    $"Failed to remove sync metadata from provider '{provider.Name}'.");
+                            }
+                            await TryUpdateProviderCatalogAsync(
+                                provider.Id,
+                                manifest: null,
+                                removeItem: item,
+                                context.CancellationToken);
+                            context.Log(
+                                $"Removed {item.DisplayName} from {provider.Name}",
+                                OperationLogLevel.Success);
+                        });
+                    await PublishCurrentPlacementAsync(
+                        provider.Id,
+                        desired: false,
+                        SecretPlacementStatus.NotStored);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    await PublishCurrentPlacementAsync(
+                        provider.Id,
+                        desired: false,
+                        SecretPlacementStatus.Failed,
+                        ex.Message);
+                    throw;
+                }
+                completedSteps++;
+                context.SetProgress(completedSteps * 100 / totalSteps);
+            }
+
+            if (previousItemToRemove is not null)
+            {
+                foreach (var provider in providers)
+                {
+                    context.CancellationToken.ThrowIfCancellationRequested();
+                    await RunProviderStepAsync(
+                        $"cleanup:{provider.Id}",
+                        $"Removing old copy from {provider.Name}",
+                        "Old copy removed",
+                        async () =>
+                        {
+                            var providerInstance = await _providerRegistry.GetProviderAsync(provider.Id);
+                            if (providerInstance is null ||
+                                !await providerInstance.TestConnectionAsync(context.CancellationToken))
+                            {
+                                throw new BackgroundTaskTransientException(
+                                    $"Provider '{provider.Name}' is unavailable; the old item was retained.");
+                            }
+
+                            if (!await adapter.DeleteProviderAsync(
+                                    previousItemToRemove,
+                                    provider.Id,
+                                    context.CancellationToken) ||
+                                !await DeleteManifestAsync(
+                                    provider.Id,
+                                    previousItemToRemove,
+                                    context.CancellationToken))
+                            {
+                                throw new BackgroundTaskTransientException(
+                                    $"Failed to remove the old item from provider '{provider.Name}'.");
+                            }
+                            await TryUpdateProviderCatalogAsync(
+                                provider.Id,
+                                manifest: null,
+                                removeItem: previousItemToRemove,
+                                context.CancellationToken);
+                        });
+                    await PublishPlacementChangedAsync(
+                        previousItemToRemove,
+                        new ProviderPlacementState(
+                            provider.Id,
+                            Desired: false,
+                            Observed: false,
+                            SecretPlacementStatus.NotStored),
+                        context.CancellationToken);
+                    completedSteps++;
+                    context.SetProgress(completedSteps * 100 / totalSteps);
+                }
+
+                context.Log(
+                    $"Removed old provider copies of {previousItemToRemove.DisplayName}",
+                    OperationLogLevel.Success);
+                NotifyItemStateChanged(previousItemToRemove);
+            }
+
+            context.SetStatus("Placement is up to date");
+            context.SetProgress(100);
+        }
+        finally
+        {
+            NotifyItemStateChanged(item);
+        }
+    }
+
+    private BackgroundTaskRequest CreateRequest(
+        SecretItemRef item,
+        IReadOnlyCollection<string> desiredProviderIds,
+        string? sourceProviderId,
+        SecretItemRef? previousItem)
+    {
+        var parameters = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["kind"] = item.Kind.ToString(),
+            ["itemId"] = item.Id,
+            ["displayName"] = item.DisplayName,
+            ["desiredProviderIds"] = JsonSerializer.Serialize(desiredProviderIds, _jsonOptions)
+        };
+        if (!string.IsNullOrWhiteSpace(sourceProviderId))
+            parameters["sourceProviderId"] = sourceProviderId;
+        if (previousItem is not null)
+        {
+            parameters["previousKind"] = previousItem.Kind.ToString();
+            parameters["previousItemId"] = previousItem.Id;
+            parameters["previousDisplayName"] = previousItem.DisplayName;
+        }
+
+        return new BackgroundTaskRequest(
+            TaskType,
+            $"Sync {item.DisplayName}",
+            $"Update secrets-provider placement for {item.DisplayName}.",
+            parameters,
+            CoalesceKey: GetCoalesceKey(item),
+            ItemRoute: GetItemRoute(item.Kind));
+    }
+
+    private BackgroundTaskRequest CreateSelectionChangeRequest(
+        SecretItemRef item,
+        IReadOnlyDictionary<string, bool> changes)
+    {
+        var parameters = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["kind"] = item.Kind.ToString(),
+            ["itemId"] = item.Id,
+            ["displayName"] = item.DisplayName,
+            ["providerSelectionChanges"] = JsonSerializer.Serialize(changes, _jsonOptions)
+        };
+        return new BackgroundTaskRequest(
+            TaskType,
+            $"Sync {item.DisplayName}",
+            $"Update secrets-provider placement for {item.DisplayName}.",
+            parameters,
+            CoalesceKey: GetCoalesceKey(item),
+            ItemRoute: GetItemRoute(item.Kind));
+    }
+
+    private async Task<ProviderSyncCatalog?> GetProviderCatalogSnapshotAsync(
+        string providerId,
+        CancellationToken cancellationToken) =>
+        await GetSnapshotAsync(
+            _catalogSnapshots,
+            providerId,
+            () => ReadProviderCatalogUncachedAsync(providerId),
+            cancellationToken);
+
+    private async Task<IReadOnlySet<string>> GetProviderPresenceSnapshotAsync(
+        ISecretItemAdapter adapter,
+        string providerId,
+        CancellationToken cancellationToken)
+    {
+        var key = GetPresenceSnapshotKey(providerId, adapter.Kind);
+        return await GetSnapshotAsync(
+            _presenceSnapshots,
+            key,
+            async () => adapter.ExtractProviderItemIds(
+                await GetProviderKeySnapshotAsync(providerId, CancellationToken.None)),
+            cancellationToken);
+    }
+
+    private async Task<IReadOnlyList<string>> GetProviderKeySnapshotAsync(
+        string providerId,
+        CancellationToken cancellationToken) =>
+        await GetSnapshotAsync(
+            _providerKeySnapshots,
+            providerId,
+            async () =>
+            {
+                var provider = await _providerRegistry.GetProviderAsync(providerId);
+                if (provider is null)
+                    throw new InvalidOperationException($"Provider '{providerId}' is not configured.");
+
+                return await provider.ListSecretsAsync(
+                    prefix: null,
+                    cancellationToken: CancellationToken.None);
+            },
+            cancellationToken);
+
+    private async Task<T> GetSnapshotAsync<T>(
+        ConcurrentDictionary<string, TimedSnapshot<T>> snapshots,
+        string key,
+        Func<Task<T>> load,
+        CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            var now = DateTime.UtcNow;
+            if (snapshots.TryGetValue(key, out var current) &&
+                current.ExpiresAtUtc > now)
+            {
+                return await current.Value.Value.WaitAsync(cancellationToken);
+            }
+
+            var replacement = new TimedSnapshot<T>(
+                now + StatusSnapshotLifetime,
+                new Lazy<Task<T>>(
+                    load,
+                    LazyThreadSafetyMode.ExecutionAndPublication));
+            var accepted = current is null
+                ? snapshots.TryAdd(key, replacement)
+                : snapshots.TryUpdate(key, replacement, current);
+            if (!accepted)
+                continue;
+
+            try
+            {
+                return await replacement.Value.Value.WaitAsync(cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch
+            {
+                snapshots.TryRemove(
+                    new KeyValuePair<string, TimedSnapshot<T>>(key, replacement));
+                throw;
+            }
+        }
+    }
+
+    private async Task<ProviderSyncCatalog?> ReadProviderCatalogUncachedAsync(string providerId)
+    {
+        var provider = await _providerRegistry.GetProviderAsync(providerId);
+        if (provider is null)
+            throw new InvalidOperationException($"Provider '{providerId}' is not configured.");
+
+        var keys = await GetProviderKeySnapshotAsync(providerId, CancellationToken.None);
+        if (!keys.Any(key => SecretItemAdapterHelper.StorageKeysEqual(key, CatalogKey)))
+            return null;
+
+        var bytes = await provider.GetSecretAsync(CatalogKey, CancellationToken.None);
+        if (bytes is null)
+            return null;
+
+        return JsonSerializer.Deserialize<ProviderSyncCatalog>(bytes, _jsonOptions);
+    }
+
+    private async Task TryUpdateProviderCatalogAsync(
+        string providerId,
+        SecretSyncManifest? manifest,
+        SecretItemRef? removeItem,
+        CancellationToken cancellationToken)
+    {
+        var writeLock = _catalogWriteLocks.GetOrAdd(providerId, _ => new SemaphoreSlim(1, 1));
+        await writeLock.WaitAsync(cancellationToken);
+        try
+        {
+            var provider = await _providerRegistry.GetProviderAsync(providerId);
+            if (provider is null)
+                return;
+
+            ProviderSyncCatalog? catalog = null;
+            try
+            {
+                if (await provider.SecretExistsAsync(CatalogKey, cancellationToken))
+                {
+                    var bytes = await provider.GetSecretAsync(CatalogKey, cancellationToken);
+                    if (bytes is not null)
+                        catalog = JsonSerializer.Deserialize<ProviderSyncCatalog>(bytes, _jsonOptions);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(
+                    $"Could not read sync catalog from provider '{providerId}': {ex.Message}");
+                return;
+            }
+
+            var entries = catalog?.Entries is null
+                ? new Dictionary<string, ProviderSyncCatalogEntry>(StringComparer.Ordinal)
+                : new Dictionary<string, ProviderSyncCatalogEntry>(
+                    catalog.Entries,
+                    StringComparer.Ordinal);
+            if (manifest is not null)
+            {
+                var item = new SecretItemRef(
+                    manifest.Kind,
+                    manifest.ItemId,
+                    manifest.DisplayName);
+                entries[GetCatalogEntryKey(item)] = new ProviderSyncCatalogEntry(
+                    manifest.Kind,
+                    manifest.ItemId,
+                    manifest.DisplayName,
+                    manifest.Revision,
+                    manifest.ContentHash,
+                    manifest.DesiredProviderIds.ToList(),
+                    manifest.UpdatedAtUtc);
+            }
+            if (removeItem is not null)
+                entries.Remove(GetCatalogEntryKey(removeItem));
+
+            var updated = new ProviderSyncCatalog(
+                ProviderSyncCatalog.CurrentSchemaVersion,
+                entries,
+                DateTime.UtcNow);
+            var stored = await provider.StoreSecretAsync(
+                CatalogKey,
+                JsonSerializer.SerializeToUtf8Bytes(updated, _jsonOptions),
+                new Dictionary<string, string>
+                {
+                    ["SherpaKind"] = "SyncCatalog",
+                    ["SchemaVersion"] = ProviderSyncCatalog.CurrentSchemaVersion.ToString(
+                        System.Globalization.CultureInfo.InvariantCulture)
+                },
+                cancellationToken);
+            if (!stored)
+                _logger.LogWarning($"Provider '{providerId}' rejected the sync catalog update.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning($"Could not update sync catalog for provider '{providerId}': {ex.Message}");
+        }
+        finally
+        {
+            InvalidateProviderStatusSnapshots(providerId);
+            writeLock.Release();
+        }
+    }
+
+    private void InvalidateProviderStatusSnapshots(string providerId)
+    {
+        _catalogSnapshots.TryRemove(providerId, out _);
+        _providerKeySnapshots.TryRemove(providerId, out _);
+        var prefix = providerId + "|";
+        foreach (var key in _presenceSnapshots.Keys.Where(key =>
+            key.StartsWith(prefix, StringComparison.Ordinal)))
+        {
+            _presenceSnapshots.TryRemove(key, out _);
+        }
+    }
+
+    private void InvalidateAllStatusSnapshots()
+    {
+        _catalogSnapshots.Clear();
+        _providerKeySnapshots.Clear();
+        _presenceSnapshots.Clear();
+    }
+
+    private static string GetPresenceSnapshotKey(
+        string providerId,
+        SecretItemKind kind) =>
+        $"{providerId}|{kind}";
+
+    private static string GetCatalogEntryKey(SecretItemRef item) =>
+        $"{item.Kind}:{item.Id}";
+
+    private BackgroundTaskInfo? GetLatestTask(SecretItemRef item) =>
+        _backgroundTasks.Tasks
+            .Where(task => string.Equals(task.Request.CoalesceKey, GetCoalesceKey(item), StringComparison.Ordinal))
+            .OrderByDescending(task => task.CreatedAtUtc)
+            .FirstOrDefault();
+
+    private static SecretPlacementStatus GetPlacementStatus(
+        bool desired,
+        bool observed,
+        ProviderObservation observation,
+        ProviderSyncCatalogEntry? selectedEntry,
+        bool hasConflict,
+        BackgroundTaskInfo? task)
+    {
+        if (observation.Error is not null)
+            return SecretPlacementStatus.Unavailable;
+        if (hasConflict && observed)
+            return SecretPlacementStatus.Conflict;
+        if (task?.State is BackgroundTaskState.Pending or BackgroundTaskState.Running &&
+            desired != observed)
+        {
+            return SecretPlacementStatus.Pending;
+        }
+        if (task?.State == BackgroundTaskState.Failed && desired != observed)
+            return SecretPlacementStatus.Failed;
+        if (!desired && !observed)
+            return SecretPlacementStatus.NotStored;
+        if (!desired && observed)
+            return SecretPlacementStatus.Failed;
+        if (desired && !observed)
+            return SecretPlacementStatus.Failed;
+        if (selectedEntry is not null &&
+            !string.IsNullOrEmpty(observation.ContentHash) &&
+            !string.Equals(
+                selectedEntry.ContentHash,
+                observation.ContentHash,
+                StringComparison.Ordinal))
+        {
+            return SecretPlacementStatus.Failed;
+        }
+
+        return SecretPlacementStatus.Synced;
+    }
+
+    private static ProviderSyncCatalogEntry? SelectCatalogEntry(
+        IReadOnlyDictionary<string, ProviderObservation> observations) =>
+        observations.Values
+            .Where(observation => observation.Observed &&
+                observation.Revision.HasValue &&
+                observation.DesiredProviderIds is not null)
+            .OrderByDescending(observation => observation.Revision)
+            .Select(observation => new ProviderSyncCatalogEntry(
+                SecretItemKind.ManagedSecret,
+                string.Empty,
+                string.Empty,
+                observation.Revision!.Value,
+                observation.ContentHash ?? string.Empty,
+                observation.DesiredProviderIds!.ToList(),
+                DateTime.MinValue))
+            .FirstOrDefault();
+
+    private SecretSyncManifest? SelectManifest(
+        IEnumerable<(string ProviderId, SecretSyncManifest Manifest)> manifests) =>
+        manifests
+            .Select(pair => pair.Manifest)
+            .OrderByDescending(manifest => manifest.Revision)
+            .ThenByDescending(manifest => manifest.UpdatedAtUtc)
+            .FirstOrDefault();
+
+    private async Task<SecretSyncManifest?> ReadManifestAsync(
+        string providerId,
+        SecretItemRef item,
+        CancellationToken cancellationToken)
+    {
+        var provider = await _providerRegistry.GetProviderAsync(providerId);
+        if (provider is null)
+            throw new InvalidOperationException($"Provider '{providerId}' is not configured.");
+
+        var bytes = await provider.GetSecretAsync(GetManifestKey(item), cancellationToken);
+        return bytes is null
+            ? null
+            : JsonSerializer.Deserialize<SecretSyncManifest>(bytes, _jsonOptions);
+    }
+
+    private async Task<bool> WriteManifestAsync(
+        string providerId,
+        SecretSyncManifest manifest,
+        CancellationToken cancellationToken)
+    {
+        var provider = await _providerRegistry.GetProviderAsync(providerId);
+        if (provider is null)
+            return false;
+
+        var item = new SecretItemRef(manifest.Kind, manifest.ItemId, manifest.DisplayName);
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(manifest, _jsonOptions);
+        return await provider.StoreSecretAsync(
+            GetManifestKey(item),
+            bytes,
+            new Dictionary<string, string>
+            {
+                ["SherpaKind"] = "SyncManifest",
+                ["ItemKind"] = manifest.Kind.ToString(),
+                ["ItemId"] = manifest.ItemId,
+                ["Revision"] = manifest.Revision.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                ["ContentHash"] = manifest.ContentHash
+            },
+            cancellationToken);
+    }
+
+    private async Task<bool> DeleteManifestAsync(
+        string providerId,
+        SecretItemRef item,
+        CancellationToken cancellationToken)
+    {
+        var provider = await _providerRegistry.GetProviderAsync(providerId);
+        if (provider is null)
+            return false;
+
+        var key = GetManifestKey(item);
+        if (!await provider.SecretExistsAsync(key, cancellationToken))
+            return true;
+
+        return await provider.DeleteSecretAsync(key, cancellationToken);
+    }
+
+    private static string GetManifestKey(SecretItemRef item)
+    {
+        var itemHash = Convert.ToHexString(
+            System.Security.Cryptography.SHA256.HashData(Encoding.UTF8.GetBytes(item.Id)))
+            .ToLowerInvariant();
+        return $"{ManifestPrefix}{item.Kind}/{itemHash}";
+    }
+
+    private static string GetCoalesceKey(SecretItemRef item) =>
+        $"{TaskType}:{item.Kind}:{item.Id}";
+
+    private static string GetItemRoute(SecretItemKind kind) => kind switch
+    {
+        SecretItemKind.ManagedSecret => "/secrets",
+        SecretItemKind.AndroidKeystore => "/keystores",
+        SecretItemKind.Certificate => "/certificates",
+        SecretItemKind.ProvisioningProfile => "/profiles",
+        SecretItemKind.PublishProfile => "/secrets/publish",
+        _ => "/"
+    };
+
+    private static HashSet<string>? TryParseDesiredProviders(
+        IReadOnlyDictionary<string, string> parameters)
+    {
+        if (!parameters.TryGetValue("desiredProviderIds", out var json))
+            return null;
+
+        var providerIds = JsonSerializer.Deserialize<List<string>>(json) ?? [];
+        return providerIds.ToHashSet(StringComparer.Ordinal);
+    }
+
+    private static Dictionary<string, bool> ParseProviderSelectionChanges(
+        IReadOnlyDictionary<string, string> parameters)
+    {
+        if (!parameters.TryGetValue("providerSelectionChanges", out var json))
+            return new Dictionary<string, bool>(StringComparer.Ordinal);
+
+        return JsonSerializer.Deserialize<Dictionary<string, bool>>(json)
+            ?? new Dictionary<string, bool>(StringComparer.Ordinal);
+    }
+
+    private static void ApplyProviderSelectionChanges(
+        HashSet<string> providerIds,
+        IReadOnlyDictionary<string, bool> changes)
+    {
+        foreach (var (providerId, desired) in changes)
+        {
+            if (desired)
+                providerIds.Add(providerId);
+            else
+                providerIds.Remove(providerId);
+        }
+    }
+
+    private static SecretItemRef ParseItem(IReadOnlyDictionary<string, string> parameters)
+    {
+        if (!parameters.TryGetValue("kind", out var kindValue) ||
+            !Enum.TryParse<SecretItemKind>(kindValue, out var kind) ||
+            !parameters.TryGetValue("itemId", out var itemId) ||
+            !parameters.TryGetValue("displayName", out var displayName))
+        {
+            throw new InvalidOperationException("The sync task is missing its item identity.");
+        }
+
+        return new SecretItemRef(kind, itemId, displayName);
+    }
+
+    private static bool TryParsePreviousItem(
+        IReadOnlyDictionary<string, string> parameters,
+        out SecretItemRef item)
+    {
+        item = default!;
+        if (!parameters.TryGetValue("previousKind", out var kindValue) ||
+            !Enum.TryParse<SecretItemKind>(kindValue, out var kind) ||
+            !parameters.TryGetValue("previousItemId", out var itemId) ||
+            !parameters.TryGetValue("previousDisplayName", out var displayName))
+        {
+            return false;
+        }
+
+        item = new SecretItemRef(kind, itemId, displayName);
+        return true;
+    }
+
+    private ISecretItemAdapter GetAdapter(SecretItemKind kind) =>
+        _adapters.TryGetValue(kind, out var adapter)
+            ? adapter
+            : throw new InvalidOperationException($"No sync adapter is registered for {kind}.");
+
+    private async Task PublishPlacementChangedAsync(
+        SecretItemRef item,
+        ProviderPlacementState placement,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _mediator.Publish(
+                new SecretProviderPlacementChangedEvent(item, placement),
+                cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                $"Could not publish provider state for '{item.DisplayName}' and '{placement.ProviderId}': {ex.Message}");
+        }
+    }
+
+    private void NotifyItemStateChanged(SecretItemRef item)
+    {
+        if (ItemStateChanged is null)
+            return;
+
+        foreach (Action<SecretItemRef> subscriber in ItemStateChanged.GetInvocationList())
+        {
+            try
+            {
+                subscriber(item);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning($"A secret sync notification subscriber failed: {ex.Message}");
+            }
+        }
+    }
+
+    private sealed record ProviderObservation(
+        bool Observed,
+        string? ContentHash,
+        long? Revision,
+        IReadOnlyList<string>? DesiredProviderIds,
+        string? Error
+    );
+
+    private sealed record CompletedProviderObservation(
+        CloudSecretsProviderConfig Provider,
+        ProviderObservation Observation
+    );
+
+    private sealed record TimedSnapshot<T>(
+        DateTime ExpiresAtUtc,
+        Lazy<Task<T>> Value
+    );
+}

--- a/src/MauiSherpa.Core/Services/SettingsMigrationService.cs
+++ b/src/MauiSherpa.Core/Services/SettingsMigrationService.cs
@@ -85,7 +85,8 @@ public class SettingsMigrationService : ISettingsMigrationService
                 Name: p.Name,
                 ProviderType: p.ProviderType,
                 Settings: new Dictionary<string, string>(p.Settings),
-                IsActive: !string.IsNullOrEmpty(p.Name)
+                IsActive: !string.IsNullOrEmpty(p.Name),
+                DefaultItemKinds: p.EffectiveDefaultItemKinds.ToList()
             )).ToList();
 
             var activeProvider = _cloudSecrets.ActiveProvider;

--- a/src/MauiSherpa.Core/Services/VaultwardenProvider.cs
+++ b/src/MauiSherpa.Core/Services/VaultwardenProvider.cs
@@ -146,12 +146,12 @@ public class VaultwardenProvider : ICloudSecretsProvider
         catch (FormatException ex)
         {
             _logger.LogError($"Vaultwarden secret not base64 encoded: {key} - {ex.Message}");
-            return null;
+            throw;
         }
         catch (Exception ex)
         {
             _logger.LogError($"Vaultwarden get secret error: {ex.Message}", ex);
-            return null;
+            throw;
         }
     }
 
@@ -249,7 +249,7 @@ public class VaultwardenProvider : ICloudSecretsProvider
         catch (Exception ex)
         {
             _logger.LogError($"Vaultwarden secret exists check error: {ex.Message}", ex);
-            return false;
+            throw;
         }
     }
 

--- a/src/MauiSherpa.LinuxGtk/LinuxToolbarManager.cs
+++ b/src/MauiSherpa.LinuxGtk/LinuxToolbarManager.cs
@@ -281,11 +281,14 @@ public class LinuxToolbarManager
 
             var names = _cachedAppleIdentities.Select(i => i.Name).ToArray();
             var selectedIndex = 0;
-            if (_appleIdentityState.SelectedIdentity is { } selected)
+            var preferredId = _appleIdentityState.SelectedIdentity?.Id ??
+                _appleIdentityState.LastSelectedIdentityId;
+            if (!string.IsNullOrWhiteSpace(preferredId))
             {
-                var idx = _cachedAppleIdentities.ToList().FindIndex(i => i.Id == selected.Id);
+                var idx = _cachedAppleIdentities.ToList().FindIndex(i => i.Id == preferredId);
                 if (idx >= 0) selectedIndex = idx;
             }
+            _appleIdentityState.SetSelectedIdentity(_cachedAppleIdentities[selectedIndex]);
 
             var stringList = Gtk.StringList.New(names);
             _identityDropdown = Gtk.DropDown.New(stringList, null);
@@ -315,11 +318,14 @@ public class LinuxToolbarManager
 
             var names = _cachedGoogleIdentities.Select(i => i.Name).ToArray();
             var selectedIndex = 0;
-            if (_googleIdentityState.SelectedIdentity is { } selected)
+            var preferredId = _googleIdentityState.SelectedIdentity?.Id ??
+                _googleIdentityState.LastSelectedIdentityId;
+            if (!string.IsNullOrWhiteSpace(preferredId))
             {
-                var idx = _cachedGoogleIdentities.ToList().FindIndex(i => i.Id == selected.Id);
+                var idx = _cachedGoogleIdentities.ToList().FindIndex(i => i.Id == preferredId);
                 if (idx >= 0) selectedIndex = idx;
             }
+            _googleIdentityState.SetSelectedIdentity(_cachedGoogleIdentities[selectedIndex]);
 
             var stringList = Gtk.StringList.New(names);
             _identityDropdown = Gtk.DropDown.New(stringList, null);

--- a/src/MauiSherpa.MacOS/BlazorContentPage.cs
+++ b/src/MauiSherpa.MacOS/BlazorContentPage.cs
@@ -73,6 +73,8 @@ public class BlazorContentPage : ContentPage
         _identityState = serviceProvider.GetRequiredService<IAppleIdentityStateService>();
         _googleIdentityService = serviceProvider.GetRequiredService<IGoogleIdentityService>();
         _googleIdentityState = serviceProvider.GetRequiredService<IGoogleIdentityStateService>();
+        _identityState.OnSelectionChanged += OnIdentitySelectionChanged;
+        _googleIdentityState.OnSelectionChanged += OnIdentitySelectionChanged;
         _xcodeDownloadAuthService = serviceProvider.GetRequiredService<IAppleDownloadAuthService>();
         _alertService = serviceProvider.GetRequiredService<IAlertService>();
         _preferences = serviceProvider.GetRequiredService<IPreferences>();
@@ -884,20 +886,18 @@ public class BlazorContentPage : ContentPage
         if (identityNative?.Menu == null) return;
 
         var identities = _cachedGoogleIdentities;
-        var selectedId = _googleIdentityState.SelectedIdentity?.Id;
+        var selected = identities.FirstOrDefault(identity =>
+                identity.Id == _googleIdentityState.SelectedIdentity?.Id) ??
+            identities.FirstOrDefault(identity =>
+                identity.Id == _googleIdentityState.LastSelectedIdentityId) ??
+            identities[0];
+        var selectedId = selected.Id;
+        if (!EqualityComparer<GoogleIdentity?>.Default.Equals(_googleIdentityState.SelectedIdentity, selected))
+            _googleIdentityState.SetSelectedIdentity(selected);
 
-        if (selectedId == null && identities.Count > 0)
-        {
-            _googleIdentityState.SetSelectedIdentity(identities[0]);
-            selectedId = identities[0].Id;
-        }
+        UpdateNativeIdentityLabel(identityNative, selected.Name, "flame");
 
-        var selectedName = _googleIdentityState.SelectedIdentity?.Name ?? identities[0].Name;
-        identityNative.Image = NSImage.GetSystemSymbol("flame", null);
-        identityNative.Title = selectedName;
-        identityNative.Label = selectedName;
-
-        var newMenu = new NSMenu();
+        var newMenu = new NSMenu { Title = selected.Name };
         for (int i = 0; i < identities.Count; i++)
         {
             var identity = identities[i];
@@ -909,8 +909,8 @@ public class BlazorContentPage : ContentPage
                 var selected = identities.FirstOrDefault(x => x.Id == id);
                 if (selected != null)
                 {
+                    UpdateNativeIdentityLabel(identityNative, selected.Name, "flame");
                     _googleIdentityState.SetSelectedIdentity(selected);
-                    Dispatcher.Dispatch(() => UpdateToolbarVisibility());
                 }
             });
             menuItem.Target = target;
@@ -952,20 +952,18 @@ public class BlazorContentPage : ContentPage
         if (identityNative?.Menu == null) return;
 
         var identities = _cachedIdentities;
-        var selectedId = _identityState.SelectedIdentity?.Id;
+        var selected = identities.FirstOrDefault(identity =>
+                identity.Id == _identityState.SelectedIdentity?.Id) ??
+            identities.FirstOrDefault(identity =>
+                identity.Id == _identityState.LastSelectedIdentityId) ??
+            identities[0];
+        var selectedId = selected.Id;
+        if (!EqualityComparer<AppleIdentity?>.Default.Equals(_identityState.SelectedIdentity, selected))
+            _identityState.SetSelectedIdentity(selected);
 
-        if (selectedId == null && identities.Count > 0)
-        {
-            _identityState.SetSelectedIdentity(identities[0]);
-            selectedId = identities[0].Id;
-        }
+        UpdateNativeIdentityLabel(identityNative, selected.Name, "apple.logo");
 
-        var selectedName = _identityState.SelectedIdentity?.Name ?? identities[0].Name;
-        identityNative.Image = NSImage.GetSystemSymbol("apple.logo", null);
-        identityNative.Title = selectedName;
-        identityNative.Label = selectedName;
-
-        var newMenu = new NSMenu();
+        var newMenu = new NSMenu { Title = selected.Name };
         for (int i = 0; i < identities.Count; i++)
         {
             var identity = identities[i];
@@ -977,8 +975,8 @@ public class BlazorContentPage : ContentPage
                 var selected = identities.FirstOrDefault(x => x.Id == id);
                 if (selected != null)
                 {
+                    UpdateNativeIdentityLabel(identityNative, selected.Name, "apple.logo");
                     _identityState.SetSelectedIdentity(selected);
-                    Dispatcher.Dispatch(() => UpdateToolbarVisibility());
                 }
             });
             menuItem.Target = target;
@@ -1001,6 +999,36 @@ public class BlazorContentPage : ContentPage
         newMenu.AddItem(settingsItem);
 
         identityNative.Menu = newMenu;
+    }
+
+    void OnIdentitySelectionChanged()
+    {
+        if (!AppleRoutes.Contains(_currentRoute) && !GoogleRoutes.Contains(_currentRoute))
+            return;
+
+        Dispatcher.Dispatch(() =>
+        {
+            // AppKit does not refresh the rendered NSMenuToolbarItem title after
+            // changing Label/Title. Recreate the item with the selected identity.
+            _toolbarInitialized = false;
+            _toolbarVisibilityApplied = false;
+            _nativeIdentityMenu = null;
+            OnToolbarChanged();
+        });
+    }
+
+    static void UpdateNativeIdentityLabel(
+        NSMenuToolbarItem toolbarItem,
+        string selectedName,
+        string systemImageName)
+    {
+        toolbarItem.Image = NSImage.GetSystemSymbol(systemImageName, null);
+        toolbarItem.Title = selectedName;
+        toolbarItem.Label = selectedName;
+        toolbarItem.PaletteLabel = selectedName;
+        toolbarItem.ToolTip = selectedName;
+        if (toolbarItem.Menu is not null)
+            toolbarItem.Menu.Title = selectedName;
     }
 
     void FullRebuildToolbar()
@@ -1297,8 +1325,15 @@ public class BlazorContentPage : ContentPage
         }
 
         var identities = _cachedIdentities;
-        var selectedId = _identityState.SelectedIdentity?.Id;
-        var selectedName = _identityState.SelectedIdentity?.Name ?? identities[0].Name;
+        var selected = identities.FirstOrDefault(identity =>
+                identity.Id == _identityState.SelectedIdentity?.Id) ??
+            identities.FirstOrDefault(identity =>
+                identity.Id == _identityState.LastSelectedIdentityId) ??
+            identities[0];
+        var selectedId = selected.Id;
+        var selectedName = selected.Name;
+        if (!EqualityComparer<AppleIdentity?>.Default.Equals(_identityState.SelectedIdentity, selected))
+            _identityState.SetSelectedIdentity(selected);
 
         var menu = new MacOSMenuToolbarItem
         {

--- a/src/MauiSherpa.MacOS/MacOSMauiProgram.cs
+++ b/src/MauiSherpa.MacOS/MacOSMauiProgram.cs
@@ -96,6 +96,7 @@ public static class MacOSMauiProgram
         // but MAUI's TryAddSingleton may have already captured the portable stubs.
         // Re-register with factories that resolve to the updated .Default values at runtime.
         builder.Services.AddSingleton<IPreferences>(_ => Preferences.Default);
+        builder.Services.AddSingleton<IIdentitySelectionStore, IdentitySelectionStore>();
         builder.Services.AddSingleton<ILauncher>(_ => Launcher.Default);
         builder.Services.AddSingleton<IClipboard>(_ => Clipboard.Default);
         builder.Services.AddSingleton<ISecureStorage>(_ => SecureStorage.Default);
@@ -118,6 +119,11 @@ public static class MacOSMauiProgram
         builder.Services.AddSingleton<IOperationModalService>(sp => sp.GetRequiredService<OperationModalService>());
         builder.Services.AddSingleton<MultiOperationModalService>();
         builder.Services.AddSingleton<IMultiOperationModalService>(sp => sp.GetRequiredService<MultiOperationModalService>());
+        builder.Services.AddSingleton<BackgroundTaskService>();
+        builder.Services.AddSingleton<IBackgroundTaskService>(sp => sp.GetRequiredService<BackgroundTaskService>());
+        builder.Services.AddSingleton<SecretSyncCoordinator>();
+        builder.Services.AddSingleton<ISecretSyncCoordinator>(sp => sp.GetRequiredService<SecretSyncCoordinator>());
+        builder.Services.AddSingleton<IBackgroundTaskHandler>(sp => sp.GetRequiredService<SecretSyncCoordinator>());
 
         // Core services
         builder.Services.AddSingleton<IAndroidSdkService, AndroidSdkService>();
@@ -196,9 +202,16 @@ public static class MacOSMauiProgram
 
         // Cloud Secrets Storage services
         builder.Services.AddSingleton<ICloudSecretsProviderFactory, CloudSecretsProviderFactory>();
-        builder.Services.AddSingleton<ICloudSecretsService, CloudSecretsService>();
+        builder.Services.AddSingleton<CloudSecretsService>();
+        builder.Services.AddSingleton<ICloudSecretsService>(sp => sp.GetRequiredService<CloudSecretsService>());
+        builder.Services.AddSingleton<ISecretsProviderRegistry>(sp => sp.GetRequiredService<CloudSecretsService>());
         builder.Services.AddSingleton<IManagedSecretsService, ManagedSecretsService>();
         builder.Services.AddSingleton<ICertificateSyncService, CertificateSyncService>();
+        builder.Services.AddSingleton<ISecretItemAdapter, ManagedSecretItemAdapter>();
+        builder.Services.AddSingleton<ISecretItemAdapter, AndroidKeystoreItemAdapter>();
+        builder.Services.AddSingleton<ISecretItemAdapter, CertificateItemAdapter>();
+        builder.Services.AddSingleton<ISecretItemAdapter, ProvisioningProfileItemAdapter>();
+        builder.Services.AddSingleton<ISecretItemAdapter, PublishProfileItemAdapter>();
 
         // CI/CD Secrets Publisher services
         builder.Services.AddSingleton<ISecretsPublisherFactory, SecretsPublisherFactory>();
@@ -241,6 +254,7 @@ public static class MacOSMauiProgram
         builder.AddShinyMediator(cfg =>
         {
             cfg.UseMaui();
+            cfg.UseBlazor();
             cfg.AddMauiPersistentCache();
             cfg.AddStandardAppSupportMiddleware();
         });

--- a/src/MauiSherpa.MacOS/MauiSherpa.MacOS.csproj
+++ b/src/MauiSherpa.MacOS/MauiSherpa.MacOS.csproj
@@ -42,6 +42,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
     <PackageReference Include="Sentry.Maui" Version="6.4.0" />
     <PackageReference Include="Shiny.Mediator.Caching.MicrosoftMemoryCache" Version="6.6.2" />
+    <PackageReference Include="Shiny.Mediator.Blazor" Version="6.6.2" />
     <PackageReference Include="Shiny.Mediator.Maui" Version="6.6.2" />
     <PackageReference Include="Microsoft.Maui.DevFlow.Agent" Version="0.1.0-preview.7.26230.1" Condition="'$(Configuration)' == 'Debug'" />
     <PackageReference Include="Microsoft.Maui.DevFlow.Blazor" Version="0.1.0-preview.7.26230.1" Condition="'$(Configuration)' == 'Debug'" />

--- a/src/MauiSherpa/Components/AppleIdentityPicker.razor
+++ b/src/MauiSherpa/Components/AppleIdentityPicker.razor
@@ -211,10 +211,11 @@ else
             return;
         }
         
-        // Restore selection or select first
-        if (IdentityState.SelectedIdentity != null)
+        // Restore the in-memory selection, then the last persisted selection.
+        var preferredIdentityId = IdentityState.SelectedIdentity?.Id ?? IdentityState.LastSelectedIdentityId;
+        if (!string.IsNullOrWhiteSpace(preferredIdentityId))
         {
-            var selected = identities.FirstOrDefault(i => i.Id == IdentityState.SelectedIdentity.Id);
+            var selected = identities.FirstOrDefault(i => i.Id == preferredIdentityId);
             if (selected != null)
             {
                 selectedIdentityId = selected.Id;

--- a/src/MauiSherpa/Components/BackgroundTaskCenter.razor
+++ b/src/MauiSherpa/Components/BackgroundTaskCenter.razor
@@ -1,0 +1,447 @@
+@using MauiSherpa.Core.Interfaces
+@inject IBackgroundTaskService BackgroundTasks
+@inject NavigationManager Navigation
+@inject IJSRuntime JS
+@implements IAsyncDisposable
+
+<div class="background-task-center"
+     id="@_rootId"
+     data-open="@_isOpen.ToString().ToLowerInvariant()">
+    <button type="button"
+            class="task-center-trigger @GetTriggerClass()"
+            data-popover-trigger
+            aria-label="@GetTriggerLabel()"
+            aria-haspopup="dialog"
+            aria-expanded="@_isOpen"
+            aria-controls="@_flyoutId"
+            title="@GetTriggerLabel()"
+            @onclick="ToggleAsync">
+        <i class="@GetTriggerIcon()" aria-hidden="true"></i>
+        @if (BadgeCount > 0)
+        {
+            <span class="task-badge @(NeedsAttention.Count > 0 ? "attention" : "")"
+                  aria-hidden="true">@FormatCount(BadgeCount)</span>
+        }
+    </button>
+
+    <div class="background-task-visually-hidden" aria-live="polite" aria-atomic="true">@_announcement</div>
+
+    @if (_isOpen)
+    {
+        <section class="task-center-flyout"
+                 id="@_flyoutId"
+                 role="dialog"
+                 aria-modal="false"
+                 aria-labelledby="@_headingId">
+            <header class="task-center-flyout-header">
+                <div>
+                    <h2 id="@_headingId">Background tasks</h2>
+                    <p>Progress and recent activity</p>
+                </div>
+                <div class="task-center-header-actions">
+                    @if (CompletedTaskCount > 0)
+                    {
+                        <button type="button"
+                                class="task-center-clear"
+                                disabled="@_isClearingCompleted"
+                                aria-label="@($"Clear {CompletedTaskCount} completed background tasks")"
+                                @onclick="ClearCompletedAsync">
+                            <i class="fa-solid @(_isClearingCompleted ? "fa-spinner fa-spin" : "fa-broom")"
+                               aria-hidden="true"></i>
+                            <span>Clear completed</span>
+                        </button>
+                    }
+                    <button type="button"
+                            class="task-center-close"
+                            data-popover-initial-focus
+                            aria-label="Close background tasks"
+                            title="Close"
+                            @onclick="CloseAsync">
+                        <i class="fa-solid fa-xmark" aria-hidden="true"></i>
+                    </button>
+                </div>
+            </header>
+
+            @if (!BackgroundTasks.IsPersistent)
+            {
+                <div class="task-center-persistence-warning" role="note">
+                    <i class="fa-solid fa-triangle-exclamation" aria-hidden="true"></i>
+                    <span>Task history is temporary and may be lost when the app closes.</span>
+                </div>
+            }
+
+            @if (!string.IsNullOrWhiteSpace(_operationError))
+            {
+                <div class="task-center-error" role="alert">
+                    <i class="fa-solid fa-circle-exclamation" aria-hidden="true"></i>
+                    <span>@_operationError</span>
+                </div>
+            }
+
+            <div class="background-task-groups">
+                @if (RunningTasks.Count > 0)
+                {
+                    <section class="background-task-group" aria-labelledby="@_runningHeadingId">
+                        <h3 id="@_runningHeadingId">
+                            <span>Running</span>
+                            <span class="task-group-count">@RunningTasks.Count</span>
+                        </h3>
+                        @foreach (var item in RunningTasks)
+                        {
+                            <BackgroundTaskItem Item="@item"
+                                                IsBusy="@_busyTaskIds.Contains(item.Id)"
+                                                IsNavigable="@CanNavigateToItem(item)"
+                                                NavigateRequested="NavigateToItemAsync"
+                                                CancelRequested="CancelAsync" />
+                        }
+                    </section>
+                }
+
+                @if (NeedsAttention.Count > 0)
+                {
+                    <section class="background-task-group" aria-labelledby="@_attentionHeadingId">
+                        <h3 id="@_attentionHeadingId" class="task-group-attention">
+                            <span>Needs attention</span>
+                            <span class="task-group-count">@NeedsAttention.Count</span>
+                        </h3>
+                        @foreach (var item in NeedsAttention)
+                        {
+                            <BackgroundTaskItem Item="@item"
+                                                IsBusy="@_busyTaskIds.Contains(item.Id)"
+                                                IsNavigable="@CanNavigateToItem(item)"
+                                                NavigateRequested="NavigateToItemAsync"
+                                                RetryRequested="RetryAsync"
+                                                DismissRequested="DismissAsync" />
+                        }
+                    </section>
+                }
+
+                @if (RecentTasks.Count > 0)
+                {
+                    <section class="background-task-group" aria-labelledby="@_recentHeadingId">
+                        <h3 id="@_recentHeadingId">
+                            <span>Recent</span>
+                            <span class="task-group-count">@RecentTasks.Count</span>
+                        </h3>
+                        @foreach (var item in RecentTasks)
+                        {
+                            <BackgroundTaskItem Item="@item"
+                                                IsBusy="@_busyTaskIds.Contains(item.Id)"
+                                                IsNavigable="@CanNavigateToItem(item)"
+                                                NavigateRequested="NavigateToItemAsync"
+                                                RetryRequested="RetryAsync"
+                                                DismissRequested="DismissAsync" />
+                        }
+                    </section>
+                }
+
+                @if (_tasks.Count == 0)
+                {
+                    <div class="background-task-empty">
+                        <span class="background-task-empty-icon" aria-hidden="true">
+                            <i class="fa-solid fa-list-check"></i>
+                        </span>
+                        <strong>No background tasks</strong>
+                        <span>Long-running work will appear here.</span>
+                    </div>
+                }
+            </div>
+        </section>
+    }
+</div>
+
+@code {
+    private readonly string _rootId = $"background-task-center-{Guid.NewGuid():N}";
+    private readonly string _flyoutId = $"background-task-flyout-{Guid.NewGuid():N}";
+    private readonly string _headingId = $"background-task-heading-{Guid.NewGuid():N}";
+    private readonly string _runningHeadingId = $"background-task-running-{Guid.NewGuid():N}";
+    private readonly string _attentionHeadingId = $"background-task-attention-{Guid.NewGuid():N}";
+    private readonly string _recentHeadingId = $"background-task-recent-{Guid.NewGuid():N}";
+    private readonly HashSet<string> _busyTaskIds = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, BackgroundTaskState> _knownStates = new(StringComparer.Ordinal);
+    private IReadOnlyList<BackgroundTaskInfo> _tasks = Array.Empty<BackgroundTaskInfo>();
+    private DotNetObjectReference<BackgroundTaskCenter>? _dotNetReference;
+    private IJSObjectReference? _interopModule;
+    private bool _interopBound;
+    private bool _isOpen;
+    private bool _isClearingCompleted;
+    private bool _restoreFocus;
+    private string _announcement = "";
+    private string? _operationError;
+
+    [Parameter]
+    public EventCallback<BackgroundTaskInfo> ItemNavigationRequested { get; set; }
+
+    [Parameter]
+    public int MaxRecentItems { get; set; } = 5;
+
+    private IReadOnlyList<BackgroundTaskInfo> RunningTasks => _tasks
+        .Where(item => item.State is BackgroundTaskState.Pending or BackgroundTaskState.Running)
+        .ToArray();
+
+    private IReadOnlyList<BackgroundTaskInfo> NeedsAttention => _tasks
+        .Where(item => item.State is BackgroundTaskState.Failed or BackgroundTaskState.Interrupted)
+        .ToArray();
+
+    private IReadOnlyList<BackgroundTaskInfo> RecentTasks => _tasks
+        .Where(item => item.State is BackgroundTaskState.Succeeded or BackgroundTaskState.Cancelled)
+        .Take(Math.Max(0, MaxRecentItems))
+        .ToArray();
+
+    private int BadgeCount => NeedsAttention.Count > 0
+        ? NeedsAttention.Count
+        : RunningTasks.Count;
+
+    private int CompletedTaskCount => _tasks.Count(item =>
+        item.State is BackgroundTaskState.Succeeded or BackgroundTaskState.Cancelled);
+
+    protected override async Task OnInitializedAsync()
+    {
+        BackgroundTasks.TasksChanged += HandleTasksChanged;
+        try
+        {
+            await BackgroundTasks.InitializeAsync();
+            RefreshTasks(announceChanges: false);
+        }
+        catch (Exception ex)
+        {
+            _operationError = SanitizeText(ex.Message, 300);
+        }
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _interopModule ??= await JS.InvokeAsync<IJSObjectReference>(
+                "import",
+                "./js/mauiSherpaPopovers.js");
+            await _interopModule.InvokeVoidAsync(
+                "ensureStylesheets",
+                new[]
+                {
+                    "./css/backgroundTaskCenter.css",
+                    "./css/backgroundTaskItem.css"
+                });
+        }
+
+        if (_isOpen && !_interopBound)
+        {
+            _interopModule ??= await JS.InvokeAsync<IJSObjectReference>(
+                "import",
+                "./js/mauiSherpaPopovers.js");
+            _dotNetReference ??= DotNetObjectReference.Create(this);
+            await _interopModule.InvokeVoidAsync("bindPopover", _rootId, _dotNetReference);
+            _interopBound = true;
+        }
+        else if (!_isOpen && _restoreFocus && _interopModule is not null)
+        {
+            _restoreFocus = false;
+            await _interopModule.InvokeVoidAsync("focusTrigger", _rootId);
+        }
+    }
+
+    private Task ToggleAsync()
+    {
+        if (_isOpen)
+            return CloseAsync();
+
+        _operationError = null;
+        _isOpen = true;
+        return Task.CompletedTask;
+    }
+
+    [JSInvokable]
+    public Task CloseFromJavaScript(bool restoreFocus) =>
+        CloseAsync(restoreFocus);
+
+    private Task CloseAsync() => CloseAsync(restoreFocus: true);
+
+    private async Task CloseAsync(bool restoreFocus)
+    {
+        if (!_isOpen)
+            return;
+
+        _isOpen = false;
+        _restoreFocus = restoreFocus;
+        if (_interopBound && _interopModule is not null)
+        {
+            await _interopModule.InvokeVoidAsync("unbindPopover", _rootId);
+            _interopBound = false;
+        }
+
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private void HandleTasksChanged()
+    {
+        _ = InvokeAsync(() =>
+        {
+            RefreshTasks(announceChanges: true);
+            StateHasChanged();
+        });
+    }
+
+    private void RefreshTasks(bool announceChanges)
+    {
+        var updated = BackgroundTasks.Tasks;
+
+        if (announceChanges)
+        {
+            var changedItem = updated.FirstOrDefault(item =>
+                _knownStates.TryGetValue(item.Id, out var previousState) &&
+                previousState != item.State);
+
+            if (changedItem is not null)
+            {
+                _announcement = changedItem.State switch
+                {
+                    BackgroundTaskState.Succeeded => $"{changedItem.Request.Title} completed.",
+                    BackgroundTaskState.Failed or BackgroundTaskState.Interrupted =>
+                        $"{changedItem.Request.Title} needs attention.",
+                    BackgroundTaskState.Cancelled => $"{changedItem.Request.Title} was cancelled.",
+                    BackgroundTaskState.Running => $"{changedItem.Request.Title} started.",
+                    _ => $"{changedItem.Request.Title} is {GetStateText(changedItem.State)}."
+                };
+            }
+        }
+
+        _tasks = updated;
+        _knownStates.Clear();
+        foreach (var item in updated)
+            _knownStates[item.Id] = item.State;
+    }
+
+    private Task RetryAsync(string taskId) =>
+        RunActionAsync(taskId, () => BackgroundTasks.RetryAsync(taskId), "Task queued to retry.");
+
+    private Task CancelAsync(string taskId) =>
+        RunActionAsync(taskId, () => BackgroundTasks.CancelAsync(taskId), "Cancellation requested.");
+
+    private Task DismissAsync(string taskId) =>
+        RunActionAsync(taskId, () => BackgroundTasks.DismissAsync(taskId), "Task dismissed.");
+
+    private async Task ClearCompletedAsync()
+    {
+        if (_isClearingCompleted)
+            return;
+
+        _isClearingCompleted = true;
+        _operationError = null;
+        var count = CompletedTaskCount;
+        try
+        {
+            await BackgroundTasks.ClearCompletedAsync();
+            _announcement = count == 1
+                ? "Cleared 1 completed task."
+                : $"Cleared {count} completed tasks.";
+            RefreshTasks(announceChanges: false);
+        }
+        catch (Exception ex)
+        {
+            _operationError = SanitizeText(ex.Message, 300);
+            _announcement = $"Completed tasks could not be cleared. {_operationError}";
+        }
+        finally
+        {
+            _isClearingCompleted = false;
+        }
+    }
+
+    private async Task RunActionAsync(string taskId, Func<Task> action, string successMessage)
+    {
+        if (!_busyTaskIds.Add(taskId))
+            return;
+
+        _operationError = null;
+        try
+        {
+            await action();
+            _announcement = successMessage;
+            RefreshTasks(announceChanges: false);
+        }
+        catch (Exception ex)
+        {
+            _operationError = SanitizeText(ex.Message, 300);
+            _announcement = $"The task action failed. {_operationError}";
+        }
+        finally
+        {
+            _busyTaskIds.Remove(taskId);
+        }
+    }
+
+    private async Task NavigateToItemAsync(BackgroundTaskInfo item)
+    {
+        await CloseAsync();
+
+        if (ItemNavigationRequested.HasDelegate)
+        {
+            await ItemNavigationRequested.InvokeAsync(item);
+        }
+        else if (!string.IsNullOrWhiteSpace(item.Request.ItemRoute))
+        {
+            Navigation.NavigateTo(item.Request.ItemRoute);
+        }
+    }
+
+    private bool CanNavigateToItem(BackgroundTaskInfo item) =>
+        ItemNavigationRequested.HasDelegate || !string.IsNullOrWhiteSpace(item.Request.ItemRoute);
+
+    private string GetTriggerLabel()
+    {
+        if (NeedsAttention.Count == 1)
+            return "Background tasks: 1 task needs attention";
+        if (NeedsAttention.Count > 1)
+            return $"Background tasks: {NeedsAttention.Count} tasks need attention";
+        if (RunningTasks.Count == 1)
+            return "Background tasks: 1 task in progress";
+        if (RunningTasks.Count > 1)
+            return $"Background tasks: {RunningTasks.Count} tasks in progress";
+        return "Background tasks";
+    }
+
+    private string GetTriggerClass() => NeedsAttention.Count > 0
+        ? "has-attention"
+        : RunningTasks.Count > 0
+            ? "has-running"
+            : "";
+
+    private string GetTriggerIcon() => RunningTasks.Count > 0
+        ? "fa-solid fa-arrows-rotate task-trigger-spinning"
+        : "fa-solid fa-list-check";
+
+    private static string GetStateText(BackgroundTaskState state) =>
+        state.ToString().ToLowerInvariant();
+
+    private static string FormatCount(int count) => count > 99 ? "99+" : count.ToString();
+
+    private static string SanitizeText(string? value, int maxLength)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return "The operation could not be completed.";
+
+        var singleLine = value.ReplaceLineEndings(" ").Trim();
+        var sanitized = string.Concat(singleLine.Where(character => !char.IsControl(character)));
+        return sanitized.Length <= maxLength ? sanitized : $"{sanitized[..maxLength]}…";
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        BackgroundTasks.TasksChanged -= HandleTasksChanged;
+
+        try
+        {
+            if (_interopModule is not null)
+            {
+                await _interopModule.InvokeVoidAsync("unbindPopover", _rootId);
+                await _interopModule.DisposeAsync();
+            }
+        }
+        catch (JSDisconnectedException)
+        {
+        }
+
+        _dotNetReference?.Dispose();
+    }
+}

--- a/src/MauiSherpa/Components/BackgroundTaskItem.razor
+++ b/src/MauiSherpa/Components/BackgroundTaskItem.razor
@@ -1,0 +1,280 @@
+@using MauiSherpa.Core.Interfaces
+
+<article class="task-item state-@Item.State.ToString().ToLowerInvariant()">
+    <div class="task-item-heading">
+        <span class="task-state-icon @GetStateClass()" title="@GetStateText()">
+            <i class="@GetStateIcon()" aria-hidden="true"></i>
+            <span class="background-task-visually-hidden">@GetStateText()</span>
+        </span>
+        <div class="task-title-block">
+            @if (CanNavigate)
+            {
+                <button type="button"
+                        class="task-title task-link"
+                        disabled="@IsBusy"
+                        title="Open related item"
+                        @onclick="NavigateAsync">
+                    <span>@Item.Request.Title</span>
+                    <i class="fa-solid fa-arrow-up-right-from-square" aria-hidden="true"></i>
+                </button>
+            }
+            else
+            {
+                <strong class="task-title">@Item.Request.Title</strong>
+            }
+            @if (!string.IsNullOrWhiteSpace(Item.Request.Description))
+            {
+                <span class="task-description">@SanitizeText(Item.Request.Description, 240)</span>
+            }
+        </div>
+    </div>
+
+    @if (IsActive)
+    {
+        <div class="task-progress">
+            <div class="task-progress-copy">
+                <span>@GetStatusText()</span>
+                @if (Item.Progress.HasValue)
+                {
+                    <span>@Item.Progress%</span>
+                }
+            </div>
+            <div class="task-progress-track"
+                 role="progressbar"
+                 aria-label="@($"{Item.Request.Title} progress")"
+                 aria-valuemin="0"
+                 aria-valuemax="100"
+                 aria-valuenow="@Item.Progress">
+                @if (Item.Progress.HasValue)
+                {
+                    <span class="task-progress-value" style="@($"width: {Item.Progress.Value}%")"></span>
+                }
+                else
+                {
+                    <span class="task-progress-value indeterminate"></span>
+                }
+            </div>
+        </div>
+    }
+    else if (!string.IsNullOrWhiteSpace(Item.Status))
+    {
+        <div class="task-status">@SanitizeText(Item.Status, 180)</div>
+    }
+
+    @if (Item.Steps is { Count: > 0 } steps)
+    {
+        <ol class="task-steps" aria-label="@($"{Item.Request.Title} provider progress")">
+            @foreach (var step in steps)
+            {
+                <li class="task-step state-@step.State.ToString().ToLowerInvariant()"
+                    aria-label="@GetStepAccessibleText(step)">
+                    <span class="task-step-icon" aria-hidden="true">
+                        <i class="@GetStepIcon(step.State)"></i>
+                    </span>
+                    <span class="task-step-label">@SanitizeText(step.Label, 80)</span>
+                    <span class="task-step-status">
+                        @SanitizeText(step.Status, 120, GetStepStateText(step.State))
+                    </span>
+                    @if (!string.IsNullOrWhiteSpace(step.Error))
+                    {
+                        <span class="task-step-error">@SanitizeText(step.Error, 240)</span>
+                    }
+                </li>
+            }
+        </ol>
+    }
+
+    @if (!string.IsNullOrWhiteSpace(Item.Error))
+    {
+        <div class="task-error">
+            <i class="fa-solid fa-circle-exclamation" aria-hidden="true"></i>
+            <span>@SanitizeText(Item.Error, 500)</span>
+        </div>
+    }
+
+    @if (Item.Log.Count > 0)
+    {
+        <details class="task-log">
+            <summary>
+                <i class="fa-solid fa-terminal" aria-hidden="true"></i>
+                Activity log
+                <span>@Item.Log.Count</span>
+            </summary>
+            <ol>
+                @foreach (var entry in Item.Log.TakeLast(Math.Max(0, MaxLogEntries)))
+                {
+                    <li class="log-@entry.Level.ToString().ToLowerInvariant()">
+                        <time datetime="@entry.Timestamp.ToString("O")"
+                              title="@entry.Timestamp.ToLocalTime().ToString("F")">
+                            @entry.Timestamp.ToLocalTime().ToString("HH:mm:ss")
+                        </time>
+                        <span>@SanitizeText(entry.Message, 500)</span>
+                    </li>
+                }
+            </ol>
+        </details>
+    }
+
+    <footer class="task-footer">
+        <time datetime="@GetRelevantTime().ToString("O")"
+              title="@GetRelevantTime().ToLocalTime().ToString("F")">
+            @GetRelevantTime().ToLocalTime().ToString("g")
+        </time>
+        <div class="task-actions">
+            @if (CanRetry)
+            {
+                <button type="button"
+                        class="task-action"
+                        disabled="@IsBusy"
+                        @onclick="RetryAsync">
+                    <i class="fa-solid fa-rotate-right" aria-hidden="true"></i>
+                    Retry
+                </button>
+            }
+            @if (IsActive)
+            {
+                <button type="button"
+                        class="task-action task-action-danger"
+                        disabled="@IsBusy"
+                        @onclick="CancelAsync">
+                    <i class="fa-solid fa-ban" aria-hidden="true"></i>
+                    Cancel
+                </button>
+            }
+            @if (CanDismiss)
+            {
+                <button type="button"
+                        class="task-action"
+                        disabled="@IsBusy"
+                        @onclick="DismissAsync">
+                    <i class="fa-solid fa-xmark" aria-hidden="true"></i>
+                    Dismiss
+                </button>
+            }
+        </div>
+    </footer>
+</article>
+
+@code {
+    [Parameter, EditorRequired]
+    public BackgroundTaskInfo Item { get; set; } = default!;
+
+    [Parameter]
+    public bool IsBusy { get; set; }
+
+    [Parameter]
+    public bool IsNavigable { get; set; }
+
+    [Parameter]
+    public int MaxLogEntries { get; set; } = 6;
+
+    [Parameter]
+    public EventCallback<BackgroundTaskInfo> NavigateRequested { get; set; }
+
+    [Parameter]
+    public EventCallback<string> RetryRequested { get; set; }
+
+    [Parameter]
+    public EventCallback<string> CancelRequested { get; set; }
+
+    [Parameter]
+    public EventCallback<string> DismissRequested { get; set; }
+
+    private bool IsActive =>
+        Item.State is BackgroundTaskState.Pending or BackgroundTaskState.Running;
+
+    private bool CanNavigate => IsNavigable && NavigateRequested.HasDelegate;
+
+    private bool CanRetry =>
+        RetryRequested.HasDelegate &&
+        Item.State is BackgroundTaskState.Failed or
+            BackgroundTaskState.Interrupted or
+            BackgroundTaskState.Cancelled;
+
+    private bool CanDismiss =>
+        DismissRequested.HasDelegate &&
+        Item.State is not BackgroundTaskState.Pending and not BackgroundTaskState.Running;
+
+    private Task NavigateAsync() => NavigateRequested.InvokeAsync(Item);
+    private Task RetryAsync() => RetryRequested.InvokeAsync(Item.Id);
+    private Task CancelAsync() => CancelRequested.InvokeAsync(Item.Id);
+    private Task DismissAsync() => DismissRequested.InvokeAsync(Item.Id);
+
+    private string GetStatusText() =>
+        SanitizeText(Item.Status, 180, Item.State == BackgroundTaskState.Pending ? "Waiting to start" : "In progress");
+
+    private string GetStateText() => Item.State switch
+    {
+        BackgroundTaskState.Pending => "Waiting",
+        BackgroundTaskState.Running => "Running",
+        BackgroundTaskState.Succeeded => "Completed",
+        BackgroundTaskState.Failed => "Failed",
+        BackgroundTaskState.Cancelled => "Cancelled",
+        BackgroundTaskState.Interrupted => "Interrupted",
+        _ => "Unknown"
+    };
+
+    private string GetStateClass() => Item.State switch
+    {
+        BackgroundTaskState.Succeeded => "success",
+        BackgroundTaskState.Failed or BackgroundTaskState.Interrupted => "error",
+        BackgroundTaskState.Cancelled => "warning",
+        BackgroundTaskState.Pending or BackgroundTaskState.Running => "active",
+        _ => ""
+    };
+
+    private string GetStateIcon() => Item.State switch
+    {
+        BackgroundTaskState.Pending => "fa-solid fa-clock",
+        BackgroundTaskState.Running => IsBusy
+            ? "fa-solid fa-spinner fa-spin"
+            : "fa-solid fa-arrows-rotate",
+        BackgroundTaskState.Succeeded => "fa-solid fa-circle-check",
+        BackgroundTaskState.Failed => "fa-solid fa-circle-exclamation",
+        BackgroundTaskState.Cancelled => "fa-solid fa-circle-minus",
+        BackgroundTaskState.Interrupted => "fa-solid fa-plug-circle-xmark",
+        _ => "fa-solid fa-circle"
+    };
+
+    private static string GetStepStateText(BackgroundTaskStepState state) => state switch
+    {
+        BackgroundTaskStepState.Pending => "Waiting",
+        BackgroundTaskStepState.Running => "In progress",
+        BackgroundTaskStepState.Succeeded => "Completed",
+        BackgroundTaskStepState.Failed => "Failed",
+        BackgroundTaskStepState.Cancelled => "Cancelled",
+        _ => "Unknown"
+    };
+
+    private static string GetStepIcon(BackgroundTaskStepState state) => state switch
+    {
+        BackgroundTaskStepState.Pending => "fa-regular fa-circle",
+        BackgroundTaskStepState.Running => "fa-solid fa-spinner fa-spin",
+        BackgroundTaskStepState.Succeeded => "fa-solid fa-circle-check",
+        BackgroundTaskStepState.Failed => "fa-solid fa-circle-exclamation",
+        BackgroundTaskStepState.Cancelled => "fa-solid fa-circle-minus",
+        _ => "fa-solid fa-circle"
+    };
+
+    private static string GetStepAccessibleText(BackgroundTaskStepInfo step)
+    {
+        var state = GetStepStateText(step.State);
+        var status = string.IsNullOrWhiteSpace(step.Status) ? state : step.Status;
+        return string.IsNullOrWhiteSpace(step.Error)
+            ? $"{step.Label}: {status}"
+            : $"{step.Label}: {status}. {step.Error}";
+    }
+
+    private DateTime GetRelevantTime() =>
+        Item.CompletedAtUtc ?? Item.StartedAtUtc ?? Item.CreatedAtUtc;
+
+    private static string SanitizeText(string? value, int maxLength, string fallback = "")
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return fallback;
+
+        var singleLine = value.ReplaceLineEndings(" ").Trim();
+        var sanitized = string.Concat(singleLine.Where(character => !char.IsControl(character)));
+        return sanitized.Length <= maxLength ? sanitized : $"{sanitized[..maxLength]}…";
+    }
+}

--- a/src/MauiSherpa/Components/GoogleIdentityPicker.razor
+++ b/src/MauiSherpa/Components/GoogleIdentityPicker.razor
@@ -182,9 +182,10 @@ else
             return;
         }
 
-        if (IdentityState.SelectedIdentity != null)
+        var preferredIdentityId = IdentityState.SelectedIdentity?.Id ?? IdentityState.LastSelectedIdentityId;
+        if (!string.IsNullOrWhiteSpace(preferredIdentityId))
         {
-            var selected = identities.FirstOrDefault(i => i.Id == IdentityState.SelectedIdentity.Id);
+            var selected = identities.FirstOrDefault(i => i.Id == preferredIdentityId);
             if (selected != null)
             {
                 selectedIdentityId = selected.Id;

--- a/src/MauiSherpa/Components/MainLayout.razor
+++ b/src/MauiSherpa/Components/MainLayout.razor
@@ -13,6 +13,7 @@
 @inject IToolbarService ToolbarService
 @inject NavigationManager NavManager
 @inject ICopilotContextService CopilotContext
+@inject IBackgroundTaskService BackgroundTasks
 @implements IDisposable
 
 <div class="main-layout @ThemeClass @PlatformClass">
@@ -148,6 +149,11 @@
 <!-- Global Toast Notifications -->
 <MauiSherpa.Components.ToastContainer />
 
+<!-- Global background task manager -->
+<div class="global-background-task-center">
+    <MauiSherpa.Components.BackgroundTaskCenter />
+</div>
+
 @code {
     private string ThemeClass => ThemeService.IsDarkMode ? "theme-dark" : "theme-light";
     private string PlatformClass => PlatformInfo.IsMacOS ? "platform-macos" : PlatformInfo.IsWindows ? "platform-windows" : PlatformInfo.IsMacCatalyst ? "platform-mac" : "platform-linux";
@@ -180,6 +186,9 @@
             
             // Run settings migration in background
             _ = RunMigrationAsync();
+
+            // Resume secure background work after the UI has initialized.
+            _ = BackgroundTasks.InitializeAsync();
 
             // Start watching for ADB device changes
             _ = DeviceWatcher.StartAsync();
@@ -306,6 +315,18 @@
         height: 100vh;
         width: 100vw;
         --titlebar-height: 28px;
+    }
+
+    .global-background-task-center {
+        position: fixed;
+        right: 1rem;
+        bottom: 1rem;
+        z-index: 900;
+    }
+
+    .global-background-task-center .task-center-flyout {
+        inset-block-start: auto;
+        inset-block-end: calc(100% + 0.5rem);
     }
 
     .sidebar {
@@ -476,6 +497,7 @@
         flex: 1;
         padding: 30px;
         padding-top: calc(var(--titlebar-height) + 10px);
+        padding-bottom: 5rem;
         overflow-y: auto;
         background-color: var(--bg-primary);
         color: var(--text-primary);
@@ -587,6 +609,7 @@
 
     .platform-macos .content {
         padding: 15px;
+        padding-bottom: 5rem;
         /* Reserve a right-hand gutter so content never sits under the
            floating viewport scrollbar (WKWebView document-level scroll). */
         padding-right: 23px;

--- a/src/MauiSherpa/Components/SecretProviderPicker.razor
+++ b/src/MauiSherpa/Components/SecretProviderPicker.razor
@@ -1,0 +1,438 @@
+@using MauiSherpa.Core.Interfaces
+@inject IJSRuntime JS
+@implements IAsyncDisposable
+
+<div class="secret-provider-picker"
+     id="@_rootId"
+     data-open="@_isOpen.ToString().ToLowerInvariant()">
+    <button type="button"
+            class="provider-trigger @GetTriggerStateClass()"
+            data-popover-trigger
+            aria-label="@GetTriggerLabel()"
+            aria-haspopup="dialog"
+            aria-expanded="@_isOpen"
+            aria-controls="@_popoverId"
+            title="@GetTriggerLabel()"
+            @onclick="ToggleAsync">
+        <span class="fa-layers fa-fw provider-trigger-icon" aria-hidden="true">
+            <i class="fa-solid fa-cloud"></i>
+            @if (HasLoadingState)
+            {
+                <i class="fa-solid fa-arrows-rotate provider-trigger-loading"></i>
+            }
+            else
+            {
+                <i class="fa-solid fa-key provider-trigger-key"></i>
+            }
+        </span>
+        @if (DesiredProviderCount > 0)
+        {
+            <span class="provider-count" aria-hidden="true">@FormatCount(DesiredProviderCount)</span>
+        }
+        @if (HasAttentionState)
+        {
+            <span class="attention-dot" aria-hidden="true"></span>
+        }
+    </button>
+
+    @if (_isOpen)
+    {
+        <section class="provider-popover"
+                 id="@_popoverId"
+                 role="dialog"
+                 aria-modal="false"
+                 aria-labelledby="@_headingId"
+                 aria-describedby="@_helperId">
+            <header class="secret-provider-popover-header">
+                <div>
+                    <h2 id="@_headingId">Sync providers</h2>
+                    <p>Choose where this item should be stored.</p>
+                </div>
+                <button type="button"
+                        class="secret-provider-close"
+                        aria-label="Close and apply sync provider changes"
+                        title="Close"
+                        @onclick="CloseAndCommitAsync">
+                    <i class="fa-solid fa-xmark" aria-hidden="true"></i>
+                </button>
+            </header>
+
+            <div class="provider-list" role="group" aria-label="Configured secret providers">
+                @if (ConfiguredProviders.Count == 0)
+                {
+                    <div class="empty-providers">
+                        <i class="fa-solid fa-cloud-circle-xmark" aria-hidden="true"></i>
+                        <span>No secret providers are configured.</span>
+                    </div>
+                }
+                else
+                {
+                    @foreach (var provider in ConfiguredProviders)
+                    {
+                        var placement = GetPlacement(provider.Id);
+                        var isDesired = _draftDesired.Contains(provider.Id);
+                        var status = GetDisplayStatus(placement, isDesired);
+                        var isLoading = status == SecretPlacementStatus.Loading;
+                        var cannotAdd = !CanAddProviderCopy && !isDesired;
+                        <label class="provider-option @GetStatusClass(status)">
+                            <input type="checkbox"
+                                   checked="@isDesired"
+                                   disabled="@(isLoading || cannotAdd)"
+                                   aria-label="Store in @provider.Name"
+                                   @onchange="eventArgs => SetDesired(provider.Id, eventArgs)" />
+                            <span class="provider-icon" aria-hidden="true">
+                                <i class="@GetProviderIcon(provider.ProviderType)"></i>
+                            </span>
+                            <span class="provider-copy">
+                                <span class="provider-name">@provider.Name</span>
+                                <span class="provider-observation">
+                                    @if (isLoading)
+                                    {
+                                        <span>Checking stored state…</span>
+                                    }
+                                    else
+                                    {
+                                        <span>@(isDesired ? "Desired" : "Not desired")</span>
+                                        <span aria-hidden="true"> · </span>
+                                        <span>@(placement?.Observed == true ? "Stored" : "Not stored")</span>
+                                    }
+                                </span>
+                            </span>
+                            <span class="provider-status-pill">
+                                <i class="@GetStatusIcon(status)" aria-hidden="true"></i>
+                                @GetStatusText(status)
+                            </span>
+                        </label>
+                    }
+                }
+            </div>
+
+            @if (!CanAddProviderCopy && !string.IsNullOrWhiteSpace(UnavailableSourceReason))
+            {
+                <div class="provider-source-warning" role="note">
+                    <i class="fa-solid fa-key" aria-hidden="true"></i>
+                    <span>@UnavailableSourceReason</span>
+                </div>
+            }
+
+            @if (SyncState.HasConflict && ConflictSourceRequested.HasDelegate)
+            {
+                <div class="provider-conflict-resolution" role="alert">
+                    <div>
+                        <i class="fa-solid fa-code-compare" aria-hidden="true"></i>
+                        <span>Copies differ. Choose which provider should overwrite the others.</span>
+                    </div>
+                    <div class="provider-conflict-actions">
+                        @foreach (var provider in ConfiguredProviders.Where(provider =>
+                            GetPlacement(provider.Id)?.Observed == true))
+                        {
+                            <button type="button"
+                                    @onclick="() => ChooseConflictSourceAsync(provider.Id)">
+                                Use @provider.Name
+                            </button>
+                        }
+                    </div>
+                </div>
+            }
+
+            <footer class="secret-provider-popover-footer">
+                <i class="fa-solid fa-circle-info" aria-hidden="true"></i>
+                <span id="@_helperId">@GetHelperText()</span>
+            </footer>
+        </section>
+    }
+</div>
+
+@code {
+    private readonly string _rootId = $"secret-provider-picker-{Guid.NewGuid():N}";
+    private readonly string _popoverId = $"secret-provider-popover-{Guid.NewGuid():N}";
+    private readonly string _headingId = $"secret-provider-heading-{Guid.NewGuid():N}";
+    private readonly string _helperId = $"secret-provider-helper-{Guid.NewGuid():N}";
+    private readonly HashSet<string> _draftDesired = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _initialDesired = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _modifiedProviders = new(StringComparer.Ordinal);
+    private DotNetObjectReference<SecretProviderPicker>? _dotNetReference;
+    private IJSObjectReference? _interopModule;
+    private bool _interopBound;
+    private bool _isOpen;
+    private bool _restoreFocus;
+
+    [Parameter, EditorRequired]
+    public SecretItemSyncState SyncState { get; set; } = default!;
+
+    [Parameter, EditorRequired]
+    public IReadOnlyList<CloudSecretsProviderConfig> ConfiguredProviders { get; set; } =
+        Array.Empty<CloudSecretsProviderConfig>();
+
+    [Parameter]
+    public EventCallback<IReadOnlyDictionary<string, bool>> PlacementChangesCommitted { get; set; }
+
+    [Parameter]
+    public bool EmptySelectionRequiresConfirmation { get; set; }
+
+    [Parameter]
+    public bool CanAddProviderCopy { get; set; } = true;
+
+    [Parameter]
+    public string? UnavailableSourceReason { get; set; }
+
+    [Parameter]
+    public EventCallback<string> ConflictSourceRequested { get; set; }
+
+    private int DesiredProviderCount => _isOpen
+        ? _draftDesired.Count
+        : SyncState.Providers.Count(provider => provider.Desired);
+
+    private bool HasAttentionState => SyncState.HasConflict ||
+        SyncState.Providers.Any(provider =>
+            provider.Status is SecretPlacementStatus.Failed or
+                SecretPlacementStatus.Unavailable or
+                SecretPlacementStatus.Conflict);
+
+    private bool HasLoadingState => SyncState.Providers.Any(provider =>
+        provider.Status == SecretPlacementStatus.Loading);
+
+    protected override void OnParametersSet()
+    {
+        if (!_isOpen)
+            ResetDraft();
+        else
+            MergeLoadedProviderState();
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _interopModule ??= await JS.InvokeAsync<IJSObjectReference>(
+                "import",
+                "./js/mauiSherpaPopovers.js");
+            await _interopModule.InvokeVoidAsync(
+                "ensureStylesheet",
+                "./css/secretProviderPicker.css");
+        }
+
+        if (_isOpen && !_interopBound)
+        {
+            _interopModule ??= await JS.InvokeAsync<IJSObjectReference>(
+                "import",
+                "./js/mauiSherpaPopovers.js");
+            _dotNetReference ??= DotNetObjectReference.Create(this);
+            await _interopModule.InvokeVoidAsync("bindPopover", _rootId, _dotNetReference);
+            _interopBound = true;
+        }
+        else if (!_isOpen && _restoreFocus && _interopModule is not null)
+        {
+            _restoreFocus = false;
+            await _interopModule.InvokeVoidAsync("focusTrigger", _rootId);
+        }
+    }
+
+    private async Task ToggleAsync()
+    {
+        if (_isOpen)
+        {
+            await CloseAndCommitAsync();
+            return;
+        }
+
+        ResetDraft();
+        _isOpen = true;
+    }
+
+    private void ResetDraft()
+    {
+        _draftDesired.Clear();
+        _initialDesired.Clear();
+        _modifiedProviders.Clear();
+
+        foreach (var provider in SyncState.Providers.Where(provider => provider.Desired))
+        {
+            _draftDesired.Add(provider.ProviderId);
+            _initialDesired.Add(provider.ProviderId);
+        }
+    }
+
+    private void SetDesired(string providerId, ChangeEventArgs eventArgs)
+    {
+        _modifiedProviders.Add(providerId);
+        if (eventArgs.Value is true)
+            _draftDesired.Add(providerId);
+        else
+            _draftDesired.Remove(providerId);
+    }
+
+    [JSInvokable]
+    public Task CloseFromJavaScript(bool restoreFocus) =>
+        CloseAndCommitAsync(restoreFocus);
+
+    private Task CloseAndCommitAsync() => CloseAndCommitAsync(restoreFocus: true);
+
+    private async Task CloseAndCommitAsync(bool restoreFocus)
+    {
+        if (!_isOpen)
+            return;
+
+        _isOpen = false;
+        _restoreFocus = restoreFocus;
+
+        if (_interopBound && _interopModule is not null)
+        {
+            await _interopModule.InvokeVoidAsync("unbindPopover", _rootId);
+            _interopBound = false;
+        }
+
+        var changed = !_draftDesired.SetEquals(_initialDesired);
+        await InvokeAsync(StateHasChanged);
+
+        if (changed)
+        {
+            IReadOnlyDictionary<string, bool> changes = _modifiedProviders
+                .ToDictionary(
+                    providerId => providerId,
+                    providerId => _draftDesired.Contains(providerId),
+                    StringComparer.Ordinal);
+            await PlacementChangesCommitted.InvokeAsync(changes);
+        }
+    }
+
+    private void MergeLoadedProviderState()
+    {
+        foreach (var provider in SyncState.Providers.Where(provider =>
+            provider.Status != SecretPlacementStatus.Loading &&
+            !_modifiedProviders.Contains(provider.ProviderId)))
+        {
+            if (provider.Desired)
+            {
+                _draftDesired.Add(provider.ProviderId);
+                _initialDesired.Add(provider.ProviderId);
+            }
+            else
+            {
+                _draftDesired.Remove(provider.ProviderId);
+                _initialDesired.Remove(provider.ProviderId);
+            }
+        }
+    }
+
+    private ProviderPlacementState? GetPlacement(string providerId) =>
+        SyncState.Providers.FirstOrDefault(provider =>
+            string.Equals(provider.ProviderId, providerId, StringComparison.Ordinal));
+
+    private async Task ChooseConflictSourceAsync(string providerId)
+    {
+        await CloseAndCommitAsync();
+        await ConflictSourceRequested.InvokeAsync(providerId);
+    }
+
+    private SecretPlacementStatus GetDisplayStatus(
+        ProviderPlacementState? placement,
+        bool draftDesired)
+    {
+        if (placement is null)
+            return draftDesired ? SecretPlacementStatus.Pending : SecretPlacementStatus.NotStored;
+
+        if (placement.Desired != draftDesired)
+            return SecretPlacementStatus.Pending;
+
+        return placement.Status;
+    }
+
+    private string GetHelperText()
+    {
+        if (EmptySelectionRequiresConfirmation && _draftDesired.Count == 0)
+            return "Removing all providers requires confirmation from the containing page when this menu closes.";
+
+        return _draftDesired.SetEquals(_initialDesired)
+            ? "Changes take effect when this menu closes."
+            : "Provider changes will be applied when this menu closes.";
+    }
+
+    private string GetTriggerLabel()
+    {
+        var count = SyncState.Providers.Count(provider => provider.Desired);
+        var state = HasAttentionState ? " Sync needs attention." : "";
+        return count switch
+        {
+            0 => $"Choose secret sync providers.{state}",
+            1 => $"Secret sync uses 1 provider.{state}",
+            _ => $"Secret sync uses {count} providers.{state}"
+        };
+    }
+
+    private string GetTriggerStateClass()
+    {
+        if (SyncState.HasConflict)
+            return "provider-trigger-state-conflict";
+        if (!CanAddProviderCopy && DesiredProviderCount == 0)
+            return "provider-trigger-state-failed";
+        if (HasLoadingState)
+            return "provider-trigger-state-loading";
+        if (SyncState.Providers.Any(provider => provider.Status == SecretPlacementStatus.Failed))
+            return "provider-trigger-state-failed";
+        if (SyncState.Providers.Any(provider =>
+                provider.Status is SecretPlacementStatus.Pending or SecretPlacementStatus.Unavailable))
+            return "provider-trigger-state-pending";
+        if (SyncState.Providers.Any(provider => provider.Status == SecretPlacementStatus.Synced))
+            return "provider-trigger-state-synced";
+        return "provider-trigger-state-idle";
+    }
+
+    private static string GetStatusClass(SecretPlacementStatus status) =>
+        $"provider-placement-status-{status.ToString().ToLowerInvariant()}";
+
+    private static string GetStatusText(SecretPlacementStatus status) => status switch
+    {
+        SecretPlacementStatus.Loading => "Checking",
+        SecretPlacementStatus.NotStored => "Not synced",
+        SecretPlacementStatus.Synced => "Synced",
+        SecretPlacementStatus.Pending => "Pending",
+        SecretPlacementStatus.Failed => "Failed",
+        SecretPlacementStatus.Unavailable => "Unavailable",
+        SecretPlacementStatus.Conflict => "Conflict",
+        _ => "Unknown"
+    };
+
+    private static string GetStatusIcon(SecretPlacementStatus status) => status switch
+    {
+        SecretPlacementStatus.Loading => "fa-solid fa-spinner fa-spin",
+        SecretPlacementStatus.Synced => "fa-solid fa-circle-check",
+        SecretPlacementStatus.Pending => "fa-solid fa-clock",
+        SecretPlacementStatus.Failed => "fa-solid fa-circle-exclamation",
+        SecretPlacementStatus.Unavailable => "fa-solid fa-circle-minus",
+        SecretPlacementStatus.Conflict => "fa-solid fa-code-compare",
+        _ => "fa-regular fa-circle"
+    };
+
+    private static string GetProviderIcon(CloudSecretsProviderType providerType) => providerType switch
+    {
+        CloudSecretsProviderType.AzureKeyVault => "fa-solid fa-vault",
+        CloudSecretsProviderType.AwsSecretsManager => "fa-brands fa-aws",
+        CloudSecretsProviderType.GoogleSecretManager => "fa-brands fa-google",
+        CloudSecretsProviderType.Infisical => "fa-solid fa-shield-halved",
+        CloudSecretsProviderType.OnePassword => "fa-solid fa-key",
+        CloudSecretsProviderType.Vaultwarden => "fa-solid fa-shield",
+        CloudSecretsProviderType.AzureDevOps => "fa-brands fa-microsoft",
+        CloudSecretsProviderType.Local => "fa-solid fa-database",
+        _ => "fa-solid fa-cloud"
+    };
+
+    private static string FormatCount(int count) => count > 99 ? "99+" : count.ToString();
+
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            if (_interopModule is not null)
+            {
+                await _interopModule.InvokeVoidAsync("unbindPopover", _rootId);
+                await _interopModule.DisposeAsync();
+            }
+        }
+        catch (JSDisconnectedException)
+        {
+        }
+
+        _dotNetReference?.Dispose();
+    }
+}

--- a/src/MauiSherpa/Components/SecretProviderPickerHost.razor
+++ b/src/MauiSherpa/Components/SecretProviderPickerHost.razor
@@ -1,0 +1,285 @@
+@using MauiSherpa.Core.Interfaces
+@using MauiSherpa.Core.Requests
+@using Shiny.Mediator
+@inject ISecretsProviderRegistry ProviderRegistry
+@inject ISecretSyncCoordinator SyncCoordinator
+@inject IBackgroundTaskService BackgroundTasks
+@inject IAlertService AlertService
+@implements IDisposable
+@implements IEventHandler<SecretProviderPlacementChangedEvent>
+
+<SecretProviderPicker SyncState="_state"
+                      ConfiguredProviders="_providers"
+                      CanAddProviderCopy="@EffectiveCanAddProviderCopy"
+                      UnavailableSourceReason="@UnavailableSourceReason"
+                      EmptySelectionRequiresConfirmation="EmptySelectionRequiresConfirmation"
+                      PlacementChangesCommitted="ChangeDesiredProvidersAsync"
+                      ConflictSourceRequested="ResolveConflictAsync" />
+
+@code {
+    private IReadOnlyList<CloudSecretsProviderConfig> _providers =
+        Array.Empty<CloudSecretsProviderConfig>();
+    private SecretItemSyncState _state = new(
+        new SecretItemRef(SecretItemKind.ManagedSecret, "", ""),
+        Array.Empty<ProviderPlacementState>(),
+        HasConflict: false);
+    private SecretItemRef? _loadedItem;
+    private CancellationTokenSource? _loadCts;
+    private Task<SecretItemSyncState>? _stateLoadTask;
+
+    [Parameter, EditorRequired]
+    public SecretItemRef Item { get; set; } = default!;
+
+    [Parameter]
+    public bool EmptySelectionRequiresConfirmation { get; set; }
+
+    [Parameter]
+    public bool CanAddProviderCopy { get; set; } = true;
+
+    [Parameter]
+    public string? UnavailableSourceReason { get; set; }
+
+    private bool EffectiveCanAddProviderCopy =>
+        CanAddProviderCopy || _state.Providers.Any(provider => provider.Observed);
+
+    protected override void OnInitialized()
+    {
+        SyncCoordinator.ItemStateChanged += OnItemStateChanged;
+        BackgroundTasks.TasksChanged += OnTasksChanged;
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (_loadedItem is null ||
+            _loadedItem.Kind != Item.Kind ||
+            !string.Equals(_loadedItem.Id, Item.Id, StringComparison.Ordinal))
+        {
+            await ReloadAsync();
+        }
+    }
+
+    private async Task ChangeDesiredProvidersAsync(IReadOnlyDictionary<string, bool> changes)
+    {
+        if (!EffectiveCanAddProviderCopy && changes.Values.Any(desired => desired))
+        {
+            await AlertService.ShowAlertAsync(
+                "Private Key Required",
+                UnavailableSourceReason ??
+                    "No local or provider copy is available to sync.");
+            return;
+        }
+
+        var knownDesiredProviderIds = _state.Providers
+            .Where(provider => provider.Desired)
+            .Select(provider => provider.ProviderId)
+            .ToHashSet(StringComparer.Ordinal);
+        foreach (var (providerId, desired) in changes)
+        {
+            if (desired)
+                knownDesiredProviderIds.Add(providerId);
+            else
+                knownDesiredProviderIds.Remove(providerId);
+        }
+
+        if (knownDesiredProviderIds.Count == 0 && EmptySelectionRequiresConfirmation)
+        {
+            var confirmed = await AlertService.ShowConfirmAsync(
+                "Remove All Provider Copies",
+                $"Remove '{Item.DisplayName}' from every secrets provider? This deletes the item and cannot be undone.");
+            if (!confirmed)
+            {
+                await ReloadAsync();
+                return;
+            }
+        }
+
+        await SyncCoordinator.UpdateDesiredProvidersAsync(Item, changes);
+        await ReloadAsync();
+    }
+
+    private async Task ResolveConflictAsync(string providerId)
+    {
+        var providerName = _providers
+            .FirstOrDefault(provider => provider.Id == providerId)?.Name ?? providerId;
+        var confirmed = await AlertService.ShowConfirmAsync(
+            "Resolve Provider Conflict",
+            $"Use the copy from '{providerName}' as the source and overwrite the other selected provider copies?");
+        if (!confirmed)
+            return;
+
+        await SyncCoordinator.ResolveConflictAsync(Item, providerId);
+        await ReloadAsync();
+    }
+
+    private void OnItemStateChanged(SecretItemRef item)
+    {
+        if (item.Kind != Item.Kind ||
+            !string.Equals(item.Id, Item.Id, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        _ = InvokeAsync(async () =>
+        {
+            await ReloadAsync();
+            StateHasChanged();
+        });
+    }
+
+    public async Task Handle(
+        SecretProviderPlacementChangedEvent @event,
+        IMediatorContext context,
+        CancellationToken cancellationToken)
+    {
+        if (@event.Item.Kind != Item.Kind ||
+            !string.Equals(@event.Item.Id, Item.Id, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        await InvokeAsync(() =>
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return;
+
+            var placements = _state.Providers.ToList();
+            var index = placements.FindIndex(provider =>
+                string.Equals(
+                    provider.ProviderId,
+                    @event.Placement.ProviderId,
+                    StringComparison.Ordinal));
+            if (index >= 0)
+                placements[index] = @event.Placement;
+            else
+                placements.Add(@event.Placement);
+
+            _state = _state with
+            {
+                Providers = placements,
+                HasConflict = placements.Any(provider =>
+                    provider.Status == SecretPlacementStatus.Conflict)
+            };
+            StateHasChanged();
+        });
+    }
+
+    private void OnTasksChanged()
+    {
+        var pendingTaskId = _state?.PendingTaskId;
+        if (string.IsNullOrEmpty(pendingTaskId))
+            return;
+
+        var task = BackgroundTasks.Tasks.FirstOrDefault(task => task.Id == pendingTaskId);
+        if (task?.State is BackgroundTaskState.Pending or BackgroundTaskState.Running)
+            return;
+
+        _ = InvokeAsync(async () =>
+        {
+            await ReloadAsync();
+            StateHasChanged();
+        });
+    }
+
+    private async Task ReloadAsync()
+    {
+        _loadCts?.Cancel();
+        _loadCts?.Dispose();
+        _loadCts = new CancellationTokenSource();
+        var cancellationToken = _loadCts.Token;
+        _loadedItem = Item;
+        _providers = await ProviderRegistry.GetProvidersAsync();
+        var previousByProvider = _state.Providers.ToDictionary(
+            provider => provider.ProviderId,
+            StringComparer.Ordinal);
+        _state = new SecretItemSyncState(
+            Item,
+            _providers.Select(provider =>
+            {
+                previousByProvider.TryGetValue(provider.Id, out var previous);
+                return new ProviderPlacementState(
+                    provider.Id,
+                    previous?.Desired ?? false,
+                    previous?.Observed ?? false,
+                    SecretPlacementStatus.Loading,
+                    previous?.Revision,
+                    previous?.ContentHash);
+            }).ToList(),
+            HasConflict: false,
+            PendingTaskId: _state.PendingTaskId);
+        await InvokeAsync(StateHasChanged);
+
+        var progress = new Progress<ProviderPlacementState>(placement =>
+        {
+            _ = InvokeAsync(() =>
+            {
+                if (cancellationToken.IsCancellationRequested ||
+                    _state.Item.Kind != Item.Kind ||
+                    !string.Equals(_state.Item.Id, Item.Id, StringComparison.Ordinal))
+                {
+                    return;
+                }
+
+                var placements = _state.Providers.ToList();
+                var index = placements.FindIndex(provider =>
+                    string.Equals(provider.ProviderId, placement.ProviderId, StringComparison.Ordinal));
+                if (index >= 0)
+                    placements[index] = placement;
+                _state = _state with { Providers = placements };
+                StateHasChanged();
+            });
+        });
+        _stateLoadTask = SyncCoordinator.GetStateProgressivelyAsync(
+            Item,
+            progress,
+            cancellationToken);
+        _ = CompleteStateLoadAsync(_stateLoadTask, cancellationToken);
+    }
+
+    private async Task CompleteStateLoadAsync(
+        Task<SecretItemSyncState> loadTask,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var loaded = await loadTask;
+            if (cancellationToken.IsCancellationRequested)
+                return;
+
+            await InvokeAsync(() =>
+            {
+                EnsurePlacementProviders(loaded);
+                _state = loaded;
+                StateHasChanged();
+            });
+        }
+        catch (OperationCanceledException)
+        {
+        }
+    }
+
+    private void EnsurePlacementProviders(SecretItemSyncState state)
+    {
+        var configuredIds = _providers
+            .Select(provider => provider.Id)
+            .ToHashSet(StringComparer.Ordinal);
+        var missing = state.Providers
+            .Where(provider => !configuredIds.Contains(provider.ProviderId))
+            .Select(provider => new CloudSecretsProviderConfig(
+                provider.ProviderId,
+                $"Disconnected ({provider.ProviderId})",
+                CloudSecretsProviderType.None,
+                new Dictionary<string, string>(),
+                new List<SecretItemKind>()))
+            .ToList();
+        if (missing.Count > 0)
+            _providers = _providers.Concat(missing).ToList();
+    }
+
+    public void Dispose()
+    {
+        SyncCoordinator.ItemStateChanged -= OnItemStateChanged;
+        BackgroundTasks.TasksChanged -= OnTasksChanged;
+        _loadCts?.Cancel();
+        _loadCts?.Dispose();
+    }
+}

--- a/src/MauiSherpa/MauiProgram.cs
+++ b/src/MauiSherpa/MauiProgram.cs
@@ -105,6 +105,7 @@ public static class MauiProgram
         builder.Services.AddSingleton<IDialogService, DialogService>();
         builder.Services.AddSingleton<IFileSystemService, FileSystemService>();
         builder.Services.AddSingleton<IPreferences>(_ => Preferences.Default);
+        builder.Services.AddSingleton<IIdentitySelectionStore, IdentitySelectionStore>();
         builder.Services.AddSingleton<ILauncher>(_ => Launcher.Default);
         builder.Services.AddSingleton<IClipboard>(_ => Clipboard.Default);
         builder.Services.AddSingleton<ISecureStorage>(_ => SecureStorage.Default);
@@ -130,6 +131,11 @@ public static class MauiProgram
         builder.Services.AddSingleton<IOperationModalService>(sp => sp.GetRequiredService<OperationModalService>());
         builder.Services.AddSingleton<MultiOperationModalService>();
         builder.Services.AddSingleton<IMultiOperationModalService>(sp => sp.GetRequiredService<MultiOperationModalService>());
+        builder.Services.AddSingleton<BackgroundTaskService>();
+        builder.Services.AddSingleton<IBackgroundTaskService>(sp => sp.GetRequiredService<BackgroundTaskService>());
+        builder.Services.AddSingleton<SecretSyncCoordinator>();
+        builder.Services.AddSingleton<ISecretSyncCoordinator>(sp => sp.GetRequiredService<SecretSyncCoordinator>());
+        builder.Services.AddSingleton<IBackgroundTaskHandler>(sp => sp.GetRequiredService<SecretSyncCoordinator>());
 
         // Core services
         builder.Services.AddSingleton<IAndroidSdkService, AndroidSdkService>();
@@ -217,9 +223,16 @@ public static class MauiProgram
         
         // Cloud Secrets Storage services
         builder.Services.AddSingleton<ICloudSecretsProviderFactory, CloudSecretsProviderFactory>();
-        builder.Services.AddSingleton<ICloudSecretsService, CloudSecretsService>();
+        builder.Services.AddSingleton<CloudSecretsService>();
+        builder.Services.AddSingleton<ICloudSecretsService>(sp => sp.GetRequiredService<CloudSecretsService>());
+        builder.Services.AddSingleton<ISecretsProviderRegistry>(sp => sp.GetRequiredService<CloudSecretsService>());
         builder.Services.AddSingleton<IManagedSecretsService, ManagedSecretsService>();
         builder.Services.AddSingleton<ICertificateSyncService, CertificateSyncService>();
+        builder.Services.AddSingleton<ISecretItemAdapter, ManagedSecretItemAdapter>();
+        builder.Services.AddSingleton<ISecretItemAdapter, AndroidKeystoreItemAdapter>();
+        builder.Services.AddSingleton<ISecretItemAdapter, CertificateItemAdapter>();
+        builder.Services.AddSingleton<ISecretItemAdapter, ProvisioningProfileItemAdapter>();
+        builder.Services.AddSingleton<ISecretItemAdapter, PublishProfileItemAdapter>();
 
         // CI/CD Secrets Publisher services
         builder.Services.AddSingleton<ISecretsPublisherFactory, SecretsPublisherFactory>();
@@ -262,6 +275,7 @@ public static class MauiProgram
         builder.AddShinyMediator(cfg =>
         {
             cfg.UseMaui();
+            cfg.UseBlazor();
             cfg.AddMauiPersistentCache(); // Use persistent cache (includes memory caching)
             cfg.AddStandardAppSupportMiddleware();
         });

--- a/src/MauiSherpa/MauiSherpa.csproj
+++ b/src/MauiSherpa/MauiSherpa.csproj
@@ -56,6 +56,7 @@
     <PackageReference Include="Microsoft.Maui.DevFlow.Blazor" Version="0.1.0-preview.7.26230.1" Condition="'$(Configuration)' == 'Debug'" />
     <PackageReference Include="Sentry.Maui" Version="6.4.0" />
     <PackageReference Include="Shiny.Mediator.Caching.MicrosoftMemoryCache" Version="6.6.2" />
+    <PackageReference Include="Shiny.Mediator.Blazor" Version="6.6.2" />
     <PackageReference Include="Shiny.Mediator.Maui" Version="6.6.2" />
   </ItemGroup>
 

--- a/src/MauiSherpa/Pages/Certificates.razor
+++ b/src/MauiSherpa/Pages/Certificates.razor
@@ -25,6 +25,7 @@
 @inject IPlatformService PlatformInfo
 @inject IPreferences AppPreferences
 @inject ILocalVaultAccessService LocalVaultAccess
+@inject ISecretSyncCoordinator SecretSyncCoordinator
 
 <h1><i class="fas fa-certificate"></i> Certificates</h1>
 
@@ -41,15 +42,6 @@
         <button class="btn btn-success" @onclick="ShowCreateDialog" disabled="@isLoading">
             <i class="fas fa-plus"></i> Create Certificate
         </button>
-        @if (CloudSecretsService.ActiveProvider != null)
-        {
-            <button class="btn btn-outline-primary" @onclick="SyncAllFromCloud" disabled="@(isLoading || !HasCloudOnlyCerts)">
-                <i class="fas fa-cloud-download-alt"></i> Install All from Cloud
-            </button>
-            <button class="btn btn-outline-primary" @onclick="SyncAllToCloud" disabled="@(isLoading || !HasLocalOnlyCerts)">
-                <i class="fas fa-cloud-upload-alt"></i> Upload All to Cloud
-            </button>
-        }
     </div>
     }
 
@@ -174,54 +166,30 @@
                             {
                                 <span class="badge badge-valid">Valid</span>
                             }
-                            @* Sync status badge *@
-                            @if (CloudSecretsService.ActiveProvider != null)
-                            {
-                                <span class="badge @GetSyncBadgeClass(syncStatus)" title="@GetSyncStatusTooltip(syncStatus)">
-                                    <i class="@GetSyncStatusIcon(syncStatus)"></i> @GetSyncStatusText(syncStatus)
-                                </span>
-                            }
                         </div>
                         <div class="cert-expiry">
                             Expires: @cert.ExpirationDate.ToString("MMM dd, yyyy")
                         </div>
                     </div>
                     <div class="cert-actions">
-                        @if (CloudSecretsService.ActiveProvider != null)
+                        @if (!string.IsNullOrWhiteSpace(cert.SerialNumber))
                         {
-                            var currentCertId = cert.Id;
-                            var currentSyncStatus = syncStatus;
-                            <button class="btn btn-secondary btn-icon" @onclick="@(() => ToggleSyncMenu(currentCertId))" @onclick:stopPropagation="true" title="Sync">
-                                <i class="fas fa-cloud"></i>
-                            </button>
-                            @if (openSyncMenuCertId == currentCertId)
+                            <MauiSherpa.Components.SecretProviderPickerHost
+                                @key="@($"certificate-sync-{cert.SerialNumber}")"
+                                Item="@(new SecretItemRef(SecretItemKind.Certificate, GetCertificateSyncItemId(cert.SerialNumber), cert.Name))"
+                                CanAddProviderCopy="@(syncStatus != SecretLocation.None)"
+                                UnavailableSourceReason="This certificate has no matching private key in Keychain and no provider copy. Import or install its private key before syncing." />
+                            @if (syncStatus is SecretLocation.CloudOnly or SecretLocation.Both)
                             {
-                                <div class="cert-dropdown-menu">
-                                    @if (currentSyncStatus == SecretLocation.LocalOnly || currentSyncStatus == SecretLocation.Both)
-                                    {
-                                        <button type="button" class="cert-dropdown-item" @onclick="@(() => HandleUploadClick(currentCertId))">
-                                            <i class="fas fa-cloud-upload-alt"></i> Upload to Cloud
-                                        </button>
-                                        <button type="button" class="cert-dropdown-item danger" @onclick="@(() => DeleteLocalCertificate(cert))">
-                                            <i class="fas fa-trash-alt"></i> Delete from Keychain
-                                        </button>
-                                    }
-                                    @if (currentSyncStatus == SecretLocation.CloudOnly || currentSyncStatus == SecretLocation.Both)
-                                    {
-                                        <button type="button" class="cert-dropdown-item" @onclick="@(() => HandleInstallClick(currentCertId))">
-                                            <i class="fas fa-download"></i> Install Locally
-                                        </button>
-                                        <button type="button" class="cert-dropdown-item danger" @onclick="@(() => DeleteFromCloud(cert))">
-                                            <i class="fas fa-cloud"></i> Delete from Cloud
-                                        </button>
-                                    }
-                                    @if (currentSyncStatus == SecretLocation.None)
-                                    {
-                                        <div class="cert-dropdown-item disabled">
-                                            <i class="fas fa-exclamation-circle"></i> No private key
-                                        </div>
-                                    }
-                                </div>
+                                <button class="btn btn-secondary btn-icon" @onclick="@(() => InstallLocally(cert))" title="Install private key locally">
+                                    <i class="fas fa-download"></i>
+                                </button>
+                            }
+                            @if (syncStatus is SecretLocation.LocalOnly or SecretLocation.Both)
+                            {
+                                <button class="btn btn-secondary btn-icon" @onclick="@(() => DeleteLocalCertificate(cert))" title="Delete private key from Keychain">
+                                    <i class="fas fa-hard-drive"></i>
+                                </button>
                             }
                         }
                         <button class="btn btn-secondary btn-icon" @onclick="@(() => ShowExportDialog(cert))" 
@@ -771,6 +739,16 @@
 
         await AlertService.ShowToastAsync($"Certificate saved: ~/Downloads/{fileName}");
         await RefreshData(forceRefresh: true);
+        var createdCertificate = certificates.FirstOrDefault(certificate =>
+            string.Equals(certificate.Id, certResult.CertificateId, StringComparison.Ordinal));
+        if (createdCertificate is not null && !string.IsNullOrWhiteSpace(createdCertificate.SerialNumber))
+        {
+            await SecretSyncCoordinator.SetDefaultProvidersAsync(
+                new SecretItemRef(
+                    SecretItemKind.Certificate,
+                    GetCertificateSyncItemId(createdCertificate.SerialNumber),
+                    createdCertificate.Name));
+        }
     }
 
     private async Task ShowExportDialog(AppleCertificate cert)
@@ -1058,6 +1036,13 @@
 
     private static bool SerialsMatch(string? a, string? b)
         => (a ?? "").TrimStart('0').Equals((b ?? "").TrimStart('0'), StringComparison.OrdinalIgnoreCase);
+
+    private static string GetCertificateSyncItemId(string serialNumber) =>
+        new string(serialNumber
+            .Where(char.IsLetterOrDigit)
+            .Select(char.ToUpperInvariant)
+            .ToArray())
+        .TrimStart('0');
 
     private string FormatCertType(string? certType)
     {

--- a/src/MauiSherpa/Pages/Keystores.razor
+++ b/src/MauiSherpa/Pages/Keystores.razor
@@ -26,6 +26,7 @@
 @inject IPlatformService PlatformInfo
 @inject IPreferences AppPreferences
 @inject ILocalVaultAccessService LocalVaultAccess
+@inject ISecretSyncCoordinator SecretSyncCoordinator
 
 <h1><i class="fas fa-key"></i> Keystores</h1>
 @if (RequiresLocalVaultAccess)
@@ -57,15 +58,6 @@ else
     <button class="btn btn-secondary" @onclick="ImportKeystore" disabled="@isLoading">
         <i class="fas fa-file-import"></i> Import
     </button>
-    @if (CloudSecretsService.ActiveProvider != null)
-    {
-        <button class="btn btn-outline-primary" @onclick="SyncAllFromCloud" disabled="@(isLoading || !HasCloudOnlyKeystores)">
-            <i class="fas fa-cloud-download-alt"></i> Install All from Cloud
-        </button>
-        <button class="btn btn-outline-primary" @onclick="SyncAllToCloud" disabled="@(isLoading || !HasLocalOnlyKeystores)">
-            <i class="fas fa-cloud-upload-alt"></i> Upload All to Cloud
-        </button>
-    }
 </div>
 }
 
@@ -80,7 +72,9 @@ else
                 <p>Configure a secrets provider in <a href="/settings">Settings</a> to securely store signing keystores and passwords. Use a cloud provider to sync across machines.</p>
             </div>
         </div>
-        <button type="button" class="btn-close" @onclick="DismissSyncHint" title="Dismiss">×</button>
+        <button type="button" class="btn-close" @onclick="DismissSyncHint" title="Dismiss" aria-label="Dismiss sync hint">
+            <i class="fas fa-xmark" aria-hidden="true"></i>
+        </button>
     </div>
 }
 
@@ -118,18 +112,11 @@ else
     <div class="keystores-grid">
         @foreach (var ks in FilteredKeystores)
         {
-            var syncLocation = GetSyncLocation(ks.Id);
             <div class="keystore-card">
                 <div class="keystore-content">
                     <div class="keystore-info">
                         <h3 class="keystore-alias">@ks.Alias</h3>
                         <span class="badge badge-type">@ks.KeystoreType</span>
-                        @if (CloudSecretsService.ActiveProvider != null)
-                        {
-                            <span class="badge @GetSyncBadgeClass(syncLocation)" title="@GetSyncStatusTooltip(syncLocation)">
-                                <i class="@GetSyncStatusIcon(syncLocation)"></i> @GetSyncStatusText(syncLocation)
-                            </span>
-                        }
                     </div>
                     <div class="keystore-details">
                         <div class="detail-row">
@@ -143,43 +130,15 @@ else
                     </div>
                 </div>
                 <div class="keystore-actions">
+                        <MauiSherpa.Components.SecretProviderPickerHost
+                            @key="@($"keystore-sync-{ks.Alias}")"
+                            Item="@(new SecretItemRef(SecretItemKind.AndroidKeystore, ks.Alias, ks.Alias))" />
                         <button class="btn btn-secondary btn-icon" title="View Signatures" @onclick="@(() => ShowSignatures(ks))">
                             <i class="fas fa-fingerprint"></i>
                         </button>
                         <button class="btn btn-secondary btn-icon" title="Export PEPK" @onclick="@(() => ShowPepkDialog(ks))">
                             <i class="fas fa-file-export"></i>
                         </button>
-                        @if (CloudSecretsService.ActiveProvider != null)
-                        {
-                            <div class="sync-menu-wrapper">
-                                <button class="btn btn-secondary btn-icon" @onclick="@(() => ToggleSyncMenu(ks.Id))" @onclick:stopPropagation="true" title="Sync">
-                                    <i class="fas fa-cloud"></i>
-                                </button>
-                                @if (openSyncMenuId == ks.Id)
-                                {
-                                    <div class="sync-dropdown-menu">
-                                        @if (syncLocation == "local" || syncLocation == "synced")
-                                        {
-                                            <button type="button" class="sync-dropdown-item" @onclick="@(() => HandleUploadClick(ks))">
-                                                <i class="fas fa-cloud-upload-alt"></i> Upload to Cloud
-                                            </button>
-                                        }
-                                        @if (syncLocation == "cloud" || syncLocation == "synced")
-                                        {
-                                            <button type="button" class="sync-dropdown-item danger" @onclick="@(() => DeleteFromCloud(ks.Id, ks.Alias))">
-                                                <i class="fas fa-cloud"></i> Delete from Cloud
-                                            </button>
-                                        }
-                                        @if (syncLocation == "none")
-                                        {
-                                            <div class="sync-dropdown-item disabled">
-                                                <i class="fas fa-exclamation-circle"></i> No sync available
-                                            </div>
-                                        }
-                                    </div>
-                                }
-                            </div>
-                        }
                         <button class="btn btn-danger btn-icon" title="Remove" @onclick="@(() => RemoveKeystore(ks))">
                             <i class="fas fa-trash"></i>
                         </button>
@@ -195,7 +154,7 @@ else
                     <div class="keystore-info">
                         <h3 class="keystore-alias"><i class="fas fa-cloud"></i> @cs.Alias</h3>
                         <span class="badge badge-sync-cloud" title="Exists in cloud only — install locally to use">
-                            🟡 Cloud
+                            <i class="fas fa-cloud" aria-hidden="true"></i> Cloud
                         </span>
                     </div>
                     <div class="keystore-details">
@@ -206,6 +165,9 @@ else
                     </div>
                 </div>
                 <div class="keystore-actions">
+                    <MauiSherpa.Components.SecretProviderPickerHost
+                        @key="@($"keystore-sync-{cs.Alias}")"
+                        Item="@(new SecretItemRef(SecretItemKind.AndroidKeystore, cs.Alias, cs.Alias))" />
                     <button class="btn btn-primary btn-sm" @onclick="@(() => DownloadFromCloud(cs))">
                         <i class="fas fa-download"></i> Install Locally
                     </button>
@@ -411,6 +373,16 @@ else
         });
 
         await RefreshData(true);
+        var createdKeystore = keystores.FirstOrDefault(keystore =>
+            string.Equals(keystore.Alias, result.Alias, StringComparison.OrdinalIgnoreCase));
+        if (createdKeystore is not null)
+        {
+            await SecretSyncCoordinator.SetDefaultProvidersAsync(
+                new SecretItemRef(
+                    SecretItemKind.AndroidKeystore,
+                    createdKeystore.Alias,
+                    createdKeystore.Alias));
+        }
         ToastService.ShowSuccess($"Keystore '{result.Alias}' created!");
     }
 
@@ -450,6 +422,11 @@ else
 
         await KeystoreService.AddKeystoreAsync(keystore);
         await SecureStorage.SetAsync($"android_keystore_pwd_{keystore.Id}", password);
+        await SecretSyncCoordinator.SetDefaultProvidersAsync(
+            new SecretItemRef(
+                SecretItemKind.AndroidKeystore,
+                keystore.Alias,
+                keystore.Alias));
         await RefreshData(true);
         ToastService.ShowSuccess($"Keystore '{alias}' imported!");
     }

--- a/src/MauiSherpa/Pages/Modals/CloudProviderModal.razor
+++ b/src/MauiSherpa/Pages/Modals/CloudProviderModal.razor
@@ -97,6 +97,7 @@
     private string providerName = "";
     private CloudSecretsProviderType providerType = CloudSecretsProviderType.Local;
     private Dictionary<string, string> providerSettings = new();
+    private List<SecretItemKind> defaultItemKinds = SecretItemKinds.All.ToList();
     private IEnumerable<CloudSecretsProviderType> AddableProviderTypes =>
         CloudSecretsProviderFactory.SupportedProviders.Where(type => type != CloudSecretsProviderType.Local);
 
@@ -122,6 +123,7 @@
             providerName = provider.Name;
             providerType = provider.ProviderType;
             providerSettings = new Dictionary<string, string>(provider.Settings);
+            defaultItemKinds = provider.EffectiveDefaultItemKinds.ToList();
         }
         else
         {
@@ -154,7 +156,8 @@
             isEditing ? editingId : Guid.NewGuid().ToString("N"),
             providerName,
             providerType,
-            new Dictionary<string, string>(providerSettings));
+            new Dictionary<string, string>(providerSettings),
+            defaultItemKinds);
         ModalParams.Complete(config);
     }
 

--- a/src/MauiSherpa/Pages/ProvisioningProfiles.razor
+++ b/src/MauiSherpa/Pages/ProvisioningProfiles.razor
@@ -17,6 +17,7 @@
 @inject IToolbarService ToolbarService
 @inject IPlatformService PlatformInfo
 @inject ILocalVaultAccessService LocalVaultAccess
+@inject ISecretSyncCoordinator SecretSyncCoordinator
 @implements IDisposable
 
 <h1><i class="fas fa-id-card"></i> Provisioning Profiles</h1>
@@ -173,6 +174,9 @@
                         </div>
                     </div>
                     <div class="profile-actions">
+                        <MauiSherpa.Components.SecretProviderPickerHost
+                            @key="@($"profile-sync-{profile.Id}")"
+                            Item="@(new SecretItemRef(SecretItemKind.ProvisioningProfile, profile.Id, profile.Name))" />
                         <button class="btn btn-secondary btn-icon" @onclick="@(() => ShowEditDialog(profile))" disabled="@isLoading" title="Edit">
                             <i class="fas fa-edit"></i>
                         </button>
@@ -473,7 +477,14 @@
         var page = new MauiSherpa.Pages.Modals.CreateProfilePage(BridgeHolder);
         var result = await FormModalService.ShowAsync<AppleProfile>(page);
         if (result != null)
+        {
+            await SecretSyncCoordinator.SetDefaultProvidersAsync(
+                new SecretItemRef(
+                    SecretItemKind.ProvisioningProfile,
+                    result.Id,
+                    result.Name));
             await RefreshData(forceRefresh: true);
+        }
     }
 
     private async Task ShowEditDialog(AppleProfile profile)

--- a/src/MauiSherpa/Pages/Secrets.razor
+++ b/src/MauiSherpa/Pages/Secrets.razor
@@ -17,16 +17,16 @@
 @inject IFormModalService FormModalService
 @inject HybridFormBridgeHolder BridgeHolder
 @inject ILocalVaultAccessService LocalVaultAccess
+@inject ISecretSyncCoordinator SecretSyncCoordinator
 @implements IDisposable
 
 <div class="page-header">
     <h1><i class="fas fa-vault"></i> Secrets</h1>
-    @if (CloudSecretsService.ActiveProvider is not null)
+    @if (providers.Count > 0)
     {
-        <div class="provider-info" title="Selected secrets provider">
+        <div class="provider-info" title="Configured secrets providers">
             <i class="fas fa-shield-alt"></i>
-            <span>@CloudSecretsService.ActiveProvider.Name</span>
-            <span class="provider-type">(@FormatProviderType(CloudSecretsService.ActiveProvider.ProviderType))</span>
+            <span>@providers.Count @(providers.Count == 1 ? "provider" : "providers") available</span>
         </div>
     }
 </div>
@@ -47,7 +47,7 @@
     </div>
 }
 
-@if (CloudSecretsService.ActiveProvider is null)
+@if (providers.Count == 0)
 {
     <div class="empty-state">
         <div class="empty-icon"><i class="fas fa-cloud-slash"></i></div>
@@ -60,15 +60,6 @@ else
     @if (!PlatformInfo.HasNativeToolbar)
     {
     <div class="toolbar">
-        <label class="provider-picker">
-            <span>Provider</span>
-            <select class="filter-select" value="@CloudSecretsService.ActiveProvider.Id" @onchange="OnProviderChanged" disabled="@isLoading">
-                @foreach (var provider in providers)
-                {
-                    <option value="@provider.Id">@GetProviderDisplayName(provider)</option>
-                }
-            </select>
-        </label>
         <button class="btn btn-primary" @onclick="RefreshAsync" disabled="@isLoading">
             <i class="fas @(isLoading ? "fa-spinner fa-spin" : "fa-sync-alt")"></i> Refresh
         </button>
@@ -238,6 +229,10 @@ else
                         </div>
                     </div>
                     <div class="secret-actions">
+                        <MauiSherpa.Components.SecretProviderPickerHost
+                            @key="@($"secret-sync-{secret.Key}")"
+                            Item="@(new SecretItemRef(SecretItemKind.ManagedSecret, secret.Key, GetSecretDisplayName(secret)))"
+                            EmptySelectionRequiresConfirmation="true" />
                         @if (secret.Type == ManagedSecretType.String)
                         {
                             <button class="btn btn-secondary btn-icon" @onclick="@(() => CopySecretToClipboard(secret.Key))" title="Copy to clipboard">
@@ -269,7 +264,6 @@ else
     List<ManagedSecret> secrets = new();
     List<ManagedSecretFolder> folders = new();
     List<CloudSecretsProviderConfig> providers = new();
-    List<string> providerFilterIds = new();
     bool isLoading = false;
     string errorMessage = "";
     string searchText = "";
@@ -351,7 +345,6 @@ else
     {
         ToolbarService.ToolbarItemClicked += OnToolbarItemClicked;
         ToolbarService.SearchTextChanged += OnSearchTextChanged;
-        ToolbarService.FilterChanged += OnToolbarFilterChanged;
         LocalVaultAccess.StateChanged += OnLocalVaultStateChanged;
 
         await CloudSecretsService.InitializeAsync();
@@ -395,30 +388,16 @@ else
         InvokeAsync(() => { searchText = text; StateHasChanged(); });
     }
 
-    private void OnToolbarFilterChanged(string filterId, int selectedIndex)
-    {
-        if (filterId != "provider")
-            return;
-
-        InvokeAsync(async () =>
-        {
-            await SelectProviderByIndexAsync(selectedIndex);
-            StateHasChanged();
-        });
-    }
-
     public void Dispose()
     {
         ToolbarService.ToolbarItemClicked -= OnToolbarItemClicked;
         ToolbarService.SearchTextChanged -= OnSearchTextChanged;
-        ToolbarService.FilterChanged -= OnToolbarFilterChanged;
         LocalVaultAccess.StateChanged -= OnLocalVaultStateChanged;
     }
 
     bool ShouldShowLocalVaultNotice =>
         LocalVaultAccess.GetState().RequiresUserAction &&
-        (CloudSecretsService.ActiveProvider?.ProviderType == CloudSecretsProviderType.Local ||
-            providers.All(p => p.ProviderType == CloudSecretsProviderType.Local));
+        providers.Any(p => p.ProviderType == CloudSecretsProviderType.Local);
 
     void OnLocalVaultStateChanged()
     {
@@ -491,33 +470,8 @@ else
         ToolbarService.SetItems(actions.ToArray());
         if (resetSearch || ToolbarService.SearchPlaceholder is null)
             ToolbarService.SetSearch("Search secrets...");
-        ConfigureProviderFilter();
+        ToolbarService.SetFilters();
         UpdateNativeToolbarItemStates();
-    }
-
-    void ConfigureProviderFilter()
-    {
-        if (!PlatformInfo.HasNativeToolbar)
-            return;
-
-        if (providers.Count == 0 || CloudSecretsService.ActiveProvider is null)
-        {
-            providerFilterIds.Clear();
-            ToolbarService.SetFilters();
-            return;
-        }
-
-        var toolbarProviders = providers.ToList();
-        if (!toolbarProviders.Any(p => p.Id == CloudSecretsService.ActiveProvider.Id))
-            toolbarProviders.Insert(0, CloudSecretsService.ActiveProvider);
-
-        providerFilterIds = toolbarProviders.Select(p => p.Id).ToList();
-        var options = toolbarProviders.Select(GetProviderDisplayName).ToArray();
-        var selectedIndex = toolbarProviders.FindIndex(p => p.Id == CloudSecretsService.ActiveProvider.Id);
-        if (selectedIndex < 0)
-            selectedIndex = 0;
-
-        ToolbarService.SetFilters(new ToolbarFilter("provider", "Providers", options, selectedIndex));
     }
 
     void UpdateNativeToolbarItemStates()
@@ -535,8 +489,6 @@ else
 
     async Task RefreshAsync()
     {
-        if (CloudSecretsService.ActiveProvider is null) return;
-
         isLoading = true;
         errorMessage = "";
         UpdateNativeToolbarItemStates();
@@ -562,51 +514,6 @@ else
         }
     }
 
-    async Task OnProviderChanged(ChangeEventArgs e)
-    {
-        var providerId = e.Value?.ToString();
-        if (string.IsNullOrWhiteSpace(providerId))
-            return;
-
-        await SelectProviderAsync(providerId);
-    }
-
-    async Task SelectProviderByIndexAsync(int selectedIndex)
-    {
-        if (selectedIndex < 0 || selectedIndex >= providerFilterIds.Count)
-            return;
-
-        await SelectProviderAsync(providerFilterIds[selectedIndex]);
-    }
-
-    async Task SelectProviderAsync(string providerId)
-    {
-        if (CloudSecretsService.ActiveProvider?.Id == providerId)
-            return;
-
-        isLoading = true;
-        UpdateNativeToolbarItemStates();
-        StateHasChanged();
-
-        try
-        {
-            await CloudSecretsService.SetActiveProviderAsync(providerId);
-            await LoadProvidersAsync();
-            searchText = "";
-            filterType = "";
-            currentFolder = "/";
-            secrets.Clear();
-            folders.Clear();
-            ConfigureNativeToolbar(resetSearch: true);
-            await RefreshAsync();
-        }
-        finally
-        {
-            isLoading = false;
-            UpdateNativeToolbarItemStates();
-            StateHasChanged();
-        }
-    }
 
     async Task ShowCreateModal()
     {
@@ -614,7 +521,7 @@ else
         var result = await FormModalService.ShowAsync<SecretCreateResult>(page);
         if (result == null) return;
 
-        await OperationModal.RunAsync(
+        var createResult = await OperationModal.RunAsync(
             "Creating Secret",
             $"Storing secret '{result.Key}' in secrets provider...",
             async ctx =>
@@ -622,6 +529,11 @@ else
                 return await SecretsService.CreateAsync(result.Key, result.Value, result.Type, result.Description,
                     result.OriginalFileName, result.Metadata);
             });
+        if (createResult.Success)
+        {
+            await SecretSyncCoordinator.SetDefaultProvidersAsync(
+                new SecretItemRef(SecretItemKind.ManagedSecret, result.Key, GetSecretName(result.Key)));
+        }
 
         await RefreshAsync();
         NavigateToFolder(GetSecretFolder(result.Key));
@@ -657,10 +569,15 @@ else
             return;
         }
 
-        await OperationModal.RunAsync(
+        var folderResult = await OperationModal.RunAsync(
             "Creating Folder",
             $"Creating folder '{newFolderPath}' in secrets provider...",
             async ctx => await SecretsService.CreateFolderAsync(newFolderPath));
+        if (folderResult.Success)
+        {
+            await SecretSyncCoordinator.SetDefaultProvidersAsync(
+                ManagedSecretItemAdapter.CreateFolderItem(newFolderPath));
+        }
 
         await RefreshAsync();
         NavigateToFolder(newFolderPath);
@@ -703,6 +620,62 @@ else
             return;
         }
 
+        var folderMoves = new List<(SecretItemRef Previous, SecretItemRef Current, List<string> Providers)>();
+        var affectedFolderPaths = new[] { normalizedPath }
+            .Concat(folders
+                .Select(folder => folder.Path)
+                .Where(path =>
+                    path == normalizedPath ||
+                    path.StartsWith(normalizedPath + "/", StringComparison.Ordinal)))
+            .Distinct(StringComparer.Ordinal);
+        foreach (var affectedFolderPath in affectedFolderPaths)
+        {
+            var previous = ManagedSecretItemAdapter.CreateFolderItem(affectedFolderPath);
+            var movedPath = MoveFolderPath(
+                affectedFolderPath,
+                normalizedPath,
+                newFolderPath);
+            var state = await SecretSyncCoordinator.GetStateAsync(previous);
+            folderMoves.Add((
+                previous,
+                ManagedSecretItemAdapter.CreateFolderItem(movedPath),
+                state.Providers
+                    .Where(provider => provider.Desired)
+                    .Select(provider => provider.ProviderId)
+                    .ToList()));
+        }
+        var moves = new List<(SecretItemRef Previous, SecretItemRef Current, List<string> Providers)>();
+        foreach (var secret in secrets.Where(secret =>
+            IsInFolderTree(GetSecretFolder(secret.Key), normalizedPath)))
+        {
+            var previous = new SecretItemRef(
+                SecretItemKind.ManagedSecret,
+                secret.Key,
+                GetSecretDisplayName(secret));
+            var state = await SecretSyncCoordinator.GetStateAsync(previous);
+            if (state.HasConflict)
+            {
+                ToastService.ShowError(
+                    $"Resolve the provider conflict for '{secret.Key}' before renaming this folder.");
+                return;
+            }
+
+            var movedKey = MoveSecretKey(
+                secret.Key,
+                normalizedPath,
+                newFolderPath);
+            moves.Add((
+                previous,
+                new SecretItemRef(
+                    SecretItemKind.ManagedSecret,
+                    movedKey,
+                    GetSecretName(movedKey)),
+                state.Providers
+                    .Where(provider => provider.Desired)
+                    .Select(provider => provider.ProviderId)
+                    .ToList()));
+        }
+
         var renamed = await OperationModal.RunAsync(
             "Renaming Folder",
             $"Renaming folder '{normalizedPath}' to '{newFolderPath}'...",
@@ -711,6 +684,26 @@ else
         await RefreshAsync();
         if (renamed.Success)
         {
+            if (CloudSecretsService.ActiveProvider is not null)
+            {
+                foreach (var folderMove in folderMoves)
+                {
+                    await SecretSyncCoordinator.MoveAsync(
+                        folderMove.Previous,
+                        folderMove.Current,
+                        folderMove.Providers,
+                        CloudSecretsService.ActiveProvider.Id);
+                }
+                foreach (var move in moves)
+                {
+                    await SecretSyncCoordinator.MoveAsync(
+                        move.Previous,
+                        move.Current,
+                        move.Providers,
+                        CloudSecretsService.ActiveProvider.Id);
+                }
+            }
+
             if (currentFolder == normalizedPath || currentFolder.StartsWith(normalizedPath + "/", StringComparison.Ordinal))
                 NavigateToFolder(newFolderPath + currentFolder[normalizedPath.Length..]);
             else
@@ -750,6 +743,9 @@ else
         await RefreshAsync();
         if (deleted.Success)
         {
+            await SecretSyncCoordinator.SetDesiredProvidersAsync(
+                ManagedSecretItemAdapter.CreateFolderItem(normalizedPath),
+                Array.Empty<string>());
             if (currentFolder == normalizedPath || currentFolder.StartsWith(normalizedPath + "/", StringComparison.Ordinal))
                 NavigateToFolder(GetParentFolder(normalizedPath));
         }
@@ -761,12 +757,27 @@ else
 
     async Task ShowEditModal(ManagedSecret secret)
     {
+        var originalItem = new SecretItemRef(
+            SecretItemKind.ManagedSecret,
+            secret.Key,
+            GetSecretDisplayName(secret));
+        var originalState = await SecretSyncCoordinator.GetStateAsync(originalItem);
+        if (originalState.HasConflict)
+        {
+            ToastService.ShowError("Resolve the provider conflict before editing or moving this secret.");
+            return;
+        }
+        if (!string.IsNullOrEmpty(originalState.PendingTaskId))
+        {
+            ToastService.ShowInfo("Wait for the current sync task to finish before editing this secret.");
+            return;
+        }
         var page = new EditSecretPage(BridgeHolder, secret, AllKnownFolderPaths.ToList());
         var result = await FormModalService.ShowAsync<EditSecretResult>(page);
         if (result == null) return;
 
         var isMove = !string.Equals(result.OriginalKey, result.Key, StringComparison.Ordinal);
-        await OperationModal.RunAsync(
+        var updateResult = await OperationModal.RunAsync(
             isMove ? "Moving Secret" : "Updating Secret",
             isMove
                 ? $"Moving secret '{result.OriginalKey}' to '{result.Key}' in secrets provider..."
@@ -777,6 +788,35 @@ else
                     ? await SecretsService.MoveAsync(result.OriginalKey, result.Key, result.Value ?? result.FileBytes, result.Description, metadata: result.Metadata)
                     : await SecretsService.UpdateAsync(result.Key, result.Value ?? result.FileBytes, result.Description, metadata: result.Metadata);
             });
+
+        if (updateResult.Success)
+        {
+            var updatedItem = new SecretItemRef(
+               SecretItemKind.ManagedSecret,
+               result.Key,
+               GetSecretName(result.Key));
+            if (isMove)
+            {
+               var desired = originalState.Providers
+                   .Where(provider => provider.Desired)
+                   .Select(provider => provider.ProviderId)
+                   .ToList();
+               if (CloudSecretsService.ActiveProvider is not null)
+               {
+                   await SecretSyncCoordinator.MoveAsync(
+                       originalItem,
+                       updatedItem,
+                       desired,
+                       CloudSecretsService.ActiveProvider.Id);
+               }
+            }
+            else if (CloudSecretsService.ActiveProvider is not null)
+            {
+               await SecretSyncCoordinator.ResolveConflictAsync(
+                   updatedItem,
+                   CloudSecretsService.ActiveProvider.Id);
+            }
+        }
 
         await RefreshAsync();
         if (isMove)
@@ -791,15 +831,13 @@ else
 
         if (!confirmed) return;
 
-        await OperationModal.RunAsync(
-            "Deleting Secret",
-            $"Removing secret '{secret.Key}' from secrets provider...",
-            async ctx =>
-            {
-                return await SecretsService.DeleteAsync(secret.Key);
-            });
-
-        await RefreshAsync();
+        await SecretSyncCoordinator.SetDesiredProvidersAsync(
+            new SecretItemRef(
+                SecretItemKind.ManagedSecret,
+                secret.Key,
+                GetSecretDisplayName(secret)),
+            Array.Empty<string>());
+        ToastService.ShowInfo($"Deletion of '{secret.Key}' was queued.");
     }
 
     async Task CopySecretToClipboard(string key)
@@ -852,25 +890,6 @@ else
             Logger.LogError($"Failed to download secret file: {ex}");
             ToastService.ShowError($"Download failed: {ex.Message}");
         }
-    }
-
-    string FormatProviderType(CloudSecretsProviderType type) => type switch
-    {
-        CloudSecretsProviderType.Local => "Local",
-        CloudSecretsProviderType.AzureKeyVault => "Azure Key Vault",
-        CloudSecretsProviderType.AwsSecretsManager => "AWS Secrets Manager",
-        CloudSecretsProviderType.GoogleSecretManager => "Google Secret Manager",
-        CloudSecretsProviderType.Infisical => "Infisical",
-        CloudSecretsProviderType.AzureDevOps => "Azure DevOps",
-        _ => type.ToString()
-    };
-
-    string GetProviderDisplayName(CloudSecretsProviderConfig provider)
-    {
-        if (provider.ProviderType == CloudSecretsProviderType.Local)
-            return "Local";
-
-        return $"{provider.Name} ({FormatProviderType(provider.ProviderType)})";
     }
 
     void NavigateToFolder(string folder)
@@ -930,6 +949,31 @@ else
         return secretFolder == folder ||
             (folder != "/" && secretFolder.StartsWith(folder + "/", StringComparison.Ordinal)) ||
             (folder == "/" && secretFolder == "/");
+    }
+
+    static string MoveSecretKey(
+        string key,
+        string oldFolderPath,
+        string newFolderPath)
+    {
+        var oldPrefix = oldFolderPath.TrimStart('/') + "/";
+        var relativeKey = key.StartsWith(oldPrefix, StringComparison.Ordinal)
+            ? key[oldPrefix.Length..]
+            : key;
+        return newFolderPath.TrimStart('/') + "/" + relativeKey;
+    }
+
+    static string MoveFolderPath(
+        string folderPath,
+        string oldFolderPath,
+        string newFolderPath)
+    {
+        var relativePath = folderPath == oldFolderPath
+            ? ""
+            : folderPath[(oldFolderPath.Length + 1)..];
+        return SecretPath.NormalizeFolderPath(string.IsNullOrEmpty(relativePath)
+            ? newFolderPath
+            : newFolderPath + "/" + relativePath);
     }
 
     static IEnumerable<string> GetAncestorFolders(string folder)

--- a/src/MauiSherpa/Pages/SecretsPublish.razor
+++ b/src/MauiSherpa/Pages/SecretsPublish.razor
@@ -9,6 +9,7 @@
 @inject IFormModalService FormModalService
 @inject HybridFormBridgeHolder BridgeHolder
 @inject ICloudSecretsService CloudSecretsService
+@inject ISecretSyncCoordinator SecretSyncCoordinator
 @implements IDisposable
 
 <h1><i class="fas fa-upload"></i> Publish Profiles</h1>
@@ -44,6 +45,10 @@ else
                 <div class="profile-header">
                     <div class="profile-title">@profile.Name</div>
                     <div class="profile-actions">
+                        <MauiSherpa.Components.SecretProviderPickerHost
+                            @key="@($"publish-profile-sync-{profile.Id}")"
+                            Item="@(new SecretItemRef(SecretItemKind.PublishProfile, profile.Id, profile.Name))"
+                            EmptySelectionRequiresConfirmation="true" />
                         <button class="btn-icon" @onclick="@(() => EditProfile(profile))" title="Edit">
                             <i class="fa-solid fa-pen"></i>
                         </button>
@@ -187,6 +192,11 @@ else
 
         if (result is not null)
         {
+            await SecretSyncCoordinator.SetDefaultProvidersAsync(
+                new SecretItemRef(
+                    SecretItemKind.PublishProfile,
+                    result.Id,
+                    result.Name));
             await LoadProfilesAsync();
             await AlertService.ShowToastAsync($"Profile '{result.Name}' created.");
         }
@@ -194,11 +204,21 @@ else
 
     async Task EditProfile(PublishProfile profile)
     {
+        var item = new SecretItemRef(
+            SecretItemKind.PublishProfile,
+            profile.Id,
+            profile.Name);
         var page = new Modals.PublishProfileEditorPage(BridgeHolder, profile);
         var result = await FormModalService.ShowAsync<PublishProfile?>(page);
 
         if (result is not null)
         {
+            if (CloudSecretsService.ActiveProvider is not null)
+            {
+                await SecretSyncCoordinator.ResolveConflictAsync(
+                    item with { DisplayName = result.Name },
+                    CloudSecretsService.ActiveProvider.Id);
+            }
             await LoadProfilesAsync();
             await AlertService.ShowToastAsync($"Profile '{result.Name}' updated.");
         }
@@ -212,8 +232,13 @@ else
 
         if (confirmed)
         {
-            await ProfileService.DeleteProfileAsync(profile.Id);
-            await AlertService.ShowToastAsync($"Profile '{profile.Name}' deleted.");
+            await SecretSyncCoordinator.SetDesiredProvidersAsync(
+                new SecretItemRef(
+                    SecretItemKind.PublishProfile,
+                    profile.Id,
+                    profile.Name),
+                Array.Empty<string>());
+            await AlertService.ShowToastAsync($"Deletion of '{profile.Name}' was queued.");
         }
     }
 

--- a/src/MauiSherpa/Pages/Settings.razor
+++ b/src/MauiSherpa/Pages/Settings.razor
@@ -417,8 +417,12 @@
     <h2><i class="fas fa-vault"></i> Secrets Storage</h2>
     <p class="section-description">
         Store app secrets, signing certificates, and publish profiles securely.
-        The default Local provider keeps secrets on this machine; cloud providers can sync across machines and CI/CD pipelines.
+        Local Vault keeps encrypted copies on this machine; cloud providers can sync across machines and CI/CD pipelines.
     </p>
+    <div class="provider-defaults-notice" role="note">
+        <i class="fas fa-circle-info"></i>
+        <span><strong>Defaults apply only to new items.</strong> Changing them does not move, copy, or remove anything already stored.</span>
+    </div>
 
     @if (ShouldShowLocalVaultNotice)
     {
@@ -449,9 +453,8 @@
         <div class="connected-list">
             @foreach (var provider in cloudProviders)
             {
-                var isActive = CloudSecretsService.ActiveProvider?.Id == provider.Id;
                 var providerUrl = GetProviderUrl(provider);
-                <div class="connected-list-item @(isActive ? "active" : "")">
+                <div class="connected-list-item">
                     <div class="provider-header">
                         <div class="provider-info">
                             <i class="@GetProviderIcon(provider.ProviderType) provider-icon"></i>
@@ -462,18 +465,8 @@
                                     <i class="fas fa-external-link-alt"></i>
                                 </a>
                             }
-                            @if (isActive)
-                            {
-                                <span class="active-badge">Active</span>
-                            }
                         </div>
                         <div class="provider-actions">
-                            @if (!isActive)
-                            {
-                                <button class="btn btn-sm btn-primary" @onclick="@(() => SetActiveProvider(provider))" title="Set as Active">
-                                    <i class="fas fa-check"></i> Activate
-                                </button>
-                            }
                             <button class="btn btn-sm btn-secondary" @onclick="@(() => TestProvider(provider))" title="Test Connection">
                                 <i class="fas fa-plug"></i> Test
                             </button>
@@ -555,6 +548,22 @@
                             </div>
                         }
                     </div>
+                    <fieldset class="provider-defaults">
+                        <legend>Store new items here by default</legend>
+                        <div class="provider-default-options">
+                            @foreach (var itemKind in SecretItemKinds.All)
+                            {
+                                var optionId = $"provider-{provider.Id}-{itemKind}";
+                                <label class="provider-default-option" for="@optionId">
+                                    <input id="@optionId"
+                                           type="checkbox"
+                                           checked="@provider.StoresByDefault(itemKind)"
+                                           @onchange="eventArgs => SetProviderDefaultAsync(provider, itemKind, eventArgs)" />
+                                    <span>@GetItemKindLabel(itemKind)</span>
+                                </label>
+                            }
+                        </div>
+                    </fieldset>
                 </div>
             }
         </div>
@@ -1268,6 +1277,26 @@
         color: var(--text-muted);
         font-size: 0.875rem;
     }
+    .provider-defaults-notice {
+        display: flex;
+        align-items: flex-start;
+        gap: 0.625rem;
+        padding: 0.75rem 0.875rem;
+        margin-bottom: 1rem;
+        color: var(--text-secondary);
+        background: var(--accent-bg);
+        border: 1px solid var(--border-color);
+        border-radius: 0.625rem;
+        font-size: 0.8125rem;
+        line-height: 1.45;
+    }
+    .provider-defaults-notice i {
+        color: var(--accent-primary);
+        margin-top: 0.125rem;
+    }
+    .provider-defaults-notice strong {
+        color: var(--text-primary);
+    }
     .empty-providers {
         padding: 1.5rem;
         text-align: center;
@@ -1357,6 +1386,48 @@
         display: flex;
         flex-wrap: wrap;
         gap: 1rem 1.25rem;
+    }
+
+    .provider-defaults {
+        margin: 1rem 0 0;
+        padding: 0.875rem;
+        border: 1px solid var(--border-color);
+        border-radius: 0.625rem;
+    }
+
+    .provider-defaults legend {
+        padding: 0 0.375rem;
+        color: var(--text-secondary);
+        font-size: 0.75rem;
+        font-weight: 700;
+    }
+
+    .provider-default-options {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem 1rem;
+    }
+
+    .provider-default-option {
+        min-height: 2.75rem;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        color: var(--text-primary);
+        cursor: pointer;
+        font-size: 0.8125rem;
+    }
+
+    .provider-default-option input {
+        width: 1rem;
+        height: 1rem;
+        accent-color: var(--accent-primary);
+    }
+
+    .provider-default-option:focus-within {
+        outline: 2px solid var(--accent-primary);
+        outline-offset: 2px;
+        border-radius: 0.25rem;
     }
 
     /* Backup & Restore Styles */
@@ -1600,8 +1671,7 @@
 
     private bool ShouldShowLocalVaultNotice =>
         LocalVaultAccess.GetState().RequiresUserAction &&
-        (CloudSecretsService.ActiveProvider?.ProviderType == CloudSecretsProviderType.Local ||
-            cloudProviders.All(p => p.ProviderType == CloudSecretsProviderType.Local));
+        cloudProviders.Any(p => p.ProviderType == CloudSecretsProviderType.Local);
 
     private void OnLocalVaultStateChanged()
     {
@@ -2355,8 +2425,8 @@
     private async Task DeleteProvider(CloudSecretsProviderConfig provider)
     {
         var confirm = await AlertService.ShowConfirmAsync(
-            "Delete Provider",
-            $"Are you sure you want to delete '{provider.Name}'?");
+            "Disconnect Provider",
+            $"Disconnect '{provider.Name}' from MAUI Sherpa? Remote secrets will not be deleted, and existing items that reference this provider will show it as unavailable.");
         
         if (!confirm) return;
         
@@ -2366,7 +2436,7 @@
         cloudProviders.Remove(provider);
         StateHasChanged();
         
-        await AlertService.ShowToastAsync("Provider deleted");
+        await AlertService.ShowToastAsync("Provider disconnected");
         await LoadCloudProviders();
     }
     
@@ -2379,12 +2449,40 @@
             await AlertService.ShowAlertAsync("Connection Failed", "Could not connect to the secrets provider. Check your credentials and settings.");
     }
     
-    private async Task SetActiveProvider(CloudSecretsProviderConfig provider)
+    private async Task SetProviderDefaultAsync(
+        CloudSecretsProviderConfig provider,
+        SecretItemKind itemKind,
+        ChangeEventArgs eventArgs)
     {
-        await CloudSecretsService.SetActiveProviderAsync(provider.Id);
-        await AlertService.ShowToastAsync($"'{provider.Name}' is now the active provider");
+        var enabled = eventArgs.Value is bool value && value;
+        var defaults = provider.EffectiveDefaultItemKinds.ToHashSet();
+        if (enabled)
+            defaults.Add(itemKind);
+        else
+            defaults.Remove(itemKind);
+
+        var updated = provider with
+        {
+            DefaultItemKinds = defaults.OrderBy(kind => kind).ToList()
+        };
+        await CloudSecretsService.SaveProviderAsync(updated);
+
+        var index = cloudProviders.FindIndex(existing => existing.Id == provider.Id);
+        if (index >= 0)
+            cloudProviders[index] = updated;
+
         StateHasChanged();
     }
+
+    private static string GetItemKindLabel(SecretItemKind itemKind) => itemKind switch
+    {
+        SecretItemKind.ManagedSecret => "Secrets",
+        SecretItemKind.AndroidKeystore => "Keystores",
+        SecretItemKind.Certificate => "Certificates",
+        SecretItemKind.ProvisioningProfile => "Provisioning profiles",
+        SecretItemKind.PublishProfile => "Publish profiles",
+        _ => itemKind.ToString()
+    };
 
     // CI/CD Publisher Methods
     
@@ -2583,7 +2681,8 @@
                     provider.Id,
                     provider.Name,
                     provider.ProviderType,
-                    new Dictionary<string, string>(provider.Settings)));
+                    new Dictionary<string, string>(provider.Settings),
+                    provider.DefaultItemKinds ?? SecretItemKinds.All.ToList()));
             }
 
             if (!string.IsNullOrEmpty(settings.ActiveCloudProviderId) &&

--- a/src/MauiSherpa/Services/IdentitySelectionStore.cs
+++ b/src/MauiSherpa/Services/IdentitySelectionStore.cs
@@ -1,0 +1,40 @@
+using MauiSherpa.Core.Interfaces;
+
+namespace MauiSherpa.Services;
+
+public sealed class IdentitySelectionStore : IIdentitySelectionStore
+{
+    private const string AppleIdentityKey = "last_selected_apple_identity_id";
+    private const string GoogleIdentityKey = "last_selected_google_identity_id";
+
+    private readonly IPreferences _preferences;
+
+    public IdentitySelectionStore(IPreferences preferences)
+    {
+        _preferences = preferences;
+    }
+
+    public string? GetLastAppleIdentityId() =>
+        GetIdentityId(AppleIdentityKey);
+
+    public void SetLastAppleIdentityId(string identityId) =>
+        SetIdentityId(AppleIdentityKey, identityId);
+
+    public string? GetLastGoogleIdentityId() =>
+        GetIdentityId(GoogleIdentityKey);
+
+    public void SetLastGoogleIdentityId(string identityId) =>
+        SetIdentityId(GoogleIdentityKey, identityId);
+
+    private string? GetIdentityId(string key)
+    {
+        var identityId = _preferences.Get(key, string.Empty);
+        return string.IsNullOrWhiteSpace(identityId) ? null : identityId;
+    }
+
+    private void SetIdentityId(string key, string identityId)
+    {
+        if (!string.IsNullOrWhiteSpace(identityId))
+            _preferences.Set(key, identityId);
+    }
+}

--- a/src/MauiSherpa/Services/LocalSecretsKeyStore.cs
+++ b/src/MauiSherpa/Services/LocalSecretsKeyStore.cs
@@ -13,14 +13,20 @@ public class LocalSecretsKeyStore : ILocalSecretsKeyStore, ILocalVaultAccessServ
     private const int KeySize = 32;
 
     private readonly ISecureStorage _secureStorage;
+    private readonly ILegacySecureStorageService _legacySecureStorage;
     private readonly IPreferences _preferences;
     private readonly ILoggingService _logger;
     private readonly SemaphoreSlim _keyLock = new(1, 1);
     private string? _cachedKey;
 
-    public LocalSecretsKeyStore(ISecureStorage secureStorage, IPreferences preferences, ILoggingService logger)
+    public LocalSecretsKeyStore(
+        ISecureStorage secureStorage,
+        ILegacySecureStorageService legacySecureStorage,
+        IPreferences preferences,
+        ILoggingService logger)
     {
         _secureStorage = secureStorage;
+        _legacySecureStorage = legacySecureStorage;
         _preferences = preferences;
         _logger = logger;
     }
@@ -82,7 +88,7 @@ public class LocalSecretsKeyStore : ILocalSecretsKeyStore, ILocalVaultAccessServ
             if (!forcePrompt && GetState().RequiresUserAction)
                 throw new LocalVaultUnavailableException(GetState().Message ?? "Local vault access requires user approval.");
 
-            var existing = await _secureStorage.GetAsync(KeyName);
+            var existing = await GetStoredKeyAsync(KeyName);
             if (!string.IsNullOrWhiteSpace(existing))
             {
                 _cachedKey = existing;
@@ -90,18 +96,18 @@ public class LocalSecretsKeyStore : ILocalSecretsKeyStore, ILocalVaultAccessServ
                 return existing;
             }
 
-            var legacy = await _secureStorage.GetAsync(LegacyKeyName);
+            var legacy = await GetStoredKeyAsync(LegacyKeyName);
             if (!string.IsNullOrWhiteSpace(legacy))
             {
-                await _secureStorage.SetAsync(KeyName, legacy);
-                _secureStorage.Remove(LegacyKeyName);
+                await StoreKeyAsync(KeyName, legacy);
+                await RemoveStoredKeyAsync(LegacyKeyName);
                 _cachedKey = legacy;
                 ClearAccessFailure();
                 return legacy;
             }
 
             var key = Convert.ToBase64String(RandomNumberGenerator.GetBytes(KeySize));
-            await _secureStorage.SetAsync(KeyName, key);
+            await StoreKeyAsync(KeyName, key);
             _cachedKey = key;
             ClearAccessFailure();
             return key;
@@ -121,6 +127,39 @@ public class LocalSecretsKeyStore : ILocalSecretsKeyStore, ILocalVaultAccessServ
         {
             _keyLock.Release();
         }
+    }
+
+    private async Task<string?> GetStoredKeyAsync(string key)
+    {
+#if DEBUG
+        var developmentValue = await _legacySecureStorage.GetAsync(key);
+        if (!string.IsNullOrWhiteSpace(developmentValue))
+            return developmentValue;
+
+        var keychainValue = await _secureStorage.GetAsync(key);
+        if (!string.IsNullOrWhiteSpace(keychainValue))
+            await _legacySecureStorage.SetAsync(key, keychainValue);
+
+        return keychainValue;
+#else
+        return await _secureStorage.GetAsync(key);
+#endif
+    }
+
+    private async Task StoreKeyAsync(string key, string value)
+    {
+        await _secureStorage.SetAsync(key, value);
+#if DEBUG
+        await _legacySecureStorage.SetAsync(key, value);
+#endif
+    }
+
+    private async Task RemoveStoredKeyAsync(string key)
+    {
+        _secureStorage.Remove(key);
+#if DEBUG
+        await _legacySecureStorage.RemoveAsync(key);
+#endif
     }
 
     private void RecordAccessFailure(string message, Exception exception)

--- a/src/MauiSherpa/Services/WindowsTitleBarManager.cs
+++ b/src/MauiSherpa/Services/WindowsTitleBarManager.cs
@@ -522,7 +522,11 @@ public class WindowsTitleBarManager
                 if (_cachedAppleIdentities?.Count > 0)
                 {
                     if (_appleIdentityState.SelectedIdentity == null)
-                        _appleIdentityState.SetSelectedIdentity(_cachedAppleIdentities[0]);
+                    {
+                        var preferred = _cachedAppleIdentities.FirstOrDefault(identity =>
+                            identity.Id == _appleIdentityState.LastSelectedIdentityId);
+                        _appleIdentityState.SetSelectedIdentity(preferred ?? _cachedAppleIdentities[0]);
+                    }
                     OnToolbarChanged();
                 }
             });
@@ -531,7 +535,9 @@ public class WindowsTitleBarManager
 
         if (_cachedAppleIdentities.Count == 0) return null;
 
-        var selected = _appleIdentityState.SelectedIdentity;
+        var selected = _appleIdentityState.SelectedIdentity ??
+            _cachedAppleIdentities.FirstOrDefault(identity =>
+                identity.Id == _appleIdentityState.LastSelectedIdentityId);
         if (selected == null && _cachedAppleIdentities.Count > 0)
         {
             selected = _cachedAppleIdentities[0];
@@ -585,7 +591,11 @@ public class WindowsTitleBarManager
                 if (_cachedGoogleIdentities?.Count > 0)
                 {
                     if (_googleIdentityState.SelectedIdentity == null)
-                        _googleIdentityState.SetSelectedIdentity(_cachedGoogleIdentities[0]);
+                    {
+                        var preferred = _cachedGoogleIdentities.FirstOrDefault(identity =>
+                            identity.Id == _googleIdentityState.LastSelectedIdentityId);
+                        _googleIdentityState.SetSelectedIdentity(preferred ?? _cachedGoogleIdentities[0]);
+                    }
                     OnToolbarChanged();
                 }
             });
@@ -594,7 +604,9 @@ public class WindowsTitleBarManager
 
         if (_cachedGoogleIdentities.Count == 0) return null;
 
-        var selected = _googleIdentityState.SelectedIdentity;
+        var selected = _googleIdentityState.SelectedIdentity ??
+            _cachedGoogleIdentities.FirstOrDefault(identity =>
+                identity.Id == _googleIdentityState.LastSelectedIdentityId);
         if (selected == null && _cachedGoogleIdentities.Count > 0)
         {
             selected = _cachedGoogleIdentities[0];

--- a/src/MauiSherpa/wwwroot/css/backgroundTaskCenter.css
+++ b/src/MauiSherpa/wwwroot/css/backgroundTaskCenter.css
@@ -1,0 +1,324 @@
+.background-task-center {
+    position: relative;
+    display: inline-block;
+    color: var(--text-primary);
+}
+
+.task-center-trigger,
+.task-center-close,
+.task-center-clear {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--border-color);
+    background: var(--card-bg);
+    color: var(--text-secondary);
+    cursor: pointer;
+    touch-action: manipulation;
+    transition:
+        background-color 180ms ease-out,
+        border-color 180ms ease-out,
+        color 180ms ease-out,
+        box-shadow 180ms ease-out;
+}
+
+.task-center-trigger {
+    position: relative;
+    width: 44px;
+    min-width: 44px;
+    height: 44px;
+    padding: 0;
+    border-radius: 0.625rem;
+    font-size: 1rem;
+}
+
+.task-center-trigger:hover,
+.task-center-close:hover,
+.task-center-clear:hover:not(:disabled) {
+    background: var(--bg-hover);
+    color: var(--text-primary);
+}
+
+.task-center-trigger:focus-visible,
+.task-center-close:focus-visible,
+.task-center-clear:focus-visible {
+    outline: 2px solid var(--accent-primary);
+    outline-offset: 2px;
+}
+
+.task-center-trigger.has-running {
+    color: var(--accent-primary);
+    border-color: color-mix(in srgb, var(--accent-primary) 55%, var(--border-color));
+}
+
+.task-center-trigger.has-attention {
+    color: var(--accent-danger);
+    border-color: color-mix(in srgb, var(--accent-danger) 60%, var(--border-color));
+}
+
+.task-badge {
+    position: absolute;
+    inset-block-start: -0.35rem;
+    inset-inline-end: -0.35rem;
+    min-width: 1.2rem;
+    height: 1.2rem;
+    padding: 0 0.25rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 2px solid var(--bg-primary);
+    border-radius: 999px;
+    background: var(--accent-primary);
+    color: var(--text-inverse);
+    font-size: 0.625rem;
+    font-weight: 700;
+    line-height: 1;
+    font-variant-numeric: tabular-nums;
+}
+
+.task-badge.attention {
+    background: var(--accent-danger);
+}
+
+.task-center-flyout {
+    position: absolute;
+    z-index: 1000;
+    inset-block-start: calc(100% + 0.5rem);
+    inset-inline-end: 0;
+    width: min(26rem, calc(100vw - 2rem));
+    overflow: hidden;
+    border: 1px solid var(--border-color);
+    border-radius: 0.875rem;
+    background: var(--bg-secondary);
+    box-shadow: var(--card-shadow-lg);
+    animation: task-center-in 180ms ease-out;
+}
+
+.task-center-flyout-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 1rem;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.task-center-flyout-header h2 {
+    margin: 0;
+    color: var(--text-primary);
+    font-size: 1rem;
+    font-weight: 650;
+    line-height: 1.35;
+}
+
+.task-center-flyout-header p {
+    margin: 0.2rem 0 0;
+    color: var(--text-muted);
+    font-size: 0.8125rem;
+    line-height: 1.45;
+}
+
+.task-center-close {
+    flex: 0 0 auto;
+    width: 44px;
+    height: 44px;
+    margin: -0.5rem -0.5rem 0 0;
+    padding: 0;
+    border-color: transparent;
+    border-radius: 0.5rem;
+    background: transparent;
+}
+
+.task-center-header-actions {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.25rem;
+    margin: -0.5rem -0.5rem 0 0;
+}
+
+.task-center-header-actions .task-center-close {
+    margin: 0;
+}
+
+.task-center-clear {
+    min-height: 44px;
+    padding: 0 0.625rem;
+    gap: 0.375rem;
+    border-color: transparent;
+    border-radius: 0.5rem;
+    background: transparent;
+    color: var(--text-muted);
+    font: inherit;
+    font-size: 0.75rem;
+    font-weight: 600;
+}
+
+.task-center-clear:disabled {
+    cursor: wait;
+    opacity: 0.55;
+}
+
+.task-center-persistence-warning,
+.task-center-error {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    margin: 0.75rem 0.75rem 0;
+    padding: 0.625rem 0.75rem;
+    border-radius: 0.5rem;
+    font-size: 0.75rem;
+    line-height: 1.45;
+}
+
+.task-center-persistence-warning {
+    background: color-mix(in srgb, var(--accent-warning) 13%, transparent);
+    color: var(--text-secondary);
+}
+
+.task-center-persistence-warning i {
+    margin-top: 0.1rem;
+    color: var(--accent-warning);
+}
+
+.task-center-error {
+    background: color-mix(in srgb, var(--accent-danger) 13%, transparent);
+    color: var(--accent-danger);
+}
+
+.task-center-error i {
+    margin-top: 0.1rem;
+}
+
+.background-task-groups {
+    max-height: min(36rem, calc(100vh - 10rem));
+    padding: 0.75rem;
+    overflow-y: auto;
+}
+
+.background-task-group + .background-task-group {
+    margin-top: 1rem;
+}
+
+.background-task-group h3 {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin: 0 0 0.5rem;
+    padding: 0 0.25rem;
+    color: var(--text-secondary);
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    line-height: 1.4;
+    text-transform: uppercase;
+}
+
+.background-task-group h3.task-group-attention {
+    color: var(--accent-danger);
+}
+
+.task-group-count {
+    min-width: 1.25rem;
+    padding: 0.1rem 0.35rem;
+    border-radius: 999px;
+    background: var(--bg-tertiary);
+    color: inherit;
+    font-size: 0.6875rem;
+    text-align: center;
+    font-variant-numeric: tabular-nums;
+}
+
+.background-task-empty {
+    min-height: 12rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.375rem;
+    padding: 1.5rem;
+    color: var(--text-muted);
+    font-size: 0.8125rem;
+    text-align: center;
+}
+
+.background-task-empty strong {
+    margin-top: 0.25rem;
+    color: var(--text-primary);
+    font-size: 0.875rem;
+}
+
+.background-task-empty-icon {
+    width: 2.75rem;
+    height: 2.75rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background: var(--bg-tertiary);
+    color: var(--text-secondary);
+    font-size: 1.125rem;
+}
+
+.background-task-visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+@keyframes task-center-in {
+    from {
+        opacity: 0;
+        transform: translateY(-0.25rem) scale(0.98);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
+
+@keyframes task-center-spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+.task-trigger-spinning {
+    animation: task-center-spin 1.1s linear infinite;
+}
+
+@media (max-width: 480px) {
+    .task-center-flyout {
+        position: fixed;
+        inset-block-start: auto;
+        inset-inline: 1rem;
+        inset-block-end: 1rem;
+        width: auto;
+        max-height: calc(100dvh - 2rem);
+    }
+
+    .background-task-groups {
+        max-height: calc(100dvh - 11rem);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .task-center-trigger,
+    .task-center-close {
+        transition: none;
+    }
+
+    .task-center-flyout {
+        animation: none;
+    }
+
+    .task-trigger-spinning {
+        animation: none;
+    }
+}

--- a/src/MauiSherpa/wwwroot/css/backgroundTaskItem.css
+++ b/src/MauiSherpa/wwwroot/css/backgroundTaskItem.css
@@ -1,0 +1,407 @@
+.task-item {
+    padding: 0.75rem;
+    border: 1px solid var(--border-color);
+    border-radius: 0.75rem;
+    background: var(--card-bg);
+    color: var(--text-primary);
+}
+
+.task-item + .task-item {
+    margin-top: 0.5rem;
+}
+
+.task-item-heading {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.625rem;
+}
+
+.task-state-icon {
+    flex: 0 0 auto;
+    width: 1.75rem;
+    height: 1.75rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background: var(--bg-tertiary);
+    color: var(--text-muted);
+    font-size: 0.75rem;
+}
+
+.task-state-icon.active {
+    background: color-mix(in srgb, var(--accent-primary) 14%, transparent);
+    color: var(--accent-primary);
+}
+
+.task-state-icon.success {
+    background: color-mix(in srgb, var(--accent-success) 14%, transparent);
+    color: var(--accent-success);
+}
+
+.task-state-icon.error {
+    background: color-mix(in srgb, var(--accent-danger) 14%, transparent);
+    color: var(--accent-danger);
+}
+
+.task-state-icon.warning {
+    background: color-mix(in srgb, var(--accent-warning) 14%, transparent);
+    color: var(--accent-warning);
+}
+
+.task-title-block {
+    min-width: 0;
+    flex: 1;
+}
+
+.task-title {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    width: 100%;
+    margin: 0;
+    color: var(--text-primary);
+    font-size: 0.875rem;
+    font-weight: 650;
+    line-height: 1.4;
+    text-align: start;
+}
+
+button.task-title {
+    min-height: 44px;
+    margin: -0.5rem 0 -0.2rem;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    cursor: pointer;
+}
+
+.task-title span {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.task-link i {
+    flex: 0 0 auto;
+    color: var(--text-muted);
+    font-size: 0.6875rem;
+}
+
+.task-link:hover {
+    color: var(--accent-primary);
+}
+
+.task-link:focus-visible,
+.task-action:focus-visible,
+.task-log summary:focus-visible {
+    outline: 2px solid var(--accent-primary);
+    outline-offset: 2px;
+    border-radius: 0.25rem;
+}
+
+.task-link:disabled,
+.task-action:disabled {
+    cursor: not-allowed;
+    opacity: 0.45;
+}
+
+.task-description {
+    display: -webkit-box;
+    margin-top: 0.125rem;
+    overflow: hidden;
+    color: var(--text-muted);
+    font-size: 0.75rem;
+    line-height: 1.4;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+}
+
+.task-progress {
+    margin-top: 0.625rem;
+}
+
+.task-progress-copy {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-bottom: 0.3rem;
+    color: var(--text-secondary);
+    font-size: 0.75rem;
+    line-height: 1.3;
+    font-variant-numeric: tabular-nums;
+}
+
+.task-progress-track {
+    height: 0.375rem;
+    overflow: hidden;
+    border-radius: 999px;
+    background: var(--bg-tertiary);
+}
+
+.task-progress-value {
+    display: block;
+    height: 100%;
+    border-radius: inherit;
+    background: var(--accent-primary);
+}
+
+.task-progress-value.indeterminate {
+    width: 35%;
+    animation: task-progress 1.2s ease-in-out infinite;
+}
+
+.task-status {
+    margin-top: 0.5rem;
+    color: var(--text-secondary);
+    font-size: 0.75rem;
+    line-height: 1.4;
+}
+
+.task-steps {
+    display: grid;
+    gap: 0.25rem;
+    margin: 0.625rem 0 0;
+    padding: 0;
+    list-style: none;
+}
+
+.task-step {
+    display: grid;
+    grid-template-columns: 1rem minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 0.375rem;
+    min-height: 1.5rem;
+    color: var(--text-secondary);
+    font-size: 0.72rem;
+    line-height: 1.35;
+}
+
+.task-step-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-muted);
+    font-size: 0.625rem;
+}
+
+.task-step-label {
+    min-width: 0;
+    overflow: hidden;
+    color: var(--text-primary);
+    font-weight: 600;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.task-step-status {
+    color: var(--text-muted);
+    text-align: end;
+}
+
+.task-step.state-running .task-step-icon {
+    color: var(--accent-primary);
+}
+
+.task-step.state-succeeded .task-step-icon {
+    color: var(--accent-success);
+}
+
+.task-step.state-failed .task-step-icon,
+.task-step-error {
+    color: var(--accent-danger);
+}
+
+.task-step.state-cancelled .task-step-icon {
+    color: var(--accent-warning);
+}
+
+.task-step-error {
+    grid-column: 2 / -1;
+    overflow-wrap: anywhere;
+}
+
+.task-error {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.4rem;
+    margin-top: 0.625rem;
+    padding: 0.5rem 0.625rem;
+    border-radius: 0.5rem;
+    background: color-mix(in srgb, var(--accent-danger) 12%, transparent);
+    color: var(--accent-danger);
+    font-size: 0.75rem;
+    line-height: 1.45;
+    overflow-wrap: anywhere;
+    user-select: text;
+}
+
+.task-error i {
+    margin-top: 0.1rem;
+}
+
+.task-log {
+    margin-top: 0.5rem;
+    color: var(--text-secondary);
+    font-size: 0.75rem;
+}
+
+.task-log summary {
+    min-height: 44px;
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    width: fit-content;
+    cursor: pointer;
+}
+
+.task-log summary > span {
+    min-width: 1.15rem;
+    padding: 0.05rem 0.3rem;
+    border-radius: 999px;
+    background: var(--bg-tertiary);
+    color: var(--text-muted);
+    font-size: 0.625rem;
+    text-align: center;
+}
+
+.task-log ol {
+    max-height: 9rem;
+    margin: 0 0 0.25rem;
+    padding: 0.5rem;
+    overflow: auto;
+    border-radius: 0.5rem;
+    background: var(--bg-primary);
+    list-style: none;
+    font-family: "SF Mono", Menlo, Monaco, Consolas, monospace;
+    font-size: 0.6875rem;
+    line-height: 1.45;
+    user-select: text;
+}
+
+.task-log li {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: 0.5rem;
+}
+
+.task-log li + li {
+    margin-top: 0.25rem;
+}
+
+.task-log time {
+    color: var(--text-muted);
+    font-variant-numeric: tabular-nums;
+}
+
+.task-log li > span {
+    overflow-wrap: anywhere;
+}
+
+.task-log .log-error,
+.task-log .log-warning {
+    color: var(--accent-danger);
+}
+
+.task-log .log-success {
+    color: var(--accent-success);
+}
+
+.task-footer {
+    min-height: 44px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-top: 0.5rem;
+    border-top: 1px solid var(--border-color);
+}
+
+.task-footer > time {
+    color: var(--text-muted);
+    font-size: 0.6875rem;
+    font-variant-numeric: tabular-nums;
+}
+
+.task-actions {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+}
+
+.task-action {
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35rem;
+    padding: 0 0.5rem;
+    border: 0;
+    border-radius: 0.375rem;
+    background: transparent;
+    color: var(--accent-primary);
+    font: inherit;
+    font-size: 0.75rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 160ms ease-out, color 160ms ease-out;
+}
+
+.task-action:hover {
+    background: var(--bg-hover);
+}
+
+.task-action-danger {
+    color: var(--accent-danger);
+}
+
+.background-task-visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+@keyframes task-progress {
+    from {
+        transform: translateX(-110%);
+    }
+
+    to {
+        transform: translateX(300%);
+    }
+}
+
+@media (max-width: 480px) {
+    .task-footer {
+        align-items: flex-start;
+        flex-direction: column;
+        padding-top: 0.5rem;
+    }
+
+    .task-actions {
+        width: 100%;
+        justify-content: flex-start;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .task-progress-value,
+    .task-action {
+        transition: none;
+    }
+
+    .task-progress-value.indeterminate {
+        width: 100%;
+        opacity: 0.55;
+        animation: none;
+    }
+}

--- a/src/MauiSherpa/wwwroot/css/secretProviderPicker.css
+++ b/src/MauiSherpa/wwwroot/css/secretProviderPicker.css
@@ -1,0 +1,497 @@
+.secret-provider-picker {
+    position: relative;
+    width: 44px;
+    height: 44px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 44px;
+    color: var(--text-primary);
+}
+
+.provider-trigger,
+.secret-provider-close {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--border-color);
+    background: var(--card-bg);
+    color: var(--text-secondary);
+    cursor: pointer;
+    touch-action: manipulation;
+    transition:
+        background-color 180ms ease-out,
+        border-color 180ms ease-out,
+        color 180ms ease-out,
+        box-shadow 180ms ease-out;
+}
+
+.provider-trigger {
+    position: relative;
+    width: 32px;
+    min-width: 32px;
+    height: 32px;
+    padding: 0;
+    border-radius: 0.375rem;
+}
+
+.provider-trigger::after {
+    content: "";
+    position: absolute;
+    inset: -6px;
+}
+
+.provider-trigger:hover,
+.secret-provider-close:hover {
+    background: var(--bg-hover);
+    color: var(--text-primary);
+}
+
+.provider-trigger:focus-visible,
+.secret-provider-close:focus-visible {
+    outline: 2px solid var(--accent-primary);
+    outline-offset: 2px;
+}
+
+.provider-trigger-icon {
+    position: relative;
+    display: inline-block;
+    width: 1.5rem;
+    height: 1.25rem;
+    font-size: 1.1rem;
+    line-height: 1;
+}
+
+.provider-trigger-icon > .fa-cloud {
+    position: absolute;
+    inset: 50% auto auto 50%;
+    transform: translate(-50%, -50%);
+}
+
+.provider-trigger-key {
+    position: absolute !important;
+    inset: 50% auto auto 50% !important;
+    transform: translate(-50%, -32%) scale(0.62) !important;
+    color: var(--bg-primary);
+    font-size: 0.55rem !important;
+    line-height: 1;
+}
+
+.provider-trigger-loading {
+    position: absolute !important;
+    inset: 0 !important;
+    display: inline-flex !important;
+    align-items: center;
+    justify-content: center;
+    width: 100% !important;
+    height: 100% !important;
+    color: var(--card-bg);
+    font-size: 0.5rem !important;
+    line-height: 1;
+    transform-origin: center;
+    animation: provider-loading-spin 1s linear infinite;
+}
+
+.provider-trigger-state-synced {
+    color: var(--accent-success);
+    border-color: color-mix(in srgb, var(--accent-success) 55%, var(--border-color));
+}
+
+.provider-trigger-state-pending {
+    color: var(--accent-warning);
+    border-color: color-mix(in srgb, var(--accent-warning) 55%, var(--border-color));
+}
+
+.provider-trigger-state-loading {
+    color: var(--accent-primary);
+    border-color: color-mix(in srgb, var(--accent-primary) 45%, var(--border-color));
+}
+
+.provider-trigger-state-failed,
+.provider-trigger-state-conflict {
+    color: var(--accent-danger);
+    border-color: color-mix(in srgb, var(--accent-danger) 60%, var(--border-color));
+}
+
+.provider-count {
+    position: absolute;
+    inset-block-start: -0.35rem;
+    inset-inline-end: -0.35rem;
+    min-width: 1.2rem;
+    height: 1.2rem;
+    padding: 0 0.25rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 2px solid var(--bg-primary);
+    border-radius: 999px;
+    background: var(--accent-primary);
+    color: var(--text-inverse);
+    font-size: 0.625rem;
+    font-weight: 700;
+    line-height: 1;
+    font-variant-numeric: tabular-nums;
+}
+
+.attention-dot {
+    position: absolute;
+    inset-block-end: 0.2rem;
+    inset-inline-end: 0.2rem;
+    width: 0.5rem;
+    height: 0.5rem;
+    border: 2px solid var(--card-bg);
+    border-radius: 50%;
+    background: var(--accent-danger);
+}
+
+.provider-popover {
+    position: absolute;
+    z-index: 1000;
+    inset-block-start: calc(100% + 0.5rem);
+    inset-inline-end: 0;
+    width: min(22rem, calc(100vw - 2rem));
+    overflow: hidden;
+    border: 1px solid var(--border-color);
+    border-radius: 0.875rem;
+    background: var(--bg-secondary);
+    box-shadow: var(--card-shadow-lg);
+    animation: provider-popover-in 180ms ease-out;
+}
+
+.secret-provider-popover-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 1rem;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.secret-provider-popover-header h2 {
+    margin: 0;
+    color: var(--text-primary);
+    font-size: 1rem;
+    font-weight: 650;
+    line-height: 1.35;
+}
+
+.secret-provider-popover-header p {
+    margin: 0.2rem 0 0;
+    color: var(--text-muted);
+    font-size: 0.8125rem;
+    line-height: 1.45;
+}
+
+.secret-provider-close {
+    flex: 0 0 auto;
+    width: 44px;
+    height: 44px;
+    margin: -0.5rem -0.5rem 0 0;
+    padding: 0;
+    border-color: transparent;
+    border-radius: 0.5rem;
+    background: transparent;
+}
+
+.provider-list {
+    max-height: min(22rem, calc(100vh - 12rem));
+    padding: 0.5rem;
+    overflow-y: auto;
+}
+
+.provider-option {
+    display: grid;
+    grid-template-columns: 1.25rem 1.75rem minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 0.625rem;
+    min-height: 52px;
+    padding: 0.5rem;
+    border: 1px solid transparent;
+    border-radius: 0.625rem;
+    cursor: pointer;
+    transition: background-color 160ms ease-out, border-color 160ms ease-out;
+}
+
+.provider-option:hover {
+    background: var(--bg-hover);
+}
+
+.provider-option + .provider-option {
+    margin-top: 0.25rem;
+}
+
+.provider-option input {
+    width: 1.1rem;
+    height: 1.1rem;
+    margin: 0;
+    display: grid;
+    place-content: center;
+    appearance: none;
+    border: 2px solid var(--text-muted);
+    border-radius: 0.3rem;
+    background: var(--input-bg);
+    cursor: pointer;
+}
+
+.provider-option input::before {
+    content: "";
+    width: 0.5rem;
+    height: 0.28rem;
+    border-left: 2px solid var(--text-inverse);
+    border-bottom: 2px solid var(--text-inverse);
+    transform: translateY(-0.04rem) rotate(-45deg) scale(0);
+    transition: transform 100ms ease-out;
+}
+
+.provider-option input:checked {
+    border-color: var(--accent-primary);
+    background: var(--accent-primary);
+}
+
+.provider-option input:checked::before {
+    transform: translateY(-0.04rem) rotate(-45deg) scale(1);
+}
+
+.provider-option input:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent-primary) 30%, transparent);
+}
+
+.provider-option input:disabled {
+    cursor: wait;
+    opacity: 0.55;
+}
+
+.provider-placement-status-loading {
+    cursor: wait;
+}
+
+.provider-placement-status-loading:hover {
+    background: transparent;
+}
+
+.provider-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.75rem;
+    height: 1.75rem;
+    border-radius: 0.45rem;
+    background: var(--bg-tertiary);
+    color: var(--text-secondary);
+}
+
+.provider-copy {
+    min-width: 0;
+}
+
+.provider-name,
+.provider-observation {
+    display: block;
+}
+
+.provider-name {
+    overflow: hidden;
+    color: var(--text-primary);
+    font-size: 0.875rem;
+    font-weight: 600;
+    line-height: 1.35;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.provider-observation {
+    margin-top: 0.125rem;
+    color: var(--text-muted);
+    font-size: 0.75rem;
+    line-height: 1.35;
+}
+
+.provider-status-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.25rem 0.45rem;
+    border-radius: 999px;
+    background: var(--bg-tertiary);
+    color: var(--text-secondary);
+    font-size: 0.6875rem;
+    font-weight: 650;
+    line-height: 1.2;
+    white-space: nowrap;
+}
+
+.provider-placement-status-synced .provider-status-pill {
+    background: color-mix(in srgb, var(--accent-success) 14%, transparent);
+    color: var(--accent-success);
+}
+
+.provider-placement-status-loading .provider-status-pill {
+    background: color-mix(in srgb, var(--accent-primary) 10%, transparent);
+    color: var(--accent-primary);
+}
+
+.provider-placement-status-pending .provider-status-pill {
+    background: color-mix(in srgb, var(--accent-warning) 14%, transparent);
+    color: var(--accent-warning);
+}
+
+.provider-placement-status-failed .provider-status-pill,
+.provider-placement-status-conflict .provider-status-pill {
+    background: color-mix(in srgb, var(--accent-danger) 14%, transparent);
+    color: var(--accent-danger);
+}
+
+.provider-placement-status-unavailable .provider-status-pill {
+    background: var(--bg-tertiary);
+    color: var(--text-muted);
+}
+
+.provider-source-warning {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    margin: 0 0.5rem 0.5rem;
+    padding: 0.625rem 0.75rem;
+    border: 1px solid color-mix(in srgb, var(--accent-warning) 40%, var(--border-color));
+    border-radius: 0.625rem;
+    background: color-mix(in srgb, var(--accent-warning) 10%, var(--card-bg));
+    color: var(--text-secondary);
+    font-size: 0.75rem;
+    line-height: 1.4;
+}
+
+.provider-source-warning i {
+    margin-top: 0.12rem;
+    color: var(--accent-warning);
+}
+
+.provider-conflict-resolution {
+    margin: 0 0.5rem 0.5rem;
+    padding: 0.75rem;
+    border: 1px solid color-mix(in srgb, var(--accent-danger) 45%, var(--border-color));
+    border-radius: 0.625rem;
+    background: color-mix(in srgb, var(--accent-danger) 8%, var(--card-bg));
+    color: var(--text-primary);
+    font-size: 0.75rem;
+}
+
+.provider-conflict-resolution > div:first-child {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+}
+
+.provider-conflict-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-top: 0.625rem;
+}
+
+.provider-conflict-actions button {
+    min-height: 2.75rem;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--border-color);
+    border-radius: 0.5rem;
+    background: var(--card-bg);
+    color: var(--text-primary);
+    cursor: pointer;
+}
+
+.provider-conflict-actions button:hover {
+    background: var(--bg-hover);
+}
+
+.provider-conflict-actions button:focus-visible {
+    outline: 2px solid var(--accent-primary);
+    outline-offset: 2px;
+}
+
+.secret-provider-popover-footer {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    padding: 0.75rem 1rem;
+    border-top: 1px solid var(--border-color);
+    background: var(--bg-tertiary);
+    color: var(--text-muted);
+    font-size: 0.75rem;
+    line-height: 1.45;
+}
+
+.secret-provider-popover-footer i {
+    margin-top: 0.12rem;
+    color: var(--accent-primary);
+}
+
+.empty-providers {
+    min-height: 7rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.625rem;
+    padding: 1rem;
+    color: var(--text-muted);
+    font-size: 0.8125rem;
+    text-align: center;
+}
+
+.empty-providers i {
+    color: var(--text-secondary);
+    font-size: 1.5rem;
+}
+
+@keyframes provider-popover-in {
+    from {
+        opacity: 0;
+        transform: translateY(-0.25rem) scale(0.98);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
+
+@keyframes provider-loading-spin {
+    from {
+        transform: rotate(0deg);
+    }
+
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+@media (max-width: 480px) {
+    .provider-popover {
+        position: fixed;
+        inset-block-start: auto;
+        inset-inline: 1rem;
+        inset-block-end: 1rem;
+        width: auto;
+        max-height: calc(100dvh - 2rem);
+    }
+
+    .provider-list {
+        max-height: calc(100dvh - 12rem);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .provider-trigger,
+    .secret-provider-close,
+    .provider-option {
+        transition: none;
+    }
+
+    .provider-popover {
+        animation: none;
+    }
+
+    .provider-trigger-loading {
+        animation: none;
+    }
+}

--- a/src/MauiSherpa/wwwroot/index.html
+++ b/src/MauiSherpa/wwwroot/index.html
@@ -133,6 +133,7 @@
     </div>
 
     <script src="_framework/blazor.webview.js" autostart="false"></script>
+    <script src="_content/Shiny.Mediator.Blazor/Mediator.js"></script>
     <script src="js/terminal.js"></script>
     <script src="js/modalInterop.js"></script>
     <script src="js/logScrollInterop.js"></script>

--- a/src/MauiSherpa/wwwroot/js/mauiSherpaPopovers.js
+++ b/src/MauiSherpa/wwwroot/js/mauiSherpaPopovers.js
@@ -1,0 +1,80 @@
+const popoverBindings = new Map();
+
+export function ensureStylesheet(href) {
+    const absoluteHref = new URL(href, document.baseURI).href;
+    const existing = Array.from(document.querySelectorAll("link[rel='stylesheet']"))
+        .some(link => link.href === absoluteHref);
+
+    if (existing) {
+        return;
+    }
+
+    const link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.href = href;
+    document.head.appendChild(link);
+}
+
+export function ensureStylesheets(...hrefs) {
+    hrefs.flat().forEach(ensureStylesheet);
+}
+
+export function bindPopover(rootId, dotNetReference) {
+    unbindPopover(rootId);
+
+    const root = document.getElementById(rootId);
+    if (!root) {
+        return;
+    }
+
+    const close = restoreFocus => {
+        if (root.dataset.open === "true") {
+            void dotNetReference
+                .invokeMethodAsync("CloseFromJavaScript", restoreFocus)
+                .catch(() => {});
+        }
+    };
+
+    const onPointerDown = event => {
+        if (!root.contains(event.target)) {
+            close(false);
+        }
+    };
+
+    const onKeyDown = event => {
+        if (event.key !== "Escape" || root.dataset.open !== "true") {
+            return;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+        close(true);
+    };
+
+    document.addEventListener("pointerdown", onPointerDown, true);
+    document.addEventListener("keydown", onKeyDown, true);
+    popoverBindings.set(rootId, { onPointerDown, onKeyDown });
+
+    queueMicrotask(() => {
+        const initialFocus = root.querySelector("[data-popover-initial-focus]");
+        const closeButton = root.querySelector("[aria-label^='Close']");
+        (initialFocus ?? closeButton)?.focus();
+    });
+}
+
+export function unbindPopover(rootId) {
+    const binding = popoverBindings.get(rootId);
+    if (!binding) {
+        return;
+    }
+
+    document.removeEventListener("pointerdown", binding.onPointerDown, true);
+    document.removeEventListener("keydown", binding.onKeyDown, true);
+    popoverBindings.delete(rootId);
+}
+
+export function focusTrigger(rootId) {
+    document.getElementById(rootId)
+        ?.querySelector("[data-popover-trigger]")
+        ?.focus();
+}

--- a/tests/MauiSherpa.Core.Tests/Services/AppleIdentityStateServiceTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/AppleIdentityStateServiceTests.cs
@@ -38,4 +38,40 @@ public class AppleIdentityStateServiceTests
 
         events.Should().Be(1);
     }
+
+    [Fact]
+    public void SetSelectedIdentity_PersistsLastNonNullSelection()
+    {
+        var store = new TestIdentitySelectionStore();
+        var sut = new AppleIdentityStateService(store);
+        var identity = new AppleIdentity("id1", "Team", "KEY1", "ISS1", null, "p8");
+
+        sut.SetSelectedIdentity(identity);
+        sut.SetSelectedIdentity(null);
+
+        sut.LastSelectedIdentityId.Should().Be("id1");
+        store.AppleIdentityId.Should().Be("id1");
+    }
+
+    [Fact]
+    public void Constructor_RestoresLastSelectionId()
+    {
+        var store = new TestIdentitySelectionStore { AppleIdentityId = "id2" };
+
+        var sut = new AppleIdentityStateService(store);
+
+        sut.LastSelectedIdentityId.Should().Be("id2");
+        sut.SelectedIdentity.Should().BeNull();
+    }
+
+    private sealed class TestIdentitySelectionStore : IIdentitySelectionStore
+    {
+        public string? AppleIdentityId { get; set; }
+        public string? GoogleIdentityId { get; set; }
+
+        public string? GetLastAppleIdentityId() => AppleIdentityId;
+        public void SetLastAppleIdentityId(string identityId) => AppleIdentityId = identityId;
+        public string? GetLastGoogleIdentityId() => GoogleIdentityId;
+        public void SetLastGoogleIdentityId(string identityId) => GoogleIdentityId = identityId;
+    }
 }

--- a/tests/MauiSherpa.Core.Tests/Services/BackgroundTaskServiceTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/BackgroundTaskServiceTests.cs
@@ -1,0 +1,413 @@
+using FluentAssertions;
+using MauiSherpa.Core.Interfaces;
+using MauiSherpa.Core.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+namespace MauiSherpa.Core.Tests.Services;
+
+public class BackgroundTaskServiceTests
+{
+    [Fact]
+    public async Task EnqueueAsync_ExecutesRegisteredHandler()
+    {
+        using var services = CreateServices(new CompletingHandler());
+        var sut = services.GetRequiredService<IBackgroundTaskService>();
+
+        var taskId = await sut.EnqueueAsync(CreateRequest());
+        var completed = await WaitForTerminalStateAsync(sut, taskId);
+
+        completed.State.Should().Be(BackgroundTaskState.Succeeded);
+        completed.Progress.Should().Be(100);
+        completed.Steps.Should().NotBeNull();
+        completed.Steps!.Select(step => step.Id).Should().Equal("local", "remote");
+        completed.Steps.Should().OnlyContain(step =>
+            step.State == BackgroundTaskStepState.Succeeded);
+        completed.Log.Should().Contain(entry => entry.Level == OperationLogLevel.Success);
+        sut.IsPersistent.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task EnqueueAsync_WhenHandlerFails_PreservesDesiredTaskForRetry()
+    {
+        using var services = CreateServices(new FailingHandler());
+        var sut = services.GetRequiredService<IBackgroundTaskService>();
+
+        var taskId = await sut.EnqueueAsync(CreateRequest());
+        var failed = await WaitForTerminalStateAsync(sut, taskId);
+
+        failed.State.Should().Be(BackgroundTaskState.Failed);
+        failed.Error.Should().Be("Provider authorization is required.");
+
+        await sut.RetryAsync(taskId);
+        var retried = await WaitForTerminalStateAsync(sut, taskId, minimumAttempt: 2);
+        retried.State.Should().Be(BackgroundTaskState.Failed);
+        retried.Attempt.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_WithLocalVault_RestoresPersistedHistory()
+    {
+        var vault = new InMemoryVaultStore();
+        using (var services = CreateServices(
+            new CompletingHandler(),
+            vault,
+            new AvailableVaultAccessService()))
+        {
+            var first = services.GetRequiredService<IBackgroundTaskService>();
+            var taskId = await first.EnqueueAsync(CreateRequest());
+            await WaitForTerminalStateAsync(first, taskId);
+            first.IsPersistent.Should().BeTrue();
+        }
+
+        using var restoredServices = CreateServices(
+            new CompletingHandler(),
+            vault,
+            new AvailableVaultAccessService());
+        var restored = restoredServices.GetRequiredService<IBackgroundTaskService>();
+        await restored.InitializeAsync();
+
+        restored.IsPersistent.Should().BeTrue();
+        restored.Tasks.Should().ContainSingle(task =>
+            task.Request.Type == "test" &&
+            task.State == BackgroundTaskState.Succeeded);
+    }
+
+    [Fact]
+    public async Task UnlockingVault_AfterMemoryOnlyStart_MergesPersistedHistory()
+    {
+        var vault = new InMemoryVaultStore();
+        using (var firstServices = CreateServices(
+            new FailingHandler(),
+            vault,
+            new AvailableVaultAccessService()))
+        {
+            var first = firstServices.GetRequiredService<IBackgroundTaskService>();
+            var taskId = await first.EnqueueAsync(CreateRequest());
+            await WaitForTerminalStateAsync(first, taskId);
+        }
+
+        var access = new MutableVaultAccessService(
+            new LocalVaultAccessState(LocalVaultAccessProblem.AccessDenied));
+        using var secondServices = CreateServices(new CompletingHandler(), vault, access);
+        var second = secondServices.GetRequiredService<IBackgroundTaskService>();
+        await second.InitializeAsync();
+        second.IsPersistent.Should().BeFalse();
+        second.Tasks.Should().BeEmpty();
+
+        access.SetState(LocalVaultAccessState.Available);
+
+        var timeout = DateTime.UtcNow.AddSeconds(5);
+        while (DateTime.UtcNow < timeout && second.Tasks.Count == 0)
+            await Task.Delay(20);
+
+        second.IsPersistent.Should().BeTrue();
+        second.Tasks.Should().ContainSingle(task =>
+            task.State == BackgroundTaskState.Failed &&
+            task.Error == "Provider authorization is required.");
+    }
+
+    [Fact]
+    public async Task CancelAsync_ForPendingTask_PreventsExecution()
+    {
+        var handler = new ControlledHandler();
+        using var services = CreateServices(handler);
+        var sut = services.GetRequiredService<IBackgroundTaskService>();
+        var firstId = await sut.EnqueueAsync(CreateRequest() with { CoalesceKey = "test:first" });
+
+        await handler.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var secondId = await sut.EnqueueAsync(CreateRequest() with { CoalesceKey = "test:second" });
+        await sut.CancelAsync(secondId);
+        handler.Release.TrySetResult();
+
+        await WaitForTerminalStateAsync(sut, firstId);
+        var cancelled = await WaitForTerminalStateAsync(sut, secondId);
+
+        cancelled.State.Should().Be(BackgroundTaskState.Cancelled);
+        handler.ExecutionCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task RetryAsync_WhenNewerDecisionExists_RejectsStaleTask()
+    {
+        var handler = new SwitchableHandler { ShouldFail = true };
+        using var services = CreateServices(handler);
+        var sut = services.GetRequiredService<IBackgroundTaskService>();
+        var staleTaskId = await sut.EnqueueAsync(CreateRequest());
+        await WaitForTerminalStateAsync(sut, staleTaskId);
+
+        handler.ShouldFail = false;
+        var currentTaskId = await sut.EnqueueAsync(CreateRequest());
+        await WaitForTerminalStateAsync(sut, currentTaskId);
+
+        Func<Task> act = () => sut.RetryAsync(staleTaskId);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*superseded*");
+    }
+
+    [Fact]
+    public async Task ClearCompletedAsync_RemovesSuccessAndRetainsFailures()
+    {
+        var handler = new SwitchableHandler();
+        using var services = CreateServices(handler);
+        var sut = services.GetRequiredService<IBackgroundTaskService>();
+        var completedId = await sut.EnqueueAsync(
+            CreateRequest() with { CoalesceKey = "test:completed" });
+        await WaitForTerminalStateAsync(sut, completedId);
+        handler.ShouldFail = true;
+        var failedId = await sut.EnqueueAsync(
+            CreateRequest() with { CoalesceKey = "test:failed" });
+        await WaitForTerminalStateAsync(sut, failedId);
+
+        await sut.ClearCompletedAsync();
+
+        sut.Tasks.Should().ContainSingle(task =>
+            task.Id == failedId && task.State == BackgroundTaskState.Failed);
+    }
+
+    [Fact]
+    public async Task ClearCompletedAsync_PersistsClearedHistory()
+    {
+        var vault = new InMemoryVaultStore();
+        using (var services = CreateServices(
+            new CompletingHandler(),
+            vault,
+            new AvailableVaultAccessService()))
+        {
+            var sut = services.GetRequiredService<IBackgroundTaskService>();
+            var taskId = await sut.EnqueueAsync(CreateRequest());
+            await WaitForTerminalStateAsync(sut, taskId);
+
+            await sut.ClearCompletedAsync();
+
+            sut.Tasks.Should().BeEmpty();
+        }
+
+        using var restoredServices = CreateServices(
+            new CompletingHandler(),
+            vault,
+            new AvailableVaultAccessService());
+        var restored = restoredServices.GetRequiredService<IBackgroundTaskService>();
+        await restored.InitializeAsync();
+
+        restored.Tasks.Should().BeEmpty();
+    }
+
+    private static ServiceProvider CreateServices(
+        IBackgroundTaskHandler handler,
+        ILocalVaultStore? vaultStore = null,
+        ILocalVaultAccessService? vaultAccess = null)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(new Mock<ILoggingService>().Object);
+        services.AddSingleton<IBackgroundTaskHandler>(handler);
+        if (vaultStore is not null)
+            services.AddSingleton(vaultStore);
+        if (vaultAccess is not null)
+            services.AddSingleton(vaultAccess);
+        services.AddSingleton<BackgroundTaskService>();
+        services.AddSingleton<IBackgroundTaskService>(provider =>
+            provider.GetRequiredService<BackgroundTaskService>());
+        return services.BuildServiceProvider();
+    }
+
+    private static BackgroundTaskRequest CreateRequest() => new(
+        "test",
+        "Test task",
+        "Exercise the background queue.",
+        new Dictionary<string, string> { ["desiredProviderIds"] = "[\"local\"]" },
+        CoalesceKey: "test:item");
+
+    private static async Task<BackgroundTaskInfo> WaitForTerminalStateAsync(
+        IBackgroundTaskService service,
+        string taskId,
+        int minimumAttempt = 1)
+    {
+        var timeout = DateTime.UtcNow.AddSeconds(5);
+        while (DateTime.UtcNow < timeout)
+        {
+            var task = service.Tasks.Single(info => info.Id == taskId);
+            if ((task.Attempt >= minimumAttempt || task.State == BackgroundTaskState.Cancelled) &&
+                task.State is BackgroundTaskState.Succeeded or
+                    BackgroundTaskState.Failed or
+                    BackgroundTaskState.Cancelled)
+            {
+                return task;
+            }
+
+            await Task.Delay(20);
+        }
+
+        throw new TimeoutException("Background task did not finish.");
+    }
+
+    private sealed class CompletingHandler : IBackgroundTaskHandler
+    {
+        public string Type => "test";
+
+        public Task ExecuteAsync(BackgroundTaskRequest request, IBackgroundTaskContext context)
+        {
+            context.SetStatus("Working");
+            context.SetProgress(50);
+            context.SetSteps(
+            [
+                new("local", "Local Vault", BackgroundTaskStepState.Pending, "Waiting"),
+                new("remote", "Remote", BackgroundTaskStepState.Pending, "Waiting")
+            ]);
+            context.UpdateStep("local", BackgroundTaskStepState.Running, "Syncing");
+            context.UpdateStep("local", BackgroundTaskStepState.Succeeded, "Synced");
+            context.UpdateStep("remote", BackgroundTaskStepState.Running, "Syncing");
+            context.UpdateStep("remote", BackgroundTaskStepState.Succeeded, "Synced");
+            context.Log("Finished the provider step.", OperationLogLevel.Success);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FailingHandler : IBackgroundTaskHandler
+    {
+        public string Type => "test";
+
+        public Task ExecuteAsync(BackgroundTaskRequest request, IBackgroundTaskContext context) =>
+            throw new InvalidOperationException("Provider authorization is required.");
+    }
+
+    private sealed class ControlledHandler : IBackgroundTaskHandler
+    {
+        public string Type => "test";
+        public TaskCompletionSource Started { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource Release { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public int ExecutionCount { get; private set; }
+
+        public async Task ExecuteAsync(
+            BackgroundTaskRequest request,
+            IBackgroundTaskContext context)
+        {
+            ExecutionCount++;
+            Started.TrySetResult();
+            await Release.Task.WaitAsync(context.CancellationToken);
+        }
+    }
+
+    private sealed class SwitchableHandler : IBackgroundTaskHandler
+    {
+        public string Type => "test";
+        public bool ShouldFail { get; set; }
+
+        public Task ExecuteAsync(
+            BackgroundTaskRequest request,
+            IBackgroundTaskContext context)
+        {
+            if (ShouldFail)
+                throw new InvalidOperationException("Expected test failure.");
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class AvailableVaultAccessService : ILocalVaultAccessService
+    {
+        public LocalVaultAccessState GetState() => LocalVaultAccessState.Available;
+
+        public Task<LocalVaultAccessState> RequestAccessAsync(
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(LocalVaultAccessState.Available);
+
+        public event Action? StateChanged
+        {
+            add { }
+            remove { }
+        }
+    }
+
+    private sealed class MutableVaultAccessService(
+        LocalVaultAccessState state) : ILocalVaultAccessService
+    {
+        private LocalVaultAccessState _state = state;
+
+        public LocalVaultAccessState GetState() => _state;
+
+        public Task<LocalVaultAccessState> RequestAccessAsync(
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(_state);
+
+        public event Action? StateChanged;
+
+        public void SetState(LocalVaultAccessState state)
+        {
+            _state = state;
+            StateChanged?.Invoke();
+        }
+    }
+
+    private sealed class InMemoryVaultStore : ILocalVaultStore
+    {
+        private LocalVaultItem? _item;
+
+        public string DatabasePath => "memory";
+
+        public Task<LocalVaultItem> PutAsync(
+            string scope,
+            string path,
+            string key,
+            byte[] value,
+            string contentType,
+            Dictionary<string, string>? metadata = null,
+            CancellationToken cancellationToken = default)
+        {
+            _item = new LocalVaultItem
+            {
+                Id = LocalVaultItem.CreateId(scope, path, key),
+                Scope = scope,
+                Path = path,
+                Key = key,
+                Value = value.ToArray(),
+                ContentType = contentType,
+                Metadata = metadata ?? [],
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            };
+            return Task.FromResult(_item);
+        }
+
+        public Task<LocalVaultItem?> GetAsync(
+            string scope,
+            string path,
+            string key,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(
+                _item is not null &&
+                _item.Scope == scope &&
+                _item.Path == path &&
+                _item.Key == key
+                    ? _item
+                    : null);
+
+        public Task<bool> RemoveAsync(
+            string scope,
+            string path,
+            string key,
+            CancellationToken cancellationToken = default)
+        {
+            var existed = _item is not null;
+            _item = null;
+            return Task.FromResult(existed);
+        }
+
+        public Task<bool> ExistsAsync(
+            string scope,
+            string path,
+            string key,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(_item is not null);
+
+        public Task<IReadOnlyList<LocalVaultItem>> ListAsync(
+            string scope,
+            string? path = null,
+            string? keyPrefix = null,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<LocalVaultItem>>(
+                _item is null ? [] : [_item]);
+    }
+}

--- a/tests/MauiSherpa.Core.Tests/Services/CloudSecretsServiceTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/CloudSecretsServiceTests.cs
@@ -294,7 +294,7 @@ public class CloudSecretsServiceTests
     }
 
     [Fact]
-    public async Task SaveProviderAsync_WithUnavailableVaultStore_PersistsMetadataAndSettingsToJson()
+    public async Task SaveProviderAsync_WithUnreadableVault_DoesNotOverwriteProviderMetadata()
     {
         var fileSystem = new InMemoryFileSystem();
         var service = CreateService(fileSystem: fileSystem, vaultStore: new ThrowingLocalVaultStore());
@@ -310,12 +310,10 @@ public class CloudSecretsServiceTests
                 ["ClientSecret"] = "secret"
             });
 
-        await service.SaveProviderAsync(provider);
-        var providers = await service.GetProvidersAsync();
+        Func<Task> act = () => service.SaveProviderAsync(provider);
 
-        providers.Should().ContainSingle(p => p.Id == "remote");
-        fileSystem.Files.Should().ContainKey(Path.Combine(AppDataPath.GetAppDataDirectory(), "cloud-secrets-providers.json"));
-        fileSystem.Files.Should().ContainKey(Path.Combine(AppDataPath.GetAppDataDirectory(), "cloud-secrets-remote.json"));
+        await act.Should().ThrowAsync<LocalVaultUnavailableException>();
+        fileSystem.Files.Should().BeEmpty();
     }
 
     [Fact]
@@ -359,6 +357,58 @@ public class CloudSecretsServiceTests
         (await fileSystem.FileExistsAsync(providerSettingsPath)).Should().BeFalse();
         (await vaultStore.GetAsync(LocalVaultScopes.CloudProvider, "/", "providers")).Should().NotBeNull();
         (await vaultStore.GetAsync(LocalVaultScopes.CloudProvider, "/providers", "settings-remote")).Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task SaveProviderAsync_WithoutDefaultPolicy_EnablesEveryItemKind()
+    {
+        var service = CreateService();
+        await service.SaveProviderAsync(new CloudSecretsProviderConfig(
+            "remote",
+            "Remote",
+            CloudSecretsProviderType.AzureKeyVault,
+            new Dictionary<string, string>()));
+
+        var provider = await service.GetProviderConfigAsync("remote");
+
+        provider.Should().NotBeNull();
+        provider!.EffectiveDefaultItemKinds.Should().BeEquivalentTo(SecretItemKinds.All);
+    }
+
+    [Fact]
+    public async Task SaveProviderAsync_PersistsExplicitDefaultPolicy()
+    {
+        var service = CreateService();
+        await service.SaveProviderAsync(new CloudSecretsProviderConfig(
+            "remote",
+            "Remote",
+            CloudSecretsProviderType.AzureKeyVault,
+            new Dictionary<string, string>(),
+            [SecretItemKind.ManagedSecret, SecretItemKind.Certificate]));
+
+        var provider = await service.GetProviderConfigAsync("remote");
+
+        provider.Should().NotBeNull();
+        provider!.EffectiveDefaultItemKinds.Should().Equal(
+            SecretItemKind.ManagedSecret,
+            SecretItemKind.Certificate);
+    }
+
+    [Fact]
+    public async Task GetProviderAsync_ConcurrentCallsShareProviderInstance()
+    {
+        var service = CreateService();
+        await service.SaveProviderAsync(new CloudSecretsProviderConfig(
+            "remote",
+            "Remote",
+            CloudSecretsProviderType.AzureKeyVault,
+            new Dictionary<string, string>()));
+
+        var providers = await Task.WhenAll(
+            Enumerable.Range(0, 32).Select(_ => service.GetProviderAsync("remote")));
+
+        providers.Should().OnlyContain(provider => provider != null);
+        providers.Should().OnlyContain(provider => ReferenceEquals(provider, providers[0]));
     }
 
     private static CloudSecretsService CreateService(

--- a/tests/MauiSherpa.Core.Tests/Services/GoogleIdentityStateServiceTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/GoogleIdentityStateServiceTests.cs
@@ -1,0 +1,44 @@
+using FluentAssertions;
+using MauiSherpa.Core.Interfaces;
+using MauiSherpa.Core.Services;
+
+namespace MauiSherpa.Core.Tests.Services;
+
+public class GoogleIdentityStateServiceTests
+{
+    [Fact]
+    public void SetSelectedIdentity_PersistsLastNonNullSelection()
+    {
+        var store = new TestIdentitySelectionStore();
+        var sut = new GoogleIdentityStateService(store);
+        var identity = new GoogleIdentity("id1", "Project", "project-id", "test@example.com", null, "{}");
+
+        sut.SetSelectedIdentity(identity);
+        sut.SetSelectedIdentity(null);
+
+        sut.LastSelectedIdentityId.Should().Be("id1");
+        store.GoogleIdentityId.Should().Be("id1");
+    }
+
+    [Fact]
+    public void Constructor_RestoresLastSelectionId()
+    {
+        var store = new TestIdentitySelectionStore { GoogleIdentityId = "id2" };
+
+        var sut = new GoogleIdentityStateService(store);
+
+        sut.LastSelectedIdentityId.Should().Be("id2");
+        sut.SelectedIdentity.Should().BeNull();
+    }
+
+    private sealed class TestIdentitySelectionStore : IIdentitySelectionStore
+    {
+        public string? AppleIdentityId { get; set; }
+        public string? GoogleIdentityId { get; set; }
+
+        public string? GetLastAppleIdentityId() => AppleIdentityId;
+        public void SetLastAppleIdentityId(string identityId) => AppleIdentityId = identityId;
+        public string? GetLastGoogleIdentityId() => GoogleIdentityId;
+        public void SetLastGoogleIdentityId(string identityId) => GoogleIdentityId = identityId;
+    }
+}

--- a/tests/MauiSherpa.Core.Tests/Services/ManagedSecretsServiceTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/ManagedSecretsServiceTests.cs
@@ -164,6 +164,52 @@ public class ManagedSecretsServiceTests
     }
 
     [Fact]
+    public async Task RenameFolderAsync_WhenNewMetadataFails_RollsBackWithoutDeletingOriginal()
+    {
+        SetupActiveProvider();
+        var created = DateTime.UtcNow.AddDays(-1);
+        var secret = new ManagedSecret(
+            "team/api-key",
+            ManagedSecretType.String,
+            "API Key",
+            null,
+            created,
+            created);
+        SetupSecretMetadataList(secret);
+        SetupSecretValue(secret.Key, "api-value");
+        SetupFolderList(new ManagedSecretFolder("/team", "team", created));
+        _cloudService.Setup(x => x.StoreSecretAsync(
+                It.IsAny<string>(),
+                It.IsAny<byte[]>(),
+                It.IsAny<Dictionary<string, string>?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _cloudService.Setup(x => x.StoreSecretAsync(
+                "sherpa-secrets-meta/project/api-key",
+                It.IsAny<byte[]>(),
+                null,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _cloudService.Setup(x => x.DeleteSecretAsync(
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var result = await _sut.RenameFolderAsync("/team", "/project");
+
+        result.Should().BeFalse();
+        _cloudService.Verify(x => x.DeleteSecretAsync(
+            "sherpa-secrets/project/api-key",
+            It.IsAny<CancellationToken>()), Times.Once);
+        _cloudService.Verify(x => x.DeleteSecretAsync(
+            "sherpa-secrets/team/api-key",
+            It.IsAny<CancellationToken>()), Times.Never);
+        _cloudService.Verify(x => x.DeleteSecretAsync(
+            "sherpa-secrets-meta/team/api-key",
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
     public async Task RenameFolderAsync_ExistingTargetSecret_ReturnsFalse()
     {
         SetupActiveProvider();

--- a/tests/MauiSherpa.Core.Tests/Services/SecretSyncCoordinatorTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/SecretSyncCoordinatorTests.cs
@@ -1,0 +1,574 @@
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using MauiSherpa.Core.Interfaces;
+using MauiSherpa.Core.Requests;
+using MauiSherpa.Core.Services;
+using Moq;
+using Shiny.Mediator;
+
+namespace MauiSherpa.Core.Tests.Services;
+
+public class SecretSyncCoordinatorTests
+{
+    [Fact]
+    public async Task SetDesiredProvidersAsync_QueuesOnlyTypedReferences()
+    {
+        var registry = CreateRegistry();
+        var tasks = new RecordingBackgroundTasks();
+        var adapter = new FakeAdapter();
+        var sut = CreateCoordinator(registry, tasks, adapter);
+        var item = new SecretItemRef(SecretItemKind.ManagedSecret, "api-key", "API key");
+
+        var taskId = await sut.SetDesiredProvidersAsync(item, ["remote", "local"]);
+
+        taskId.Should().NotBeNull();
+        var request = tasks.Tasks.Should().ContainSingle().Subject.Request;
+        request.Type.Should().Be(SecretSyncCoordinator.TaskType);
+        request.Parameters.Should().ContainKey("itemId").WhoseValue.Should().Be("api-key");
+        request.Parameters.Values.Should().NotContain(value => value.Contains("secret-value", StringComparison.Ordinal));
+        JsonSerializer.Deserialize<List<string>>(request.Parameters["desiredProviderIds"])
+            .Should().Equal("local", "remote");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenLocalIsDesired_WritesLocalBeforeRemote()
+    {
+        var registry = CreateRegistry();
+        var tasks = new RecordingBackgroundTasks();
+        var adapter = new FakeAdapter
+        {
+            LocalPayload = CreatePayload("same-value")
+        };
+        var sut = CreateCoordinator(registry, tasks, adapter);
+        var item = adapter.LocalPayload.Item;
+        var request = CreateSyncRequest(item, ["remote", "local"]);
+
+        var context = new RecordingTaskContext();
+        await sut.ExecuteAsync(request, context);
+
+        adapter.WriteOrder.Should().Equal("local", "remote");
+        context.Steps.Select(step => step.Id).Should().Equal("sync:local", "sync:remote");
+        context.Steps.Should().OnlyContain(step => step.State == BackgroundTaskStepState.Succeeded);
+        context.StepTransitions.Take(4).Should().Equal(
+            ("sync:local", BackgroundTaskStepState.Running),
+            ("sync:local", BackgroundTaskStepState.Succeeded),
+            ("sync:remote", BackgroundTaskStepState.Running),
+            ("sync:remote", BackgroundTaskStepState.Succeeded));
+        adapter.ProviderPayloads.Keys.Should().BeEquivalentTo("local", "remote");
+        registry.Providers["local"].Values.Keys.Should()
+            .ContainSingle(key => key.StartsWith(GetManifestPrefix(), StringComparison.Ordinal));
+        registry.Providers["remote"].Values.Keys.Should()
+            .ContainSingle(key => key.StartsWith(GetManifestPrefix(), StringComparison.Ordinal));
+        registry.Providers["local"].Values.Should().ContainKey("sherpa-sync-catalog-v1");
+        registry.Providers["remote"].Values.Should().ContainKey("sherpa-sync-catalog-v1");
+        registry.Providers["remote"].MissingSecretReadCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenLocalWriteFails_DoesNotAttemptRemoteWrite()
+    {
+        var registry = CreateRegistry();
+        var adapter = new FakeAdapter
+        {
+            LocalPayload = CreatePayload("same-value")
+        };
+        adapter.FailedWrites.Add("local");
+        var sut = CreateCoordinator(registry, new RecordingBackgroundTasks(), adapter);
+        var context = new RecordingTaskContext();
+        var request = CreateSyncRequest(adapter.LocalPayload.Item, ["remote", "local"]);
+
+        Func<Task> act = () => sut.ExecuteAsync(request, context);
+
+        await act.Should().ThrowAsync<BackgroundTaskTransientException>();
+        adapter.WriteOrder.Should().Equal("local");
+        context.Steps.Single(step => step.Id == "sync:local").State
+            .Should().Be(BackgroundTaskStepState.Failed);
+        context.Steps.Single(step => step.Id == "sync:remote").State
+            .Should().Be(BackgroundTaskStepState.Pending);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenRemovingCopies_RemovesLocalBeforeRemote()
+    {
+        var registry = new FakeProviderRegistry(
+            new CloudSecretsProviderConfig(
+                "remote",
+                "Remote",
+                CloudSecretsProviderType.AzureKeyVault,
+                new Dictionary<string, string>()),
+            new CloudSecretsProviderConfig(
+                "local",
+                "Local",
+                CloudSecretsProviderType.Local,
+                new Dictionary<string, string>()));
+        var adapter = new FakeAdapter
+        {
+            LocalPayload = CreatePayload("same-value")
+        };
+        var sut = CreateCoordinator(registry, new RecordingBackgroundTasks(), adapter);
+        var item = adapter.LocalPayload.Item;
+        await sut.ExecuteAsync(
+            CreateSyncRequest(item, ["remote", "local"]),
+            new RecordingTaskContext());
+        adapter.DeleteOrder.Clear();
+
+        var context = new RecordingTaskContext();
+        await sut.ExecuteAsync(CreateSyncRequest(item, []), context);
+
+        adapter.DeleteOrder.Should().Equal("local", "remote");
+        context.Steps.Select(step => step.Id).Should().Equal("remove:local", "remove:remote");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PublishesEachProviderPlacementAsItChanges()
+    {
+        var registry = CreateRegistry();
+        var adapter = new FakeAdapter
+        {
+            LocalPayload = CreatePayload("same-value")
+        };
+        var events = new List<SecretProviderPlacementChangedEvent>();
+        var mediator = CreateMediator(events);
+        var sut = CreateCoordinator(
+            registry,
+            new RecordingBackgroundTasks(),
+            adapter,
+            mediator);
+
+        await sut.ExecuteAsync(
+            CreateSyncRequest(adapter.LocalPayload.Item, ["remote", "local"]),
+            new RecordingTaskContext());
+
+        events.Select(@event => (@event.Placement.ProviderId, @event.Placement.Status))
+            .Should().Equal(
+                ("local", SecretPlacementStatus.Pending),
+                ("local", SecretPlacementStatus.Synced),
+                ("remote", SecretPlacementStatus.Pending),
+                ("remote", SecretPlacementStatus.Synced));
+    }
+
+    [Fact]
+    public async Task GetStateAsync_WithDivergentProviderPayloads_ReportsConflict()
+    {
+        var registry = CreateRegistry();
+        var adapter = new FakeAdapter();
+        adapter.ProviderPayloads["local"] = CreatePayload("local-value");
+        adapter.ProviderPayloads["remote"] = CreatePayload("remote-value");
+        var sut = CreateCoordinator(registry, new RecordingBackgroundTasks(), adapter);
+
+        var state = await sut.GetStateAsync(CreatePayload("local-value").Item);
+
+        state.HasConflict.Should().BeTrue();
+        state.Providers.Where(provider => provider.Observed)
+            .Should().OnlyContain(provider => provider.Status == SecretPlacementStatus.Conflict);
+    }
+
+    [Fact]
+    public async Task GetStateAsync_AfterFailedWrite_KeepsRequestedProviderDesired()
+    {
+        var registry = CreateRegistry();
+        var adapter = new FakeAdapter();
+        adapter.ProviderPayloads["local"] = CreatePayload("same-value");
+        var item = adapter.ProviderPayloads["local"].Item;
+        var tasks = new RecordingBackgroundTasks();
+        await tasks.EnqueueAsync(CreateSyncRequest(item, ["local", "remote"]));
+        tasks.SetLatestState(BackgroundTaskState.Failed, "Remote provider unavailable");
+        var sut = CreateCoordinator(registry, tasks, adapter);
+
+        var state = await sut.GetStateAsync(item);
+
+        state.Providers.Single(provider => provider.ProviderId == "remote").Desired.Should().BeTrue();
+        state.Providers.Single(provider => provider.ProviderId == "remote").Status
+            .Should().Be(SecretPlacementStatus.Failed);
+    }
+
+    [Fact]
+    public async Task GetStateProgressivelyAsync_ReportsEachProviderAsItCompletes()
+    {
+        var registry = CreateRegistry();
+        var adapter = new FakeAdapter();
+        adapter.ProviderPayloads["local"] = CreatePayload("same-value");
+        var progress = new RecordingProgress<ProviderPlacementState>();
+        var sut = CreateCoordinator(registry, new RecordingBackgroundTasks(), adapter);
+
+        var state = await sut.GetStateProgressivelyAsync(
+            CreatePayload("same-value").Item,
+            progress);
+
+        progress.Values.Select(value => value.ProviderId)
+            .Should().BeEquivalentTo("local", "remote");
+        progress.Values.Should().OnlyContain(value =>
+            value.Status != SecretPlacementStatus.Loading);
+        state.Providers.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task UpdateDesiredProvidersAsync_QueuesOnlyChangedProviders()
+    {
+        var registry = CreateRegistry();
+        var tasks = new RecordingBackgroundTasks();
+        var sut = CreateCoordinator(registry, tasks, new FakeAdapter());
+        var item = new SecretItemRef(SecretItemKind.ManagedSecret, "api-key", "API key");
+
+        await sut.UpdateDesiredProvidersAsync(
+            item,
+            new Dictionary<string, bool> { ["remote"] = true });
+
+        var request = tasks.Tasks.Should().ContainSingle().Subject.Request;
+        request.Parameters.Should().NotContainKey("desiredProviderIds");
+        JsonSerializer.Deserialize<Dictionary<string, bool>>(
+                request.Parameters["providerSelectionChanges"])
+            .Should().Contain("remote", true);
+    }
+
+    [Fact]
+    public async Task GetStateAsync_ReusesProviderSnapshotsAcrossVisibleRows()
+    {
+        var registry = CreateRegistry();
+        var adapter = new FakeAdapter();
+        adapter.ProviderPayloads["local"] = CreatePayload("same-value");
+        var sut = CreateCoordinator(registry, new RecordingBackgroundTasks(), adapter);
+        var item = adapter.ProviderPayloads["local"].Item;
+
+        await Task.WhenAll(Enumerable.Range(0, 20)
+            .Select(_ => sut.GetStateProgressivelyAsync(item)));
+
+        adapter.PresenceScanCount.Should().Be(2);
+        registry.Providers.Values.Sum(provider => provider.GetSecretCallCount)
+            .Should().Be(0);
+        registry.Providers.Values.Sum(provider => provider.ListSecretsCallCount)
+            .Should().Be(2);
+    }
+
+    private static SecretSyncCoordinator CreateCoordinator(
+        FakeProviderRegistry registry,
+        RecordingBackgroundTasks tasks,
+        FakeAdapter adapter,
+        Mock<IMediator>? mediator = null) =>
+        new(
+            registry,
+            tasks,
+            (mediator ?? CreateMediator()).Object,
+            [adapter],
+            new Mock<ILoggingService>().Object);
+
+    private static Mock<IMediator> CreateMediator(
+        List<SecretProviderPlacementChangedEvent>? events = null)
+    {
+        var mediator = new Mock<IMediator>();
+        mediator
+            .Setup(instance => instance.Publish(
+                It.IsAny<SecretProviderPlacementChangedEvent>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<bool>(),
+                It.IsAny<Action<IMediatorContext>?>()))
+            .Callback<SecretProviderPlacementChangedEvent, CancellationToken, bool, Action<IMediatorContext>?>(
+                (@event, _, _, _) => events?.Add(@event))
+            .ReturnsAsync(Mock.Of<IMediatorContext>());
+        return mediator;
+    }
+
+    private static FakeProviderRegistry CreateRegistry() => new(
+        new CloudSecretsProviderConfig(
+            "local",
+            "Local",
+            CloudSecretsProviderType.Local,
+            new Dictionary<string, string>()),
+        new CloudSecretsProviderConfig(
+            "remote",
+            "Remote",
+            CloudSecretsProviderType.AzureKeyVault,
+            new Dictionary<string, string>()));
+
+    private static SecretItemPayload CreatePayload(string value)
+    {
+        var bytes = Encoding.UTF8.GetBytes(value);
+        return new SecretItemPayload(
+            new SecretItemRef(SecretItemKind.ManagedSecret, "api-key", "API key"),
+            0,
+            Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(bytes)),
+            [new SecretArtifact("sherpa-secrets/api-key", bytes)]);
+    }
+
+    private static BackgroundTaskRequest CreateSyncRequest(
+        SecretItemRef item,
+        IReadOnlyCollection<string> providers) =>
+        new(
+            SecretSyncCoordinator.TaskType,
+            $"Sync {item.DisplayName}",
+            "Sync item",
+            new Dictionary<string, string>
+            {
+                ["kind"] = item.Kind.ToString(),
+                ["itemId"] = item.Id,
+                ["displayName"] = item.DisplayName,
+                ["desiredProviderIds"] = JsonSerializer.Serialize(providers)
+            },
+            $"secret-sync:{item.Kind}:{item.Id}");
+
+    private static string GetManifestPrefix() => "sherpa-sync-manifests/";
+
+    private sealed class FakeProviderRegistry : ISecretsProviderRegistry
+    {
+        private readonly List<CloudSecretsProviderConfig> _configs;
+
+        public FakeProviderRegistry(params CloudSecretsProviderConfig[] configs)
+        {
+            _configs = configs.ToList();
+            Providers = configs.ToDictionary(
+                config => config.Id,
+                config => new InMemoryProvider(config.ProviderType, config.Name),
+                StringComparer.Ordinal);
+        }
+
+        public Dictionary<string, InMemoryProvider> Providers { get; }
+        public event Action? ProvidersChanged;
+
+        public Task<IReadOnlyList<CloudSecretsProviderConfig>> GetProvidersAsync() =>
+            Task.FromResult<IReadOnlyList<CloudSecretsProviderConfig>>(_configs);
+
+        public Task<CloudSecretsProviderConfig?> GetProviderConfigAsync(string providerId) =>
+            Task.FromResult(_configs.FirstOrDefault(provider => provider.Id == providerId));
+
+        public Task<ICloudSecretsProvider?> GetProviderAsync(string providerId) =>
+            Task.FromResult<ICloudSecretsProvider?>(
+                Providers.TryGetValue(providerId, out var provider) ? provider : null);
+
+        public Task SaveProviderAsync(CloudSecretsProviderConfig provider) =>
+            throw new NotSupportedException();
+
+        public Task DeleteProviderAsync(string providerId) =>
+            throw new NotSupportedException();
+
+        public Task<bool> TestProviderConnectionAsync(string providerId) =>
+            Task.FromResult(Providers.ContainsKey(providerId));
+    }
+
+    private sealed class InMemoryProvider(
+        CloudSecretsProviderType providerType,
+        string displayName) : ICloudSecretsProvider
+    {
+        public Dictionary<string, byte[]> Values { get; } = new(StringComparer.Ordinal);
+        public CloudSecretsProviderType ProviderType { get; } = providerType;
+        public string DisplayName { get; } = displayName;
+        public int GetSecretCallCount { get; private set; }
+        public int ListSecretsCallCount { get; private set; }
+        public int MissingSecretReadCount { get; private set; }
+
+        public Task<bool> TestConnectionAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(true);
+
+        public Task<bool> StoreSecretAsync(
+            string key,
+            byte[] value,
+            Dictionary<string, string>? metadata = null,
+            CancellationToken cancellationToken = default)
+        {
+            Values[key] = value.ToArray();
+            return Task.FromResult(true);
+        }
+
+        public Task<byte[]?> GetSecretAsync(string key, CancellationToken cancellationToken = default)
+        {
+            GetSecretCallCount++;
+            if (!Values.TryGetValue(key, out var value))
+            {
+                MissingSecretReadCount++;
+                return Task.FromResult<byte[]?>(null);
+            }
+
+            return Task.FromResult<byte[]?>(value.ToArray());
+        }
+
+        public Task<Dictionary<string, string>?> GetSecretMetadataAsync(
+            string key,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult<Dictionary<string, string>?>([]);
+
+        public Task<bool> SetSecretMetadataAsync(
+            string key,
+            Dictionary<string, string> metadata,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(true);
+
+        public Task<bool> DeleteSecretAsync(string key, CancellationToken cancellationToken = default) =>
+            Task.FromResult(Values.Remove(key));
+
+        public Task<bool> SecretExistsAsync(string key, CancellationToken cancellationToken = default) =>
+            Task.FromResult(Values.ContainsKey(key));
+
+        public Task<IReadOnlyList<string>> ListSecretsAsync(
+            string? prefix = null,
+            CancellationToken cancellationToken = default)
+        {
+            ListSecretsCallCount++;
+            return Task.FromResult<IReadOnlyList<string>>(Values.Keys
+                .Where(key => prefix is null || key.StartsWith(prefix, StringComparison.Ordinal))
+                .ToList());
+        }
+    }
+
+    private sealed class FakeAdapter : ISecretItemAdapter
+    {
+        public SecretItemKind Kind => SecretItemKind.ManagedSecret;
+        public bool IsProviderOwned => true;
+        public SecretItemPayload? LocalPayload { get; set; }
+        public Dictionary<string, SecretItemPayload> ProviderPayloads { get; } = new(StringComparer.Ordinal);
+        public List<string> WriteOrder { get; } = [];
+        public List<string> DeleteOrder { get; } = [];
+        public HashSet<string> FailedWrites { get; } = new(StringComparer.Ordinal);
+        public int PresenceScanCount { get; private set; }
+
+        public Task<IReadOnlyList<SecretItemRef>> ListLocalItemsAsync(
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<SecretItemRef>>(
+                LocalPayload is null ? [] : [LocalPayload.Item]);
+
+        public Task<IReadOnlyList<SecretItemRef>> ListProviderItemsAsync(
+            string providerId,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<SecretItemRef>>(
+                ProviderPayloads.TryGetValue(providerId, out var payload) ? [payload.Item] : []);
+
+        public Task<IReadOnlySet<string>> ListProviderItemIdsAsync(
+            string providerId,
+            CancellationToken cancellationToken = default)
+        {
+            PresenceScanCount++;
+            return Task.FromResult<IReadOnlySet<string>>(
+                ProviderPayloads.TryGetValue(providerId, out var payload)
+                    ? new HashSet<string>([payload.Item.Id], StringComparer.Ordinal)
+                    : new HashSet<string>(StringComparer.Ordinal));
+        }
+
+        public IReadOnlySet<string> ExtractProviderItemIds(IReadOnlyList<string> providerKeys)
+        {
+            PresenceScanCount++;
+            return ProviderPayloads.Values
+                .Select(payload => payload.Item.Id)
+                .ToHashSet(StringComparer.Ordinal);
+        }
+
+        public Task<SecretItemPayload?> ReadLocalAsync(
+            SecretItemRef item,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(LocalPayload);
+
+        public Task<SecretItemPayload?> ReadProviderAsync(
+            SecretItemRef item,
+            string providerId,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(
+                ProviderPayloads.TryGetValue(providerId, out var payload) ? payload : null);
+
+        public Task<bool> WriteProviderAsync(
+            SecretItemPayload payload,
+            string providerId,
+            CancellationToken cancellationToken = default)
+        {
+            WriteOrder.Add(providerId);
+            if (FailedWrites.Contains(providerId))
+                return Task.FromResult(false);
+            ProviderPayloads[providerId] = payload;
+            return Task.FromResult(true);
+        }
+
+        public Task<bool> DeleteProviderAsync(
+            SecretItemRef item,
+            string providerId,
+            CancellationToken cancellationToken = default)
+        {
+            DeleteOrder.Add(providerId);
+            return Task.FromResult(ProviderPayloads.Remove(providerId));
+        }
+    }
+
+    private sealed class RecordingBackgroundTasks : IBackgroundTaskService
+    {
+        private readonly List<BackgroundTaskInfo> _tasks = [];
+
+        public bool IsPersistent => false;
+        public IReadOnlyList<BackgroundTaskInfo> Tasks => _tasks;
+        public event Action? TasksChanged;
+
+        public Task InitializeAsync(CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+
+        public Task<string> EnqueueAsync(
+            BackgroundTaskRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            var id = Guid.NewGuid().ToString("N");
+            _tasks.Add(new BackgroundTaskInfo(
+                id,
+                request,
+                BackgroundTaskState.Pending,
+                null,
+                "Queued",
+                null,
+                DateTime.UtcNow,
+                null,
+                null,
+                [],
+                0));
+            TasksChanged?.Invoke();
+            return Task.FromResult(id);
+        }
+
+        public void SetLatestState(BackgroundTaskState state, string? error)
+        {
+            var latest = _tasks[^1];
+            _tasks[^1] = latest with { State = state, Error = error };
+            TasksChanged?.Invoke();
+        }
+
+        public Task RetryAsync(string taskId, CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+
+        public Task CancelAsync(string taskId) => Task.CompletedTask;
+
+        public Task DismissAsync(string taskId, CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+
+        public Task ClearCompletedAsync(CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+    }
+
+    private sealed class RecordingTaskContext : IBackgroundTaskContext
+    {
+        public List<BackgroundTaskStepInfo> Steps { get; private set; } = [];
+        public List<(string StepId, BackgroundTaskStepState State)> StepTransitions { get; } = [];
+        public CancellationToken CancellationToken => CancellationToken.None;
+        public void SetStatus(string status) { }
+        public void SetProgress(int? progress) { }
+        public void SetSteps(IReadOnlyList<BackgroundTaskStepInfo> steps) =>
+            Steps = steps.ToList();
+
+        public void UpdateStep(
+            string stepId,
+            BackgroundTaskStepState state,
+            string? status = null,
+            string? error = null)
+        {
+            var index = Steps.FindIndex(step => step.Id == stepId);
+            index.Should().BeGreaterThanOrEqualTo(0);
+            Steps[index] = Steps[index] with
+            {
+                State = state,
+                Status = status ?? Steps[index].Status,
+                Error = error
+            };
+            StepTransitions.Add((stepId, state));
+        }
+
+        public void Log(string message, OperationLogLevel level = OperationLogLevel.Info) { }
+    }
+
+    private sealed class RecordingProgress<T> : IProgress<T>
+    {
+        public List<T> Values { get; } = [];
+
+        public void Report(T value) => Values.Add(value);
+    }
+}


### PR DESCRIPTION
MAUI Sherpa currently treats cloud secret storage as a single active-provider choice, which prevents users from keeping each sensitive item in the provider set that best fits its backup and publishing needs. This change adds item-level multi-provider placement with progressive status and recoverable background reconciliation.

## What changed

- Adds a provider registry and conflict-aware sync coordinator for managed secrets, Android keystores, certificates, provisioning profiles, and publish profiles.
- Uses typed item adapters and manifests so provider copies can be compared, moved, removed, and retried without persisting secret payloads in task records.
- Prioritizes Local Vault within each reconciliation and batches provider inventory reads to avoid per-row status calls.
- Adds a persistent background task center with coalescing, retries, cancellation, restart recovery, per-provider progress, live Shiny.Mediator placement events, and completed-history clearing.
- Adds a shared cloud/vault picker to every supported item surface plus per-provider, per-item-type defaults in Settings. Defaults are explicitly non-retroactive.
- Preserves the last Apple and Google identity selection and fixes native macOS toolbar labels after identity changes.
- Tightens provider not-found/error handling, including Infisical fast-path behavior, and improves macOS Debug Local Vault access and duplicate native-reference handling.

## Review notes

Background records contain only item/provider references and state. They persist through Local Vault when available and fall back to memory-only execution when it is unavailable. Reconciliation is still represented as one logical item job with provider substeps; independent provider-lane scheduling is intentionally deferred so source selection, revisions, coalescing, and conflict decisions cannot diverge.

## Validation

- `dotnet test tests/MauiSherpa.Core.Tests/MauiSherpa.Core.Tests.csproj` (552 passed)
- `dotnet build src/MauiSherpa.MacOS -f net10.0-macos --no-restore --verbosity minimal`