### PR TITLE
Expand Apple certificate and publishing workflows

### DIFF
--- a/src/MauiSherpa.Cli/Commands/Apple/ProfilesCommand.cs
+++ b/src/MauiSherpa.Cli/Commands/Apple/ProfilesCommand.cs
@@ -557,7 +557,7 @@ public static class ProfilesCommand
 
             return new CertInfo(
                 c.Id,
-                c.Attributes?.DisplayName ?? c.Attributes?.Name ?? "",
+                c.Attributes?.Name ?? c.Attributes?.DisplayName ?? "",
                 c.Attributes?.CertificateTypeValue ?? c.Attributes?.CertificateType.ToString() ?? "DEVELOPMENT",
                 expirationDate);
         }).ToList();

--- a/src/MauiSherpa.Core/Interfaces.cs
+++ b/src/MauiSherpa.Core/Interfaces.cs
@@ -783,7 +783,8 @@ public record AppleProfile(
     string State,
     DateTime ExpirationDate,
     string? BundleId,
-    string Uuid
+    string Uuid,
+    IReadOnlyList<string>? CertificateIds = null
 );
 
 public interface IAppleIdentityService
@@ -878,7 +879,10 @@ public record AppleCertificateCreateResult(
     string CertificateId,
     byte[] PfxData,
     DateTime ExpirationDate,
-    string? Passphrase = null
+    string? Passphrase = null,
+    string? SerialNumber = null,
+    string? CommonName = null,
+    string? CertificateType = null
 );
 
 // Apple Root/Intermediate Certificates (for macOS keychain management)
@@ -3867,6 +3871,17 @@ public record PublishProfilePublisher(
 /// Apple config within a publish profile. All items are optional —
 /// include any combination of certificate, profile, notarization.
 /// </summary>
+public record PublishProfileCertificateSelection(
+    string SerialNumber,
+    string Name
+);
+
+public record PublishProfileProvisioningProfileSelection(
+    string Id,
+    string Uuid,
+    string Name
+);
+
 public record PublishProfileAppleConfig(
     string Label,
     string? IdentityId,
@@ -3884,7 +3899,34 @@ public record PublishProfileAppleConfig(
     string? NotarizationPasswordManualValue,
     string? NotarizationTeamIdManualValue,
     Dictionary<string, List<string>> KeyMappings
-);
+)
+{
+    public List<PublishProfileCertificateSelection> SigningCertificates { get; init; } = new();
+    public List<PublishProfileProvisioningProfileSelection> ProvisioningProfiles { get; init; } = new();
+
+    public IReadOnlyList<PublishProfileCertificateSelection> GetSigningCertificates() =>
+        SigningCertificates.Count > 0
+            ? SigningCertificates
+            : string.IsNullOrWhiteSpace(CertificateSerialNumber)
+                ? Array.Empty<PublishProfileCertificateSelection>()
+                : new[] { new PublishProfileCertificateSelection(CertificateSerialNumber, CertificateSerialNumber) };
+
+    public IReadOnlyList<PublishProfileProvisioningProfileSelection> GetProvisioningProfiles() =>
+        ProvisioningProfiles.Count > 0
+            ? ProvisioningProfiles
+            : string.IsNullOrWhiteSpace(ProfileId)
+                ? Array.Empty<PublishProfileProvisioningProfileSelection>()
+                : new[]
+                {
+                    new PublishProfileProvisioningProfileSelection(
+                        ProfileId,
+                        ProfileUuid ?? string.Empty,
+                        ProfileId)
+                };
+
+    public static string GetProvisioningProfileSecretKey(string prefix, int index, int count) =>
+        count == 1 ? $"{prefix}_PROFILE" : $"{prefix}_PROFILE_{index + 1}";
+}
 
 /// <summary>
 /// Apple developer identity within a publish profile.

--- a/src/MauiSherpa.Core/Services/AppleConnectService.cs
+++ b/src/MauiSherpa.Core/Services/AppleConnectService.cs
@@ -11,6 +11,8 @@ namespace MauiSherpa.Core.Services;
 /// </summary>
 public class AppleConnectService : IAppleConnectService
 {
+    private const string CertificateAliasKeyPrefix = "apple_certificate_alias_";
+
     private readonly IAppleIdentityStateService _identityState;
     private readonly IAppleIdentityService _identityService;
     private readonly ISecureStorageService _secureStorage;
@@ -384,8 +386,8 @@ public class AppleConnectService : IAppleConnectService
                 fieldsCertificates: new[] { "displayName", "name", "certificateType", "platform", "serialNumber", "certificateContent" },
                 cancellationToken: default);
 
-            var certs = response.Data
-                .Select(c =>
+            var certs = await Task.WhenAll(response.Data
+                .Select(async c =>
                 {
                     var expirationDate = DateTime.UtcNow.AddYears(1); // fallback
                     try
@@ -399,15 +401,18 @@ public class AppleConnectService : IAppleConnectService
                     }
                     catch { }
 
+                    var alias = await GetCertificateAliasAsync(c.Id);
                     return new AppleCertificate(
                         c.Id,
-                        c.Attributes?.DisplayName ?? c.Attributes?.Name ?? "",
+                        ResolveCertificateDisplayName(
+                            alias,
+                            c.Attributes?.Name,
+                            c.Attributes?.DisplayName),
                         c.Attributes?.CertificateTypeValue ?? c.Attributes?.CertificateType.ToString() ?? "DEVELOPMENT",
                         c.Attributes?.PlatformValue ?? c.Attributes?.Platform.ToString() ?? "",
                         expirationDate,
                         c.Attributes?.SerialNumber ?? "");
-                })
-                .ToList();
+                }));
             
             foreach (var cert in certs)
             {
@@ -432,13 +437,20 @@ public class AppleConnectService : IAppleConnectService
             
             var certType = ParseCertificateType(certificateType);
             
-            // Use machine name as default common name
-            var cn = commonName ?? Environment.MachineName;
+            var fallbackName = string.IsNullOrWhiteSpace(Environment.UserName)
+                ? Environment.MachineName
+                : Environment.UserName;
+            var cn = ResolveCertificateCommonName(
+                commonName,
+                _identityState.SelectedIdentity?.Name,
+                fallbackName);
             
             // Generate local RSA key pair and CSR so we retain the private key
             using var rsa = RSA.Create(2048);
+            var subjectBuilder = new X500DistinguishedNameBuilder();
+            subjectBuilder.AddCommonName(cn);
             var csrRequest = new CertificateRequest(
-                $"CN={cn}", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+                subjectBuilder.Build(), rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
             var csrPem = csrRequest.CreateSigningRequestPem();
 
             // Submit our CSR to Apple (private key stays local)
@@ -450,12 +462,30 @@ public class AppleConnectService : IAppleConnectService
             using var certWithKey = cert.CopyWithPrivateKey(rsa);
             
             var pfxData = certWithKey.Export(X509ContentType.Pfx, passphrase);
+            var serialNumber = string.IsNullOrWhiteSpace(response.Data.Attributes.SerialNumber)
+                ? cert.SerialNumber
+                : response.Data.Attributes.SerialNumber;
+            var responseCertificateType = string.IsNullOrWhiteSpace(response.Data.Attributes.CertificateTypeValue)
+                ? certType.ToString()
+                : response.Data.Attributes.CertificateTypeValue;
+
+            try
+            {
+                await _secureStorage.SetAsync(GetCertificateAliasKey(response.Data.Id), cn);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning($"Certificate was created, but its local alias could not be saved: {ex.Message}");
+            }
             
             return new AppleCertificateCreateResult(
                 response.Data.Id,
                 pfxData,
                 cert.NotAfter,
-                passphrase);
+                passphrase,
+                serialNumber,
+                cn,
+                responseCertificateType);
         }
         catch (Exception ex)
         {
@@ -464,20 +494,62 @@ public class AppleConnectService : IAppleConnectService
         }
     }
 
