### PR TITLE
Improve provisioning profile regeneration and cleanup

### DIFF
--- a/src/MauiSherpa.Core/Interfaces.cs
+++ b/src/MauiSherpa.Core/Interfaces.cs
@@ -635,6 +635,7 @@ public static class CapabilityCategories
     /// </summary>
     public static readonly IReadOnlySet<string> NonToggleableCapabilities = new HashSet<string>
     {
+        "APP_GROUPS",
         "CARPLAY_PLAYABLE_CONTENT",
         "MARZIPAN",
         "COMMUNICATION_NOTIFICATIONS",
@@ -787,6 +788,26 @@ public record AppleProfile(
     IReadOnlyList<string>? CertificateIds = null
 );
 
+public sealed record InstalledProvisioningProfileAssessment(
+    string Path,
+    string FileName,
+    string Name,
+    string? Uuid,
+    string? BundleId,
+    string? TeamIdentifier,
+    string ProfileKind,
+    string Location,
+    DateTimeOffset? CreationDate,
+    DateTimeOffset? ExpirationDate,
+    int CertificateCount,
+    bool HasMatchingCertificate,
+    bool IsExpired,
+    bool IsOlderVersion,
+    bool IsReadable,
+    bool RecommendedForDeletion,
+    IReadOnlyList<string> Reasons
+);
+
 public interface IAppleIdentityService
 {
     Task<IReadOnlyList<AppleIdentity>> GetIdentitiesAsync();
@@ -855,10 +876,13 @@ public interface IAppleConnectService
     // Provisioning Profiles
     Task<IReadOnlyList<AppleProfile>> GetProfilesAsync();
     Task<AppleProfile> CreateProfileAsync(AppleProfileCreateRequest request);
+    Task<AppleProfile> RegenerateProfileAsync(string existingProfileId, AppleProfileCreateRequest request);
     Task<byte[]> DownloadProfileAsync(string id);
     Task DeleteProfileAsync(string id);
     Task<string> InstallProfileAsync(string id);
     Task<int> InstallProfilesAsync(IEnumerable<string> ids, IProgress<string>? progress = null);
+    Task<IReadOnlyList<string>> GetProvisioningProfilesDirectoriesAsync();
+    Task<IReadOnlyList<string>> FindInstalledProfilePathsAsync(string uuid);
 }
 
 /// <summary>
@@ -4151,6 +4175,7 @@ public record AppPreferences
     public string XcodeBundleSeparator { get; init; } = XcodeBundleSeparatorOptions.Underscore;
     public string XcodeSelectionAction { get; init; } = XcodeSelectionActionOptions.Rename;
     public bool XcodeCreateSymlinkOnSelect { get; init; } = false;
+    public string ProvisioningProfilesDirectory { get; init; } = ProvisioningProfilesDirectoryOptions.Auto;
 }
 
 public static class XcodeArchiveExtractorOptions
@@ -4178,6 +4203,14 @@ public static class XcodeSelectionActionOptions
 {
     public const string None = "none";
     public const string Rename = "rename";
+}
+
+public static class ProvisioningProfilesDirectoryOptions
+{
+    public const string Auto = "auto";
+    public const string Xcode16AndLater = "xcode-16-and-later";
+    public const string Xcode15AndEarlier = "xcode-15-and-earlier";
+    public const string Both = "both";
 }
 
 public record PushTestingSettings

--- a/src/MauiSherpa.Core/Services/AppleConnectService.cs
+++ b/src/MauiSherpa.Core/Services/AppleConnectService.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using AppleDev;
 using AppleAppStoreConnect;
 using MauiSherpa.Core.Interfaces;
 
@@ -16,17 +17,20 @@ public class AppleConnectService : IAppleConnectService
     private readonly IAppleIdentityStateService _identityState;
     private readonly IAppleIdentityService _identityService;
     private readonly ISecureStorageService _secureStorage;
+    private readonly IEncryptedSettingsService _settingsService;
     private readonly ILoggingService _logger;
 
     public AppleConnectService(
         IAppleIdentityStateService identityState,
         IAppleIdentityService identityService,
         ISecureStorageService secureStorage,
+        IEncryptedSettingsService settingsService,
         ILoggingService logger)
     {
         _identityState = identityState;
         _identityService = identityService;
         _secureStorage = secureStorage;
+        _settingsService = settingsService;
         _logger = logger;
     }
 
@@ -675,6 +679,148 @@ public class AppleConnectService : IAppleConnectService
         }
     }
 
+    public async Task<AppleProfile> RegenerateProfileAsync(
+        string existingProfileId,
+        AppleProfileCreateRequest request)
+    {
+        _logger.LogInformation($"Regenerating profile: {request.Name} ({existingProfileId})");
+
+        var existingContent = await DownloadProfileAsync(existingProfileId);
+        if (existingContent.Length == 0)
+        {
+            throw new InvalidOperationException(
+                "The existing profile could not be inspected, so regeneration was stopped before deleting it.");
+        }
+
+        ProvisioningProfileInfo existingProfile;
+        try
+        {
+            existingProfile = await ProvisioningProfiles.ParseAsync(existingContent).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException(
+                "The existing profile entitlements could not be inspected, so regeneration was stopped before deleting it.",
+                ex);
+        }
+
+        var existingAppGroups = GetAppGroups(existingProfile.Entitlements);
+        var validationRequest = request with
+        {
+            Name = $"Sherpa Validation {Guid.NewGuid():N}"[..34]
+        };
+        var validationProfile = await CreateProfileAsync(validationRequest);
+
+        try
+        {
+            await EnsureProfileAppGroupsAsync(validationProfile.Id, existingAppGroups);
+        }
+        catch
+        {
+            await TryDeleteValidationProfileAsync(validationProfile.Id);
+            throw;
+        }
+
+        try
+        {
+            await DeleteProfileAsync(existingProfileId);
+        }
+        catch
+        {
+            await TryDeleteValidationProfileAsync(validationProfile.Id);
+            throw;
+        }
+
+        AppleProfile? regeneratedProfile = null;
+        try
+        {
+            regeneratedProfile = await CreateProfileAsync(request);
+            await EnsureProfileAppGroupsAsync(regeneratedProfile.Id, existingAppGroups);
+        }
+        catch (Exception ex)
+        {
+            if (regeneratedProfile is not null)
+                await TryDeleteValidationProfileAsync(regeneratedProfile.Id);
+
+            throw new InvalidOperationException(
+                $"The original profile was deleted, but its replacement could not be completed. " +
+                $"The valid temporary profile '{validationProfile.Name}' was retained in Apple Developer.",
+                ex);
+        }
+
+        await TryDeleteValidationProfileAsync(validationProfile.Id);
+        return regeneratedProfile;
+    }
+
+    internal static void EnsureAppGroupsPreserved(
+        IReadOnlyDictionary<string, object> existingEntitlements,
+        IReadOnlyDictionary<string, object> regeneratedEntitlements)
+    {
+        var existingGroups = GetAppGroups(existingEntitlements);
+        if (existingGroups.Count == 0)
+            return;
+
+        var selectedGroups = GetAppGroups(regeneratedEntitlements)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var missingGroups = existingGroups
+            .Where(group => !selectedGroups.Contains(group))
+            .ToList();
+
+        if (missingGroups.Count > 0)
+        {
+            throw new InvalidOperationException(
+                $"The selected Bundle ID is missing App Group assignments used by the existing profile: {string.Join(", ", missingGroups)}. " +
+                "Assign the required App Group in Apple Developer → Identifiers before regenerating. " +
+                "The existing profile was not deleted.");
+        }
+    }
+
+    private async Task EnsureProfileAppGroupsAsync(
+        string profileId,
+        IReadOnlyList<string> expectedAppGroups)
+    {
+        var content = await DownloadProfileAsync(profileId);
+        if (content.Length == 0)
+            throw new InvalidOperationException("The regenerated profile content is empty.");
+
+        var profile = await ProvisioningProfiles.ParseAsync(content).ConfigureAwait(false);
+        EnsureAppGroupsPreserved(
+            new Dictionary<string, object>
+            {
+                ["com.apple.security.application-groups"] = expectedAppGroups.ToArray()
+            },
+            profile.Entitlements);
+    }
+
+    private async Task TryDeleteValidationProfileAsync(string profileId)
+    {
+        try
+        {
+            await DeleteProfileAsync(profileId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning($"Could not delete temporary validation profile '{profileId}': {ex.Message}");
+        }
+    }
+
+    private static IReadOnlyList<string> GetAppGroups(
+        IReadOnlyDictionary<string, object> entitlements)
+    {
+        if (!entitlements.TryGetValue("com.apple.security.application-groups", out var value))
+            return [];
+
+        return value switch
+        {
+            string text when !string.IsNullOrWhiteSpace(text) => [text],
+            IEnumerable<object> values => values
+                .OfType<string>()
+                .Where(item => !string.IsNullOrWhiteSpace(item))
+                .ToList(),
+            _ => []
+        };
+    }
+
     public async Task<byte[]> DownloadProfileAsync(string id)
     {
         _logger.LogInformation($"Downloading profile: {id}");
@@ -732,21 +878,24 @@ public class AppleConnectService : IAppleConnectService
                 throw new InvalidOperationException("Profile content is empty");
             }
 
-            var profilesDir = GetProvisioningProfilesDirectory();
-            if (!Directory.Exists(profilesDir))
+            var profile = await ProvisioningProfiles.ParseAsync(content).ConfigureAwait(false);
+            var extension = profile.Platform.Any(platform =>
+                string.Equals(platform, "MacOS", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(platform, "OSX", StringComparison.OrdinalIgnoreCase))
+                ? "provisionprofile"
+                : "mobileprovision";
+            var directories = await GetProvisioningProfilesDirectoriesAsync().ConfigureAwait(false);
+            var installedPaths = new List<string>();
+
+            foreach (var directory in directories)
             {
-                Directory.CreateDirectory(profilesDir);
+                var filePath = Path.Combine(directory, $"{profile.Uuid}.{extension}");
+                await WriteFileAtomicallyAsync(filePath, content).ConfigureAwait(false);
+                installedPaths.Add(filePath);
+                _logger.LogInformation($"Profile installed to: {filePath}");
             }
 
-            // Parse the profile to get UUID for filename
-            var uuid = ExtractProfileUuid(content);
-            var fileName = $"{uuid}.mobileprovision";
-            var filePath = Path.Combine(profilesDir, fileName);
-
-            await File.WriteAllBytesAsync(filePath, content);
-            _logger.LogInformation($"Profile installed to: {filePath}");
-
-            return filePath;
+            return installedPaths[0];
         }
         catch (Exception ex)
         {
@@ -782,40 +931,101 @@ public class AppleConnectService : IAppleConnectService
         return installed;
     }
 
-    private static string GetProvisioningProfilesDirectory()
+    public async Task<IReadOnlyList<string>> GetProvisioningProfilesDirectoriesAsync()
     {
-        // macOS: ~/Library/MobileDevice/Provisioning Profiles
-        // Windows: Not typically used, but we can use a similar path
-        if (OperatingSystem.IsMacOS() || OperatingSystem.IsMacCatalyst())
+        var autoDirectory = (await ProvisioningProfiles.GetDirectory().ConfigureAwait(false)).FullName;
+        var preference = ProvisioningProfilesDirectoryOptions.Auto;
+
+        try
         {
-            return Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-                "Library", "MobileDevice", "Provisioning Profiles");
+            var settings = await _settingsService.GetSettingsAsync().ConfigureAwait(false);
+            preference = settings.Preferences.ProvisioningProfilesDirectory;
         }
-        
-        // Fallback for other platforms
-        return Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "MobileDevice", "Provisioning Profiles");
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                $"Failed to read the provisioning profiles directory preference; using Auto: {ex.Message}");
+        }
+
+        return ResolveProvisioningProfilesDirectories(
+            preference,
+            autoDirectory,
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            OperatingSystem.IsMacOS() || OperatingSystem.IsMacCatalyst());
     }
 
