### PR TITLE
Add multi-certificate P12 export

### DIFF
--- a/src/MauiSherpa.Core/Interfaces.cs
+++ b/src/MauiSherpa.Core/Interfaces.cs
@@ -1630,6 +1630,14 @@ public interface ILocalCertificateService
     /// <param name="password">Password to protect the P12 file</param>
     /// <returns>P12 file contents</returns>
     Task<byte[]> ExportP12Async(string identity, string password);
+
+    /// <summary>
+    /// Exports selected signing identities into a single P12/PFX bundle.
+    /// </summary>
+    /// <param name="identities">The identities to include in the bundle</param>
+    /// <param name="password">Password to protect the P12 file</param>
+    /// <returns>P12 file contents containing only the selected identities</returns>
+    Task<byte[]> ExportP12Async(IReadOnlyList<LocalSigningIdentity> identities, string password);
     
     /// <summary>
     /// Exports a certificate (public key only) as a .cer file

--- a/src/MauiSherpa.Core/Services/CertificateBundleUtilities.cs
+++ b/src/MauiSherpa.Core/Services/CertificateBundleUtilities.cs
@@ -1,0 +1,76 @@
+using System.Security.Cryptography.X509Certificates;
+using MauiSherpa.Core.Interfaces;
+
+namespace MauiSherpa.Core.Services;
+
+internal static class CertificateBundleUtilities
+{
+    public static byte[] ExportSelectedIdentities(
+        byte[] sourceP12,
+        string sourcePassword,
+        IReadOnlyCollection<LocalSigningIdentity> selectedIdentities,
+        string exportPassword)
+    {
+        ArgumentNullException.ThrowIfNull(sourceP12);
+        ArgumentNullException.ThrowIfNull(selectedIdentities);
+
+        if (sourceP12.Length == 0)
+            throw new ArgumentException("P12 data cannot be empty.", nameof(sourceP12));
+        if (selectedIdentities.Count == 0)
+            throw new ArgumentException("At least one signing identity must be selected.", nameof(selectedIdentities));
+
+        var selectedHashes = selectedIdentities
+            .Select(identity => NormalizeHex(identity.Hash))
+            .Where(hash => hash.Length > 0)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var selectedSerials = selectedIdentities
+            .Select(identity => NormalizeHex(identity.SerialNumber).TrimStart('0'))
+            .Where(serial => serial.Length > 0)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var imported = X509CertificateLoader.LoadPkcs12Collection(
+            sourceP12,
+            sourcePassword,
+            X509KeyStorageFlags.Exportable);
+
+        try
+        {
+            var selected = new X509Certificate2Collection();
+            foreach (var certificate in imported.Cast<X509Certificate2>())
+            {
+                var hash = NormalizeHex(certificate.Thumbprint);
+                var serial = NormalizeHex(certificate.SerialNumber).TrimStart('0');
+                if (!selectedHashes.Contains(hash) && !selectedSerials.Contains(serial))
+                    continue;
+
+                if (!certificate.HasPrivateKey)
+                {
+                    throw new InvalidOperationException(
+                        $"Certificate '{certificate.GetNameInfo(X509NameType.SimpleName, false)}' has no private key.");
+                }
+
+                selected.Add(certificate);
+            }
+
+            if (selected.Count != selectedIdentities.Count)
+            {
+                throw new InvalidOperationException(
+                    $"Only {selected.Count} of {selectedIdentities.Count} selected signing identities were found in the exported keychain bundle.");
+            }
+
+            return selected.Export(X509ContentType.Pfx, exportPassword)
+                ?? throw new InvalidOperationException("Failed to export the selected certificate bundle.");
+        }
+        finally
+        {
+            foreach (var certificate in imported)
+                certificate.Dispose();
+        }
+    }
+
+    private static string NormalizeHex(string? value) =>
+        new((value ?? string.Empty)
+            .Where(char.IsLetterOrDigit)
+            .Select(char.ToUpperInvariant)
+            .ToArray());
+}

--- a/src/MauiSherpa.Core/Services/LocalCertificateService.cs
+++ b/src/MauiSherpa.Core/Services/LocalCertificateService.cs
@@ -137,17 +137,39 @@ public partial class LocalCertificateService : ILocalCertificateService
         if (string.IsNullOrEmpty(identity))
             throw new ArgumentException("Identity cannot be empty", nameof(identity));
 
-        _logger.LogInformation($"Exporting P12 for identity: {identity}");
+        var availableIdentities = await GetSigningIdentitiesAsync();
+        var selectedIdentity = availableIdentities.FirstOrDefault(candidate =>
+            string.Equals(candidate.Identity, identity, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(candidate.Hash, identity, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(candidate.SerialNumber, identity, StringComparison.OrdinalIgnoreCase));
+        if (selectedIdentity is null)
+            throw new InvalidOperationException($"Signing identity not found: {identity}");
 
-        var tempFile = Path.GetTempFileName();
+        return await ExportP12Async([selectedIdentity], password);
+    }
+
+    public async Task<byte[]> ExportP12Async(
+        IReadOnlyList<LocalSigningIdentity> identities,
+        string password)
+    {
+        if (!IsSupported)
+            throw new PlatformNotSupportedException("P12 export is only supported on macOS");
+
+        ArgumentNullException.ThrowIfNull(identities);
+        if (identities.Count == 0)
+            throw new ArgumentException("At least one signing identity must be selected.", nameof(identities));
+
+        _logger.LogInformation($"Exporting {identities.Count} selected signing identity(ies) to P12");
+
+        var tempFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.p12");
         var loginKeychain = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
             "Library/Keychains/login.keychain-db");
         
         try
         {
-            // Use security command to export the identity
-            // security export -t identities -f pkcs12 -P password -o output.p12
+            // security can only export all identities, so filter the resulting bundle
+            // down to the requested hashes before returning it.
             var result = await RunSecurityCommandAsync(
                 "export",
                 "-t", "identities",
@@ -163,15 +185,18 @@ public partial class LocalCertificateService : ILocalCertificateService
                 throw new InvalidOperationException($"Failed to export P12: {result.Error}");
             }
 
-            // Read the exported file
             var p12Data = await File.ReadAllBytesAsync(tempFile);
-            _logger.LogInformation($"Exported P12: {p12Data.Length} bytes");
-            
-            return p12Data;
+            var selectedP12 = CertificateBundleUtilities.ExportSelectedIdentities(
+                p12Data,
+                password,
+                identities,
+                password);
+            _logger.LogInformation($"Exported selected P12 bundle: {selectedP12.Length} bytes");
+
+            return selectedP12;
         }
         finally
         {
-            // Clean up temp file
             try { File.Delete(tempFile); } catch { }
         }
     }