-    internal static CertificateType ParseCertificateType(string certificateType) =>
-        certificateType.ToUpperInvariant() switch
+    internal static CertificateType ParseCertificateType(string certificateType)
+    {
+        if (Enum.TryParse<CertificateType>(
+                certificateType?.Trim(),
+                ignoreCase: true,
+                out var parsed) &&
+            parsed != CertificateType.Unknown)
         {
-            "DEVELOPMENT" => CertificateType.DEVELOPMENT,
-            "DISTRIBUTION" => CertificateType.DISTRIBUTION,
-            "IOS_DEVELOPMENT" => CertificateType.IOS_DEVELOPMENT,
-            "IOS_DISTRIBUTION" => CertificateType.IOS_DISTRIBUTION,
-            "MAC_APP_DEVELOPMENT" => CertificateType.MAC_APP_DEVELOPMENT,
-            "MAC_APP_DISTRIBUTION" => CertificateType.MAC_APP_DISTRIBUTION,
-            "MAC_INSTALLER_DISTRIBUTION" => CertificateType.MAC_INSTALLER_DISTRIBUTION,
-            "DEVELOPER_ID_APPLICATION" => CertificateType.DEVELOPER_ID_APPLICATION,
-            "DEVELOPER_ID_KEXT" => CertificateType.DEVELOPER_ID_KEXT,
-            _ => CertificateType.DEVELOPMENT
-        };
+            return parsed;
+        }
+
+        throw new ArgumentException(
+            $"Unsupported Apple certificate type '{certificateType}'.",
+            nameof(certificateType));
+    }
+
+    internal static string ResolveCertificateCommonName(
+        string? commonName,
+        string? selectedIdentityName,
+        string fallbackName)
+    {
+        var resolved = !string.IsNullOrWhiteSpace(commonName)
+            ? commonName
+            : !string.IsNullOrWhiteSpace(selectedIdentityName)
+                ? selectedIdentityName
+                : fallbackName;
+        return resolved.Trim();
+    }
+
+    internal static string ResolveCertificateDisplayName(
+        string? alias,
+        string? name,
+        string? displayName)
+    {
+        if (!string.IsNullOrWhiteSpace(alias))
+            return alias.Trim();
+        if (!string.IsNullOrWhiteSpace(name))
+            return name.Trim();
+        return displayName?.Trim() ?? string.Empty;
+    }
+
+    private async Task<string?> GetCertificateAliasAsync(string certificateId)
+    {
+        try
+        {
+            return await _secureStorage.GetAsync(GetCertificateAliasKey(certificateId));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning($"Could not load the local alias for certificate '{certificateId}': {ex.Message}");
+            return null;
+        }
+    }
+
+    private string GetCertificateAliasKey(string certificateId) =>
+        $"{CertificateAliasKeyPrefix}{_identityState.SelectedIdentity?.Id}_{certificateId}";
 
     public async Task RevokeCertificateAsync(string id)
     {
@@ -509,8 +581,8 @@ public class AppleConnectService : IAppleConnectService
             var response = await client.ListProfilesAsync(
                 filterId: null, filterName: null, 
                 filterProfileState: null, filterProfileType: null,
-                include: "bundleId", sort: null, limit: 100,
-                limitCertificates: null, limitDevices: null,
+                include: "bundleId,certificates", sort: null, limit: 100,
+                limitCertificates: 50, limitDevices: null,
                 fieldsProfiles: null, fieldsBundleIds: null,
                 fieldsCertificates: null, fieldsDevices: null,
                 cancellationToken: default);
@@ -529,6 +601,12 @@ public class AppleConnectService : IAppleConnectService
                             .ToList()
                         : [];
                     var bundleIdentifier = string.Join(", ", bundleIds);
+                    var certificateIds = p.Relationships?.TryGetValue("certificates", out var certificateRel) == true
+                        ? (certificateRel?.Data ?? [])
+                            .Select(data => data.Id)
+                            .Where(id => !string.IsNullOrWhiteSpace(id))
+                            .ToList()
+                        : [];
                     return new AppleProfile(
                         p.Id,
                         p.Attributes?.Name ?? "",
@@ -537,7 +615,8 @@ public class AppleConnectService : IAppleConnectService
                         p.Attributes?.ProfileState.ToString() ?? "ACTIVE",
                         p.Attributes?.ExpirationDate?.DateTime ?? DateTime.UtcNow.AddYears(1),
                         bundleIdentifier,
-                        p.Attributes?.Uuid ?? "");
+                        p.Attributes?.Uuid ?? "",
+                        certificateIds);
                 })
                 .ToList();
         }

--- a/src/MauiSherpa.Core/Services/AppleConnectService.cs
+++ b/src/MauiSherpa.Core/Services/AppleConnectService.cs
@@ -430,18 +430,7 @@ public class AppleConnectService : IAppleConnectService
         {
             var client = await GetClientAsync();
             
-            // Parse certificate type
-            var certType = certificateType.ToUpperInvariant() switch
-            {
-                "DEVELOPMENT" or "IOS_DEVELOPMENT" => CertificateType.IOS_DEVELOPMENT,
-                "DISTRIBUTION" or "IOS_DISTRIBUTION" => CertificateType.IOS_DISTRIBUTION,
-                "MAC_APP_DEVELOPMENT" => CertificateType.MAC_APP_DEVELOPMENT,
-                "MAC_APP_DISTRIBUTION" => CertificateType.MAC_APP_DISTRIBUTION,
-                "MAC_INSTALLER_DISTRIBUTION" => CertificateType.MAC_INSTALLER_DISTRIBUTION,
-                "DEVELOPER_ID_APPLICATION" => CertificateType.DEVELOPER_ID_APPLICATION,
-                "DEVELOPER_ID_KEXT" => CertificateType.DEVELOPER_ID_KEXT,
-                _ => CertificateType.DEVELOPMENT
-            };
+            var certType = ParseCertificateType(certificateType);
             
             // Use machine name as default common name
             var cn = commonName ?? Environment.MachineName;
@@ -474,6 +463,21 @@ public class AppleConnectService : IAppleConnectService
             throw;
         }
     }
