### PR TITLE
Fix deep link validator registration

### DIFF
--- a/src/MauiSherpa/MauiProgram.cs
+++ b/src/MauiSherpa/MauiProgram.cs
@@ -214,6 +214,7 @@ public static class MauiProgram
         builder.Services.AddSingleton<IPhysicalDeviceService, MauiSherpa.Core.Services.PhysicalDeviceService>();
         builder.Services.AddSingleton<IPhysicalDeviceLogService, PhysicalDeviceLogService>();
         builder.Services.AddSingleton<SimInspectorService>();
+        builder.Services.AddSingleton<IDeepLinkValidationService, DeepLinkValidationService>();
         
         // Cloud Secrets Storage services
         builder.Services.AddSingleton<ICloudSecretsProviderFactory, CloudSecretsProviderFactory>();


### PR DESCRIPTION
Opening the device tools UI on Windows crashes Blazor because `IDeepLinkValidationService` is injected by the inspector tabs but was not registered in the shared app composition root.

Register `DeepLinkValidationService` as a singleton for the Windows/Linux app head, matching the existing macOS registration.

Fixes: #238