-    private static string ExtractProfileUuid(byte[] content)
+    public async Task<IReadOnlyList<string>> FindInstalledProfilePathsAsync(string uuid)
     {
-        // The UUID is in the plist content of the profile
-        // Look for <key>UUID</key><string>...</string>
-        var text = System.Text.Encoding.UTF8.GetString(content);
-        var uuidKeyIndex = text.IndexOf("<key>UUID</key>");
-        if (uuidKeyIndex >= 0)
+        ArgumentException.ThrowIfNullOrWhiteSpace(uuid);
+
+        var directories = await GetProvisioningProfilesDirectoriesAsync().ConfigureAwait(false);
+        var paths = new List<string>();
+
+        foreach (var directory in directories)
         {
-            var stringStart = text.IndexOf("<string>", uuidKeyIndex);
-            var stringEnd = text.IndexOf("</string>", stringStart);
-            if (stringStart >= 0 && stringEnd > stringStart)
+            foreach (var extension in new[] { "mobileprovision", "provisionprofile" })
             {
-                return text.Substring(stringStart + 8, stringEnd - stringStart - 8);
+                var path = Path.Combine(directory, $"{uuid}.{extension}");
+                if (File.Exists(path))
+                    paths.Add(path);
             }
         }
-        
-        // Fallback to a generated UUID
-        return Guid.NewGuid().ToString("D").ToUpperInvariant();
+
+        return paths;
+    }
+
+    internal static IReadOnlyList<string> ResolveProvisioningProfilesDirectories(
+        string? preference,
+        string autoDirectory,
+        string userProfileDirectory,
+        bool isApplePlatform)
+    {
+        if (!isApplePlatform)
+            return [autoDirectory];
+
+        var xcode16Directory = Path.Combine(
+            userProfileDirectory,
+            "Library", "Developer", "Xcode", "UserData", "Provisioning Profiles");
+        var legacyDirectory = Path.Combine(
+            userProfileDirectory,
+            "Library", "MobileDevice", "Provisioning Profiles");
+
+        return preference switch
+        {
+            ProvisioningProfilesDirectoryOptions.Xcode16AndLater => [xcode16Directory],
+            ProvisioningProfilesDirectoryOptions.Xcode15AndEarlier => [legacyDirectory],
+            ProvisioningProfilesDirectoryOptions.Both => [xcode16Directory, legacyDirectory],
+            _ => [autoDirectory]
+        };
+    }
+
+    private static async Task WriteFileAtomicallyAsync(string path, byte[] content)
+    {
+        var directory = Path.GetDirectoryName(path)
+            ?? throw new InvalidOperationException($"Could not determine the directory for '{path}'.");
+        Directory.CreateDirectory(directory);
+
+        var tempPath = Path.Combine(directory, $".{Path.GetFileName(path)}.{Guid.NewGuid():N}.tmp");
+        try
+        {
+            await using (var stream = new FileStream(
+                tempPath,
+                FileMode.CreateNew,
+                FileAccess.Write,
+                FileShare.None,
+                bufferSize: 81920,
+                FileOptions.Asynchronous | FileOptions.WriteThrough))
+            {
+                await stream.WriteAsync(content).ConfigureAwait(false);
+                await stream.FlushAsync().ConfigureAwait(false);
+            }
+
+            File.Move(tempPath, path, overwrite: true);
+        }
+        finally
+        {
+            if (File.Exists(tempPath))
+                File.Delete(tempPath);
+        }
     }
 }