+
+    internal static CertificateType ParseCertificateType(string certificateType) =>
+        certificateType.ToUpperInvariant() switch
+        {
+            "DEVELOPMENT" => CertificateType.DEVELOPMENT,
+            "DISTRIBUTION" => CertificateType.DISTRIBUTION,
+            "IOS_DEVELOPMENT" => CertificateType.IOS_DEVELOPMENT,
+            "IOS_DISTRIBUTION" => CertificateType.IOS_DISTRIBUTION,
+            "MAC_APP_DEVELOPMENT" => CertificateType.MAC_APP_DEVELOPMENT,
+            "MAC_APP_DISTRIBUTION" => CertificateType.MAC_APP_DISTRIBUTION,
+            "MAC_INSTALLER_DISTRIBUTION" => CertificateType.MAC_INSTALLER_DISTRIBUTION,
+            "DEVELOPER_ID_APPLICATION" => CertificateType.DEVELOPER_ID_APPLICATION,
+            "DEVELOPER_ID_KEXT" => CertificateType.DEVELOPER_ID_KEXT,
+            _ => CertificateType.DEVELOPMENT
+        };
 
     public async Task RevokeCertificateAsync(string id)
     {

--- a/src/MauiSherpa.Core/Services/CopilotToolsService.cs
+++ b/src/MauiSherpa.Core/Services/CopilotToolsService.cs
@@ -538,19 +538,18 @@ public class CopilotToolsService : ICopilotToolsService
 
     [Description("Create a new signing certificate")]
     private async Task<string> CreateCertificateAsync(
-        [Description("Certificate type: DEVELOPMENT, DISTRIBUTION, IOS_DEVELOPMENT, IOS_DISTRIBUTION, MAC_APP_DEVELOPMENT, MAC_APP_DISTRIBUTION, DEVELOPER_ID_APPLICATION")] string certificateType,
-        [Description("Optional common name for the certificate")] string? commonName = null)
+        [Description("Certificate type: DEVELOPMENT, DISTRIBUTION, IOS_DEVELOPMENT, IOS_DISTRIBUTION, MAC_APP_DEVELOPMENT, MAC_APP_DISTRIBUTION, MAC_INSTALLER_DISTRIBUTION, DEVELOPER_ID_APPLICATION, DEVELOPER_ID_KEXT, PASS_TYPE_ID, PASS_TYPE_ID_WITH_NFC")] string certificateType)
     {
         var error = CheckIdentitySelected();
         if (error != null) return error;
 
         try
         {
-            var result = await _appleService.CreateCertificateAsync(certificateType.ToUpperInvariant(), commonName);
+            var result = await _appleService.CreateCertificateAsync(certificateType.ToUpperInvariant());
             return JsonSerializer.Serialize(new
             {
                 Success = true,
-                Message = $"Created certificate. The PFX file has been saved. Certificate ID: {result.CertificateId}",
+                Message = $"Created certificate. Certificate ID: {result.CertificateId}",
                 CertificateId = result.CertificateId,
                 ExpirationDate = result.ExpirationDate.ToString("yyyy-MM-dd")
             }, new JsonSerializerOptions { WriteIndented = true });

--- a/src/MauiSherpa.Core/Services/CopilotToolsService.cs
+++ b/src/MauiSherpa.Core/Services/CopilotToolsService.cs
@@ -538,7 +538,7 @@ public class CopilotToolsService : ICopilotToolsService
 
     [Description("Create a new signing certificate")]
     private async Task<string> CreateCertificateAsync(
-        [Description("Certificate type: IOS_DEVELOPMENT, IOS_DISTRIBUTION, MAC_APP_DEVELOPMENT, MAC_APP_DISTRIBUTION, DEVELOPER_ID_APPLICATION")] string certificateType,
+        [Description("Certificate type: DEVELOPMENT, DISTRIBUTION, IOS_DEVELOPMENT, IOS_DISTRIBUTION, MAC_APP_DEVELOPMENT, MAC_APP_DISTRIBUTION, DEVELOPER_ID_APPLICATION")] string certificateType,
         [Description("Optional common name for the certificate")] string? commonName = null)
     {
         var error = CheckIdentitySelected();

--- a/src/MauiSherpa.Core/Services/PublishProfileService.cs
+++ b/src/MauiSherpa.Core/Services/PublishProfileService.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Text.Json;
 using MauiSherpa.Core.Interfaces;
@@ -238,28 +240,46 @@ public class PublishProfileService : IPublishProfileService
             // Build prefix using platform/distribution enums (must match AppleConfigVM.GetDefaultKeys)
             var prefix = GetAppleKeyPrefix(apple);
 
-            // Certificate P12
-            if (!string.IsNullOrEmpty(apple.CertificateSerialNumber))
+            // Signing certificates share one P12 output so CI only needs one import step.
+            var signingCertificates = apple.GetSigningCertificates();
+            if (signingCertificates.Count > 0)
             {
-                progress?.Report($"Fetching certificate for {apple.Label}...");
+                progress?.Report($"Fetching {signingCertificates.Count} certificate(s) for {apple.Label}...");
                 try
                 {
-                    var (p12Bytes, certPassword) = await _certSync.GetCertificateSecretsAsync(apple.CertificateSerialNumber, autoUploadFromKeychain: true, ct);
-                    if (p12Bytes is not null)
+                    var bundles = new List<(byte[] P12, string? Password)>();
+                    foreach (var selection in signingCertificates)
                     {
-                        var defaultKey = $"{prefix}_CERTIFICATE_P12";
-                        AddMappedSecrets(secrets, apple.KeyMappings, defaultKey, Convert.ToBase64String(p12Bytes));
+                        var (p12Bytes, certPassword) = await _certSync.GetCertificateSecretsAsync(
+                            selection.SerialNumber,
+                            autoUploadFromKeychain: true,
+                            ct);
+                        if (p12Bytes is null)
+                        {
+                            throw new InvalidOperationException(
+                                $"Certificate '{selection.Name}' has no available private key.");
+                        }
+                        bundles.Add((p12Bytes, certPassword));
                     }
 
-                    if (!string.IsNullOrEmpty(certPassword))
+                    var (combinedP12, combinedPassword) = CombineCertificateBundles(bundles);
+                    AddMappedSecrets(
+                        secrets,
+                        apple.KeyMappings,
+                        $"{prefix}_CERTIFICATE_P12",
+                        Convert.ToBase64String(combinedP12));
+                    if (!string.IsNullOrEmpty(combinedPassword))
                     {
-                        var defaultKey = $"{prefix}_CERTIFICATE_PASSWORD";
-                        AddMappedSecrets(secrets, apple.KeyMappings, defaultKey, certPassword);
+                        AddMappedSecrets(
+                            secrets,
+                            apple.KeyMappings,
+                            $"{prefix}_CERTIFICATE_PASSWORD",
+                            combinedPassword);
                     }
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogWarning($"Failed to resolve certificate for {apple.Label}: {ex.Message}");
+                    _logger.LogWarning($"Failed to resolve certificates for {apple.Label}: {ex.Message}");
                 }
             }
 
@@ -288,19 +308,24 @@ public class PublishProfileService : IPublishProfileService
                 }
             }
 
-            // Provisioning Profile
-            if (!string.IsNullOrEmpty(apple.ProfileId))
+            // Provisioning profiles remain separate base64 values because mobileprovision files cannot be combined.
+            var provisioningProfiles = apple.GetProvisioningProfiles();
+            for (var index = 0; index < provisioningProfiles.Count; index++)
             {
-                progress?.Report($"Fetching provisioning profile for {apple.Label}...");
+                var selectedProfile = provisioningProfiles[index];
+                progress?.Report($"Fetching provisioning profile {index + 1} of {provisioningProfiles.Count} for {apple.Label}...");
                 try
                 {
-                    var profileBytes = await _appleConnect.DownloadProfileAsync(apple.ProfileId);
-                    var defaultKey = $"{prefix}_PROFILE";
+                    var profileBytes = await _appleConnect.DownloadProfileAsync(selectedProfile.Id);
+                    var defaultKey = PublishProfileAppleConfig.GetProvisioningProfileSecretKey(
+                        prefix,
+                        index,
+                        provisioningProfiles.Count);
                     AddMappedSecrets(secrets, apple.KeyMappings, defaultKey, Convert.ToBase64String(profileBytes));
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogWarning($"Failed to resolve profile for {apple.Label}: {ex.Message}");
+                    _logger.LogWarning($"Failed to resolve profile '{selectedProfile.Name}' for {apple.Label}: {ex.Message}");
                 }
             }
 
@@ -491,6 +516,48 @@ public class PublishProfileService : IPublishProfileService
 
         progress?.Report($"Resolved {secrets.Count} secrets");
         return secrets;
+    }
+
+    internal static (byte[] P12, string Password) CombineCertificateBundles(
+        IReadOnlyList<(byte[] P12, string? Password)> bundles)
+    {
+        if (bundles.Count == 0)
+            throw new ArgumentException("At least one certificate bundle is required.", nameof(bundles));
+        if (bundles.Count == 1)
+            return (bundles[0].P12, bundles[0].Password ?? string.Empty);
+
+        var combined = new X509Certificate2Collection();
+        try
+        {
+            foreach (var bundle in bundles)
+            {
+                var imported = new X509Certificate2Collection();
+                imported.Import(
+                    bundle.P12,
+                    bundle.Password,
+                    X509KeyStorageFlags.Exportable);
+                foreach (var certificate in imported)
+                {
+                    if (combined.Cast<X509Certificate2>().Any(existing =>
+                        string.Equals(existing.Thumbprint, certificate.Thumbprint, StringComparison.OrdinalIgnoreCase)))
+                    {
+                        certificate.Dispose();
+                        continue;
+                    }
+                    combined.Add(certificate);
+                }
+            }
+
+            var password = Convert.ToBase64String(RandomNumberGenerator.GetBytes(24));
+            var p12 = combined.Export(X509ContentType.Pfx, password)
+                ?? throw new InvalidOperationException("Failed to export the combined certificate bundle.");
+            return (p12, password);
+        }
+        finally
+        {
+            foreach (var certificate in combined)
+                certificate.Dispose();
+        }
     }
 
     static void AddMappedSecrets(

--- a/src/MauiSherpa/Pages/Certificates.razor
+++ b/src/MauiSherpa/Pages/Certificates.razor
@@ -720,35 +720,97 @@
 
     private async Task ShowCreateDialog()
     {
-        var page = new CreateCertificatePage(AppleService);
-        var certResult = await FormModalService.ShowAsync<AppleCertificateCreateResult>(page);
-        if (certResult == null) return;
+        var page = new CreateCertificatePage(
+            requireDiskExport: !LocalCertificateService.IsSupported);
+        var request = await FormModalService.ShowAsync<CreateCertificateFormResult>(page);
+        if (request == null) return;
 
-        // Import into the local keychain so the cert is available for signing, export, and cloud backup
-        if (LocalCertificateService.IsSupported)
+        string? savePath = null;
+        if (request.SaveToDisk)
         {
-            var imported = await LocalCertificateService.ImportP12Async(
-                certResult.PfxData, certResult.Passphrase ?? "");
-            if (!imported)
-                Logger.LogWarning("Certificate was created but could not be imported into the local keychain");
+            var typeName = request.CertificateType.ToLowerInvariant().Replace('_', '-');
+            savePath = await DialogService.PickSaveFileAsync(
+                "Save Certificate",
+                $"{typeName}-{DateTime.Now:yyyyMMdd-HHmmss}.p12",
+                "p12");
+            if (string.IsNullOrWhiteSpace(savePath)) return;
         }
 
-        var fileName = $"certificate_{DateTime.Now:yyyyMMdd_HHmmss}.pfx";
-        var downloadsPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Downloads", fileName);
-        await File.WriteAllBytesAsync(downloadsPath, certResult.PfxData);
+        AppleCertificateCreateResult? certResult = null;
+        var importedLocally = false;
+        var operation = await OperationModal.RunAsync(
+            "Create Certificate",
+            $"Creating {request.CertificateType.Replace('_', ' ')} certificate...",
+            async ctx =>
+            {
+                ctx.SetStatus("Submitting certificate request to Apple...");
+                certResult = await AppleService.CreateCertificateAsync(
+                    request.CertificateType,
+                    commonName: null,
+                    passphrase: request.Passphrase);
+                ctx.LogSuccess("Apple issued the certificate");
 
-        await AlertService.ShowToastAsync($"Certificate saved: ~/Downloads/{fileName}");
+                if (LocalCertificateService.IsSupported)
+                {
+                    ctx.SetStatus($"Installing certificate in the {PlatformInfo.PlatformName} certificate store...");
+                    importedLocally = await LocalCertificateService.ImportP12Async(
+                        certResult.PfxData,
+                        certResult.Passphrase ?? "",
+                        ctx.CancellationToken);
+                    if (importedLocally)
+                        ctx.LogSuccess("Certificate installed locally");
+                    else
+                        ctx.LogWarning("Certificate could not be installed locally");
+                }
+
+                if (!string.IsNullOrWhiteSpace(savePath))
+                {
+                    ctx.SetStatus("Saving certificate copy...");
+                    await File.WriteAllBytesAsync(savePath, certResult.PfxData, ctx.CancellationToken);
+                    ctx.LogSuccess($"Saved certificate to {savePath}");
+                }
+
+                return true;
+            },
+            canCancel: false);
+        if (!operation.Success || certResult == null) return;
+
+        if (LocalCertificateService.IsSupported && !importedLocally && string.IsNullOrWhiteSpace(savePath))
+        {
+            await AlertService.ShowAlertAsync(
+                "Local Installation Failed",
+                "Apple issued the certificate, but its private key could not be installed locally. Choose a location to save a recovery copy.");
+            savePath = await DialogService.PickSaveFileAsync(
+                "Save Certificate Recovery Copy",
+                $"{request.CertificateType.ToLowerInvariant().Replace('_', '-')}-{DateTime.Now:yyyyMMdd-HHmmss}.p12",
+                "p12");
+            if (!string.IsNullOrWhiteSpace(savePath))
+            {
+                await File.WriteAllBytesAsync(savePath, certResult.PfxData);
+            }
+        }
+
         await RefreshData(forceRefresh: true);
         var createdCertificate = certificates.FirstOrDefault(certificate =>
             string.Equals(certificate.Id, certResult.CertificateId, StringComparison.Ordinal));
-        if (createdCertificate is not null && !string.IsNullOrWhiteSpace(createdCertificate.SerialNumber))
+        var serialNumber = createdCertificate?.SerialNumber ?? certResult.SerialNumber;
+        var certificateName = createdCertificate?.Name ?? certResult.CommonName ?? request.CertificateType;
+        if (importedLocally &&
+            !string.IsNullOrWhiteSpace(serialNumber))
         {
             await SecretSyncCoordinator.SetDefaultProvidersAsync(
                 new SecretItemRef(
                     SecretItemKind.Certificate,
-                    GetCertificateSyncItemId(createdCertificate.SerialNumber),
-                    createdCertificate.Name));
+                    GetCertificateSyncItemId(serialNumber),
+                    certificateName));
         }