--- a/src/MauiSherpa.MacOS/BlazorContentPage.cs
+++ b/src/MauiSherpa.MacOS/BlazorContentPage.cs
@@ -386,7 +386,7 @@ public class BlazorContentPage : ContentPage
     List<NSObject> _nativeMenuTargets = new();
 
     // Superset signature for the initial build — includes all possible items
-    static readonly string SupersetSignature = "refresh,create,import,install-missing,save,reset,release-notes,|S|F|I";
+    static readonly string SupersetSignature = "refresh,create,export,export-selected,cancel-selection,import,install-missing,save,reset,release-notes,|S|F|I";
 
     void OnToolbarChanged()
     {
@@ -1068,6 +1068,9 @@ public class BlazorContentPage : ContentPage
             var supersetActions = new[]
             {
                 ("create", "New Secret", "plus"),
+                ("export", "Export", "square.and.arrow.up"),
+                ("export-selected", "Export Selected", "square.and.arrow.up"),
+                ("cancel-selection", "Cancel", "xmark"),
                 ("create-folder", "New Folder", "folder.badge.plus"),
                 ("rename-folder", "Rename Folder", "pencil"),
                 ("delete-folder", "Delete Folder", "trash"),

--- a/src/MauiSherpa/Pages/Certificates.razor
+++ b/src/MauiSherpa/Pages/Certificates.razor
@@ -36,12 +36,27 @@
     @if (!PlatformInfo.HasNativeToolbar)
     {
     <div class="toolbar">
-        <button class="btn btn-primary" @onclick="@(() => RefreshData(forceRefresh: true))" disabled="@isLoading">
-            <i class="fas @(isLoading ? "fa-spinner fa-spin" : "fa-sync-alt")"></i> Refresh
-        </button>
-        <button class="btn btn-success" @onclick="ShowCreateDialog" disabled="@isLoading">
-            <i class="fas fa-plus"></i> Create Certificate
-        </button>
+        @if (isSelectionMode)
+        {
+            <button class="btn btn-primary" @onclick="ExportSelectedAsync" disabled="@(selectedCertificateIds.Count == 0)">
+                <i class="fas fa-file-export"></i> Export Selected
+            </button>
+            <button class="btn btn-secondary" @onclick="CancelSelectionMode">
+                <i class="fas fa-times"></i> Cancel
+            </button>
+        }
+        else
+        {
+            <button class="btn btn-primary" @onclick="@(() => RefreshData(forceRefresh: true))" disabled="@isLoading">
+                <i class="fas @(isLoading ? "fa-spinner fa-spin" : "fa-sync-alt")"></i> Refresh
+            </button>
+            <button class="btn btn-success" @onclick="ShowCreateDialog" disabled="@isLoading">
+                <i class="fas fa-plus"></i> Create Certificate
+            </button>
+            <button class="btn btn-secondary" @onclick="BeginSelectionModeAsync" disabled="@isLoading">
+                <i class="fas fa-file-export"></i> Export
+            </button>
+        }
     </div>
     }
 
@@ -107,6 +122,19 @@
         Showing @FilteredCertificates.Count() of @certificates.Count certificates
     </div>
 
+    @if (isSelectionMode)
+    {
+        <div class="selection-bar">
+            <label class="select-all-checkbox">
+                <input type="checkbox"
+                       checked="@AllVisibleExportableSelected"
+                       @onchange="ToggleAllVisible" />
+                <span>Select all exportable certificates shown</span>
+            </label>
+            <span class="selection-count">@selectedCertificateIds.Count selected</span>
+        </div>
+    }
+
     <div class="cert-list">
         @if (isLoading && certificates.Count == 0)
         {
@@ -134,7 +162,18 @@
                 var isExpiringSoon = !isExpired && cert.ExpirationDate < DateTime.UtcNow.AddDays(30);
                 var syncStatus = GetSyncStatus(cert);
                 
-                <div class="cert-card @(isExpired ? "expired" : isExpiringSoon ? "expiring" : "")">
+                var canExportP12 = HasLocalIdentity(cert);
+
+                <div class="cert-card @(isExpired ? "expired" : isExpiringSoon ? "expiring" : "") @(selectedCertificateIds.Contains(cert.Id) ? "selected" : "") @((isSelectionMode && !canExportP12) ? "not-exportable" : "")">
+                    @if (isSelectionMode)
+                    {
+                        <label class="cert-select" title="@(canExportP12 ? "Include in P12 bundle" : "No local private key available")">
+                            <input type="checkbox"
+                                   checked="@selectedCertificateIds.Contains(cert.Id)"
+                                   disabled="@(!canExportP12)"
+                                   @onchange="@(e => ToggleCertificateSelection(cert.Id, e.Value is bool selected && selected))" />
+                        </label>
+                    }
                     <div class="cert-icon"><i class="fas fa-lock"></i></div>
                     <div class="cert-details">
                         <div class="cert-name"><span>@cert.Name</span></div>
@@ -171,6 +210,8 @@
                             Expires: @cert.ExpirationDate.ToString("MMM dd, yyyy")
                         </div>
                     </div>
+                    @if (!isSelectionMode)
+                    {
                     <div class="cert-actions">
                         @if (!string.IsNullOrWhiteSpace(cert.SerialNumber))
                         {
@@ -179,16 +220,10 @@
                                 Item="@(new SecretItemRef(SecretItemKind.Certificate, GetCertificateSyncItemId(cert.SerialNumber), cert.Name))"
                                 CanAddProviderCopy="@(syncStatus != SecretLocation.None)"
                                 UnavailableSourceReason="This certificate has no matching private key in Keychain and no provider copy. Import or install its private key before syncing." />
-                            @if (syncStatus is SecretLocation.CloudOnly or SecretLocation.Both)
+                            @if (syncStatus is SecretLocation.CloudOnly)
                             {
                                 <button class="btn btn-secondary btn-icon" @onclick="@(() => InstallLocally(cert))" title="Install private key locally">
                                     <i class="fas fa-download"></i>
-                                </button>
-                            }
-                            @if (syncStatus is SecretLocation.LocalOnly or SecretLocation.Both)
-                            {
-                                <button class="btn btn-secondary btn-icon" @onclick="@(() => DeleteLocalCertificate(cert))" title="Delete private key from Keychain">
-                                    <i class="fas fa-hard-drive"></i>
                                 </button>
                             }
                         }
@@ -196,11 +231,19 @@
                                 disabled="@isLoading" title="Export">
                             <i class="fas fa-file-export"></i>
                         </button>
+                        @if (!string.IsNullOrWhiteSpace(cert.SerialNumber) &&
+                             syncStatus is SecretLocation.LocalOnly or SecretLocation.Both)
+                        {
+                            <button class="btn btn-danger btn-icon" @onclick="@(() => DeleteLocalCertificate(cert))" title="Delete private key from Keychain">
+                                <i class="fas fa-trash-alt"></i>
+                            </button>
+                        }
                         <button class="btn btn-danger btn-icon" @onclick="@(() => RevokeCertificate(cert))" 
                                 disabled="@isLoading" title="Revoke">
                             <i class="fas fa-ban"></i>
                         </button>
                     </div>
+                    }
                 </div>
             }
         }
@@ -396,6 +439,8 @@
 
     .cert-card.expired { border-left-color: #f56565; opacity: 0.7; }
     .cert-card.expiring { border-left-color: var(--accent-warning); }
+    .cert-card.selected { box-shadow: 0 0 0 2px var(--accent-primary); }
+    .cert-card.not-exportable { opacity: 0.55; }
 
     .cert-icon { font-size: 1.5rem; color: #6b46c1; }
     .cert-icon i { font-size: 1.25rem; }
@@ -413,6 +458,43 @@
     .cert-expiry { font-size: 0.8125rem; color: var(--text-muted); margin-top: 0.5rem; }
     .cert-badges { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-top: 0.5rem; }
     .cert-actions { display: flex; gap: 0.25rem; align-items: center; position: relative; }
+    .cert-select {
+        display: flex;
+        align-items: center;
+        align-self: center;
+        cursor: pointer;
+    }
+    .cert-select input {
+        width: 18px;
+        height: 18px;
+        accent-color: var(--accent-primary);
+    }
+
+    .selection-bar {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+        padding: 0.75rem 1rem;
+        margin-bottom: 0.75rem;
+        background: var(--card-bg);
+        border: 1px solid var(--border-color);
+        border-radius: var(--card-radius);
+    }
+    .select-all-checkbox {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        color: var(--text-secondary);
+        cursor: pointer;
+        font-size: 0.875rem;
+    }
+    .select-all-checkbox input { accent-color: var(--accent-primary); }
+    .selection-count {
+        color: var(--text-muted);
+        font-size: 0.8125rem;
+        white-space: nowrap;
+    }
 
     .btn-copy {
         background: none;
@@ -493,6 +575,9 @@
     private string filterType = "";
     private string filterPlatform = "";
     private string filterStatus = "";
+    private bool isSelectionMode;
+    private readonly HashSet<string> selectedCertificateIds = new(StringComparer.Ordinal);
+    private IReadOnlyList<LocalSigningIdentity> localIdentities = Array.Empty<LocalSigningIdentity>();
     
     // Sync state
     private Dictionary<string, CertificateSecretInfo> syncStatuses = new();
@@ -515,6 +600,19 @@
         .OrderByDescending(c => c.ExpirationDate > DateTime.UtcNow) // Valid first
         .ThenBy(c => c.ExpirationDate);
 
+    private bool AllVisibleExportableSelected
+    {
+        get
+        {
+            var exportableIds = FilteredCertificates
+                .Where(HasLocalIdentity)
+                .Select(certificate => certificate.Id)
+                .ToList();
+            return exportableIds.Count > 0 &&
+                   exportableIds.All(selectedCertificateIds.Contains);
+        }
+    }
+
     // Computed properties for bulk sync buttons
     private bool HasCloudOnlyCerts => syncStatuses.Values.Any(s => s.Location == SecretLocation.CloudOnly);
     private bool HasLocalOnlyCerts => syncStatuses.Values.Any(s => s.Location == SecretLocation.LocalOnly);
@@ -536,16 +634,7 @@
 
     protected override async Task OnInitializedAsync()
     {
-        ToolbarService.SetItems(
-            new ToolbarAction("refresh", "Refresh", "arrow.clockwise"),
-            new ToolbarAction("create", "Create Certificate", "plus")
-        );
-        ToolbarService.SetSearch("Search certificates...");
-        ToolbarService.SetFilters(
-            new ToolbarFilter("type", "Type", ["All Types", "Development", "Distribution", "Developer ID"]),
-            new ToolbarFilter("platform", "Platform", ["All Platforms", "iOS", "macOS"]),
-            new ToolbarFilter("status", "Status", ["All Statuses", "Valid", "Expiring Soon", "Expired"])
-        );
+        ConfigureToolbar();
         ToolbarService.ToolbarItemClicked += OnToolbarItemClicked;
         ToolbarService.SearchTextChanged += OnSearchTextChanged;
         ToolbarService.FilterChanged += OnFilterChanged;
@@ -628,6 +717,9 @@
                     try { await RefreshData(forceRefresh: true); } finally { ToolbarService.SetItemEnabled("refresh", true); }
                     break;
                 case "create": await ShowCreateDialog(); break;
+                case "export": await BeginSelectionModeAsync(); break;
+                case "export-selected": await ExportSelectedAsync(); break;
+                case "cancel-selection": CancelSelectionMode(); break;
             }
             StateHasChanged();
         });
@@ -815,15 +907,108 @@
 
     private async Task ShowExportDialog(AppleCertificate cert)
     {
-        IReadOnlyList<LocalSigningIdentity>? localIds = null;
         if (LocalCertificateService.IsSupported)
         {
-            localIds = await LocalCertificateService.GetSigningIdentitiesAsync();
+            localIdentities = await LocalCertificateService.GetSigningIdentitiesAsync();
         }
 
-        var page = new ExportCertificatePage(BridgeHolder, cert, localIds);
+        var page = new ExportCertificatePage(BridgeHolder, [cert], localIdentities);
         await FormModalService.ShowAsync<bool>(page);
     }
+
+    private void ConfigureToolbar()
+    {
+        if (isSelectionMode)
+        {
+            ToolbarService.SetItems(
+                new ToolbarAction("export-selected", "Export Selected", "square.and.arrow.up"),
+                new ToolbarAction("cancel-selection", "Cancel", "xmark", IsPrimary: false));
+            ToolbarService.SetItemEnabled("export-selected", selectedCertificateIds.Count > 0);
+        }
+        else
+        {
+            ToolbarService.SetItems(
+                new ToolbarAction("refresh", "Refresh", "arrow.clockwise"),
+                new ToolbarAction("create", "Create Certificate", "plus"),
+                new ToolbarAction("export", "Export", "square.and.arrow.up"));
+        }
+
+        ToolbarService.SetSearch("Search certificates...");
+        ToolbarService.SetFilters(
+            new ToolbarFilter("type", "Type", ["All Types", "Development", "Distribution", "Developer ID"]),
+            new ToolbarFilter("platform", "Platform", ["All Platforms", "iOS", "macOS"]),
+            new ToolbarFilter("status", "Status", ["All Statuses", "Valid", "Expiring Soon", "Expired"]));
+    }
+
+    private async Task BeginSelectionModeAsync()
+    {
+        if (!LocalCertificateService.IsSupported)
+        {
+            await AlertService.ShowAlertAsync(
+                "Not Supported",
+                $"Certificate bundle export is not supported on {PlatformInfo.PlatformName}.");
+            return;
+        }
+
+        localIdentities = await LocalCertificateService.GetSigningIdentitiesAsync();
+        if (!certificates.Any(HasLocalIdentity))
+        {
+            await AlertService.ShowAlertAsync(
+                "No Exportable Certificates",
+                "No certificates with local private keys are available to export.");
+            return;
+        }
+
+        isSelectionMode = true;
+        selectedCertificateIds.Clear();
+        ConfigureToolbar();
+    }
+
+    private void CancelSelectionMode()
+    {
+        isSelectionMode = false;
+        selectedCertificateIds.Clear();
+        ConfigureToolbar();
+    }
+
+    private void ToggleCertificateSelection(string certificateId, bool selected)
+    {
+        if (selected)
+            selectedCertificateIds.Add(certificateId);
+        else
+            selectedCertificateIds.Remove(certificateId);
+        ToolbarService.SetItemEnabled("export-selected", selectedCertificateIds.Count > 0);
+    }
+
+    private void ToggleAllVisible(ChangeEventArgs args)
+    {
+        var exportableIds = FilteredCertificates
+            .Where(HasLocalIdentity)
+            .Select(certificate => certificate.Id)
+            .ToList();
+        if (args.Value is bool selected && selected)
+            selectedCertificateIds.UnionWith(exportableIds);
+        else
+            selectedCertificateIds.ExceptWith(exportableIds);
+        ToolbarService.SetItemEnabled("export-selected", selectedCertificateIds.Count > 0);
+    }
+
+    private async Task ExportSelectedAsync()
+    {
+        var selectedCertificates = certificates
+            .Where(certificate => selectedCertificateIds.Contains(certificate.Id))
+            .ToList();
+        if (selectedCertificates.Count == 0)
+            return;
+
+        var page = new ExportCertificatePage(BridgeHolder, selectedCertificates, localIdentities);
+        var exported = await FormModalService.ShowAsync<bool>(page);
+        if (exported)
+            CancelSelectionMode();
+    }
+
+    private bool HasLocalIdentity(AppleCertificate certificate) =>
+        localIdentities.Any(identity => SerialsMatch(identity.SerialNumber, certificate.SerialNumber));
 
     private async Task RevokeCertificate(AppleCertificate cert)
     {

--- a/src/MauiSherpa/Pages/Modals/ExportCertificateModal.razor
+++ b/src/MauiSherpa/Pages/Modals/ExportCertificateModal.razor
@@ -16,42 +16,59 @@
 @if (bridge != null)
 {
     <div class="form-content">
-        @if (exportCertificate != null)
+        @if (exportCertificates.Count > 0)
         {
             <div class="cert-export-info">
-                <strong>@exportCertificate.Name</strong>
-                <div class="text-muted">@exportCertificate.CertificateType</div>
+                @if (exportCertificates.Count == 1)
+                {
+                    <strong>@exportCertificates[0].Name</strong>
+                    <div class="text-muted">@exportCertificates[0].CertificateType</div>
+                }
+                else
+                {
+                    <strong>@exportCertificates.Count certificates selected</strong>
+                    <div class="selected-certificates">
+                        @foreach (var certificate in exportCertificates)
+                        {
+                            <span><i class="fas fa-certificate"></i> @certificate.Name</span>
+                        }
+                    </div>
+                }
             </div>
 
-            <div class="form-group">
-                <label>Export Type</label>
-                <div class="export-type-options">
-                    <label class="radio-option">
-                        <input type="radio" name="exportType" value="p12" checked="@(exportType == "p12")" @onchange="@(() => { exportType = "p12"; OnFieldChanged(); })" />
-                        <span class="radio-label">
-                            <strong>P12 / PFX (with private key)</strong>
-                            <small>Includes both public and private key - can be used for signing</small>
-                        </span>
-                    </label>
-                    <label class="radio-option">
-                        <input type="radio" name="exportType" value="cer" checked="@(exportType == "cer")" @onchange="@(() => { exportType = "cer"; OnFieldChanged(); })" />
-                        <span class="radio-label">
-                            <strong>CER (public key only)</strong>
-                            <small>Contains only the public certificate - cannot be used for signing</small>
-                        </span>
-                    </label>
-                </div>
-            </div>
-
-            @if (exportType == "p12")
+            @if (exportCertificates.Count == 1)
             {
-                var localIdentity = localIdentities?.FirstOrDefault(i =>
-                    i.SerialNumber?.Equals(exportCertificate?.SerialNumber, StringComparison.OrdinalIgnoreCase) == true);
-                if (localIdentity == null)
+                <div class="form-group">
+                    <label>Export Type</label>
+                    <div class="export-type-options">
+                        <label class="radio-option">
+                            <input type="radio" name="exportType" value="p12" checked="@(exportType == "p12")" @onchange="@(() => { exportType = "p12"; OnFieldChanged(); })" />
+                            <span class="radio-label">
+                                <strong>P12 / PFX (with private key)</strong>
+                                <small>Includes both public and private key - can be used for signing</small>
+                            </span>
+                        </label>
+                        <label class="radio-option">
+                            <input type="radio" name="exportType" value="cer" checked="@(exportType == "cer")" @onchange="@(() => { exportType = "cer"; OnFieldChanged(); })" />
+                            <span class="radio-label">
+                                <strong>CER (public key only)</strong>
+                                <small>Contains only the public certificate - cannot be used for signing</small>
+                            </span>
+                        </label>
+                    </div>
+                </div>
+            }
+
+            @if (IsP12Export)
+            {
+                if (MissingCertificates.Count > 0)
                 {
                     <div class="alert alert-warning">
                         <i class="fas fa-exclamation-triangle"></i>
-                        Private key not found in local keychain. You can only export the public certificate.
+                        <span>
+                            Private keys were not found locally for:
+                            @string.Join(", ", MissingCertificates.Select(certificate => certificate.Name))
+                        </span>
                     </div>
                 }
                 else
@@ -59,45 +76,76 @@
                     <div class="form-group">
                         <label class="checkbox-label">
                             <input type="checkbox" @bind="exportWithPassword" @bind:after="OnFieldChanged" />
-                            <span>Protect with password</span>
+                            <span>Protect with passphrase</span>
                         </label>
                     </div>
 
                     @if (exportWithPassword)
                     {
                         <div class="form-group">
-                            <label>Password</label>
-                            <input type="password" @bind="exportPassword" @bind:after="OnFieldChanged" class="form-control" placeholder="Enter password" />
+                            <label>Passphrase</label>
+                            <input type="password" @bind="exportPassword" @bind:after="OnFieldChanged" class="form-control" placeholder="Enter passphrase" />
                         </div>
                         <div class="form-group">
-                            <label>Confirm Password</label>
-                            <input type="password" @bind="exportPasswordConfirm" @bind:after="OnFieldChanged" class="form-control" placeholder="Confirm password" />
+                            <label>Confirm Passphrase</label>
+                            <input type="password" @bind="exportPasswordConfirm" @bind:after="OnFieldChanged" class="form-control" placeholder="Confirm passphrase" />
                             @if (!string.IsNullOrEmpty(exportPassword) && !string.IsNullOrEmpty(exportPasswordConfirm) && exportPassword != exportPasswordConfirm)
                             {
-                                <small class="form-error">Passwords do not match</small>
+                                <small class="form-error">Passphrases do not match</small>
                             }
                         </div>
                     }
                 }
             }
+
+            <div class="form-group">
+                <label>Destination</label>
+                <div class="destination-options">
+                    <label class="checkbox-label destination-option">
+                        <input type="checkbox" @bind="saveToFile" @bind:after="OnFieldChanged" />
+                        <span>
+                            <strong>Save to file</strong>
+                            <small>Choose where to save the @(IsP12Export ? "P12 bundle" : "certificate")</small>
+                        </span>
+                    </label>
+                    <label class="checkbox-label destination-option">
+                        <input type="checkbox" @bind="copyAsBase64" @bind:after="OnFieldChanged" />
+                        <span>
+                            <strong>Copy as Base64</strong>
+                            <small>Copy the encoded file contents to the clipboard</small>
+                        </span>
+                    </label>
+                </div>
+                @if (!saveToFile && !copyAsBase64)
+                {
+                    <small class="form-error">Choose at least one destination</small>
+                }
+            </div>
         }
     </div>
 }
 
 @code {
-    private AppleCertificate? exportCertificate;
+    private IReadOnlyList<AppleCertificate> exportCertificates = Array.Empty<AppleCertificate>();
     private string exportType = "p12";
     private bool exportWithPassword = false;
     private string exportPassword = "";
     private string exportPasswordConfirm = "";
     private bool isExporting = false;
-    private IReadOnlyList<LocalSigningIdentity>? localIdentities;
+    private bool saveToFile = true;
+    private bool copyAsBase64;
+    private IReadOnlyList<LocalSigningIdentity> localIdentities = Array.Empty<LocalSigningIdentity>();
 
-    private bool CanExport => exportCertificate != null &&
+    private bool IsP12Export => exportCertificates.Count > 1 || exportType == "p12";
+    private IReadOnlyList<AppleCertificate> MissingCertificates => exportCertificates
+        .Where(certificate => !localIdentities.Any(identity =>
+           SerialsMatch(identity.SerialNumber, certificate.SerialNumber)))
+        .ToList();
+    private bool CanExport => exportCertificates.Count > 0 &&
         !isExporting &&
-        (exportType == "cer" ||
-         (exportType == "p12" &&
-          localIdentities?.Any(i => i.SerialNumber?.Equals(exportCertificate.SerialNumber, StringComparison.OrdinalIgnoreCase) == true) == true &&
+        (saveToFile || copyAsBase64) &&
+        (!IsP12Export ||
+         (MissingCertificates.Count == 0 &&
           (!exportWithPassword || (exportPassword == exportPasswordConfirm && !string.IsNullOrEmpty(exportPassword)))));
 
     protected override void OnInitialized()
@@ -105,69 +153,86 @@
         var bridge = BridgeHolder.Current;
         if (bridge == null) return;
 
-        exportCertificate = bridge.Parameters.GetValueOrDefault("Certificate") as AppleCertificate;
-        localIdentities = bridge.Parameters.GetValueOrDefault("LocalIdentities") as IReadOnlyList<LocalSigningIdentity>;
+        exportCertificates = bridge.Parameters.GetValueOrDefault("Certificates") as IReadOnlyList<AppleCertificate>
+            ?? Array.Empty<AppleCertificate>();
+        localIdentities = bridge.Parameters.GetValueOrDefault("LocalIdentities") as IReadOnlyList<LocalSigningIdentity>
+            ?? Array.Empty<LocalSigningIdentity>();
 
         bridge.SubmitRequested += OnSubmitRequested;
-        bridge.SetValid(CanExport);
+        bridge.PreventSubmitClose = true;
+        UpdateActionState();
     }
 
     private void OnFieldChanged()
     {
-        BridgeHolder.Current?.SetValid(CanExport);
+        UpdateActionState();
     }
 
     private async Task OnSubmitRequested()
     {
-        if (exportCertificate == null) return;
+        if (!CanExport) return;
 
         isExporting = true;
+        UpdateActionState();
         StateHasChanged();
 
         try
         {
-            var cert = exportCertificate;
-            var fileName = $"{cert.Name?.Replace(" ", "_") ?? "certificate"}_{DateTime.Now:yyyyMMdd}";
+            var cert = exportCertificates[0];
+            var fileName = exportCertificates.Count == 1
+                ? $"{SanitizeFileName(cert.Name)}_{DateTime.Now:yyyyMMdd}"
+                : $"apple-certificates_{DateTime.Now:yyyyMMdd}";
             byte[] data;
             string extension;
 
-            if (exportType == "p12")
+            if (IsP12Export)
             {
-                extension = ".p12";
-                var matchingIdentity = localIdentities?.FirstOrDefault(i =>
-                    SerialsMatch(i.SerialNumber, cert.SerialNumber));
-
-                if (matchingIdentity == null)
-                {
-                    await AlertService.ShowAlertAsync("Error", "Private key not found in local keychain.");
-                    return;
-                }
+                extension = "p12";
+                var matchingIdentities = exportCertificates
+                    .Select(certificate => localIdentities.First(identity =>
+                        SerialsMatch(identity.SerialNumber, certificate.SerialNumber)))
+                    .ToList();
 
                 var password = exportWithPassword ? exportPassword : "";
-                data = await LocalCertificateService.ExportP12Async(matchingIdentity.Identity, password);
+                data = await LocalCertificateService.ExportP12Async(matchingIdentities, password);
             }
             else
             {
-                extension = ".cer";
+                extension = "cer";
                 data = await LocalCertificateService.ExportCertificateAsync(cert.SerialNumber ?? "");
             }
 
-            var savePath = await DialogService.ShowFileDialogAsync(
-                "Save Certificate",
-                isSave: true,
-                defaultFileName: fileName + extension);
-
-            if (string.IsNullOrEmpty(savePath))
+            string? savePath = null;
+            if (saveToFile)
             {
-                return;
+                savePath = await DialogService.PickSaveFileAsync(
+                    IsP12Export ? "Save Certificate Bundle" : "Save Certificate",
+                    $"{fileName}.{extension}",
+                    extension);
+
+                if (!string.IsNullOrEmpty(savePath))
+                    await File.WriteAllBytesAsync(savePath, data);
+                else if (!copyAsBase64)
+                    return;
             }
 
-            await File.WriteAllBytesAsync(savePath, data);
-            await AlertService.ShowToastAsync($"Certificate exported to {Path.GetFileName(savePath)}");
+            if (copyAsBase64)
+                await DialogService.CopyToClipboardAsync(Convert.ToBase64String(data));
+
+            var message = (savePath, copyAsBase64) switch
+            {
+                ({ Length: > 0 }, true) => $"Saved {Path.GetFileName(savePath)} and copied Base64 to clipboard",
+                ({ Length: > 0 }, false) => $"Certificate export saved to {Path.GetFileName(savePath)}",
+                _ => "Certificate export copied to clipboard as Base64"
+            };
+            await AlertService.ShowToastAsync(message);
 
             var bridge = BridgeHolder.Current;
             if (bridge != null)
+            {
                 bridge.Result = true;
+                bridge.RequestClose();
+            }
         }
         catch (Exception ex)
         {
@@ -177,8 +242,25 @@
         finally
         {
             isExporting = false;
+            UpdateActionState();
             StateHasChanged();
         }
+    }
+
+    private void UpdateActionState()
+    {
+        BridgeHolder.Current?.SetActionState(
+            enabled: CanExport,
+            busy: isExporting,
+            actionText: isExporting ? "Exporting..." : "Export");
+    }
+
+    private static string SanitizeFileName(string value)
+    {
+        var invalidCharacters = Path.GetInvalidFileNameChars().ToHashSet();
+        return new string(value
+            .Select(character => invalidCharacters.Contains(character) || char.IsWhiteSpace(character) ? '_' : character)
+            .ToArray());
     }
 
     private static bool SerialsMatch(string? a, string? b)
@@ -207,6 +289,17 @@
         padding: 0.75rem 1rem;
         border-radius: var(--card-radius, 1rem);
     }
+    .selected-certificates {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+        margin-top: 0.5rem;
+        max-height: 110px;
+        overflow-y: auto;
+        color: var(--text-muted);
+        font-size: 0.8125rem;
+    }
+    .selected-certificates i { width: 1rem; color: var(--accent-primary); }
 
     .export-type-options { display: flex; flex-direction: column; gap: 0.75rem; }
 
@@ -232,9 +325,20 @@
 
     .checkbox-label { display: flex; align-items: center; gap: 0.5rem; cursor: pointer; }
     .checkbox-label input[type="checkbox"] { width: 18px; height: 18px; }
+    .destination-options { display: flex; flex-direction: column; gap: 0.5rem; }
+    .destination-option {
+        align-items: flex-start;
+        padding: 0.625rem 0.75rem;
+        background: var(--card-bg);
+        border-radius: var(--card-radius, 1rem);
+    }
+    .destination-option > span { display: flex; flex-direction: column; gap: 0.125rem; }
+    .destination-option strong { color: var(--text-primary); font-size: 0.875rem; }
+    .destination-option small { color: var(--text-muted); font-size: 0.75rem; }
 
     .form-group { margin-bottom: 0; }
     .form-group label { display: block; font-weight: 500; margin-bottom: 0.5rem; color: var(--text-secondary); }
+    .form-group label.checkbox-label { display: flex; }
     .form-control {
         width: 100%; padding: 0.625rem 0.75rem;
         border: 1px solid var(--border-color); border-radius: 0.375rem;

--- a/src/MauiSherpa/Pages/Modals/ExportCertificatePage.cs
+++ b/src/MauiSherpa/Pages/Modals/ExportCertificatePage.cs
@@ -11,27 +11,35 @@ namespace MauiSherpa.Pages.Modals;
 
 public class ExportCertificatePage : HybridFormPage<bool>
 {
-    protected override string FormTitle => "Export Certificate";
+    private readonly int _certificateCount;
+
+    protected override string FormTitle =>
+        _certificateCount > 1 ? "Export Certificate Bundle" : "Export Certificate";
     protected override string SubmitButtonText => "Export";
     protected override string BlazorRoute => "/modal/export-certificate";
 
     public ExportCertificatePage(
         HybridFormBridgeHolder bridgeHolder,
-        AppleCertificate certificate,
+        IReadOnlyList<AppleCertificate> certificates,
         IReadOnlyList<LocalSigningIdentity>? localIdentities = null)
         : base(bridgeHolder)
     {
-        Bridge.Parameters["Certificate"] = certificate;
+        ArgumentNullException.ThrowIfNull(certificates);
+        if (certificates.Count == 0)
+            throw new ArgumentException("At least one certificate must be selected.", nameof(certificates));
+
+        _certificateCount = certificates.Count;
+        Bridge.Parameters["Certificates"] = certificates;
         if (localIdentities != null)
             Bridge.Parameters["LocalIdentities"] = localIdentities;
 #if MACOSAPP
         MacOSPage.SetModalSheetSizesToContent(this, false);
         MacOSPage.SetModalSheetWidth(this, 550);
-        MacOSPage.SetModalSheetHeight(this, 500);
+        MacOSPage.SetModalSheetHeight(this, 620);
 #elif LINUXGTK
         GtkPage.SetModalSizesToContent(this, false);
         GtkPage.SetModalWidth(this, 550);
-        GtkPage.SetModalHeight(this, 500);
+        GtkPage.SetModalHeight(this, 620);
 #endif
     }
 }

--- a/src/MauiSherpa/Services/WindowsCertificateService.cs
+++ b/src/MauiSherpa/Services/WindowsCertificateService.cs
@@ -166,32 +166,77 @@ public class WindowsCertificateService : ILocalCertificateService
         }, cancellationToken);
     }
 
-    public Task<byte[]> ExportP12Async(string identity, string password)
+    public async Task<byte[]> ExportP12Async(string identity, string password)
     {
         if (!IsSupported)
             throw new PlatformNotSupportedException("Certificate export not supported on this platform");
+
+        if (string.IsNullOrWhiteSpace(identity))
+            throw new ArgumentException("Identity cannot be empty.", nameof(identity));
+
+        var availableIdentities = await GetSigningIdentitiesAsync();
+        var selectedIdentity = availableIdentities.FirstOrDefault(candidate =>
+            string.Equals(candidate.Identity, identity, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(candidate.Hash, identity, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(candidate.SerialNumber, identity, StringComparison.OrdinalIgnoreCase));
+        if (selectedIdentity is null)
+            throw new InvalidOperationException($"Certificate not found: {identity}");
+
+        return await ExportP12Async([selectedIdentity], password);
+    }
+
+    public Task<byte[]> ExportP12Async(
+        IReadOnlyList<LocalSigningIdentity> identities,
+        string password)
+    {
+        if (!IsSupported)
+            throw new PlatformNotSupportedException("Certificate export not supported on this platform");
+
+        ArgumentNullException.ThrowIfNull(identities);
+        if (identities.Count == 0)
+            throw new ArgumentException("At least one signing identity must be selected.", nameof(identities));
 
         return Task.Run(() =>
         {
             using var store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
             store.Open(OpenFlags.ReadOnly);
 
-            var cert = FindCertByIdentity(store, identity);
-            if (cert == null)
-                throw new InvalidOperationException($"Certificate not found: {identity}");
-
+            var selectedCertificates = new X509Certificate2Collection();
+            var thumbprints = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             try
             {
-                if (!cert.HasPrivateKey)
-                    throw new InvalidOperationException($"Certificate has no private key: {identity}");
+                foreach (var identity in identities)
+                {
+                    var certificate = !string.IsNullOrWhiteSpace(identity.Hash)
+                        ? FindCertByIdentity(store, identity.Hash)
+                        : !string.IsNullOrWhiteSpace(identity.SerialNumber)
+                            ? FindCertBySerial(store, identity.SerialNumber)
+                            : FindCertByIdentity(store, identity.Identity);
+                    if (certificate is null)
+                        throw new InvalidOperationException($"Certificate not found: {identity.Identity}");
+                    if (!certificate.HasPrivateKey)
+                    {
+                        certificate.Dispose();
+                        throw new InvalidOperationException($"Certificate has no private key: {identity.Identity}");
+                    }
+                    if (!thumbprints.Add(certificate.Thumbprint))
+                    {
+                        certificate.Dispose();
+                        continue;
+                    }
 
-                var p12 = cert.Export(X509ContentType.Pfx, password);
-                _logger.LogInformation($"Exported P12 for: {identity}");
+                    selectedCertificates.Add(certificate);
+                }
+
+                var p12 = selectedCertificates.Export(X509ContentType.Pfx, password)
+                    ?? throw new InvalidOperationException("Failed to export the selected certificate bundle.");
+                _logger.LogInformation($"Exported {selectedCertificates.Count} certificate(s) to one P12 bundle");
                 return p12;
             }
             finally
             {
-                cert.Dispose();
+                foreach (var certificate in selectedCertificates)
+                    certificate.Dispose();
             }
         });
     }

--- a/tests/MauiSherpa.Core.Tests/Services/CertificateBundleUtilitiesTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/CertificateBundleUtilitiesTests.cs
@@ -1,0 +1,112 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using FluentAssertions;
+using MauiSherpa.Core.Interfaces;
+using MauiSherpa.Core.Services;
+
+namespace MauiSherpa.Core.Tests.Services;
+
+public class CertificateBundleUtilitiesTests
+{
+    [Fact]
+    public void ExportSelectedIdentities_IncludesOnlySelectedPrivateKeys()
+    {
+        const string sourcePassword = "source-password";
+        const string exportPassword = "export-password";
+        var certificates = new[]
+        {
+            CreateCertificate("First"),
+            CreateCertificate("Second"),
+            CreateCertificate("Third")
+        };
+
+        try
+        {
+            var source = new X509Certificate2Collection(certificates);
+            var sourceP12 = source.Export(X509ContentType.Pfx, sourcePassword)!;
+            var selected = new[]
+            {
+                CreateIdentity(certificates[0]),
+                CreateIdentity(certificates[2])
+            };
+
+            var result = CertificateBundleUtilities.ExportSelectedIdentities(
+                sourceP12,
+                sourcePassword,
+                selected,
+                exportPassword);
+
+            var exported = X509CertificateLoader.LoadPkcs12Collection(
+                result,
+                exportPassword,
+                X509KeyStorageFlags.DefaultKeySet);
+            try
+            {
+                exported.Cast<X509Certificate2>().Should().HaveCount(2);
+                exported.Cast<X509Certificate2>().Should().OnlyContain(certificate => certificate.HasPrivateKey);
+                exported.Cast<X509Certificate2>()
+                    .Select(certificate => certificate.Thumbprint)
+                    .Should()
+                    .BeEquivalentTo(certificates[0].Thumbprint, certificates[2].Thumbprint);
+            }
+            finally
+            {
+                foreach (var certificate in exported)
+                    certificate.Dispose();
+            }
+        }
+        finally
+        {
+            foreach (var certificate in certificates)
+                certificate.Dispose();
+        }
+    }
+
+    [Fact]
+    public void ExportSelectedIdentities_WhenIdentityIsMissing_Throws()
+    {
+        const string password = "password";
+        using var certificate = CreateCertificate("Available");
+        var source = new X509Certificate2Collection(certificate);
+        var sourceP12 = source.Export(X509ContentType.Pfx, password)!;
+        var missingIdentity = new LocalSigningIdentity(
+            "Missing",
+            "Missing",
+            null,
+            "1234",
+            null,
+            true,
+            "00112233445566778899AABBCCDDEEFF00112233");
+
+        var action = () => CertificateBundleUtilities.ExportSelectedIdentities(
+            sourceP12,
+            password,
+            [missingIdentity],
+            password);
+
+        action.Should().Throw<InvalidOperationException>()
+            .WithMessage("Only 0 of 1 selected signing identities*");
+    }
+
+    private static LocalSigningIdentity CreateIdentity(X509Certificate2 certificate) => new(
+        certificate.GetNameInfo(X509NameType.SimpleName, false),
+        certificate.GetNameInfo(X509NameType.SimpleName, false),
+        null,
+        certificate.SerialNumber,
+        certificate.NotAfter,
+        true,
+        certificate.Thumbprint);
+
+    private static X509Certificate2 CreateCertificate(string commonName)
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest(
+            $"CN={commonName}",
+            rsa,
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
+        return request.CreateSelfSigned(
+            DateTimeOffset.UtcNow.AddMinutes(-1),
+            DateTimeOffset.UtcNow.AddDays(1));
+    }
+}


### PR DESCRIPTION
Certificate workflows often need several signing identities packaged for CI or transfer, but the Certificates page could only export one certificate at a time. This adds an explicit multi-select export mode that produces one P12 bundle and supports file and Base64 clipboard destinations.

## What changed

- Adds an Export toolbar action that transitions the certificate list into multi-select mode and limits selection to certificates with local private keys.
- Extends the export dialog with a passphrase, save-to-file, and copy-as-Base64 options that can be used independently or together.
- Exports exactly the selected identities into one P12 on macOS and Windows, rather than relying on the macOS `security export` command's unfiltered keychain bundle.
- Corrects certificate row actions so install appears only for cloud-only keys and local-key deletion is a destructive trash action beside revoke.
- Adds focused coverage for selected-certificate bundle filtering and missing identities.

## Validation

- `dotnet test tests/MauiSherpa.Core.Tests/MauiSherpa.Core.Tests.csproj --filter 'FullyQualifiedName~CertificateBundleUtilitiesTests|FullyQualifiedName~CertificateSyncServiceTests' --no-restore --verbosity quiet`
- `dotnet build src/MauiSherpa.MacOS -f net10.0-macos --no-restore --verbosity minimal`
- Exercised the macOS Export toolbar, multi-select state, and bundle dialog in the running app.

Stacked on #240.