--- a/src/MauiSherpa.Core/Services/ProvisioningProfileCleanupAnalyzer.cs
+++ b/src/MauiSherpa.Core/Services/ProvisioningProfileCleanupAnalyzer.cs
@@ -1,0 +1,305 @@
+using System.Security.Cryptography.X509Certificates;
+using AppleDev;
+using MauiSherpa.Core.Interfaces;
+
+namespace MauiSherpa.Core.Services;
+
+public static class ProvisioningProfileCleanupAnalyzer
+{
+    public static async Task<IReadOnlyList<InstalledProvisioningProfileAssessment>> AnalyzeAsync(
+        IEnumerable<string> directories,
+        IEnumerable<string?> installedCertificateSerialNumbers,
+        DateTimeOffset? now = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(directories);
+        ArgumentNullException.ThrowIfNull(installedCertificateSerialNumbers);
+
+        var currentTime = now ?? DateTimeOffset.UtcNow;
+        var installedSerials = installedCertificateSerialNumbers
+            .Where(serial => !string.IsNullOrWhiteSpace(serial))
+            .Select(serial => NormalizeSerialNumber(serial!))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var assessments = new List<InstalledProvisioningProfileAssessment>();
+
+        foreach (var directory in directories.Distinct(GetPathComparer()))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!Directory.Exists(directory))
+                continue;
+
+            var paths = Directory.EnumerateFiles(directory, "*", SearchOption.TopDirectoryOnly)
+                .Where(IsProvisioningProfileFile)
+                .OrderBy(path => path, GetPathComparer());
+
+            foreach (var path in paths)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                assessments.Add(await AnalyzeFileAsync(
+                    path,
+                    installedSerials,
+                    currentTime,
+                    cancellationToken).ConfigureAwait(false));
+            }
+        }
+
+        MarkOlderVersions(assessments);
+
+        return assessments
+            .OrderByDescending(item => item.RecommendedForDeletion)
+            .ThenBy(item => item.Name, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(item => item.CreationDate)
+            .ToList();
+    }
+
+    public static Task<int> DeleteAsync(
+        IEnumerable<string> paths,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(paths);
+
+        var deleted = 0;
+        foreach (var path in paths.Distinct(GetPathComparer()))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!IsProvisioningProfileFile(path))
+                throw new InvalidOperationException($"Refusing to delete non-profile file '{path}'.");
+
+            if (!File.Exists(path))
+                continue;
+
+            File.Delete(path);
+            deleted++;
+        }
+
+        return Task.FromResult(deleted);
+    }
+
+    private static async Task<InstalledProvisioningProfileAssessment> AnalyzeFileAsync(
+        string path,
+        IReadOnlySet<string> installedSerials,
+        DateTimeOffset now,
+        CancellationToken cancellationToken)
+    {
+        var fileName = Path.GetFileName(path);
+        var location = GetLocationLabel(path);
+
+        try
+        {
+            var content = await File.ReadAllBytesAsync(path, cancellationToken).ConfigureAwait(false);
+            var profile = await ProvisioningProfiles.ParseAsync(content).ConfigureAwait(false);
+            var provisionsAllDevices = ProvisioningProfileMetadata.ProvisionsAllDevices(content);
+            var certificateSerials = GetCertificateSerialNumbers(profile);
+            var hasMatchingCertificate = certificateSerials.Any(installedSerials.Contains);
+            var isExpired = profile.ExpirationDate <= now;
+            var reasons = new List<string>();
+
+            if (isExpired)
+                reasons.Add($"Expired {profile.ExpirationDate:MMM d, yyyy}");
+            if (!hasMatchingCertificate)
+                reasons.Add("No matching signing certificate with a private key is installed");
+
+            return new InstalledProvisioningProfileAssessment(
+                path,
+                fileName,
+                profile.Name ?? Path.GetFileNameWithoutExtension(path),
+                profile.Uuid,
+                GetBundleIdentifier(profile),
+                profile.TeamIdentifier.FirstOrDefault(),
+                GetProfileKind(profile, provisionsAllDevices),
+                location,
+                profile.CreationDate,
+                profile.ExpirationDate,
+                certificateSerials.Count,
+                hasMatchingCertificate,
+                isExpired,
+                IsOlderVersion: false,
+                IsReadable: true,
+                RecommendedForDeletion: reasons.Count > 0,
+                Reasons: reasons);
+        }
+        catch (Exception ex)
+        {
+            return new InstalledProvisioningProfileAssessment(
+                path,
+                fileName,
+                Path.GetFileNameWithoutExtension(path),
+                Uuid: null,
+                BundleId: null,
+                TeamIdentifier: null,
+                ProfileKind: "Unknown",
+                location,
+                CreationDate: null,
+                ExpirationDate: null,
+                CertificateCount: 0,
+                HasMatchingCertificate: false,
+                IsExpired: false,
+                IsOlderVersion: false,
+                IsReadable: false,
+                RecommendedForDeletion: true,
+                Reasons: [$"Profile cannot be read: {ex.Message}"]);
+        }
+    }
+
+    private static void MarkOlderVersions(List<InstalledProvisioningProfileAssessment> assessments)
+    {
+        var groups = assessments
+            .Where(item => item.IsReadable && !string.IsNullOrWhiteSpace(item.BundleId))
+            .GroupBy(
+                item => $"{item.TeamIdentifier}\0{item.BundleId}\0{item.ProfileKind}\0{item.Name}",
+                StringComparer.OrdinalIgnoreCase);
+
+        foreach (var group in groups)
+        {
+            var distinctVersions = group
+                .GroupBy(item => item.Uuid ?? item.Path, StringComparer.OrdinalIgnoreCase)
+                .Select(items => items.First())
+                .ToList();
+            if (distinctVersions.Count < 2)
+                continue;
+
+            var keeper = distinctVersions
+                .OrderByDescending(item => !item.IsExpired && item.HasMatchingCertificate)
+                .ThenByDescending(item => item.CreationDate)
+                .ThenByDescending(item => item.ExpirationDate)
+                .First();
+
+            foreach (var older in distinctVersions.Where(item =>
+                         !string.Equals(item.Uuid, keeper.Uuid, StringComparison.OrdinalIgnoreCase)))
+            {
+                for (var index = 0; index < assessments.Count; index++)
+                {
+                    var item = assessments[index];
+                    if (!string.Equals(item.Uuid, older.Uuid, StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    var reasons = item.Reasons.ToList();
+                    reasons.Add($"Older {item.ProfileKind.ToLowerInvariant()} profile for this app");
+                    assessments[index] = item with
+                    {
+                        IsOlderVersion = true,
+                        RecommendedForDeletion = true,
+                        Reasons = reasons
+                    };
+                }
+            }
+        }
+    }
+
+    private static IReadOnlyList<string> GetCertificateSerialNumbers(ProvisioningProfileInfo profile)
+    {
+        var serials = new List<string>();
+        foreach (var certificateData in profile.DeveloperCertificates)
+        {
+            try
+            {
+                using var certificate = X509CertificateLoader.LoadCertificate(certificateData);
+                serials.Add(NormalizeSerialNumber(certificate.SerialNumber));
+            }
+            catch
+            {
+                // A malformed embedded certificate contributes no usable local identity match.
+            }
+        }
+
+        return serials;
+    }
+
+    private static string? GetBundleIdentifier(ProvisioningProfileInfo profile)
+    {
+        if (!TryGetEntitlementString(profile, "application-identifier", out var applicationIdentifier) &&
+            !TryGetEntitlementString(profile, "com.apple.application-identifier", out applicationIdentifier))
+        {
+            return null;
+        }
+
+        var teamPrefix = profile.ApplicationIdentifierPrefix.FirstOrDefault();
+        if (!string.IsNullOrWhiteSpace(teamPrefix) &&
+            applicationIdentifier.StartsWith($"{teamPrefix}.", StringComparison.OrdinalIgnoreCase))
+        {
+            return applicationIdentifier[(teamPrefix.Length + 1)..];
+        }
+
+        var separator = applicationIdentifier.IndexOf('.');
+        return separator >= 0 ? applicationIdentifier[(separator + 1)..] : applicationIdentifier;
+    }
+
+    private static string GetProfileKind(
+        ProvisioningProfileInfo profile,
+        bool provisionsAllDevices)
+    {
+        var platform = profile.Platform.FirstOrDefault()?.ToUpperInvariant() switch
+        {
+            "OSX" or "MACOS" or "MAC_OS" => "macOS",
+            "TVOS" => "tvOS",
+            _ => "iOS"
+        };
+
+        if (profile.Entitlements.TryGetValue("get-task-allow", out var getTaskAllow) &&
+            getTaskAllow is true)
+        {
+            return $"{platform} Development";
+        }
+
+        return profile.ProvisionedDevices.Length > 0
+            ? $"{platform} Ad Hoc"
+            : provisionsAllDevices
+                ? $"{platform} Direct"
+                : $"{platform} App Store";
+    }
+
+    private static bool TryGetEntitlementString(
+        ProvisioningProfileInfo profile,
+        string key,
+        out string value)
+    {
+        if (profile.Entitlements.TryGetValue(key, out var entitlement) &&
+            entitlement is string text &&
+            !string.IsNullOrWhiteSpace(text))
+        {
+            value = text;
+            return true;
+        }
+
+        value = string.Empty;
+        return false;
+    }
+
+    private static string NormalizeSerialNumber(string serialNumber)
+    {
+        var normalized = serialNumber.Trim().TrimStart('0');
+        return normalized.Length == 0 ? "0" : normalized;
+    }
+
+    private static bool IsProvisioningProfileFile(string path)
+    {
+        var extension = Path.GetExtension(path);
+        return string.Equals(extension, ".mobileprovision", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(extension, ".provisionprofile", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string GetLocationLabel(string path)
+    {
+        var directory = Path.GetDirectoryName(path) ?? string.Empty;
+        if (directory.Contains(
+                Path.Combine("Developer", "Xcode", "UserData", "Provisioning Profiles"),
+                StringComparison.OrdinalIgnoreCase))
+        {
+            return "Xcode 16+";
+        }
+
+        if (directory.Contains(
+                Path.Combine("MobileDevice", "Provisioning Profiles"),
+                StringComparison.OrdinalIgnoreCase))
+        {
+            return "Xcode 15 and earlier";
+        }
+
+        return directory;
+    }
+
+    private static StringComparer GetPathComparer() =>
+        OperatingSystem.IsWindows() || OperatingSystem.IsMacOS() || OperatingSystem.IsMacCatalyst()
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal;
+}

--- a/src/MauiSherpa.Core/Services/ProvisioningProfileDownloadManager.cs
+++ b/src/MauiSherpa.Core/Services/ProvisioningProfileDownloadManager.cs
@@ -1,0 +1,345 @@
+using AppleDev;
+using MauiSherpa.Core.Interfaces;
+using System.Security.Cryptography;
+
+namespace MauiSherpa.Core.Services;
+
+public enum ProvisioningProfileDownloadConflict
+{
+    None,
+    ExistingFile,
+    NewerProfile
+}
+
+public sealed record ProvisioningProfileDownloadPlan(
+    string TargetPath,
+    IReadOnlyList<string> AutomaticReplacementPaths,
+    IReadOnlyList<string> ConfirmedReplacementPaths,
+    IReadOnlyDictionary<string, string> ExpectedFileHashes,
+    bool TargetExisted,
+    ProvisioningProfileDownloadConflict Conflict)
+{
+    public bool RequiresConfirmation => Conflict != ProvisioningProfileDownloadConflict.None;
+}
+
+public static class ProvisioningProfileDownloadManager
+{
+    public static async Task<ProvisioningProfileDownloadPlan> PlanAsync(
+        string directory,
+        string fileName,
+        AppleProfile profile,
+        byte[] incomingContent,
+        DateTimeOffset? now = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(directory);
+        ArgumentException.ThrowIfNullOrWhiteSpace(fileName);
+        ArgumentNullException.ThrowIfNull(profile);
+        ArgumentNullException.ThrowIfNull(incomingContent);
+
+        var targetPath = Path.Combine(directory, fileName);
+        if (!Directory.Exists(directory))
+        {
+            return new ProvisioningProfileDownloadPlan(
+                targetPath,
+                [],
+                [],
+                new Dictionary<string, string>(GetPathComparer()),
+                TargetExisted: false,
+                Conflict: ProvisioningProfileDownloadConflict.None);
+        }
+
+        var incoming = await ProvisioningProfiles.ParseAsync(incomingContent).ConfigureAwait(false);
+        var incomingKind = GetProfileKind(
+            incoming,
+            ProvisioningProfileMetadata.ProvisionsAllDevices(incomingContent));
+        var incomingPlatform = GetPlatform(incoming);
+        var candidates = GetNamedCopies(directory, fileName);
+        var automaticReplacements = new List<string>();
+        var confirmedReplacements = new List<string>();
+        var expectedFileHashes = new Dictionary<string, string>(GetPathComparer());
+        var hasNewerProfile = false;
+        var currentTime = now ?? DateTimeOffset.UtcNow;
+
+        foreach (var candidatePath in candidates)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var existingContent = await File.ReadAllBytesAsync(candidatePath, cancellationToken).ConfigureAwait(false);
+            expectedFileHashes[candidatePath] = Convert.ToHexString(SHA256.HashData(existingContent));
+
+            ProvisioningProfileInfo? existing = null;
+            var existingProvisionsAllDevices = false;
+            try
+            {
+                existing = await ProvisioningProfiles.ParseAsync(existingContent).ConfigureAwait(false);
+                existingProvisionsAllDevices = ProvisioningProfileMetadata.ProvisionsAllDevices(existingContent);
+            }
+            catch
+            {
+                // An unreadable exact-name collision must be confirmed before it is overwritten.
+            }
+
+            if (existing is not null &&
+                IsSameLogicalProfile(
+                    profile,
+                    incoming,
+                    incomingKind,
+                    incomingPlatform,
+                    existing,
+                    existingProvisionsAllDevices))
+            {
+                var isSameUuid = string.Equals(existing.Uuid, incoming.Uuid, StringComparison.OrdinalIgnoreCase);
+                var isExpired = existing.ExpirationDate <= currentTime;
+                var isOlder = existing.CreationDate <= incoming.CreationDate;
+
+                if (isSameUuid || isExpired || isOlder)
+                {
+                    automaticReplacements.Add(candidatePath);
+                }
+                else
+                {
+                    hasNewerProfile = true;
+                    confirmedReplacements.Add(candidatePath);
+                }
+            }
+            else if (string.Equals(candidatePath, targetPath, PathComparison))
+            {
+                confirmedReplacements.Add(candidatePath);
+            }
+        }
+
+        var conflict = hasNewerProfile
+            ? ProvisioningProfileDownloadConflict.NewerProfile
+            : confirmedReplacements.Count > 0
+                ? ProvisioningProfileDownloadConflict.ExistingFile
+                : ProvisioningProfileDownloadConflict.None;
+
+        return new ProvisioningProfileDownloadPlan(
+            targetPath,
+            automaticReplacements,
+            confirmedReplacements,
+            expectedFileHashes,
+            expectedFileHashes.Keys.Any(path =>
+                string.Equals(path, targetPath, PathComparison)),
+            conflict);
+    }
+
+    public static async Task SaveAsync(
+        ProvisioningProfileDownloadPlan plan,
+        byte[] content,
+        bool replaceConfirmedConflicts,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+        ArgumentNullException.ThrowIfNull(content);
+
+        if (plan.RequiresConfirmation && !replaceConfirmedConflicts)
+            throw new InvalidOperationException("The existing provisioning profile must be confirmed before replacement.");
+
+        var directory = Path.GetDirectoryName(plan.TargetPath);
+        if (!string.IsNullOrWhiteSpace(directory))
+            Directory.CreateDirectory(directory);
+
+        await ValidatePlanAsync(plan, cancellationToken).ConfigureAwait(false);
+
+        var tempPath = Path.Combine(
+            directory!,
+            $".{Path.GetFileName(plan.TargetPath)}.{Guid.NewGuid():N}.tmp");
+        try
+        {
+            await using (var stream = new FileStream(
+                tempPath,
+                FileMode.CreateNew,
+                FileAccess.Write,
+                FileShare.None,
+                bufferSize: 81920,
+                FileOptions.Asynchronous | FileOptions.WriteThrough))
+            {
+                await stream.WriteAsync(content, cancellationToken).ConfigureAwait(false);
+                await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            File.Move(tempPath, plan.TargetPath, overwrite: true);
+
+            foreach (var path in plan.AutomaticReplacementPaths
+                         .Concat(plan.ConfirmedReplacementPaths)
+                         .Distinct(StringComparer.OrdinalIgnoreCase))
+            {
+                if (!string.Equals(path, plan.TargetPath, PathComparison) &&
+                    File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            }
+        }
+        finally
+        {
+            if (File.Exists(tempPath))
+                File.Delete(tempPath);
+        }
+    }
+
+    private static IReadOnlyList<string> GetNamedCopies(string directory, string fileName)
+    {
+        var extension = Path.GetExtension(fileName);
+        var baseName = Path.GetFileNameWithoutExtension(fileName);
+
+        return Directory.EnumerateFiles(directory, "*", SearchOption.TopDirectoryOnly)
+            .Where(path => string.Equals(
+                Path.GetExtension(path),
+                extension,
+                StringComparison.OrdinalIgnoreCase))
+            .Where(path => IsNamedCopy(Path.GetFileNameWithoutExtension(path), baseName))
+            .ToList();
+    }
+
+    private static bool IsNamedCopy(string candidateName, string baseName)
+    {
+        if (string.Equals(candidateName, baseName, StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        if (!candidateName.StartsWith($"{baseName} (", StringComparison.OrdinalIgnoreCase) ||
+            !candidateName.EndsWith(')'))
+        {
+            return false;
+        }
+
+        var suffix = candidateName.AsSpan(baseName.Length + 2, candidateName.Length - baseName.Length - 3);
+        return int.TryParse(suffix, out var copyNumber) && copyNumber > 0;
+    }
+
+    private static async Task ValidatePlanAsync(
+        ProvisioningProfileDownloadPlan plan,
+        CancellationToken cancellationToken)
+    {
+        if (!plan.TargetExisted && File.Exists(plan.TargetPath))
+        {
+            throw new IOException(
+                $"'{plan.TargetPath}' was created after the replacement review. Download again to review the new conflict.");
+        }
+
+        foreach (var (path, expectedHash) in plan.ExpectedFileHashes)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!File.Exists(path))
+                continue;
+
+            var content = await File.ReadAllBytesAsync(path, cancellationToken).ConfigureAwait(false);
+            var currentHash = Convert.ToHexString(SHA256.HashData(content));
+            if (!string.Equals(currentHash, expectedHash, StringComparison.Ordinal))
+            {
+                throw new IOException(
+                    $"'{path}' changed after the replacement review. Download again to review the updated file.");
+            }
+        }
+    }
+
+    private static StringComparison PathComparison =>
+        OperatingSystem.IsWindows() || OperatingSystem.IsMacOS() || OperatingSystem.IsMacCatalyst()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+    private static StringComparer GetPathComparer() =>
+        PathComparison == StringComparison.OrdinalIgnoreCase
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal;
+
+    private static bool IsSameLogicalProfile(
+        AppleProfile profile,
+        ProvisioningProfileInfo incoming,
+        string incomingKind,
+        string incomingPlatform,
+        ProvisioningProfileInfo existing,
+        bool existingProvisionsAllDevices)
+    {
+        if (!string.IsNullOrWhiteSpace(incoming.Uuid) &&
+            string.Equals(incoming.Uuid, existing.Uuid, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (!string.Equals(incoming.Name, existing.Name, StringComparison.OrdinalIgnoreCase))
+            return false;
+        if (!string.Equals(
+                incomingKind,
+                GetProfileKind(existing, existingProvisionsAllDevices),
+                StringComparison.OrdinalIgnoreCase))
+            return false;
+        if (!string.Equals(incomingPlatform, GetPlatform(existing), StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var expectedBundleId = profile.BundleId;
+        var incomingBundleId = GetBundleIdentifier(incoming);
+        var existingBundleId = GetBundleIdentifier(existing);
+
+        if (!string.IsNullOrWhiteSpace(expectedBundleId))
+        {
+            return string.Equals(incomingBundleId, expectedBundleId, StringComparison.OrdinalIgnoreCase) &&
+                   string.Equals(existingBundleId, expectedBundleId, StringComparison.OrdinalIgnoreCase);
+        }
+
+        return !string.IsNullOrWhiteSpace(incomingBundleId) &&
+               string.Equals(incomingBundleId, existingBundleId, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string GetProfileKind(
+        ProvisioningProfileInfo profile,
+        bool provisionsAllDevices)
+    {
+        if (profile.Entitlements.TryGetValue("get-task-allow", out var getTaskAllow) &&
+            getTaskAllow is true)
+        {
+            return "Development";
+        }
+
+        if (profile.ProvisionedDevices.Length > 0)
+            return "Ad Hoc";
+
+        return provisionsAllDevices ? "Direct" : "App Store";
+    }
+
+    private static string GetPlatform(ProvisioningProfileInfo profile) =>
+        profile.Platform.FirstOrDefault()?.ToUpperInvariant() switch
+        {
+            "OSX" or "MACOS" or "MAC_OS" => "macOS",
+            "TVOS" => "tvOS",
+            _ => "iOS"
+        };
+
+    private static string? GetBundleIdentifier(ProvisioningProfileInfo profile)
+    {
+        if (!TryGetEntitlementString(profile, "application-identifier", out var applicationIdentifier) &&
+            !TryGetEntitlementString(profile, "com.apple.application-identifier", out applicationIdentifier))
+        {
+            return null;
+        }
+
+        var teamPrefix = profile.ApplicationIdentifierPrefix.FirstOrDefault();
+        if (!string.IsNullOrWhiteSpace(teamPrefix) &&
+            applicationIdentifier.StartsWith($"{teamPrefix}.", StringComparison.OrdinalIgnoreCase))
+        {
+            return applicationIdentifier[(teamPrefix.Length + 1)..];
+        }
+
+        var separator = applicationIdentifier.IndexOf('.');
+        return separator >= 0 ? applicationIdentifier[(separator + 1)..] : applicationIdentifier;
+    }
+
+    private static bool TryGetEntitlementString(
+        ProvisioningProfileInfo profile,
+        string key,
+        out string value)
+    {
+        if (profile.Entitlements.TryGetValue(key, out var entitlement) &&
+            entitlement is string stringValue &&
+            !string.IsNullOrWhiteSpace(stringValue))
+        {
+            value = stringValue;
+            return true;
+        }
+
+        value = string.Empty;
+        return false;
+    }
+}

--- a/src/MauiSherpa.Core/Services/ProvisioningProfileMetadata.cs
+++ b/src/MauiSherpa.Core/Services/ProvisioningProfileMetadata.cs
@@ -1,0 +1,18 @@
+using System.Security.Cryptography.Pkcs;
+using Claunia.PropertyList;
+
+namespace MauiSherpa.Core.Services;
+
+internal static class ProvisioningProfileMetadata
+{
+    public static bool ProvisionsAllDevices(byte[] content)
+    {
+        var signedCms = new SignedCms();
+        signedCms.Decode(content);
+
+        var propertyList = PropertyListParser.Parse(signedCms.ContentInfo.Content) as NSDictionary;
+        return propertyList?.TryGetValue("ProvisionsAllDevices", out var value) == true &&
+               value is NSNumber number &&
+               number.ToBool();
+    }
+}

--- a/src/MauiSherpa.MacOS/BlazorContentPage.cs
+++ b/src/MauiSherpa.MacOS/BlazorContentPage.cs
@@ -1077,6 +1077,8 @@ public class BlazorContentPage : ContentPage
                 ("up-folder", "Up Folder", "arrow.up"),
                 ("import", "Import", "square.and.arrow.down"),
                 ("open-project", "Open Project Folder", "folder"),
+                ("profiles-folder", "Profiles Folder", "folder"),
+                ("cleanup", "Clean Up", "trash"),
                 ("install-missing", "Install Missing", "arrow.down.circle"),
                 ("save", "Save", "checkmark"),
                 ("reset", "Reset to Defaults", "trash"),

--- a/src/MauiSherpa/Components/EditProfileDialog.razor
+++ b/src/MauiSherpa/Components/EditProfileDialog.razor
@@ -789,11 +789,6 @@
         errorMessage = "";
         try
         {
-            // Delete the old profile
-            await AppleService.DeleteProfileAsync(Profile.Id);
-            Logger.LogInformation($"Deleted old profile: {Profile.Name}");
-
-            // Create the new profile
             var request = new AppleProfileCreateRequest(
                 Profile.Name,
                 Profile.ProfileType,
@@ -801,7 +796,7 @@
                 selectedCertificateIds.ToList(),
                 RequiresDevices ? selectedDeviceIds.ToList() : null);
 
-            var newProfile = await AppleService.CreateProfileAsync(request);
+            var newProfile = await AppleService.RegenerateProfileAsync(Profile.Id, request);
             
             // Invalidate profiles cache after regeneration
             if (IdentityState.SelectedIdentity != null)

--- a/src/MauiSherpa/Pages/Forms/HybridFormPage.cs
+++ b/src/MauiSherpa/Pages/Forms/HybridFormPage.cs
@@ -40,6 +40,9 @@ public abstract class HybridFormPage<TResult> : ContentPage, IFormPage<TResult>,
     /// <summary>Height of the native footer actions.</summary>
     protected virtual double ActionButtonHeight => 30;
 
+    /// <summary>Whether the native submit button performs a destructive action.</summary>
+    protected virtual bool IsDestructiveSubmit => false;
+
     /// <summary>Blazor route for the form content (e.g. "/modal/edit-secret").</summary>
     protected abstract string BlazorRoute { get; }
 
@@ -179,7 +182,9 @@ public abstract class HybridFormPage<TResult> : ContentPage, IFormPage<TResult>,
             HeightRequest = ActionButtonHeight,
             IsEnabled = false,
         };
-        _submitButton.SetDynamicResource(Button.BackgroundColorProperty, FormTheme.AccentPrimary);
+        _submitButton.SetDynamicResource(
+            Button.BackgroundColorProperty,
+            IsDestructiveSubmit ? FormTheme.AccentDanger : FormTheme.AccentPrimary);
         _submitButton.Clicked += OnSubmitClicked;
 
         var footerLayout = new HorizontalStackLayout

--- a/src/MauiSherpa/Pages/Modals/EditProfileModal.razor
+++ b/src/MauiSherpa/Pages/Modals/EditProfileModal.razor
@@ -671,9 +671,6 @@
 
         try
         {
-            await AppleService.DeleteProfileAsync(Profile.Id);
-            Logger.LogInformation($"Deleted old profile: {Profile.Name}");
-
             var request = new AppleProfileCreateRequest(
                 Profile.Name,
                 Profile.ProfileType,
@@ -681,7 +678,7 @@
                 selectedCertificateIds.ToList(),
                 RequiresDevices ? selectedDeviceIds.ToList() : null);
 
-            var newProfile = await AppleService.CreateProfileAsync(request);
+            var newProfile = await AppleService.RegenerateProfileAsync(Profile.Id, request);
             
             if (IdentityState.SelectedIdentity != null)
                 await Mediator.FlushStores($"apple:profiles:{IdentityState.SelectedIdentity.Id}");

--- a/src/MauiSherpa/Pages/Modals/ProvisioningProfileCleanupModal.razor
+++ b/src/MauiSherpa/Pages/Modals/ProvisioningProfileCleanupModal.razor
@@ -1,0 +1,544 @@
+@page "/modal/provisioning-profile-cleanup"
+@using MauiSherpa.Core.Interfaces
+@using MauiSherpa.Core.Services
+@using MauiSherpa.Pages.Forms
+@inject HybridFormBridgeHolder BridgeHolder
+@inject IAppleConnectService AppleService
+@inject ILocalCertificateService LocalCertificateService
+@inject IAlertService AlertService
+@inject IFileSystemService FileSystem
+@implements IDisposable
+
+<div class="cleanup-content">
+    @if (isLoading)
+    {
+        <div class="cleanup-state" role="status">
+            <i class="fas fa-spinner fa-spin" aria-hidden="true"></i>
+            <strong>Inspecting installed profiles</strong>
+            <span>Checking expiration, duplicate versions, and local signing certificates...</span>
+        </div>
+    }
+    else if (!string.IsNullOrWhiteSpace(errorMessage))
+    {
+        <div class="cleanup-state cleanup-error" role="alert">
+            <i class="fas fa-exclamation-circle" aria-hidden="true"></i>
+            <strong>Could not inspect profiles</strong>
+            <span>@errorMessage</span>
+            <button class="btn btn-secondary" @onclick="LoadAsync">Try Again</button>
+        </div>
+    }
+    else if (profiles.Count == 0)
+    {
+        <div class="cleanup-state">
+            <i class="fas fa-folder-open" aria-hidden="true"></i>
+            <strong>No installed profiles found</strong>
+            <span>The configured provisioning profile folders are empty.</span>
+        </div>
+    }
+    else
+    {
+        <div class="cleanup-summary" aria-label="Provisioning profile cleanup summary">
+            <div class="summary-card">
+                <span class="summary-value">@profiles.Count</span>
+                <span class="summary-label">Installed</span>
+            </div>
+            <div class="summary-card recommended">
+                <span class="summary-value">@profiles.Count(profile => profile.RecommendedForDeletion)</span>
+                <span class="summary-label">Recommended</span>
+            </div>
+            <div class="summary-card healthy">
+                <span class="summary-value">@profiles.Count(profile => !profile.RecommendedForDeletion)</span>
+                <span class="summary-label">Healthy</span>
+            </div>
+        </div>
+
+        <div class="selection-toolbar">
+            <span>@selectedPaths.Count selected</span>
+            <div class="selection-actions">
+                <button class="text-button" @onclick="SelectRecommended">Select Recommended</button>
+                <button class="text-button" @onclick="ClearSelection" disabled="@(selectedPaths.Count == 0)">Clear</button>
+            </div>
+        </div>
+
+        <div class="profile-cleanup-list">
+            @foreach (var profile in profiles)
+            {
+                var isSelected = selectedPaths.Contains(profile.Path);
+                <div class="cleanup-profile-card @(isSelected ? "selected" : "") @(!profile.RecommendedForDeletion ? "healthy" : "")">
+                    <label class="selection-checkbox">
+                        <input type="checkbox"
+                               checked="@isSelected"
+                               @onchange="eventArgs => SetSelected(profile.Path, eventArgs.Value is true)"
+                               aria-label="@($"Select {profile.Name} for deletion")" />
+                    </label>
+                    <div class="profile-card-content">
+                        <div class="profile-card-header">
+                            <div class="profile-title-group">
+                                <strong>@profile.Name</strong>
+                                <span class="kind-badge">@profile.ProfileKind</span>
+                                <span class="location-badge">@profile.Location</span>
+                            </div>
+                            @if (profile.RecommendedForDeletion)
+                            {
+                                <span class="health-badge warning">
+                                    <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
+                                    Review
+                                </span>
+                            }
+                            else
+                            {
+                                <span class="health-badge good">
+                                    <i class="fas fa-check-circle" aria-hidden="true"></i>
+                                    Good
+                                </span>
+                            }
+                        </div>
+
+                        <div class="profile-meta">
+                            <span class="mono">@(profile.BundleId ?? "Unknown bundle ID")</span>
+                            @if (profile.ExpirationDate is { } expiration)
+                            {
+                                <span>Expires @expiration.ToString("MMM d, yyyy")</span>
+                            }
+                            <button type="button"
+                                    class="reveal-button"
+                                    @onclick="() => RevealProfile(profile)"
+                                    @onclick:preventDefault
+                                    aria-label="@($"Reveal {profile.Name} in Finder")"
+                                    title="Reveal in Finder">
+                                <i class="fas fa-search" aria-hidden="true"></i>
+                            </button>
+                        </div>
+
+                        @if (profile.Reasons.Count > 0)
+                        {
+                            <div class="reason-list">
+                                @foreach (var reason in profile.Reasons)
+                                {
+                                    <span class="reason">
+                                        <i class="fas fa-circle-info" aria-hidden="true"></i>
+                                        @reason
+                                    </span>
+                                }
+                            </div>
+                        }
+                        else
+                        {
+                            <div class="reason-list">
+                                <span class="reason good">
+                                    <i class="fas fa-shield-alt" aria-hidden="true"></i>
+                                    Active, current, and matched to an installed signing identity
+                                </span>
+                            </div>
+                        }
+                    </div>
+                </div>
+            }
+        </div>
+    }
+</div>
+
+@code {
+    private readonly HashSet<string> selectedPaths =
+        new(OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal);
+    private List<InstalledProvisioningProfileAssessment> profiles = [];
+    private bool isLoading = true;
+    private string? errorMessage;
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (BridgeHolder.Current is { } bridge)
+        {
+            bridge.SubmitRequested += DeleteSelectedAsync;
+            bridge.PreventSubmitClose = true;
+        }
+
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        isLoading = true;
+        errorMessage = null;
+        UpdateActionState();
+
+        try
+        {
+            var directoriesTask = AppleService.GetProvisioningProfilesDirectoriesAsync();
+            var identitiesTask = LocalCertificateService.GetSigningIdentitiesAsync();
+            await Task.WhenAll(directoriesTask, identitiesTask);
+
+            var directories = await directoriesTask;
+            var identities = await identitiesTask;
+            profiles = (await ProvisioningProfileCleanupAnalyzer.AnalyzeAsync(
+                directories,
+                identities.Where(identity => identity.IsValid).Select(identity => identity.SerialNumber)))
+                .ToList();
+            SelectRecommended();
+        }
+        catch (Exception ex)
+        {
+            profiles = [];
+            selectedPaths.Clear();
+            errorMessage = ex.Message;
+        }
+        finally
+        {
+            isLoading = false;
+            UpdateActionState();
+        }
+    }
+
+    private void SelectRecommended()
+    {
+        selectedPaths.Clear();
+        foreach (var profile in profiles.Where(profile => profile.RecommendedForDeletion))
+            selectedPaths.Add(profile.Path);
+        UpdateActionState();
+    }
+
+    private void ClearSelection()
+    {
+        selectedPaths.Clear();
+        UpdateActionState();
+    }
+
+    private void SetSelected(string path, bool selected)
+    {
+        if (selected)
+            selectedPaths.Add(path);
+        else
+            selectedPaths.Remove(path);
+        UpdateActionState();
+    }
+
+    private void UpdateActionState()
+    {
+        BridgeHolder.Current?.SetActionState(
+            enabled: !isLoading && selectedPaths.Count > 0,
+            busy: isLoading,
+            actionText: selectedPaths.Count > 0
+                ? $"Delete Selected ({selectedPaths.Count})"
+                : "Delete Selected");
+    }
+
+    private async Task DeleteSelectedAsync()
+    {
+        var bridge = BridgeHolder.Current;
+        if (bridge is null || selectedPaths.Count == 0)
+            return;
+
+        var confirmed = await AlertService.ShowConfirmAsync(
+            "Delete Provisioning Profiles",
+            $"Permanently delete {selectedPaths.Count} selected local provisioning profile(s)?",
+            "Delete",
+            "Cancel");
+        if (!confirmed)
+            return;
+
+        bridge.SetActionState(
+            enabled: false,
+            busy: true,
+            actionText: "Deleting...");
+
+        try
+        {
+            var deleted = await ProvisioningProfileCleanupAnalyzer.DeleteAsync(selectedPaths);
+            bridge.Result = deleted;
+            bridge.PreventSubmitClose = false;
+        }
+        catch
+        {
+            bridge.SetActionState(
+                enabled: selectedPaths.Count > 0,
+                busy: false,
+                actionText: $"Delete Selected ({selectedPaths.Count})");
+            throw;
+        }
+    }
+
+    private void RevealProfile(InstalledProvisioningProfileAssessment profile)
+    {
+        FileSystem.RevealInFileManager(profile.Path);
+    }
+
+    public void Dispose()
+    {
+        if (BridgeHolder.Current is { } bridge)
+            bridge.SubmitRequested -= DeleteSelectedAsync;
+    }
+}
+
+<style>
+    .cleanup-content {
+        padding: 1rem 1.25rem 1.25rem;
+        color: var(--text-primary);
+    }
+
+    .cleanup-state {
+        min-height: 280px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 0.75rem;
+        text-align: center;
+        color: var(--text-muted);
+    }
+
+    .cleanup-state > i {
+        font-size: 2rem;
+        color: var(--accent-primary);
+    }
+
+    .cleanup-state strong {
+        color: var(--text-primary);
+        font-size: 1rem;
+    }
+
+    .cleanup-error > i {
+        color: var(--accent-danger);
+    }
+
+    .cleanup-summary {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 0.75rem;
+        margin-bottom: 1rem;
+    }
+
+    .summary-card {
+        padding: 0.875rem 1rem;
+        border: 1px solid var(--border-color);
+        border-radius: var(--card-radius);
+        background: var(--card-bg);
+        display: flex;
+        align-items: baseline;
+        gap: 0.5rem;
+    }
+
+    .summary-card.recommended {
+        background: var(--status-warning-bg);
+        border-color: var(--accent-warning);
+    }
+
+    .summary-card.healthy {
+        background: var(--status-success-bg);
+        border-color: var(--accent-success);
+    }
+
+    .summary-value {
+        font-size: 1.35rem;
+        font-weight: 700;
+    }
+
+    .summary-label {
+        color: var(--text-secondary);
+        font-size: 0.8rem;
+        font-weight: 600;
+    }
+
+    .selection-toolbar {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        min-height: 44px;
+        margin-bottom: 0.625rem;
+        color: var(--text-secondary);
+        font-size: 0.8rem;
+    }
+
+    .selection-actions {
+        display: flex;
+        gap: 0.5rem;
+    }
+
+    .text-button,
+    .reveal-button {
+        border: 0;
+        background: transparent;
+        color: var(--accent-primary);
+        cursor: pointer;
+        border-radius: 0.375rem;
+    }
+
+    .text-button {
+        min-height: 36px;
+        padding: 0.5rem 0.75rem;
+        font-weight: 600;
+    }
+
+    .text-button:hover:not(:disabled),
+    .reveal-button:hover {
+        background: var(--bg-hover);
+    }
+
+    .text-button:disabled {
+        opacity: 0.45;
+        cursor: default;
+    }
+
+    .profile-cleanup-list {
+        display: flex;
+        flex-direction: column;
+        gap: 0.625rem;
+    }
+
+    .cleanup-profile-card {
+        display: flex;
+        align-items: flex-start;
+        gap: 0.875rem;
+        padding: 0.875rem 1rem;
+        border: 1px solid var(--border-color);
+        border-radius: var(--card-radius);
+        background: var(--card-bg);
+        cursor: pointer;
+        transition: border-color 160ms ease, background-color 160ms ease;
+    }
+
+    .cleanup-profile-card:hover,
+    .cleanup-profile-card.selected {
+        border-color: var(--accent-primary);
+        background: var(--accent-bg);
+    }
+
+    .selection-checkbox {
+        width: 36px;
+        height: 36px;
+        display: inline-flex;
+        align-items: flex-start;
+        justify-content: center;
+        cursor: pointer;
+        flex: 0 0 auto;
+    }
+
+    .selection-checkbox > input {
+        width: 18px;
+        height: 18px;
+        margin-top: 0.15rem;
+        accent-color: var(--accent-primary);
+    }
+
+    .profile-card-content {
+        flex: 1;
+        min-width: 0;
+    }
+
+    .profile-card-header,
+    .profile-title-group,
+    .profile-meta,
+    .reason-list {
+        display: flex;
+        align-items: center;
+    }
+
+    .profile-card-header {
+        justify-content: space-between;
+        gap: 1rem;
+    }
+
+    .profile-title-group {
+        min-width: 0;
+        gap: 0.5rem;
+        flex-wrap: wrap;
+    }
+
+    .profile-title-group strong {
+        font-size: 0.9rem;
+    }
+
+    .kind-badge,
+    .location-badge,
+    .health-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.3rem;
+        padding: 0.2rem 0.5rem;
+        border-radius: 999px;
+        font-size: 0.68rem;
+        font-weight: 700;
+        white-space: nowrap;
+    }
+
+    .kind-badge,
+    .location-badge {
+        background: var(--bg-tertiary);
+        color: var(--text-secondary);
+    }
+
+    .health-badge.warning {
+        background: var(--status-warning-bg);
+        color: var(--status-warning-text);
+    }
+
+    .health-badge.good {
+        background: var(--status-success-bg);
+        color: var(--status-success-text);
+    }
+
+    .profile-meta {
+        gap: 0.75rem;
+        margin-top: 0.45rem;
+        color: var(--text-muted);
+        font-size: 0.75rem;
+        flex-wrap: wrap;
+    }
+
+    .profile-meta .mono {
+        color: var(--text-secondary);
+        user-select: text;
+    }
+
+    .reveal-button {
+        width: 36px;
+        height: 36px;
+        margin-left: auto;
+    }
+
+    .reason-list {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 0.3rem;
+        margin-top: 0.5rem;
+    }
+
+    .reason {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        color: var(--status-warning-text);
+        font-size: 0.76rem;
+        line-height: 1.4;
+    }
+
+    .reason.good {
+        color: var(--status-success-text);
+    }
+
+    .btn {
+        min-height: 44px;
+        padding: 0.625rem 1rem;
+        border: 0;
+        border-radius: 0.5rem;
+        cursor: pointer;
+    }
+
+    .btn-secondary {
+        background: var(--bg-tertiary);
+        color: var(--text-primary);
+    }
+
+    @@media (max-width: 640px) {
+        .cleanup-summary {
+            grid-template-columns: 1fr;
+        }
+
+        .profile-card-header {
+            align-items: flex-start;
+            flex-direction: column;
+            gap: 0.5rem;
+        }
+    }
+</style>

--- a/src/MauiSherpa/Pages/Modals/ProvisioningProfileCleanupPage.cs
+++ b/src/MauiSherpa/Pages/Modals/ProvisioningProfileCleanupPage.cs
@@ -1,0 +1,31 @@
+using MauiSherpa.Pages.Forms;
+#if MACOSAPP
+using Microsoft.Maui.Platforms.MacOS.Platform;
+#endif
+#if LINUXGTK
+using Microsoft.Maui.Platforms.Linux.Gtk4.Platform;
+#endif
+
+namespace MauiSherpa.Pages.Modals;
+
+public sealed class ProvisioningProfileCleanupPage : HybridFormPage<int>
+{
+    protected override string FormTitle => "Clean Up Provisioning Profiles";
+    protected override string SubmitButtonText => "Delete Selected";
+    protected override bool IsDestructiveSubmit => true;
+    protected override string BlazorRoute => "/modal/provisioning-profile-cleanup";
+
+    public ProvisioningProfileCleanupPage(HybridFormBridgeHolder bridgeHolder)
+        : base(bridgeHolder)
+    {
+#if MACOSAPP
+        MacOSPage.SetModalSheetSizesToContent(this, false);
+        MacOSPage.SetModalSheetWidth(this, 900);
+        MacOSPage.SetModalSheetHeight(this, 680);
+#elif LINUXGTK
+        GtkPage.SetModalSizesToContent(this, false);
+        GtkPage.SetModalWidth(this, 900);
+        GtkPage.SetModalHeight(this, 680);
+#endif
+    }
+}

--- a/src/MauiSherpa/Pages/ProvisioningProfiles.razor
+++ b/src/MauiSherpa/Pages/ProvisioningProfiles.razor
@@ -1,6 +1,7 @@
 @page "/profiles"
 @using MauiSherpa.Core.Interfaces
 @using MauiSherpa.Core.Requests.Apple
+@using MauiSherpa.Core.Services
 @using MauiSherpa.Services
 @using Shiny.Mediator
 @inject IMediator Mediator
@@ -34,6 +35,12 @@
         </button>
         <button class="btn btn-primary" @onclick="@(() => RefreshData(forceRefresh: true))" disabled="@isLoading">
             <i class="fas @(isLoading ? "fa-spinner fa-spin" : "fa-sync-alt")"></i> Refresh
+        </button>
+        <button class="btn btn-secondary" @onclick="RevealProfilesFolder" disabled="@isLoading">
+            <i class="fas fa-folder-open"></i> Profiles Folder
+        </button>
+        <button class="btn btn-secondary" @onclick="ShowCleanupDialog" disabled="@isLoading">
+            <i class="fas fa-broom"></i> Clean Up
         </button>
         @if (GetInstallableProfiles().Any())
         {
@@ -195,6 +202,9 @@
                                     </button>
                                     <button class="prof-dropdown-item" @onclick="@(() => { openDropdown = null; InstallProfile(profile); })">
                                         <i class="fas fa-folder-plus"></i> Install to System
+                                    </button>
+                                    <button class="prof-dropdown-item" @onclick="@(() => RevealInstalledProfile(profile))">
+                                        <i class="fas fa-magnifying-glass"></i> @RevealProfileLabel
                                     </button>
                                     <div class="prof-dropdown-divider"></div>
                                     <button class="prof-dropdown-item danger" @onclick="@(() => { openDropdown = null; DeleteProfile(profile); })" disabled="@isLoading">
@@ -460,6 +470,7 @@
                                       !string.IsNullOrEmpty(filterState) || 
                                       !string.IsNullOrEmpty(filterType) || 
                                       !string.IsNullOrEmpty(filterPlatform);
+    private string RevealProfileLabel => PlatformInfo.IsWindows ? "Reveal in File Explorer" : "Reveal in Finder";
 
     // Get profiles that can be installed (active, not expired, matching current filters)
     private List<AppleProfile> GetInstallableProfiles() => FilteredProfiles
@@ -518,7 +529,9 @@
     {
         ToolbarService.SetItems(
             new ToolbarAction("refresh", "Refresh", "arrow.clockwise"),
-            new ToolbarAction("create", "Create Profile", "plus")
+            new ToolbarAction("create", "Create Profile", "plus"),
+            new ToolbarAction("profiles-folder", "Profiles Folder", "folder"),
+            new ToolbarAction("cleanup", "Clean Up", "trash")
         );
         ToolbarService.SetSearch("Search profiles...");
         ToolbarService.SetFilters(
@@ -589,6 +602,8 @@
                     try { await RefreshData(forceRefresh: true); } finally { ToolbarService.SetItemEnabled("refresh", true); }
                     break;
                 case "create": await ShowCreateDialog(); break;
+                case "profiles-folder": await RevealProfilesFolder(); break;
+                case "cleanup": await ShowCleanupDialog(); break;
             }
             StateHasChanged();
         });
@@ -653,22 +668,7 @@
         {
             // Save to Downloads folder by default
             var downloadsFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Downloads");
-            var fileName = SanitizeFileName($"{profile.Name}.mobileprovision");
-            var savePath = Path.Combine(downloadsFolder, fileName);
-            
-            // If file exists, add a number suffix
-            var counter = 1;
-            var baseName = Path.GetFileNameWithoutExtension(fileName);
-            while (File.Exists(savePath))
-            {
-                savePath = Path.Combine(downloadsFolder, $"{baseName} ({counter}).mobileprovision");
-                counter++;
-            }
-
-            var content = await AppleService.DownloadProfileAsync(profile.Id);
-            await File.WriteAllBytesAsync(savePath, content);
-            
-            await AlertService.ShowToastAsync($"Profile saved to Downloads: {Path.GetFileName(savePath)}");
+            await SaveDownloadedProfileAsync(profile, downloadsFolder, "Downloads");
         }
         catch (Exception ex)
         {
@@ -689,13 +689,7 @@
             var folder = await DialogService.PickFolderAsync("Select Download Location");
             if (string.IsNullOrEmpty(folder)) return;
 
-            var fileName = SanitizeFileName($"{profile.Name}.mobileprovision");
-            var savePath = Path.Combine(folder, fileName);
-
-            var content = await AppleService.DownloadProfileAsync(profile.Id);
-            await File.WriteAllBytesAsync(savePath, content);
-            
-            await AlertService.ShowToastAsync($"Profile saved to {Path.GetFileName(savePath)}");
+            await SaveDownloadedProfileAsync(profile, folder);
         }
         catch (Exception ex)
         {
@@ -711,6 +705,101 @@
     {
         var invalid = Path.GetInvalidFileNameChars();
         return string.Join("_", fileName.Split(invalid, StringSplitOptions.RemoveEmptyEntries));
+    }
+
+    private async Task SaveDownloadedProfileAsync(
+        AppleProfile profile,
+        string folder,
+        string? locationName = null)
+    {
+        var content = await AppleService.DownloadProfileAsync(profile.Id);
+        var extension = profile.Platform?.ToUpperInvariant() switch
+        {
+            "MACOS" or "MAC_OS" or "OSX" => ".provisionprofile",
+            _ => ".mobileprovision"
+        };
+        var fileName = SanitizeFileName($"{profile.Name}{extension}");
+        var plan = await ProvisioningProfileDownloadManager.PlanAsync(
+            folder,
+            fileName,
+            profile,
+            content);
+
+        var replaceConfirmedConflicts = false;
+        if (plan.RequiresConfirmation)
+        {
+            var message = plan.Conflict == ProvisioningProfileDownloadConflict.NewerProfile
+                ? $"A newer local copy of '{profile.Name}' already exists. Replace it with the downloaded profile?"
+                : $"A file named '{fileName}' already exists and could not be verified as an older copy of this profile. Replace it?";
+            replaceConfirmedConflicts = await AlertService.ShowConfirmAsync(
+                "Replace Existing Profile?",
+                message,
+                "Replace",
+                "Cancel");
+            if (!replaceConfirmedConflicts)
+                return;
+        }
+
+        var replacementCount = plan.AutomaticReplacementPaths.Count +
+                               (replaceConfirmedConflicts ? plan.ConfirmedReplacementPaths.Count : 0);
+        await ProvisioningProfileDownloadManager.SaveAsync(
+            plan,
+            content,
+            replaceConfirmedConflicts);
+
+        var location = locationName is null
+            ? Path.GetFileName(plan.TargetPath)
+            : $"{locationName}: {Path.GetFileName(plan.TargetPath)}";
+        var messagePrefix = replacementCount > 0
+            ? $"Replaced {replacementCount} older downloaded {(replacementCount == 1 ? "copy" : "copies")}"
+            : "Profile saved";
+        await AlertService.ShowToastAsync($"{messagePrefix} to {location}");
+    }
+
+    private async Task RevealProfilesFolder()
+    {
+        try
+        {
+            var directories = await AppleService.GetProvisioningProfilesDirectoriesAsync();
+            foreach (var directory in directories)
+            {
+                Directory.CreateDirectory(directory);
+                FileSystem.RevealInFileManager(directory);
+            }
+        }
+        catch (Exception ex)
+        {
+            await AlertService.ShowAlertAsync("Profiles Folder", $"Unable to open the profiles folder: {ex.Message}");
+        }
+    }
+
+    private async Task ShowCleanupDialog()
+    {
+        var page = new MauiSherpa.Pages.Modals.ProvisioningProfileCleanupPage(BridgeHolder);
+        var deleted = await FormModalService.ShowAsync<int>(page);
+        if (deleted > 0)
+            await AlertService.ShowToastAsync($"Deleted {deleted} provisioning {(deleted == 1 ? "profile" : "profiles")}");
+    }
+
+    private async Task RevealInstalledProfile(AppleProfile profile)
+    {
+        openDropdown = null;
+        try
+        {
+            var paths = await AppleService.FindInstalledProfilePathsAsync(profile.Uuid);
+            if (paths.Count == 0)
+            {
+                await AlertService.ShowToastAsync($"'{profile.Name}' is not installed locally");
+                return;
+            }
+
+            foreach (var path in paths)
+                FileSystem.RevealInFileManager(path);
+        }
+        catch (Exception ex)
+        {
+            await AlertService.ShowAlertAsync("Reveal Profile", $"Unable to reveal the profile: {ex.Message}");
+        }
     }
 
     private async Task InstallProfile(AppleProfile profile)

--- a/src/MauiSherpa/Pages/Settings.razor
+++ b/src/MauiSherpa/Pages/Settings.razor
@@ -129,6 +129,25 @@
                     </div>
                 </div>
             </div>
+            @if (PlatformInfo.IsMacOS || PlatformInfo.IsMacCatalyst)
+            {
+                <div class="setting-item setting-item-start">
+                    <label class="setting-label">Provisioning Profiles Folder</label>
+                    <div class="setting-control setting-control-stack">
+                        <select value="@provisioningProfilesDirectory" @onchange="OnProvisioningProfilesDirectoryChanged" class="setting-select-wide">
+                            <option value="@ProvisioningProfilesDirectoryOptions.Auto">Auto (based on selected Xcode)</option>
+                            <option value="@ProvisioningProfilesDirectoryOptions.Xcode16AndLater">Xcode 16+ folder</option>
+                            <option value="@ProvisioningProfilesDirectoryOptions.Xcode15AndEarlier">Xcode 15 and earlier folder</option>
+                            <option value="@ProvisioningProfilesDirectoryOptions.Both">Both folders</option>
+                        </select>
+                        <div class="setting-description setting-description-block">
+                            Auto uses <code>~/Library/Developer/Xcode/UserData/Provisioning Profiles</code> for Xcode 16+
+                            and the legacy <code>~/Library/MobileDevice/Provisioning Profiles</code> folder for older Xcode versions.
+                            Both installs each profile in both locations for compatibility with mixed tooling.
+                        </div>
+                    </div>
+                </div>
+            }
         </div>
 
         <div class="actions">
@@ -1499,6 +1518,7 @@
     private string xcodeBundleSeparator = XcodeBundleSeparatorOptions.Underscore;
     private string xcodeSelectionAction = XcodeSelectionActionOptions.Rename;
     private bool xcodeCreateSymlinkOnSelect = false;
+    private string provisioningProfilesDirectory = ProvisioningProfilesDirectoryOptions.Auto;
     private bool isNormalizingBundles = false;
     private string appVersion = "";
     private UpdateCheckResult? updateResult;
@@ -1591,6 +1611,8 @@
             xcodeSelectionAction = NormalizeXcodeSelectionAction(settings.Preferences.XcodeSelectionAction);
             xcodeCreateSymlinkOnSelect = xcodeSelectionAction == XcodeSelectionActionOptions.None &&
                 settings.Preferences.XcodeCreateSymlinkOnSelect;
+            provisioningProfilesDirectory = NormalizeProvisioningProfilesDirectory(
+                settings.Preferences.ProvisioningProfilesDirectory);
         }
         catch { }
     }
@@ -1791,6 +1813,11 @@
         xcodeCreateSymlinkOnSelect = xcodeSelectionAction == XcodeSelectionActionOptions.None && e.Value is true;
     }
 
+    private void OnProvisioningProfilesDirectoryChanged(ChangeEventArgs e)
+    {
+        provisioningProfilesDirectory = NormalizeProvisioningProfilesDirectory(e.Value?.ToString());
+    }
+
     private async Task OnXcodeBundleSeparatorChanged(ChangeEventArgs e)
     {
         var newValue = NormalizeXcodeBundleSeparator(e.Value?.ToString());
@@ -1918,7 +1945,8 @@
                     XcodeBundleSeparator = xcodeBundleSeparator,
                     XcodeSelectionAction = xcodeSelectionAction,
                     XcodeCreateSymlinkOnSelect = xcodeSelectionAction == XcodeSelectionActionOptions.None &&
-                        xcodeCreateSymlinkOnSelect
+                        xcodeCreateSymlinkOnSelect,
+                    ProvisioningProfilesDirectory = provisioningProfilesDirectory
                 }
             });
             await AlertService.ShowToastAsync("Settings saved");
@@ -1942,6 +1970,7 @@
         xcodeBundleSeparator = XcodeBundleSeparatorOptions.Underscore;
         xcodeSelectionAction = XcodeSelectionActionOptions.Rename;
         xcodeCreateSymlinkOnSelect = false;
+        provisioningProfilesDirectory = ProvisioningProfilesDirectoryOptions.Auto;
         ThemeService.SetTheme(ViewModel.Theme);
         ThemeService.SetFontScale(ViewModel.FontScale);
     }
@@ -2217,6 +2246,18 @@
         string.Equals(value, XcodeSelectionActionOptions.None, StringComparison.OrdinalIgnoreCase)
             ? XcodeSelectionActionOptions.None
             : XcodeSelectionActionOptions.Rename;
+
+    private static string NormalizeProvisioningProfilesDirectory(string? value) =>
+        value switch
+        {
+            ProvisioningProfilesDirectoryOptions.Xcode16AndLater =>
+                ProvisioningProfilesDirectoryOptions.Xcode16AndLater,
+            ProvisioningProfilesDirectoryOptions.Xcode15AndEarlier =>
+                ProvisioningProfilesDirectoryOptions.Xcode15AndEarlier,
+            ProvisioningProfilesDirectoryOptions.Both =>
+                ProvisioningProfilesDirectoryOptions.Both,
+            _ => ProvisioningProfilesDirectoryOptions.Auto
+        };
 
     // Google Identity Methods
 
@@ -2650,6 +2691,8 @@
             demoMode = settings.Preferences.DemoMode;
             xcodeArchiveExtractor = NormalizeXcodeArchiveExtractor(settings.Preferences.XcodeArchiveExtractor);
             xcodeBundleSeparator = NormalizeXcodeBundleSeparator(settings.Preferences.XcodeBundleSeparator);
+            provisioningProfilesDirectory = NormalizeProvisioningProfilesDirectory(
+                settings.Preferences.ProvisioningProfilesDirectory);
             ThemeService.SetTheme(ViewModel.Theme);
             ThemeService.SetFontScale(ViewModel.FontScale);
         }

--- a/src/MauiSherpa/Services/FileSystemService.cs
+++ b/src/MauiSherpa/Services/FileSystemService.cs
@@ -107,30 +107,29 @@ public class FileSystemService : MauiSherpa.Core.Interfaces.IFileSystemService
 
         try
         {
-#if MACCATALYST
-            // Use 'open' command on macOS - works for both files and directories
-            if (File.Exists(path))
+            if (OperatingSystem.IsMacOS() || OperatingSystem.IsMacCatalyst())
             {
-                // Reveal and select the file in Finder
-                Process.Start("open", $"-R \"{path}\"");
+                var startInfo = new ProcessStartInfo("/usr/bin/open");
+                if (File.Exists(path))
+                    startInfo.ArgumentList.Add("-R");
+                startInfo.ArgumentList.Add(path);
+                Process.Start(startInfo);
             }
-            else if (Directory.Exists(path))
+            else if (OperatingSystem.IsWindows())
             {
-                // Open the directory in Finder
-                Process.Start("open", $"\"{path}\"");
+                var startInfo = new ProcessStartInfo("explorer.exe");
+                if (File.Exists(path))
+                    startInfo.ArgumentList.Add($"/select,{path}");
+                else
+                    startInfo.ArgumentList.Add(path);
+                Process.Start(startInfo);
             }
-#elif WINDOWS
-            if (File.Exists(path))
+            else if (OperatingSystem.IsLinux() && (File.Exists(path) || Directory.Exists(path)))
             {
-                // Select the file in Explorer
-                Process.Start("explorer.exe", $"/select,\"{path}\"");
+                var startInfo = new ProcessStartInfo("xdg-open");
+                startInfo.ArgumentList.Add(File.Exists(path) ? Path.GetDirectoryName(path)! : path);
+                Process.Start(startInfo);
             }
-            else if (Directory.Exists(path))
-            {
-                // Open the directory in Explorer
-                Process.Start("explorer.exe", $"\"{path}\"");
-            }
-#endif
         }
         catch
         {

--- a/tests/MauiSherpa.Core.Tests/Services/AppleConnectServiceTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/AppleConnectServiceTests.cs
@@ -1,5 +1,6 @@
 using AppleAppStoreConnect;
 using FluentAssertions;
+using MauiSherpa.Core.Interfaces;
 using MauiSherpa.Core.Services;
 
 namespace MauiSherpa.Core.Tests.Services;
@@ -57,5 +58,107 @@ public class AppleConnectServiceTests
     {
         AppleConnectService.ResolveCertificateDisplayName(alias, name, displayName)
             .Should().Be(expected);
+    }
+
+    [Fact]
+    public void EnsureAppGroupsPreserved_RejectsMissingGroupAssignment()
+    {
+        var entitlements = new Dictionary<string, object>
+        {
+            ["com.apple.security.application-groups"] = new object[]
+            {
+                "group.com.example.shared"
+            }
+        };
+        var regeneratedEntitlements = new Dictionary<string, object>();
+
+        var action = () => AppleConnectService.EnsureAppGroupsPreserved(
+            entitlements,
+            regeneratedEntitlements);
+
+        action.Should().Throw<InvalidOperationException>()
+            .WithMessage("*missing App Group assignments*group.com.example.shared*existing profile was not deleted*");
+    }
+
+    [Fact]
+    public void EnsureAppGroupsPreserved_AllowsSelectedGroupAssignment()
+    {
+        var entitlements = new Dictionary<string, object>
+        {
+            ["com.apple.security.application-groups"] = new object[]
+            {
+                "group.com.example.shared"
+            }
+        };
+        var regeneratedEntitlements = new Dictionary<string, object>
+        {
+            ["com.apple.security.application-groups"] = new object[]
+            {
+                "group.com.example.shared"
+            }
+        };
+
+        var action = () => AppleConnectService.EnsureAppGroupsPreserved(
+            entitlements,
+            regeneratedEntitlements);
+
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void EnsureAppGroupsPreserved_RejectsDifferentSelectedGroup()
+    {
+        var entitlements = new Dictionary<string, object>
+        {
+            ["com.apple.security.application-groups"] = new object[]
+            {
+                "group.com.example.required"
+            }
+        };
+        var regeneratedEntitlements = new Dictionary<string, object>
+        {
+            ["com.apple.security.application-groups"] = new object[]
+            {
+                "group.com.example.other"
+            }
+        };
+
+        var action = () => AppleConnectService.EnsureAppGroupsPreserved(
+            entitlements,
+            regeneratedEntitlements);
+
+        action.Should().Throw<InvalidOperationException>()
+            .WithMessage("*group.com.example.required*");
+    }
+
+    [Theory]
+    [InlineData(ProvisioningProfilesDirectoryOptions.Auto, "/auto")]
+    [InlineData(ProvisioningProfilesDirectoryOptions.Xcode16AndLater, "/Users/test/Library/Developer/Xcode/UserData/Provisioning Profiles")]
+    [InlineData(ProvisioningProfilesDirectoryOptions.Xcode15AndEarlier, "/Users/test/Library/MobileDevice/Provisioning Profiles")]
+    public void ResolveProvisioningProfilesDirectories_UsesConfiguredMode(
+        string preference,
+        string expected)
+    {
+        var result = AppleConnectService.ResolveProvisioningProfilesDirectories(
+            preference,
+            "/auto",
+            "/Users/test",
+            isApplePlatform: true);
+
+        result.Should().ContainSingle().Which.Should().Be(expected);
+    }
+
+    [Fact]
+    public void ResolveProvisioningProfilesDirectories_BothReturnsNewAndLegacyFolders()
+    {
+        var result = AppleConnectService.ResolveProvisioningProfilesDirectories(
+            ProvisioningProfilesDirectoryOptions.Both,
+            "/auto",
+            "/Users/test",
+            isApplePlatform: true);
+
+        result.Should().Equal(
+            "/Users/test/Library/Developer/Xcode/UserData/Provisioning Profiles",
+            "/Users/test/Library/MobileDevice/Provisioning Profiles");
     }
 }

--- a/tests/MauiSherpa.Core.Tests/Services/ProvisioningProfileCleanupAnalyzerTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/ProvisioningProfileCleanupAnalyzerTests.cs
@@ -1,0 +1,227 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.Pkcs;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using FluentAssertions;
+using MauiSherpa.Core.Interfaces;
+using MauiSherpa.Core.Services;
+
+namespace MauiSherpa.Core.Tests.Services;
+
+public sealed class ProvisioningProfileCleanupAnalyzerTests
+{
+    [Fact]
+    public async Task AnalyzeAsync_IdentifiesExpiredOlderAndMissingCertificateProfiles()
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            using var installedCertificate = CreateCertificate("Installed");
+            using var missingCertificate = CreateCertificate("Missing");
+            var now = new DateTimeOffset(2026, 8, 22, 0, 0, 0, TimeSpan.Zero);
+
+            await WriteProfileAsync(
+                directory,
+                "old.mobileprovision",
+                CreateProfile(
+                    installedCertificate,
+                    "Example Distribution",
+                    "OLD-UUID",
+                    "com.example.app",
+                    new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                    new DateTimeOffset(2027, 1, 1, 0, 0, 0, TimeSpan.Zero)));
+            await WriteProfileAsync(
+                directory,
+                "new.mobileprovision",
+                CreateProfile(
+                    installedCertificate,
+                    "Example Distribution",
+                    "NEW-UUID",
+                    "com.example.app",
+                    new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                    new DateTimeOffset(2027, 6, 1, 0, 0, 0, TimeSpan.Zero)));
+            await WriteProfileAsync(
+                directory,
+                "expired.mobileprovision",
+                CreateProfile(
+                    installedCertificate,
+                    "Expired Distribution",
+                    "EXPIRED-UUID",
+                    "com.example.expired",
+                    new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                    new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)));
+            await WriteProfileAsync(
+                directory,
+                "missing.mobileprovision",
+                CreateProfile(
+                    missingCertificate,
+                    "Missing Certificate",
+                    "MISSING-UUID",
+                    "com.example.missing",
+                    new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                    new DateTimeOffset(2027, 1, 1, 0, 0, 0, TimeSpan.Zero)));
+
+            var profiles = await ProvisioningProfileCleanupAnalyzer.AnalyzeAsync(
+                [directory.FullName],
+                [installedCertificate.SerialNumber],
+                now);
+
+            profiles.Single(profile => profile.Uuid == "OLD-UUID")
+                .Should().Match<InstalledProvisioningProfileAssessment>(profile =>
+                    profile.IsOlderVersion &&
+                    profile.RecommendedForDeletion);
+            profiles.Single(profile => profile.Uuid == "NEW-UUID")
+                .RecommendedForDeletion.Should().BeFalse();
+            profiles.Single(profile => profile.Uuid == "EXPIRED-UUID")
+                .Should().Match<InstalledProvisioningProfileAssessment>(profile =>
+                    profile.IsExpired &&
+                    profile.RecommendedForDeletion);
+            profiles.Single(profile => profile.Uuid == "MISSING-UUID")
+                .Should().Match<InstalledProvisioningProfileAssessment>(profile =>
+                    !profile.HasMatchingCertificate &&
+                    profile.RecommendedForDeletion);
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_DoesNotTreatSameUuidInBothFoldersAsOlder()
+    {
+        var firstDirectory = Directory.CreateTempSubdirectory();
+        var secondDirectory = Directory.CreateTempSubdirectory();
+        try
+        {
+            using var certificate = CreateCertificate("Installed");
+            var content = CreateProfile(
+                certificate,
+                "Example Distribution",
+                "SAME-UUID",
+                "com.example.app",
+                new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                new DateTimeOffset(2027, 1, 1, 0, 0, 0, TimeSpan.Zero));
+            await WriteProfileAsync(firstDirectory, "SAME-UUID.mobileprovision", content);
+            await WriteProfileAsync(secondDirectory, "SAME-UUID.mobileprovision", content);
+
+            var profiles = await ProvisioningProfileCleanupAnalyzer.AnalyzeAsync(
+                [firstDirectory.FullName, secondDirectory.FullName],
+                [certificate.SerialNumber],
+                new DateTimeOffset(2026, 8, 22, 0, 0, 0, TimeSpan.Zero));
+
+            profiles.Should().HaveCount(2);
+            profiles.Should().OnlyContain(profile =>
+                !profile.IsOlderVersion &&
+                !profile.RecommendedForDeletion);
+        }
+        finally
+        {
+            firstDirectory.Delete(recursive: true);
+            secondDirectory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_DoesNotTreatDifferentNamedProfilesAsVersions()
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            using var certificate = CreateCertificate("Installed");
+            await WriteProfileAsync(
+                directory,
+                "first.mobileprovision",
+                CreateProfile(
+                    certificate,
+                    "Full Device Set",
+                    "FIRST-UUID",
+                    "com.example.app",
+                    new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                    new DateTimeOffset(2027, 1, 1, 0, 0, 0, TimeSpan.Zero)));
+            await WriteProfileAsync(
+                directory,
+                "second.mobileprovision",
+                CreateProfile(
+                    certificate,
+                    "QA Device Set",
+                    "SECOND-UUID",
+                    "com.example.app",
+                    new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                    new DateTimeOffset(2027, 1, 1, 0, 0, 0, TimeSpan.Zero)));
+
+            var profiles = await ProvisioningProfileCleanupAnalyzer.AnalyzeAsync(
+                [directory.FullName],
+                [certificate.SerialNumber],
+                new DateTimeOffset(2026, 8, 22, 0, 0, 0, TimeSpan.Zero));
+
+            profiles.Should().OnlyContain(profile =>
+                !profile.IsOlderVersion &&
+                !profile.RecommendedForDeletion);
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    private static async Task WriteProfileAsync(
+        DirectoryInfo directory,
+        string fileName,
+        byte[] content)
+    {
+        await File.WriteAllBytesAsync(Path.Combine(directory.FullName, fileName), content);
+    }
+
+    private static X509Certificate2 CreateCertificate(string commonName)
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest(
+            $"CN={commonName}",
+            rsa,
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
+        return request.CreateSelfSigned(
+            DateTimeOffset.UtcNow.AddDays(-1),
+            DateTimeOffset.UtcNow.AddDays(1));
+    }
+
+    private static byte[] CreateProfile(
+        X509Certificate2 certificate,
+        string name,
+        string uuid,
+        string bundleId,
+        DateTimeOffset creationDate,
+        DateTimeOffset expirationDate,
+        bool provisionsAllDevices = false)
+    {
+        var certificateData = Convert.ToBase64String(certificate.RawData);
+        var xml = $$"""
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+            <plist version="1.0">
+            <dict>
+                <key>AppIDName</key><string>{{name}}</string>
+                <key>ApplicationIdentifierPrefix</key><array><string>TEAMID</string></array>
+                <key>Name</key><string>{{name}}</string>
+                <key>CreationDate</key><date>{{creationDate.UtcDateTime:yyyy-MM-ddTHH:mm:ssZ}}</date>
+                <key>Platform</key><array><string>iOS</string></array>
+                <key>ExpirationDate</key><date>{{expirationDate.UtcDateTime:yyyy-MM-ddTHH:mm:ssZ}}</date>
+                <key>TeamIdentifier</key><array><string>TEAMID</string></array>
+                <key>UUID</key><string>{{uuid}}</string>
+                <key>Version</key><integer>1</integer>
+                {{(provisionsAllDevices ? "<key>ProvisionsAllDevices</key><true/>" : "")}}
+                <key>DeveloperCertificates</key><array><data>{{certificateData}}</data></array>
+                <key>Entitlements</key>
+                <dict>
+                    <key>application-identifier</key><string>TEAMID.{{bundleId}}</string>
+                </dict>
+            </dict>
+            </plist>
+            """;
+
+        var signedCms = new SignedCms(new ContentInfo(Encoding.UTF8.GetBytes(xml)));
+        signedCms.ComputeSignature(new CmsSigner(certificate));
+        return signedCms.Encode();
+    }
+}

--- a/tests/MauiSherpa.Core.Tests/Services/ProvisioningProfileDownloadManagerTests.cs
+++ b/tests/MauiSherpa.Core.Tests/Services/ProvisioningProfileDownloadManagerTests.cs
@@ -1,0 +1,305 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.Pkcs;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using FluentAssertions;
+using MauiSherpa.Core.Interfaces;
+using MauiSherpa.Core.Services;
+
+namespace MauiSherpa.Core.Tests.Services;
+
+public sealed class ProvisioningProfileDownloadManagerTests
+{
+    [Fact]
+    public async Task PlanAsync_ReplacesOlderCopiesOfSameProfile()
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            var older = CreateProfile(
+                "Profile",
+                "OLD-UUID",
+                "com.example.app",
+                new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+            var incoming = CreateProfile(
+                "Profile",
+                "NEW-UUID",
+                "com.example.app",
+                new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                new DateTimeOffset(2027, 1, 1, 0, 0, 0, TimeSpan.Zero));
+            var canonicalPath = Path.Combine(directory.FullName, "Profile.mobileprovision");
+            var numberedPath = Path.Combine(directory.FullName, "Profile (1).mobileprovision");
+            await File.WriteAllBytesAsync(canonicalPath, older);
+            await File.WriteAllBytesAsync(numberedPath, older);
+
+            var plan = await ProvisioningProfileDownloadManager.PlanAsync(
+                directory.FullName,
+                "Profile.mobileprovision",
+                CreateAppleProfile(),
+                incoming,
+                new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero));
+
+            plan.RequiresConfirmation.Should().BeFalse();
+            plan.AutomaticReplacementPaths.Should().BeEquivalentTo(canonicalPath, numberedPath);
+
+            await ProvisioningProfileDownloadManager.SaveAsync(plan, incoming, replaceConfirmedConflicts: false);
+
+            Directory.GetFiles(directory.FullName, "*.mobileprovision")
+                .Should().ContainSingle()
+                .Which.Should().Be(canonicalPath);
+            (await File.ReadAllBytesAsync(canonicalPath)).Should().Equal(incoming);
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task PlanAsync_RequiresConfirmationForUnrelatedExactName()
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            var unrelated = CreateProfile(
+                "Profile",
+                "OTHER-UUID",
+                "com.example.other",
+                new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                new DateTimeOffset(2027, 1, 1, 0, 0, 0, TimeSpan.Zero));
+            var incoming = CreateProfile(
+                "Profile",
+                "NEW-UUID",
+                "com.example.app",
+                new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                new DateTimeOffset(2027, 1, 1, 0, 0, 0, TimeSpan.Zero));
+            var existingPath = Path.Combine(directory.FullName, "Profile.mobileprovision");
+            await File.WriteAllBytesAsync(existingPath, unrelated);
+
+            var plan = await ProvisioningProfileDownloadManager.PlanAsync(
+                directory.FullName,
+                "Profile.mobileprovision",
+                CreateAppleProfile(),
+                incoming);
+
+            plan.Conflict.Should().Be(ProvisioningProfileDownloadConflict.ExistingFile);
+            plan.ConfirmedReplacementPaths.Should().ContainSingle().Which.Should().Be(existingPath);
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task PlanAsync_RequiresConfirmationForCaseOnlyExactNameCollision()
+    {
+        if (!OperatingSystem.IsMacOS() && !OperatingSystem.IsWindows())
+            return;
+
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            var unrelated = CreateProfile(
+                "Profile",
+                "OTHER-UUID",
+                "com.example.other",
+                new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                new DateTimeOffset(2027, 1, 1, 0, 0, 0, TimeSpan.Zero));
+            var incoming = CreateProfile(
+                "Profile",
+                "NEW-UUID",
+                "com.example.app",
+                new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                new DateTimeOffset(2027, 1, 1, 0, 0, 0, TimeSpan.Zero));
+            await File.WriteAllBytesAsync(
+                Path.Combine(directory.FullName, "profile.mobileprovision"),
+                unrelated);
+
+            var plan = await ProvisioningProfileDownloadManager.PlanAsync(
+                directory.FullName,
+                "Profile.mobileprovision",
+                CreateAppleProfile(),
+                incoming);
+
+            plan.Conflict.Should().Be(ProvisioningProfileDownloadConflict.ExistingFile);
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task PlanAsync_RequiresConfirmationBeforeReplacingNewerCopy()
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            var newer = CreateProfile(
+                "Profile",
+                "NEWER-UUID",
+                "com.example.app",
+                new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero),
+                new DateTimeOffset(2027, 6, 1, 0, 0, 0, TimeSpan.Zero));
+            var incoming = CreateProfile(
+                "Profile",
+                "INCOMING-UUID",
+                "com.example.app",
+                new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                new DateTimeOffset(2027, 1, 1, 0, 0, 0, TimeSpan.Zero));
+            await File.WriteAllBytesAsync(
+                Path.Combine(directory.FullName, "Profile.mobileprovision"),
+                newer);
+
+            var plan = await ProvisioningProfileDownloadManager.PlanAsync(
+                directory.FullName,
+                "Profile.mobileprovision",
+                CreateAppleProfile(),
+                incoming);
+
+            plan.Conflict.Should().Be(ProvisioningProfileDownloadConflict.NewerProfile);
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task PlanAsync_RequiresConfirmationForDifferentProfileKind()
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            var directProfile = CreateProfile(
+                "Profile",
+                "DIRECT-UUID",
+                "com.example.app",
+                new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                new DateTimeOffset(2027, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                provisionsAllDevices: true);
+            var appStoreProfile = CreateProfile(
+                "Profile",
+                "STORE-UUID",
+                "com.example.app",
+                new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                new DateTimeOffset(2027, 1, 1, 0, 0, 0, TimeSpan.Zero));
+            await File.WriteAllBytesAsync(
+                Path.Combine(directory.FullName, "Profile.mobileprovision"),
+                directProfile);
+
+            var plan = await ProvisioningProfileDownloadManager.PlanAsync(
+                directory.FullName,
+                "Profile.mobileprovision",
+                CreateAppleProfile(),
+                appStoreProfile);
+
+            plan.Conflict.Should().Be(ProvisioningProfileDownloadConflict.ExistingFile);
+            plan.AutomaticReplacementPaths.Should().BeEmpty();
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task SaveAsync_RejectsFileChangedAfterPlan()
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            var older = CreateProfile(
+                "Profile",
+                "OLD-UUID",
+                "com.example.app",
+                new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+            var incoming = CreateProfile(
+                "Profile",
+                "NEW-UUID",
+                "com.example.app",
+                new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                new DateTimeOffset(2027, 1, 1, 0, 0, 0, TimeSpan.Zero));
+            var targetPath = Path.Combine(directory.FullName, "Profile.mobileprovision");
+            await File.WriteAllBytesAsync(targetPath, older);
+
+            var plan = await ProvisioningProfileDownloadManager.PlanAsync(
+                directory.FullName,
+                "Profile.mobileprovision",
+                CreateAppleProfile(),
+                incoming);
+            await File.WriteAllTextAsync(targetPath, "changed after review");
+
+            var action = () => ProvisioningProfileDownloadManager.SaveAsync(
+                plan,
+                incoming,
+                replaceConfirmedConflicts: false);
+
+            await action.Should().ThrowAsync<IOException>()
+                .WithMessage("*changed after the replacement review*");
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    private static AppleProfile CreateAppleProfile() => new(
+        "profile-id",
+        "Profile",
+        "IOS_APP_STORE",
+        "IOS",
+        "ACTIVE",
+        new DateTime(2027, 1, 1),
+        "com.example.app",
+        "NEW-UUID");
+
+    private static byte[] CreateProfile(
+        string name,
+        string uuid,
+        string bundleId,
+        DateTimeOffset creationDate,
+        DateTimeOffset expirationDate,
+        bool provisionsAllDevices = false)
+    {
+        var xml = $$"""
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+            <plist version="1.0">
+            <dict>
+                <key>AppIDName</key><string>{{name}}</string>
+                <key>ApplicationIdentifierPrefix</key><array><string>TEAMID</string></array>
+                <key>Name</key><string>{{name}}</string>
+                <key>CreationDate</key><date>{{creationDate.UtcDateTime:yyyy-MM-ddTHH:mm:ssZ}}</date>
+                <key>Platform</key><array><string>iOS</string></array>
+                <key>ExpirationDate</key><date>{{expirationDate.UtcDateTime:yyyy-MM-ddTHH:mm:ssZ}}</date>
+                <key>TeamIdentifier</key><array><string>TEAMID</string></array>
+                <key>UUID</key><string>{{uuid}}</string>
+                <key>Version</key><integer>1</integer>
+                {{(provisionsAllDevices ? "<key>ProvisionsAllDevices</key><true/>" : "")}}
+                <key>Entitlements</key>
+                <dict>
+                    <key>application-identifier</key><string>TEAMID.{{bundleId}}</string>
+                </dict>
+            </dict>
+            </plist>
+            """;
+
+        var content = new ContentInfo(Encoding.UTF8.GetBytes(xml));
+        var signedCms = new SignedCms(content);
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest(
+            "CN=Provisioning Profile Test",
+            rsa,
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
+        using var certificate = request.CreateSelfSigned(
+            DateTimeOffset.UtcNow.AddDays(-1),
+            DateTimeOffset.UtcNow.AddDays(1));
+        signedCms.ComputeSignature(new CmsSigner(certificate));
+        return signedCms.Encode();
+    }
+}


### PR DESCRIPTION
Provisioning profile regeneration could silently lose capabilities that were no longer assigned to the App ID, while local downloads and installs accumulated stale copies across Xcode profile directories. This change makes regeneration and local profile management safer and easier to inspect.

- Preflight regeneration with a temporary generated profile and compare its actual App Group entitlements before deleting the existing profile.
- Treat App Groups as portal-managed because the current App Store Connect API cannot configure their identifier assignments.
- Replace older matching downloads atomically, prompt for ambiguous conflicts, and protect against files changing after review.
- Add Auto, Xcode 16+, Xcode 15 and earlier, and Both directory modes for installation and Finder reveal.
- Add native toolbar actions for opening profile folders and reviewing installed profiles.
- Add a cleanup dialog that explains profile health, preselects only expired, unreadable, superseded, or certificate-orphaned profiles, and confirms before deleting selected files.
- Cover entitlement validation, directory selection, download conflicts, duplicate analysis, and cleanup recommendations with focused tests.