+
+        var toast = !string.IsNullOrWhiteSpace(savePath)
+            ? $"Certificate created and saved to {Path.GetFileName(savePath)}"
+            : importedLocally
+                ? "Certificate created and installed locally"
+                : "Certificate created";
+        await AlertService.ShowToastAsync(toast);
     }
 
     private async Task ShowExportDialog(AppleCertificate cert)

--- a/src/MauiSherpa/Pages/Forms/CreateCertificatePage.cs
+++ b/src/MauiSherpa/Pages/Forms/CreateCertificatePage.cs
@@ -1,59 +1,102 @@
 using Microsoft.Maui.Controls;
-using MauiSherpa.Core.Interfaces;
+#if MACOSAPP
+using Microsoft.Maui.Platforms.MacOS.Platform;
+#endif
+#if LINUXGTK
+using Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
+#endif
 
 namespace MauiSherpa.Pages.Forms;
 
-public class CreateCertificatePage : FormPage<AppleCertificateCreateResult>
+public record CreateCertificateFormResult(
+    string CertificateType,
+    bool SaveToDisk,
+    string? Passphrase);
+
+public class CreateCertificatePage : FormPage<CreateCertificateFormResult>
 {
-    private readonly IAppleConnectService _appleService;
+    private sealed record CertificateTypeOption(string Label, string Value);
 
     private Picker _typePicker = null!;
-    private Entry _commonNameEntry = null!;
+    private CheckBox _saveToDiskCheckBox = null!;
     private Entry _passphraseEntry = null!;
 
-    private static readonly string[] CertTypeLabels =
-    {
-        "Apple Development",
-        "Apple Distribution",
-        "iOS Development",
-        "iOS Distribution",
-        "Mac Development",
-        "Mac App Distribution",
-        "Mac Installer Distribution",
-        "Developer ID Application",
-        "Developer ID Kernel Extension",
-    };
+    private readonly bool _requireDiskExport;
 
-    private static readonly string[] CertTypeValues =
+    private static readonly CertificateTypeOption[] CertificateTypes =
     {
-        "DEVELOPMENT",
-        "DISTRIBUTION",
-        "IOS_DEVELOPMENT",
-        "IOS_DISTRIBUTION",
-        "MAC_APP_DEVELOPMENT",
-        "MAC_APP_DISTRIBUTION",
-        "MAC_INSTALLER_DISTRIBUTION",
-        "DEVELOPER_ID_APPLICATION",
-        "DEVELOPER_ID_KEXT",
+        new("Apple Development", "DEVELOPMENT"),
+        new("Apple Distribution", "DISTRIBUTION"),
+        new("iOS App Development", "IOS_DEVELOPMENT"),
+        new("iOS Distribution (App Store Connect and Ad Hoc)", "IOS_DISTRIBUTION"),
+        new("Mac Development", "MAC_APP_DEVELOPMENT"),
+        new("Mac App Distribution", "MAC_APP_DISTRIBUTION"),
+        new("Mac Installer Distribution", "MAC_INSTALLER_DISTRIBUTION"),
+        new("Developer ID Application", "DEVELOPER_ID_APPLICATION"),
+        new("Developer ID Kernel Extension", "DEVELOPER_ID_KEXT"),
+        new("Pass Type ID", "PASS_TYPE_ID"),
+        new("Pass Type ID with NFC", "PASS_TYPE_ID_WITH_NFC"),
     };
 
     protected override string FormTitle => "Create Certificate";
+    protected override double FormBodyHeightRequest => 440;
 
-    // Always submittable — all fields have defaults or are optional
     protected override bool CanSubmit => _typePicker?.SelectedIndex >= 0;
 
-    public CreateCertificatePage(IAppleConnectService appleService)
+    public CreateCertificatePage(bool requireDiskExport)
     {
-        _appleService = appleService;
+        _requireDiskExport = requireDiskExport;
+
+#if MACOSAPP
+        MacOSPage.SetModalSheetSizesToContent(this, false);
+        MacOSPage.SetModalSheetWidth(this, 620);
+        MacOSPage.SetModalSheetHeight(this, 640);
+#elif LINUXGTK
+        GtkPage.SetModalSizesToContent(this, false);
+        GtkPage.SetModalWidth(this, 620);
+        GtkPage.SetModalHeight(this, 640);
+#endif
     }
 
     protected override View BuildFormContent()
     {
-        _typePicker = CreatePicker(null, CertTypeLabels);
+        _typePicker = CreatePicker(null, CertificateTypes.Select(type => type.Label).ToList());
         _typePicker.SelectedIndex = 0;
 
-        _commonNameEntry = CreateEntry(Environment.MachineName);
-        _passphraseEntry = CreatePasswordEntry("Leave empty for no passphrase");
+        _saveToDiskCheckBox = new CheckBox
+        {
+            IsChecked = _requireDiskExport,
+            IsEnabled = !_requireDiskExport,
+            VerticalOptions = LayoutOptions.Center,
+        };
+        _saveToDiskCheckBox.SetDynamicResource(CheckBox.ColorProperty, FormTheme.AccentPrimary);
+
+        var saveToDiskLabel = new Label
+        {
+            Text = "Save a copy to disk",
+            FontSize = 14,
+            VerticalOptions = LayoutOptions.Center,
+        };
+        saveToDiskLabel.SetDynamicResource(Label.TextColorProperty, FormTheme.TextPrimary);
+
+        var saveToDiskRow = new HorizontalStackLayout
+        {
+            Spacing = 8,
+            Children = { _saveToDiskCheckBox, saveToDiskLabel },
+        };
+
+        _passphraseEntry = CreatePasswordEntry("Optional; leave empty for an unprotected P12");
+        var passphraseGroup = CreateFormGroup(
+            "P12 Passphrase",
+            _passphraseEntry,
+            "Only used for the copy saved to disk");
+        passphraseGroup.IsVisible = _saveToDiskCheckBox.IsChecked;
+        _saveToDiskCheckBox.CheckedChanged += (_, args) =>
+            passphraseGroup.IsVisible = args.Value;
+
+        var storageHelp = _requireDiskExport
+            ? "Required because this platform does not provide a supported certificate store"
+            : "The certificate is installed in the platform certificate store and synced to default providers";
 
         return new VerticalStackLayout
         {
@@ -61,20 +104,21 @@ public class CreateCertificatePage : FormPage<AppleCertificateCreateResult>
             Children =
             {
                 CreateFormGroup("Certificate Type", _typePicker),
-                CreateFormGroup("Common Name", _commonNameEntry,
-                    "Defaults to your machine name if not specified"),
-                CreateFormGroup("PFX Passphrase", _passphraseEntry,
-                    "Password to protect the exported certificate file"),
+                CreateFormGroup("Certificate Storage", saveToDiskRow, storageHelp),
+                passphraseGroup,
             }
         };
     }
 
-    protected override async Task<AppleCertificateCreateResult> OnSubmitAsync()
+    protected override Task<CreateCertificateFormResult> OnSubmitAsync()
     {
-        var certType = CertTypeValues[_typePicker.SelectedIndex];
-        var commonName = string.IsNullOrWhiteSpace(_commonNameEntry.Text) ? null : _commonNameEntry.Text.Trim();
-        var passphrase = string.IsNullOrWhiteSpace(_passphraseEntry.Text) ? null : _passphraseEntry.Text;
+        var certType = CertificateTypes[_typePicker.SelectedIndex].Value;
+        var saveToDisk = _saveToDiskCheckBox.IsChecked;
+        var passphrase = saveToDisk ? _passphraseEntry.Text ?? string.Empty : null;
 
-        return await _appleService.CreateCertificateAsync(certType, commonName, passphrase);
+        return Task.FromResult(new CreateCertificateFormResult(
+            certType,
+            saveToDisk,
+            passphrase));
     }
 }

--- a/src/MauiSherpa/Pages/Forms/CreateCertificatePage.cs
+++ b/src/MauiSherpa/Pages/Forms/CreateCertificatePage.cs
@@ -13,6 +13,8 @@ public class CreateCertificatePage : FormPage<AppleCertificateCreateResult>
 
     private static readonly string[] CertTypeLabels =
     {
+        "Apple Development",
+        "Apple Distribution",
         "iOS Development",
         "iOS Distribution",
         "Mac Development",
@@ -24,6 +26,8 @@ public class CreateCertificatePage : FormPage<AppleCertificateCreateResult>
 
     private static readonly string[] CertTypeValues =
     {
+        "DEVELOPMENT",
+        "DISTRIBUTION",
         "IOS_DEVELOPMENT",
         "IOS_DISTRIBUTION",
         "MAC_APP_DEVELOPMENT",

--- a/src/MauiSherpa/Pages/Forms/FormPage.cs
+++ b/src/MauiSherpa/Pages/Forms/FormPage.cs
@@ -26,6 +26,7 @@ public abstract class FormPage<TResult> : ContentPage, IFormPage<TResult>, IForm
 
     protected abstract string FormTitle { get; }
     protected virtual string SubmitButtonText => "Create";
+    protected virtual double FormBodyHeightRequest => -1;
 
     /// <summary>Build the form fields. Return a View containing all form inputs.</summary>
     protected abstract View BuildFormContent();
@@ -80,6 +81,14 @@ public abstract class FormPage<TResult> : ContentPage, IFormPage<TResult>, IForm
 
         var formContent = BuildFormContent();
         formContent.Margin = new Thickness(28, 16, 28, 16);
+        var formScrollView = new ScrollView
+        {
+            Content = formContent,
+            VerticalScrollBarVisibility = ScrollBarVisibility.Default,
+            VerticalOptions = LayoutOptions.Fill,
+        };
+        if (FormBodyHeightRequest > 0)
+            formScrollView.HeightRequest = FormBodyHeightRequest;
 
         // Footer separator — full width
         var footerSeparator = new BoxView { HeightRequest = 1, Opacity = 0.2 };
@@ -130,18 +139,34 @@ public abstract class FormPage<TResult> : ContentPage, IFormPage<TResult>, IForm
             Children = { cancelButton, _submittingIndicator, _submitButton },
         };
 
-        Content = new VerticalStackLayout
+        var grid = new Grid
         {
-            Spacing = 0,
-            Children =
+            RowDefinitions =
             {
-                titleLabel,
-                headerSeparator,
-                formContent,
-                footerSeparator,
-                footerLayout,
+                new RowDefinition(GridLength.Auto),
+                new RowDefinition(GridLength.Auto),
+                new RowDefinition(GridLength.Star),
+                new RowDefinition(GridLength.Auto),
+                new RowDefinition(GridLength.Auto),
             },
+            RowSpacing = 0,
+            VerticalOptions = LayoutOptions.Fill,
         };
+        grid.SetDynamicResource(Grid.BackgroundColorProperty, FormTheme.PageBg);
+
+        Grid.SetRow(titleLabel, 0);
+        Grid.SetRow(headerSeparator, 1);
+        Grid.SetRow(formScrollView, 2);
+        Grid.SetRow(footerSeparator, 3);
+        Grid.SetRow(footerLayout, 4);
+
+        grid.Children.Add(titleLabel);
+        grid.Children.Add(headerSeparator);
+        grid.Children.Add(formScrollView);
+        grid.Children.Add(footerSeparator);
+        grid.Children.Add(footerLayout);
+
+        Content = grid;
     }
 
     /// <summary>Call this from subclasses when form validity changes.</summary>

--- a/src/MauiSherpa/Pages/Modals/AppleConfigVM.cs
+++ b/src/MauiSherpa/Pages/Modals/AppleConfigVM.cs
@@ -14,11 +14,13 @@ public class AppleConfigVM
     public AppleDistributionType? DistributionType { get; set; }
     public string? CertificateSerialNumber { get; set; }
     public string? CertificateName { get; set; }
+    public List<PublishProfileCertificateSelection> SigningCertificates { get; set; } = new();
     public string? InstallerCertSerialNumber { get; set; }
     public string? InstallerCertName { get; set; }
     public string? ProfileId { get; set; }
     public string? ProfileUuid { get; set; }
     public string? ProfileName { get; set; }
+    public List<PublishProfileProvisioningProfileSelection> ProvisioningProfiles { get; set; } = new();
     public bool IncludeNotarization { get; set; }
     public string? NotarizationAppleIdSecretKey { get; set; }
     public string? NotarizationPasswordSecretKey { get; set; }
@@ -108,7 +110,7 @@ public class AppleConfigVM
         };
         var prefix = $"APPLE_{platLabel}_{distLabel}";
 
-        if (!string.IsNullOrEmpty(CertificateSerialNumber))
+        if (SigningCertificates.Count > 0 || !string.IsNullOrEmpty(CertificateSerialNumber))
         {
             keys.Add($"{prefix}_CERTIFICATE_P12");
             keys.Add($"{prefix}_CERTIFICATE_PASSWORD");
@@ -118,8 +120,16 @@ public class AppleConfigVM
             keys.Add($"{prefix}_INSTALLER_P12");
             keys.Add($"{prefix}_INSTALLER_PASSWORD");
         }
-        if (!string.IsNullOrEmpty(ProfileId))
-            keys.Add($"{prefix}_PROFILE");
+        var profileCount = ProvisioningProfiles.Count > 0
+            ? ProvisioningProfiles.Count
+            : string.IsNullOrEmpty(ProfileId) ? 0 : 1;
+        for (var index = 0; index < profileCount; index++)
+        {
+            keys.Add(PublishProfileAppleConfig.GetProvisioningProfileSecretKey(
+                prefix,
+                index,
+                profileCount));
+        }
         if (IncludeNotarization)
         {
             keys.Add("APPLE_NOTARIZATION_APPLE_ID");

--- a/src/MauiSherpa/Pages/Modals/AppleConfigWizardModal.razor
+++ b/src/MauiSherpa/Pages/Modals/AppleConfigWizardModal.razor
@@ -120,8 +120,8 @@
             @if (config.WizardStep == 4)
             {
                 <div class="step-header-row">
-                    <h4>Signing Certificate <span class="optional-badge">Optional</span></h4>
-                    <button class="btn-text-action" style="@(config.CertificateSerialNumber is null ? "visibility: hidden;" : "")" @onclick="@(() => { config.CertificateSerialNumber = null; })">
+                    <h4>Signing Certificates <span class="optional-badge">Optional</span></h4>
+                    <button class="btn-text-action" style="@(!config.SigningCertificates.Any() ? "visibility: hidden;" : "")" @onclick="@(() => ClearSigningCertificates())">
                         <i class="fa-solid fa-times"></i> Clear
                     </button>
                 </div>
@@ -132,12 +132,13 @@
                         {
                             var syncLoc = GetCertSyncLocation(cert);
                             var hasLocal = syncLoc == SecretLocation.LocalOnly || syncLoc == SecretLocation.Both;
-                            <label class="cert-item @(config.CertificateSerialNumber == cert.SerialNumber ? "selected" : "") @(!hasLocal ? "no-key" : "")"
+                            var isSelected = IsSigningCertificateSelected(cert);
+                            <label class="cert-item @(isSelected ? "selected" : "") @(!hasLocal ? "no-key" : "")"
                                    title="@(!hasLocal ? "Private key not available locally" : "")">
-                                <input type="radio" name="wizardSigningCert"
+                                <input type="checkbox"
                                        disabled="@(!hasLocal)"
-                                       checked="@(config.CertificateSerialNumber == cert.SerialNumber)"
-                                       @onchange="@(() => config.CertificateSerialNumber = cert.SerialNumber)" />
+                                       checked="@isSelected"
+                                       @onchange="@(() => ToggleSigningCertificate(cert))" />
                                 <div class="cert-info">
                                     <div class="cert-name"><span class="@(demoMode ? "demo-blur" : "")">@cert.Name</span></div>
                                     <div class="cert-detail">
@@ -238,8 +239,8 @@
             @if (config.NeedsProfileStep && config.WizardStep == profileStep)
             {
                 <div class="step-header-row">
-                    <h4>Provisioning Profile <span class="optional-badge">Optional</span></h4>
-                    <button class="btn-text-action" style="@(config.ProfileId is null ? "visibility: hidden;" : "")" @onclick="@(() => { config.ProfileId = null; config.ProfileUuid = null; })">
+                    <h4>Provisioning Profiles <span class="optional-badge">Optional</span></h4>
+                    <button class="btn-text-action" style="@(!config.ProvisioningProfiles.Any() ? "visibility: hidden;" : "")" @onclick="@(() => config.ProvisioningProfiles.Clear())">
                         <i class="fa-solid fa-times"></i> Clear
                     </button>
                 </div>
@@ -248,10 +249,11 @@
                     <div class="cert-list">
                         @foreach (var prof in FilteredProfiles)
                         {
-                            <label class="cert-item @(config.ProfileId == prof.Id ? "selected" : "")">
-                                <input type="radio" name="wizardProfile"
-                                       checked="@(config.ProfileId == prof.Id)"
-                                       @onchange="@(() => { config.ProfileId = prof.Id; config.ProfileUuid = prof.Uuid; })" />
+                            var isSelected = IsProvisioningProfileSelected(prof);
+                            <label class="cert-item @(isSelected ? "selected" : "")">
+                                <input type="checkbox"
+                                       checked="@isSelected"
+                                       @onchange="@(() => ToggleProvisioningProfile(prof))" />
                                 <div class="cert-info">
                                     <div class="cert-name"><span class="@(demoMode ? "demo-blur" : "")">@prof.Name</span></div>
                                     <div class="cert-detail">
@@ -795,13 +797,8 @@
         if (string.IsNullOrEmpty(config.Label))
             config.Label = $"{config.PlatformLabel} {config.DistributionLabel}";
 
-        // Populate display names for the parent's summary cards
-        if (!string.IsNullOrEmpty(config.CertificateSerialNumber))
-            config.CertificateName = certificates.FirstOrDefault(c => c.SerialNumber == config.CertificateSerialNumber)?.Name;
         if (!string.IsNullOrEmpty(config.InstallerCertSerialNumber))
             config.InstallerCertName = certificates.FirstOrDefault(c => c.SerialNumber == config.InstallerCertSerialNumber)?.Name;
-        if (!string.IsNullOrEmpty(config.ProfileId))
-            config.ProfileName = profiles.FirstOrDefault(p => p.Id == config.ProfileId)?.Name;
 
         config.GetDefaultKeys();
 
@@ -866,20 +863,18 @@
     {
         config.Platform = platform;
         config.DistributionType = null;
-        config.CertificateSerialNumber = null;
+        ClearSigningCertificates();
         config.InstallerCertSerialNumber = null;
-        config.ProfileId = null;
-        config.ProfileUuid = null;
+        config.ProvisioningProfiles.Clear();
         UpdateWizardState();
     }
 
     private void SelectDistribution(AppleDistributionType dist)
     {
         config.DistributionType = dist;
-        config.CertificateSerialNumber = null;
+        ClearSigningCertificates();
         config.InstallerCertSerialNumber = null;
-        config.ProfileId = null;
-        config.ProfileUuid = null;
+        config.ProvisioningProfiles.Clear();
         UpdateWizardState();
     }
 
@@ -936,6 +931,70 @@
         return loc == SecretLocation.LocalOnly || loc == SecretLocation.Both;
     }
 
+    private bool IsSigningCertificateSelected(AppleCertificate certificate) =>
+        config.SigningCertificates.Any(selection =>
+            selection.SerialNumber.Equals(certificate.SerialNumber, StringComparison.OrdinalIgnoreCase));
+
+    private void ToggleSigningCertificate(AppleCertificate certificate)
+    {
+        var existing = config.SigningCertificates.FirstOrDefault(selection =>
+            selection.SerialNumber.Equals(certificate.SerialNumber, StringComparison.OrdinalIgnoreCase));
+        if (existing is null)
+        {
+            config.SigningCertificates.Add(new PublishProfileCertificateSelection(
+                certificate.SerialNumber,
+                certificate.Name));
+        }
+        else
+        {
+            config.SigningCertificates.Remove(existing);
+        }
+
+        config.ProvisioningProfiles.RemoveAll(selection =>
+        {
+            var profile = profiles.FirstOrDefault(candidate => candidate.Id == selection.Id);
+            return profile is null || !ProfileMatchesSelectedCertificates(profile);
+        });
+    }
+
+    private void ClearSigningCertificates()
+    {
+        config.SigningCertificates.Clear();
+        config.CertificateSerialNumber = null;
+        config.CertificateName = null;
+    }
+
+    private bool IsProvisioningProfileSelected(AppleProfile profile) =>
+        config.ProvisioningProfiles.Any(selection => selection.Id == profile.Id);
+
+    private void ToggleProvisioningProfile(AppleProfile profile)
+    {
+        var existing = config.ProvisioningProfiles.FirstOrDefault(selection => selection.Id == profile.Id);
+        if (existing is null)
+        {
+            config.ProvisioningProfiles.Add(new PublishProfileProvisioningProfileSelection(
+                profile.Id,
+                profile.Uuid,
+                profile.Name));
+        }
+        else
+        {
+            config.ProvisioningProfiles.Remove(existing);
+        }
+    }
+
+    private bool ProfileMatchesSelectedCertificates(AppleProfile profile)
+    {
+        var selectedCertificateIds = config.SigningCertificates
+            .Select(selection => certificates.FirstOrDefault(certificate =>
+                certificate.SerialNumber.Equals(selection.SerialNumber, StringComparison.OrdinalIgnoreCase))?.Id)
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .ToList();
+        return selectedCertificateIds.Count == 0 ||
+            selectedCertificateIds.All(id =>
+                profile.CertificateIds?.Contains(id!, StringComparer.Ordinal) == true);
+    }
+
     private IEnumerable<AppleCertificate> FilteredSigningCerts =>
         certificates.Where(c => IsSigningCertCompatible(c.CertificateType) && c.ExpirationDate > DateTime.UtcNow)
                     .OrderByDescending(c => CertHasLocalKey(c));
@@ -945,7 +1004,10 @@
                     .OrderByDescending(c => CertHasLocalKey(c));
 
     private IEnumerable<AppleProfile> FilteredProfiles =>
-        profiles.Where(p => p.State == "ACTIVE" && IsProfileCompatible(p.ProfileType));
+        profiles.Where(p =>
+            p.State == "ACTIVE" &&
+            IsProfileCompatible(p.ProfileType) &&
+            ProfileMatchesSelectedCertificates(p));
 
     private IEnumerable<(AppleDistributionType Type, string Name, string Description, string Icon)> GetAvailableDistributionTypes()
     {

--- a/src/MauiSherpa/Pages/Modals/PublishProfileEditorModal.razor
+++ b/src/MauiSherpa/Pages/Modals/PublishProfileEditorModal.razor
@@ -158,17 +158,17 @@
                                         var identityName = appleIdentities.FirstOrDefault(i => i.Id == config.IdentityId)?.Name ?? config.IdentityId;
                                         <div class="summary-item"><i class="fa-solid fa-id-badge"></i> <span class="@(demoMode ? "demo-blur" : "")">@identityName</span></div>
                                     }
-                                    @if (!string.IsNullOrEmpty(config.CertificateSerialNumber))
+                                    @if (config.SigningCertificates.Any())
                                     {
-                                        <div class="summary-item"><i class="fa-solid fa-stamp"></i> <span class="@(demoMode ? "demo-blur" : "")">@(config.CertificateName ?? config.CertificateSerialNumber)</span></div>
+                                        <div class="summary-item"><i class="fa-solid fa-stamp"></i> <span class="@(demoMode ? "demo-blur" : "")">@string.Join(", ", config.SigningCertificates.Select(certificate => certificate.Name))</span></div>
                                     }
                                     @if (!string.IsNullOrEmpty(config.InstallerCertSerialNumber))
                                     {
                                         <div class="summary-item"><i class="fa-solid fa-box"></i> <span class="@(demoMode ? "demo-blur" : "")">@(config.InstallerCertName ?? "Installer")</span></div>
                                     }
-                                    @if (!string.IsNullOrEmpty(config.ProfileId))
+                                    @if (config.ProvisioningProfiles.Any())
                                     {
-                                        <div class="summary-item"><i class="fa-solid fa-file-signature"></i> <span class="@(demoMode ? "demo-blur" : "")">@(config.ProfileName ?? config.ProfileId)</span></div>
+                                        <div class="summary-item"><i class="fa-solid fa-file-signature"></i> <span class="@(demoMode ? "demo-blur" : "")">@string.Join(", ", config.ProvisioningProfiles.Select(profile => profile.Name))</span></div>
                                     }
                                     @if (config.IncludeNotarization)
                                     {
@@ -1294,9 +1294,15 @@
                 Platform = a.Platform,
                 DistributionType = a.DistributionType,
                 CertificateSerialNumber = a.CertificateSerialNumber,
+                SigningCertificates = a.GetSigningCertificates()
+                    .Select(certificate => certificate with { })
+                    .ToList(),
                 InstallerCertSerialNumber = a.InstallerCertSerialNumber,
                 ProfileId = a.ProfileId,
                 ProfileUuid = a.ProfileUuid,
+                ProvisioningProfiles = a.GetProvisioningProfiles()
+                    .Select(profile => profile with { })
+                    .ToList(),
                 IncludeNotarization = a.IncludeNotarization,
                 NotarizationAppleIdSecretKey = a.NotarizationAppleIdSecretKey,
                 NotarizationPasswordSecretKey = a.NotarizationPasswordSecretKey,
@@ -1411,24 +1417,36 @@
             PublisherId: profilePublishers.FirstOrDefault()?.PublisherId,
             RepositoryId: profilePublishers.FirstOrDefault()?.RepositoryId,
             RepositoryFullName: profilePublishers.FirstOrDefault()?.RepositoryFullName,
-            AppleConfigs: appleConfigs.Select(a => new PublishProfileAppleConfig(
-                a.Label,
-                a.IdentityId,
-                a.Platform,
-                a.DistributionType,
-                a.CertificateSerialNumber,
-                a.InstallerCertSerialNumber,
-                a.ProfileId,
-                a.ProfileUuid,
-                a.IncludeNotarization,
-                a.NotarizationAppleIdUseManual ? null : a.NotarizationAppleIdSecretKey,
-                a.NotarizationPasswordUseManual ? null : a.NotarizationPasswordSecretKey,
-                a.NotarizationTeamIdUseManual ? null : a.NotarizationTeamIdSecretKey,
-                a.NotarizationAppleIdUseManual ? a.NotarizationAppleIdManualValue : null,
-                a.NotarizationPasswordUseManual ? a.NotarizationPasswordManualValue : null,
-                a.NotarizationTeamIdUseManual ? a.NotarizationTeamIdManualValue : null,
-                a.KeyMappings.ToDictionary(k => k.Key, k => k.Value.ToList())
-            )).ToList(),
+            AppleConfigs: appleConfigs.Select(a =>
+            {
+                var firstCertificate = a.SigningCertificates.FirstOrDefault();
+                var firstProfile = a.ProvisioningProfiles.FirstOrDefault();
+                return new PublishProfileAppleConfig(
+                    a.Label,
+                    a.IdentityId,
+                    a.Platform,
+                    a.DistributionType,
+                    firstCertificate?.SerialNumber,
+                    a.InstallerCertSerialNumber,
+                    firstProfile?.Id,
+                    firstProfile?.Uuid,
+                    a.IncludeNotarization,
+                    a.NotarizationAppleIdUseManual ? null : a.NotarizationAppleIdSecretKey,
+                    a.NotarizationPasswordUseManual ? null : a.NotarizationPasswordSecretKey,
+                    a.NotarizationTeamIdUseManual ? null : a.NotarizationTeamIdSecretKey,
+                    a.NotarizationAppleIdUseManual ? a.NotarizationAppleIdManualValue : null,
+                    a.NotarizationPasswordUseManual ? a.NotarizationPasswordManualValue : null,
+                    a.NotarizationTeamIdUseManual ? a.NotarizationTeamIdManualValue : null,
+                    a.KeyMappings.ToDictionary(k => k.Key, k => k.Value.ToList()))
+                {
+                    SigningCertificates = a.SigningCertificates
+                        .Select(certificate => certificate with { })
+                        .ToList(),
+                    ProvisioningProfiles = a.ProvisioningProfiles
+                        .Select(selectedProfile => selectedProfile with { })
+                        .ToList()
+                };
+            }).ToList(),
             AndroidConfigs: androidConfigs.Select(a => new PublishProfileAndroidConfig(
                 a.Label,
                 a.KeystoreId,

--- a/tests/MauiSherpa.Core.Tests/Services/AppleConnectServiceTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/AppleConnectServiceTests.cs
@@ -1,0 +1,25 @@
+using AppleAppStoreConnect;
+using FluentAssertions;
+using MauiSherpa.Core.Services;
+
+namespace MauiSherpa.Core.Tests.Services;
+
+public class AppleConnectServiceTests
+{
+    [Theory]
+    [InlineData("DEVELOPMENT", CertificateType.DEVELOPMENT)]
+    [InlineData("DISTRIBUTION", CertificateType.DISTRIBUTION)]
+    [InlineData("IOS_DEVELOPMENT", CertificateType.IOS_DEVELOPMENT)]
+    [InlineData("IOS_DISTRIBUTION", CertificateType.IOS_DISTRIBUTION)]
+    [InlineData("MAC_APP_DEVELOPMENT", CertificateType.MAC_APP_DEVELOPMENT)]
+    [InlineData("MAC_APP_DISTRIBUTION", CertificateType.MAC_APP_DISTRIBUTION)]
+    [InlineData("MAC_INSTALLER_DISTRIBUTION", CertificateType.MAC_INSTALLER_DISTRIBUTION)]
+    [InlineData("DEVELOPER_ID_APPLICATION", CertificateType.DEVELOPER_ID_APPLICATION)]
+    [InlineData("DEVELOPER_ID_KEXT", CertificateType.DEVELOPER_ID_KEXT)]
+    public void ParseCertificateType_ReturnsMatchingAppStoreConnectType(
+        string value,
+        CertificateType expected)
+    {
+        AppleConnectService.ParseCertificateType(value).Should().Be(expected);
+    }
+}

--- a/tests/MauiSherpa.Core.Tests/Services/AppleConnectServiceTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/AppleConnectServiceTests.cs
@@ -6,20 +6,56 @@ namespace MauiSherpa.Core.Tests.Services;
 
 public class AppleConnectServiceTests
 {
-    [Theory]
-    [InlineData("DEVELOPMENT", CertificateType.DEVELOPMENT)]
-    [InlineData("DISTRIBUTION", CertificateType.DISTRIBUTION)]
-    [InlineData("IOS_DEVELOPMENT", CertificateType.IOS_DEVELOPMENT)]
-    [InlineData("IOS_DISTRIBUTION", CertificateType.IOS_DISTRIBUTION)]
-    [InlineData("MAC_APP_DEVELOPMENT", CertificateType.MAC_APP_DEVELOPMENT)]
-    [InlineData("MAC_APP_DISTRIBUTION", CertificateType.MAC_APP_DISTRIBUTION)]
-    [InlineData("MAC_INSTALLER_DISTRIBUTION", CertificateType.MAC_INSTALLER_DISTRIBUTION)]
-    [InlineData("DEVELOPER_ID_APPLICATION", CertificateType.DEVELOPER_ID_APPLICATION)]
-    [InlineData("DEVELOPER_ID_KEXT", CertificateType.DEVELOPER_ID_KEXT)]
-    public void ParseCertificateType_ReturnsMatchingAppStoreConnectType(
-        string value,
-        CertificateType expected)
+    [Fact]
+    public void ParseCertificateType_SupportsEveryKnownAppStoreConnectType()
     {
-        AppleConnectService.ParseCertificateType(value).Should().Be(expected);
+        var knownTypes = Enum.GetValues<CertificateType>()
+            .Where(type => type != CertificateType.Unknown);
+
+        foreach (var type in knownTypes)
+        {
+            AppleConnectService.ParseCertificateType(type.ToString()).Should().Be(type);
+        }
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("UNKNOWN")]
+    [InlineData("NOT_A_CERTIFICATE_TYPE")]
+    public void ParseCertificateType_RejectsUnsupportedValues(string value)
+    {
+        var action = () => AppleConnectService.ParseCertificateType(value);
+
+        action.Should().Throw<ArgumentException>();
+    }
+
+    [Theory]
+    [InlineData("Custom Key", "Identity Name", "fallback", "Custom Key")]
+    [InlineData(" ", "Identity Name", "fallback", "Identity Name")]
+    [InlineData(null, null, "fallback", "fallback")]
+    public void ResolveCertificateCommonName_UsesFirstAvailableName(
+        string? commonName,
+        string? identityName,
+        string fallbackName,
+        string expected)
+    {
+        AppleConnectService.ResolveCertificateCommonName(
+            commonName,
+            identityName,
+            fallbackName).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("Team Signing Key", "Apple Development: Created via API", "Created via API", "Team Signing Key")]
+    [InlineData(null, "Apple Development: Created via API", "Created via API", "Apple Development: Created via API")]
+    [InlineData(null, null, "Created via API", "Created via API")]
+    public void ResolveCertificateDisplayName_PrefersLocalAlias(
+        string? alias,
+        string? name,
+        string? displayName,
+        string expected)
+    {
+        AppleConnectService.ResolveCertificateDisplayName(alias, name, displayName)
+            .Should().Be(expected);
     }
 }

--- a/tests/MauiSherpa.Core.Tests/Services/PublishProfileServiceTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/PublishProfileServiceTests.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using System.Text.Json;
 using FluentAssertions;
 using MauiSherpa.Core.Interfaces;
@@ -154,6 +156,84 @@ public class PublishProfileServiceTests
     }
 
     [Fact]
+    public async Task ResolveSecretsAsync_WithMultipleAppleAssets_CombinesCertificatesAndMapsProfilesSeparately()
+    {
+        var firstP12 = CreateTestP12("First Certificate", "first-password");
+        var secondP12 = CreateTestP12("Second Certificate", "second-password");
+        _certSync.Setup(x => x.GetCertificateSecretsAsync("CERT1", It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((firstP12, "first-password"));
+        _certSync.Setup(x => x.GetCertificateSecretsAsync("CERT2", It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((secondP12, "second-password"));
+        _appleConnect.Setup(x => x.DownloadProfileAsync("profile-1"))
+            .ReturnsAsync(new byte[] { 0x10, 0x11 });
+        _appleConnect.Setup(x => x.DownloadProfileAsync("profile-2"))
+            .ReturnsAsync(new byte[] { 0x20, 0x21 });
+
+        var config = new PublishProfileAppleConfig(
+            Label: "iOS App Store",
+            IdentityId: null,
+            Platform: ApplePlatformType.iOS,
+            DistributionType: AppleDistributionType.AppStore,
+            CertificateSerialNumber: "CERT1",
+            InstallerCertSerialNumber: null,
+            ProfileId: "profile-1",
+            ProfileUuid: "uuid-1",
+            IncludeNotarization: false,
+            NotarizationAppleIdSecretKey: null,
+            NotarizationPasswordSecretKey: null,
+            NotarizationTeamIdSecretKey: null,
+            NotarizationAppleIdManualValue: null,
+            NotarizationPasswordManualValue: null,
+            NotarizationTeamIdManualValue: null,
+            KeyMappings: new Dictionary<string, List<string>>())
+        {
+            SigningCertificates =
+            [
+                new("CERT1", "First Certificate"),
+                new("CERT2", "Second Certificate")
+            ],
+            ProvisioningProfiles =
+            [
+                new("profile-1", "uuid-1", "First Profile"),
+                new("profile-2", "uuid-2", "Second Profile")
+            ]
+        };
+        var profile = CreateProfile() with
+        {
+            AppleConfigs = [config]
+        };
+
+        var secrets = await _sut.ResolveSecretsAsync(profile);
+
+        secrets.Should().ContainKey("APPLE_IOS_APPSTORE_CERTIFICATE_P12");
+        secrets.Should().ContainKey("APPLE_IOS_APPSTORE_CERTIFICATE_PASSWORD");
+        secrets.Should().Contain(
+            "APPLE_IOS_APPSTORE_PROFILE_1",
+            Convert.ToBase64String(new byte[] { 0x10, 0x11 }));
+        secrets.Should().Contain(
+            "APPLE_IOS_APPSTORE_PROFILE_2",
+            Convert.ToBase64String(new byte[] { 0x20, 0x21 }));
+
+        var combinedP12 = Convert.FromBase64String(secrets["APPLE_IOS_APPSTORE_CERTIFICATE_P12"]);
+        var combinedCertificates = new X509Certificate2Collection();
+        combinedCertificates.Import(
+            combinedP12,
+            secrets["APPLE_IOS_APPSTORE_CERTIFICATE_PASSWORD"],
+            X509KeyStorageFlags.DefaultKeySet);
+        try
+        {
+            combinedCertificates.Cast<X509Certificate2>()
+                .Count(certificate => certificate.HasPrivateKey)
+                .Should().Be(2);
+        }
+        finally
+        {
+            foreach (var certificate in combinedCertificates)
+                certificate.Dispose();
+        }
+    }
+
+    [Fact]
     public void DeserializeProfile_WhenIdentityPropertiesAreMissing_UsesEmptyLists()
     {
         var original = CreateProfile();
@@ -172,6 +252,51 @@ public class PublishProfileServiceTests
         profile.GoogleIdentities.Should().BeEmpty();
     }
 
+    [Fact]
+    public void SerializeProfile_WithMultipleAppleAssets_RoundTripsSelections()
+    {
+        var config = new PublishProfileAppleConfig(
+            Label: "iOS Development",
+            IdentityId: "identity-1",
+            Platform: ApplePlatformType.iOS,
+            DistributionType: AppleDistributionType.Development,
+            CertificateSerialNumber: "CERT1",
+            InstallerCertSerialNumber: null,
+            ProfileId: "profile-1",
+            ProfileUuid: "uuid-1",
+            IncludeNotarization: false,
+            NotarizationAppleIdSecretKey: null,
+            NotarizationPasswordSecretKey: null,
+            NotarizationTeamIdSecretKey: null,
+            NotarizationAppleIdManualValue: null,
+            NotarizationPasswordManualValue: null,
+            NotarizationTeamIdManualValue: null,
+            KeyMappings: new Dictionary<string, List<string>>())
+        {
+            SigningCertificates =
+            [
+                new("CERT1", "First Certificate"),
+                new("CERT2", "Second Certificate")
+            ],
+            ProvisioningProfiles =
+            [
+                new("profile-1", "uuid-1", "First Profile"),
+                new("profile-2", "uuid-2", "Second Profile")
+            ]
+        };
+        var original = CreateProfile() with
+        {
+            AppleConfigs = [config]
+        };
+
+        var json = JsonSerializer.Serialize(original, JsonOptions);
+        var deserialized = JsonSerializer.Deserialize<PublishProfile>(json, JsonOptions);
+
+        deserialized.Should().NotBeNull();
+        deserialized!.AppleConfigs.Single().SigningCertificates.Should().Equal(config.SigningCertificates);
+        deserialized.AppleConfigs.Single().ProvisioningProfiles.Should().Equal(config.ProvisioningProfiles);
+    }
+
     static PublishProfile CreateProfile() => new(
         Id: "profile-1",
         Name: "Profile",
@@ -184,4 +309,18 @@ public class PublishProfileServiceTests
         SecretMappings: new List<PublishProfileSecretMapping>(),
         CreatedAt: DateTime.UtcNow,
         UpdatedAt: DateTime.UtcNow);
+
+    static byte[] CreateTestP12(string commonName, string password)
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest(
+            $"CN={commonName}",
+            rsa,
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
+        using var certificate = request.CreateSelfSigned(
+            DateTimeOffset.UtcNow.AddMinutes(-1),
+            DateTimeOffset.UtcNow.AddDays(1));
+        return certificate.Export(X509ContentType.Pfx, password);
+    }
 }


### PR DESCRIPTION
## Summary
- support every certificate type exposed by the current App Store Connect SDK
- install new certificates into Keychain or the Windows certificate store by default and sync configured default providers
- make disk export optional, revealing the save picker and P12 passphrase only when requested
- persist a local identity-based alias for API-created certificates instead of showing `Created via API`
- use a fixed native certificate sheet with a scrollable body and pinned footer
- allow multiple signing certificates in publish profiles and combine them into one P12/password pair
- allow multiple provisioning profiles and publish each as a separate indexed base64 value
- filter provisioning profiles to those containing every selected signing certificate
- retain backward compatibility with existing single-certificate/profile configurations

## Validation
- `dotnet test tests/MauiSherpa.Core.Tests/MauiSherpa.Core.Tests.csproj --filter 'FullyQualifiedName~AppleConnectServiceTests|FullyQualifiedName~PublishProfileServiceTests|FullyQualifiedName~CertificateSyncServiceTests|FullyQualifiedName~CopilotToolsServiceTests'`
- `dotnet build src/MauiSherpa.MacOS/MauiSherpa.MacOS.csproj -f net10.0-macos`
- `dotnet build src/MauiSherpa.Cli/MauiSherpa.Cli.csproj`
- manually verified the expanded Create Certificate sheet keeps its fields visible and footer pinned

## Stack
- stacked on #239