### PR TITLE
Update MAUI DevFlow tooling to preview 12

### DIFF
--- a/.claude/skills/maui-devflow-debug/SKILL.md
+++ b/.claude/skills/maui-devflow-debug/SKILL.md
@@ -1,15 +1,7 @@
 ---
 name: maui-devflow-debug
 description: >-
-  Run build, deploy, inspect, and fix loops for .NET MAUI apps that already have
-  MAUI DevFlow integrated. USE FOR: launching MAUI apps, selecting devices or
-  emulators, waiting for or recovering agent connections, broker/port/adb
-  connectivity issues, visual tree inspection, screenshots, UI interaction,
-  Blazor WebView CDP debugging, reading DevFlow logs, and iterative app
-  debugging. DO NOT USE FOR: first-time DevFlow package setup (use
-  maui-devflow-onboard), or generic desktop automation unrelated to MAUI. INVOKES:
-  maui devflow CLI, dotnet CLI, Android adb/android tools, and Apple simctl
-  tools.
+  Run DevFlow inspect-and-fix loops for MAUI apps. USE FOR: launch, device selection, agent recovery, broker/port/adb, tree/screenshot, Blazor CDP, iterative UI debugging. DO NOT USE FOR: first-time setup or non-MAUI automation. INVOKES: `maui devflow`, `dotnet`, `adb`, `simctl`.
 ---
 
 # DevFlow Debug
@@ -31,6 +23,13 @@ packages and `builder.AddMauiDevFlowAgent()` registered.
 
 - If DevFlow packages or `MauiProgram.cs` registration are missing, use `maui-devflow-onboard`.
 - If the failure is a generic build or SDK issue with no DevFlow angle, use normal .NET/MAUI diagnostics.
+
+## Optional Session Feedback Nudge
+
+If you have retried the same MAUI DevFlow workflow several times, tried multiple
+workarounds, or are ending a long DevFlow-assisted debugging session, ask
+whether the user wants to run `maui-devflow-session-review` to summarize friction
+for MAUI DevFlow product feedback. Do not run it automatically.
 
 ## Core Loop
 
@@ -60,12 +59,27 @@ packages and `builder.AddMauiDevFlowAgent()` registered.
 
    ```bash
    maui devflow wait
+   maui devflow agent status
    maui devflow ui tree --depth 3 --fields "id,type,text,automationId"
    ```
 
+   Treat `agent status` as the runtime truth for reachability and app identity.
+   `diagnose` is broader environment state; it can report broker/project details
+   without proving the current app is reachable.
+
    If `wait`, `list`, or `ui tree` cannot connect after the app is running, load `references/connectivity.md` and recover the broker/agent connection before continuing.
 
-6. Inspect, interact, capture evidence, then edit the app and repeat from launch.
+6. Prefer AutomationId-first validation for UI flows:
+
+   ```bash
+   maui devflow ui query --automationId save-button
+   maui devflow ui tap <element-id-from-query>
+   ```
+
+   If important controls do not have stable `AutomationId`s, add them before
+   relying on text, coordinates, screenshots, or brittle tree positions.
+
+7. Inspect, interact, capture evidence, then edit the app and repeat from launch.
 
 ## Critical Anti-patterns
 
@@ -74,6 +88,7 @@ packages and `builder.AddMauiDevFlowAgent()` registered.
 - Do not kill an async `dotnet build -t:Run` or `dotnet run` shell while you still need the app; that often kills the app.
 - Do not reuse a busy simulator/emulator when multiple MAUI apps or agents may be running.
 - Do not debug Blazor WebView DOM issues through the native visual tree alone; use the WebView/CDP commands.
+- Do not drive key app flows by coordinates when AutomationIds are available or can be added.
 
 ## Stop Signals
 

--- a/.claude/skills/maui-devflow-debug/references/connectivity.md
+++ b/.claude/skills/maui-devflow-debug/references/connectivity.md
@@ -33,10 +33,13 @@ Use this when a project already has DevFlow package references and `builder.AddM
    ```bash
    maui devflow list
    maui devflow wait
+   maui devflow agent status
    maui devflow ui tree --depth 1
    ```
 
-   A successful `ui tree` means connectivity is fixed; continue the main debug loop.
+   A successful `agent status` proves the CLI can reach the running app and
+   should show the expected app name/platform. A successful `ui tree` means
+   connectivity is fixed for UI automation; continue the main debug loop.
 
 ## Platform notes
 
@@ -45,18 +48,33 @@ Use this when a project already has DevFlow package references and `builder.AddM
 Android emulators run in a separate network namespace. Broker registration and CLI-to-agent traffic need opposite forwarding directions:
 
 ```bash
-maui devflow list                 # note the assigned agent port
+maui devflow diagnose             # reports Android forwarding state
+maui devflow list                 # checks/repairs forwarding when one device is online
 adb reverse tcp:19223 tcp:19223   # app in emulator -> host broker
 adb forward tcp:<port> tcp:<port> # host CLI -> app agent
 adb reverse --list
 adb forward --list
 ```
 
+When multiple Android devices/emulators are connected, use the same serial selection the CLI supports:
+
+```bash
+maui devflow diagnose --device <serial>
+maui devflow list --device <serial>
+```
+
 If no broker is available and the app uses a direct `.mauidevflow` port, forward that port instead:
 
 ```bash
+adb devices
 adb forward tcp:9223 tcp:9223
+maui devflow agent status --agent-host localhost --agent-port 9223
 ```
+
+Use this direct status check before declaring Android connectivity broken. It is
+common for broker registration to be empty while a direct, forwarded v1 agent
+connection works. In that case continue with explicit `--agent-host localhost`
+and `--agent-port <port>` until broker registration is restored.
 
 ### iOS simulator
 
@@ -94,8 +112,9 @@ pgrep -f "YourApp"
 | Symptom | Fix |
 |---------|-----|
 | `maui devflow list` shows no agents | Verify app is running in Debug, package references exist, and `AddMauiDevFlowAgent()` executes |
-| Android agent never registers | Run `adb reverse tcp:19223 tcp:19223` for broker registration |
-| Android connection refused after registration | Run `adb forward tcp:<port> tcp:<port>` using the port from `maui devflow list` |
+| Android agent never registers | Run `maui devflow diagnose --device <serial>` or manually set `adb reverse tcp:19223 tcp:19223` for broker registration |
+| Android connection refused after registration | Run `maui devflow diagnose --device <serial>` or manually set `adb forward tcp:<port> tcp:<port>` using the port from `maui devflow list` |
+| Android broker list is empty but app is running | Forward the direct `.mauidevflow` port and run `maui devflow agent status --agent-host localhost --agent-port <port>` |
 | Broker unavailable | `maui devflow broker start`; retry the command |
 | Port already in use | Identify the owner with `lsof -i :<port>` before killing a PID |
 | Multiple agents connected | Ask which app/device/agent port to target; use `--agent-port` |
@@ -110,5 +129,6 @@ pgrep -f "YourApp"
 ## Anti-patterns
 
 - Do not treat an empty `maui devflow list` as proof the project is not integrated. It only means no runtime agent is connected.
+- Do not treat an empty broker/list result as final on Android until direct forwarded `agent status` has also failed.
 - Do not use `adb reverse` for the agent HTTP port when the host CLI must connect into the emulator. Use `adb forward tcp:<port> tcp:<port>` for that direction.
 - Do not kill random processes by name. Identify the owning PID first.

--- a/.claude/skills/maui-devflow-debug/references/ios-and-mac.md
+++ b/.claude/skills/maui-devflow-debug/references/ios-and-mac.md
@@ -184,19 +184,24 @@ apple xcode list                                # installed Xcode versions
 
 ## xcrun simctl Reference
 
-Key subcommands beyond the basics:
+Key subcommands beyond the basics. Several of these are now wrapped by the `maui` CLI
+(`maui apple simulator …`) — prefer the wrapper when available so you get `--json` output and
+the standard error envelope:
 
-| Command | Use |
-|---------|-----|
-| `simctl addmedia <UDID> file.jpg` | Add photos/videos to sim |
-| `simctl openurl <UDID> "url"` | Open URL / deep link |
-| `simctl push <UDID> bundle payload.json` | Simulate push notification |
-| `simctl privacy <UDID> grant location bundle` | Grant permissions |
-| `simctl location <UDID> set 37.33,-122.03` | Set GPS location |
-| `simctl pbcopy <UDID>` | Copy stdin to clipboard |
-| `simctl pbpaste <UDID>` | Read clipboard |
-| `simctl get_app_container <UDID> bundle` | App container path |
-| `simctl listapps <UDID>` | Installed apps |
+| Command | Use | `maui` equivalent |
+|---------|-----|-------------------|
+| `simctl addmedia <UDID> file.jpg` | Add photos/videos to sim | `maui apple simulator add-media <UDID> file.jpg` |
+| `simctl openurl <UDID> "url"` | Open URL / deep link | `maui apple simulator openurl <UDID> "url"` |
+| `simctl push <UDID> bundle payload.json` | Simulate push notification | `maui apple simulator push <UDID> bundle payload.json` |
+| `simctl privacy <UDID> grant location bundle` | Grant permissions | `maui apple simulator privacy grant <UDID> location --bundle-id bundle` |
+| `simctl location <UDID> set 37.33,-122.03` | Set GPS location | `maui apple simulator location set <UDID> 37.33 -122.03` |
+| `simctl status_bar <UDID> override --time 9:41` | Override status bar | `maui apple simulator status-bar override <UDID> --time 9:41` |
+| `simctl ui <UDID> appearance dark` | Set light/dark appearance | `maui apple simulator appearance dark <UDID>` |
+| `simctl io <UDID> screenshot out.png` | Capture screenshot | `maui apple simulator screenshot <UDID> out.png` |
+| `simctl pbcopy <UDID>` | Copy stdin to clipboard | — |
+| `simctl pbpaste <UDID>` | Read clipboard | — |
+| `simctl get_app_container <UDID> bundle` | App container path | `maui apple simulator get-app-container <UDID> bundle` |
+| `simctl listapps <UDID>` | Installed apps | — |
 
 ## Troubleshooting
 
@@ -222,10 +227,20 @@ Key subcommands beyond the basics:
 ## Permission & Dialog Handling
 
 ### Pre-grant permissions (prevents dialogs from appearing)
+
+**Prefer the `maui` CLI** — `maui apple simulator privacy` now wraps `simctl privacy`
+(the `bundle-id` is optional, so you can grant for all apps), and `maui devflow ui permission`
+drives it for the agent-detected simulator:
+```bash
+maui apple simulator privacy grant <UDID> location --bundle-id com.company.appid
+maui apple simulator privacy grant <UDID> photos          # all apps (no bundle id)
+maui devflow ui permission grant location --bundle-id com.company.appid
+```
+
+Raw `xcrun simctl` fallback (only if the `maui` CLI is unavailable):
 ```bash
 # Grant specific permission before the app requests it
 xcrun simctl privacy <UDID> grant location com.company.appid
-xcrun simctl privacy <UDID> grant camera com.company.appid
 xcrun simctl privacy <UDID> grant photos com.company.appid
 xcrun simctl privacy <UDID> grant contacts com.company.appid
 xcrun simctl privacy <UDID> grant microphone com.company.appid

--- a/.claude/skills/maui-devflow-debug/references/troubleshooting.md
+++ b/.claude/skills/maui-devflow-debug/references/troubleshooting.md
@@ -1,10 +1,39 @@
 # Troubleshooting
 
 ## Table of Contents
+- [Machine-readable output and error envelope](#machine-readable-output-and-error-envelope)
 - [Connection Refused](#connection-refused--cannot-connect)
+- [Android UI Thread Exceptions](#android-ui-thread-exceptions)
 - [Build Failures](#build-failures)
 - [CDP Not Connecting](#cdp-not-connecting-blazor-hybrid)
 - [Mac Catalyst Permission Dialogs](#mac-catalyst-repeated-permission-dialogs-on-rebuild)
+
+## Machine-readable output and error envelope <a name="machine-readable-output-and-error-envelope"></a>
+
+Always pass `--json` to any `maui` command an agent will parse, and `--ci` for
+non-interactive failure-fast runs.
+
+The full `--json` error envelope contract (schema, code categories, worked examples, PowerShell and Bash consumers) is documented in
+[`src/Cli/README.md` — Error envelope](../../../../../src/Cli/README.md#error-envelope).
+
+**Quick reference** — when a non-DevFlow command fails with `--json`, stdout is a top-level JSON object (no `"error"` wrapper). Note: `maui devflow ...` uses a different JSON error shape and writes errors to stderr.
+
+```json
+{
+  "code": "E2103",
+  "category": "platform",
+  "severity": "error",
+  "message": "Android SDK licenses have not been accepted.",
+  "remediation": {
+    "type": "autofixable",
+    "command": "maui android sdk accept-licenses"
+  }
+}
+```
+
+Optional fields (`remediation`, `context`, `native_error`, `docs_url`, `correlation_id`) are **omitted entirely** when null.
+When `remediation.type` is `autofixable`, run `remediation.command` then retry the original command.
+When `remediation` is absent, surface `message` and stop retrying.
 
 ## Connection Refused / Cannot Connect
 
@@ -22,12 +51,38 @@ If `maui devflow ui status` fails with connection refused:
    With the broker, this is less common since ports are auto-assigned.
 5. **Android?** Did you run `adb reverse tcp:19223 tcp:19223` (for broker) and
    `adb forward tcp:<port> tcp:<port>` (for agent)? Re-run after each deploy.
+   If broker/list is empty, still try direct status:
+   ```bash
+   adb devices
+   adb forward tcp:9223 tcp:9223
+   maui devflow agent status --agent-host localhost --agent-port 9223
+   ```
 6. **Mac Catalyst?** Check entitlements include `network.server` (see setup.md step 5).
 7. **macOS (AppKit)?** Ensure `AddMacOSEssentials()` is called and the app window appeared.
    See [references/macos.md](macos.md) for troubleshooting.
 8. **Linux/GTK?** No special network setup needed — runs directly on localhost. Check if the app started successfully.
 9. **Broker issues?** `maui devflow broker status` to check. `maui devflow broker stop` then
    retry (CLI will auto-restart it).
+
+## Android UI Thread Exceptions
+
+If `maui devflow ui tap`, `fill`, `focus`, or other UI actions fail on Android
+with `CalledFromWrongThreadException`, treat it as likely DevFlow agent action
+dispatch trouble rather than an app logic bug, especially when manual input or
+ADB taps work.
+
+Capture evidence before changing app code:
+
+```bash
+maui devflow agent status --agent-host localhost --agent-port <port>
+maui devflow ui query --automationId <control-id> --agent-host localhost --agent-port <port>
+adb logcat -d -t 300 | grep -i "CalledFromWrongThreadException\\|DevFlow\\|DOTNET"
+```
+
+Report the DevFlow command, target platform, agent version from `agent status`,
+the queried element id/AutomationId, and the logcat exception. Do not work
+around this with coordinate-only automation unless you only need a temporary
+validation fallback.
 
 ## Build Failures
 

--- a/.claude/skills/maui-devflow-onboard/SKILL.md
+++ b/.claude/skills/maui-devflow-onboard/SKILL.md
@@ -1,14 +1,7 @@
 ---
 name: maui-devflow-onboard
 description: >-
-  Add MAUI DevFlow to a .NET MAUI project with agent package references,
-  MauiProgram.cs registration, Blazor WebView support, GTK variants, Central
-  Package Management guidance, and verification commands. USE FOR: first-time
-  DevFlow setup, reviewing what files to edit, choosing DevFlow packages, or
-  continuing after `maui devflow init` installs skills. DO NOT USE FOR:
-  troubleshooting an already-integrated app that cannot connect, iterative app
-  debugging, UI inspection, or generic MAUI build failures (use
-  maui-devflow-debug). INVOKES: maui devflow CLI and dotnet CLI.
+  Add DevFlow to a MAUI app. USE FOR: package refs, `MauiProgram` registration, Blazor WebView/GTK variants, verification after `maui devflow init`. DO NOT USE FOR: troubleshooting, debugging, UI inspection, or build failures. INVOKES: `maui devflow`, `dotnet`.
 ---
 
 # DevFlow Onboard
@@ -27,6 +20,13 @@ Use this skill to add MAUI DevFlow to a project after `maui devflow init` has in
 
 - If package references and `AddMauiDevFlowAgent()` are already present but the CLI cannot connect, use `maui-devflow-debug`.
 - If an agent is reachable and the user wants to inspect, tap, screenshot, or debug UI, use `maui-devflow-debug`.
+
+## Optional Session Feedback Nudge
+
+If onboarding required repeated DevFlow attempts, unclear package/version
+workarounds, or a long setup session, ask whether the user wants to run
+`maui-devflow-session-review` to summarize friction for MAUI DevFlow product
+feedback. Do not run it automatically.
 
 ## Workflow
 
@@ -131,7 +131,9 @@ For Mac Catalyst, ensure the Debug entitlements allow the in-app HTTP server:
 - GTK apps start the DevFlow agent after app activation.
 - Mac Catalyst Debug entitlements include `com.apple.security.network.server`.
 - `dotnet build` succeeds.
+- Important controls in the flows you plan to automate have stable `AutomationId`s.
 - A running app appears in `maui devflow list`.
+- `maui devflow agent status` returns the expected app name and platform.
 - `maui devflow ui tree --depth 1` returns a visual tree.
 
 ## References

--- a/.claude/skills/maui-devflow-session-review/SKILL.md
+++ b/.claude/skills/maui-devflow-session-review/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: maui-devflow-session-review
+description: >-
+  Review past MAUI DevFlow sessions. USE FOR: DevFlow friction reports, classifying `maui_tap`/`maui_hittest`/`maui_screenshot`/`maui_cdp_webviews` issues vs app bugs, markdown Environment/Findings reports, scrubbed dotnet/maui-labs issue drafts, workaround summaries. Does not run live `maui devflow`. DO NOT USE FOR: fixing bugs, onboarding, live debugging, or memory search.
+---
+
+# MAUI DevFlow Session Review
+
+Use this skill to turn prior MAUI DevFlow-assisted AI sessions into opt-in
+product feedback. The goal is not to fix bugs during the review; the goal is to
+identify where DevFlow caused friction, what workarounds were tried, and what
+outcome the agent eventually reached.
+
+## When to Use
+
+Use this skill when:
+
+- reviewing previous AI sessions that used `maui devflow`
+- summarizing a long or stuck MAUI DevFlow debugging session
+- finding repeated failed attempts, retries, or workarounds around DevFlow tools
+- checking whether an advertised DevFlow feature did not work in practice
+- preparing a markdown feedback report for MAUI DevFlow maintainers
+- filing GitHub issues in `dotnet/maui-labs` from session evidence
+- another DevFlow skill suggested an optional post-session feedback review
+
+## When to Stop
+
+- The top actionable friction points are summarized with evidence, environment
+  metadata, attempts, workaround, and final outcome.
+- The markdown report is written or the requested GitHub issues are filed after
+  a PII scrub.
+- Remaining evidence would require scanning outside the user-approved scope.
+- The finding is too ambiguous to classify without more context; label it
+  unknown instead of continuing to mine private history.
+
+## Workflow
+
+### 1. Confirm opt-in scope
+
+**If the user has provided session content directly in the message**, start from
+step 4 (Classify friction) immediately — do not invoke live DevFlow CLI commands,
+search tools, or session history tools. The user has already supplied the evidence.
+
+If no session content is provided, identify what the user wants reviewed:
+
+- current session
+- recent sessions matching MAUI DevFlow keywords
+- a date range, target platform, feature, command family, or app framework
+- sessions related to setup, connectivity, UI inspection, CDP, recording, logs,
+  network, storage, profiler, or DevFlow Actions
+
+Do not scan unrelated session history. This skill is opt-in telemetry: the user
+controls the scope and the output destination.
+
+Do not ask the user for session IDs, transcript paths, log paths, artifact
+paths, or other local identifiers. If a tool requires an internal handle to
+inspect a session, use it only transiently and never include it in saved or
+shared output.
+
+If another DevFlow skill suggested this review, preserve the trigger context:
+what challenge was stuck, which workarounds had already been tried, and whether
+the user wants markdown-only output or GitHub issue filing.
+
+### 2. Find DevFlow-specific sessions
+
+Use [references/session-sources.md](references/session-sources.md) to choose the
+available data source. Good candidate signals include:
+
+- `maui devflow`, `maui-devflow-onboard`, `maui-devflow-debug`, or this skill
+- CLI commands such as `maui devflow wait`, `maui devflow list`,
+  `maui devflow agent status`, `maui devflow ui tree`,
+  `maui devflow ui query`, `maui devflow recording`, `maui devflow logs`,
+  `maui devflow network`, `maui devflow diagnose`, or `maui devflow mcp`
+- MCP tools such as `maui_wait`, `maui_list_agents`, `maui_status`,
+  `maui_tree`, `maui_query`, `maui_tap`, `maui_recording_start`,
+  `maui_recording_stop`, `maui_logs`, `maui_network`, `maui_cdp_*`,
+  or `maui_invoke_action`
+- package and API names such as `Microsoft.Maui.DevFlow.Agent`,
+  `Microsoft.Maui.DevFlow.Blazor`, `Microsoft.Maui.DevFlow.Agent.Gtk`,
+  `Microsoft.Maui.DevFlow.Driver`, `builder.AddMauiDevFlowAgent()`,
+  or `AddMauiBlazorDevFlowTools()`
+- broker or port evidence such as `19223`, `9223`, `adb reverse`,
+  `adb forward`, agent registration, or direct port fallback
+
+Start narrow and widen only when the first search does not find enough evidence.
+
+### 3. Build the environment fingerprint
+
+For every report and issue, collect the metadata in
+[references/environment-fingerprint.md](references/environment-fingerprint.md):
+
+- host platform and OS version
+- AI tool or host, if detectable
+- model name and reasoning effort, if detectable
+- MAUI, .NET SDK, and MAUI DevFlow package versions, if available
+- target app platforms, such as Android, iOS, Mac Catalyst, macOS, Windows,
+  Linux/GTK, or Blazor WebView runtime
+- `maui` CLI version and invocation mode
+- embedded DevFlow package/reference versions in the app
+
+Unknown metadata is acceptable. Mark it as `Unknown` rather than guessing.
+
+### 4. Classify friction
+
+Use [references/friction-rubric.md](references/friction-rubric.md). Prioritize:
+
+- advertised DevFlow features that failed or were unavailable
+- repeated attempts at the same command, selector, connection, or setup step
+- workaround chains that eventually succeeded
+- broker discovery, direct agent port, or Android forwarding loops
+- platform-specific setup, package, entitlement, or version mismatches
+- missing stable `AutomationId`s or missing observability that made DevFlow less
+  useful
+- AI-host or model behavior that misused DevFlow guidance
+
+Separate confirmed DevFlow issues from app bugs, environment setup problems, and
+unknown causes.
+
+### 5. Capture attempts, workarounds, and outcome
+
+For each finding, record:
+
+- symptom
+- sanitized evidence summary with no session IDs, file paths, usernames, machine
+  names, emails, private URLs, or other PII
+- attempts and retries, especially repeated or contradictory actions
+- workarounds tried
+- final outcome: unresolved, worked around, solved, or unknown
+- confidence level and why
+
+Paraphrase private transcript content. Before sending, saving, or filing any
+report, scrub PII and identifiers including names, emails, usernames, session
+IDs, local file paths, machine names, private URLs, secrets, credentials, request
+bodies, screenshots, and user-specific text.
+
+### 6. Report or file issues
+
+Use [references/reporting.md](references/reporting.md). Default to a markdown
+report. File GitHub issues only when the user asks and repository access works.
+For markdown reports, include the exact sections `## Environment` and
+`## Findings`; put unknown environment details under `## Environment` as
+`Unknown` rather than omitting or guessing them.
+
+For GitHub issues, prefer one issue per actionable MAUI DevFlow product problem.
+Merge near-duplicate session evidence into the same issue body instead of
+opening many low-signal issues.
+
+Before saving markdown or filing issues, do a final privacy pass. If a useful
+finding cannot be explained without PII or local identifiers, omit it or replace
+the details with a generic description. Do not repeat the original private value
+in the output, even to say that it was scrubbed; say only that local paths,
+emails, private URLs, or other identifiers were redacted.
+
+## Optional Feedback Nudge
+
+Other MAUI DevFlow skills may suggest this review when an agent has retried the
+same DevFlow workflow several times, tried multiple workarounds, or finishes a
+long DevFlow-assisted debugging session. That nudge should ask the user whether
+they want an opt-in review; it should not run this skill automatically.
+
+## Critical Anti-Patterns
+
+| Do not | Do instead |
+| --- | --- |
+| Auto-scan all past sessions | Ask for scope and stay inside it |
+| Ask for session IDs, transcript paths, log paths, or artifact paths | Ask for a high-level scope such as time range, platform, feature, or current session |
+| Treat one ambiguous failure as a confirmed DevFlow bug | Label confidence and separate app/environment/unknown causes |
+| Include raw private transcript excerpts, screenshots, tokens, file paths, session IDs, or request bodies, even in "removed PII" notes | Paraphrase safe evidence and say identifiers were redacted without repeating them |
+| Fix the discovered issues during the review | Produce feedback unless the user separately asks for implementation |
+| File GitHub issues without user approval and repo access | Produce markdown first, then file only on request |
+| Hide successful workarounds | Capture the final working path and the failed attempts that led to it |
+
+## References
+
+- **Session sources**:
+  [references/session-sources.md](references/session-sources.md)
+- **Friction rubric**:
+  [references/friction-rubric.md](references/friction-rubric.md)
+- **Environment fingerprint**:
+  [references/environment-fingerprint.md](references/environment-fingerprint.md)
+- **Reporting and GitHub issues**:
+  [references/reporting.md](references/reporting.md)

--- a/.claude/skills/maui-devflow-session-review/references/environment-fingerprint.md
+++ b/.claude/skills/maui-devflow-session-review/references/environment-fingerprint.md
@@ -1,0 +1,107 @@
+# Environment fingerprint
+
+Every report or GitHub issue should include the best available environment
+fingerprint. Unknown values are acceptable; guessing is not.
+
+## Required fields
+
+```markdown
+## Environment
+
+- Host OS/platform: {macOS/Windows/Linux + version, if known}
+- AI tool/host: {Copilot CLI, VS Code Copilot Chat, Claude Code, other, Unknown}
+- Model: {model and reasoning effort if known, otherwise Unknown}
+- MAUI CLI: {Microsoft.Maui.Cli version and invocation mode, otherwise Unknown}
+- App framework(s): {.NET MAUI/MAUI Blazor Hybrid/GTK/WPF/macOS AppKit + versions}
+- Target platform(s): {Android/iOS/Mac Catalyst/macOS/Windows/Linux/GTK/WebView/etc.}
+- MAUI DevFlow package/reference versions: {package names and versions}
+- Review scope: {current session/recent sessions/date range/platform/feature}
+```
+
+## Host platform
+
+Use explicit session metadata when available. Otherwise collect it from safe
+local commands or project outputs, such as OS name/version or architecture. Do
+not include usernames, home paths, machine identifiers, local file paths, or
+hostnames.
+
+## AI tool and model
+
+Prefer observable metadata:
+
+- session metadata such as agent name, model ID, or usage model
+- transcript headers or host-specific run metadata
+- user-provided information
+- visible model strings in assistant/system context
+
+Common tool names to normalize:
+
+- Copilot CLI
+- VS Code GitHub Copilot Chat
+- Claude Code
+- GitHub Copilot coding agent
+- Other
+- Unknown
+
+If the model or reasoning effort cannot be detected, write `Unknown`. Do not
+infer a model from writing style.
+
+## MAUI CLI version
+
+Use the first reliable source available:
+
+- `maui --version`
+- `maui version`
+- `maui devflow diagnose`
+- JSON output from `maui devflow skills doctor`
+- local tool manifest or package version when the CLI binary is unavailable
+- command output captured in the session, after removing local identifiers
+
+Record whether the session used CLI commands, MCP tools, or both.
+
+## App frameworks and versions
+
+Collect framework versions from project files and lockfiles inside the scoped
+workspace:
+
+- `.csproj`, `Directory.Packages.props`, target frameworks, and
+  `PackageReference` entries
+- `global.json`, `.config/dotnet-tools.json`, and solution filters when relevant
+- MAUI platform package references for GTK, WPF, macOS AppKit, or Blazor WebView
+
+Only collect the versions needed to explain the finding.
+
+## Target platforms
+
+Infer targets from observable signals:
+
+- .NET target frameworks such as `net*-android`, `net*-ios`,
+  `net*-maccatalyst`, `net*-windows`, `net*-macos`, or GTK-specific head
+  projects
+- simulator, emulator, device, or desktop launch commands
+- `maui devflow device` and `maui devflow diagnose` output
+- user-provided platform context
+
+## MAUI DevFlow packages
+
+Look for package/reference names such as:
+
+- `Microsoft.Maui.Cli`
+- `Microsoft.Maui.DevFlow.Agent`
+- `Microsoft.Maui.DevFlow.Agent.Core`
+- `Microsoft.Maui.DevFlow.Agent.Gtk`
+- `Microsoft.Maui.DevFlow.Blazor`
+- `Microsoft.Maui.DevFlow.Blazor.Gtk`
+- `Microsoft.Maui.DevFlow.Driver`
+- `Microsoft.Maui.DevFlow.Logging`
+
+Include versions and whether the package came from a project reference, package
+reference, central package management entry, or local source checkout.
+
+## PII scrub
+
+Before sending, saving, or filing the environment fingerprint, remove names,
+usernames, emails, session IDs, local file paths, machine names, private server
+URLs, request bodies, user profile text, screenshots, credentials, and tokens.
+Prefer generic source types such as "project manifest" or "CLI output" over
+paths or identifiers.

--- a/.claude/skills/maui-devflow-session-review/references/friction-rubric.md
+++ b/.claude/skills/maui-devflow-session-review/references/friction-rubric.md
@@ -1,0 +1,91 @@
+# Friction rubric
+
+Classify friction by product impact, repeatability, and confidence. The goal is
+to explain what slowed the AI/user loop and what MAUI DevFlow could improve.
+
+## Severity
+
+| Severity | Signal |
+| --- | --- |
+| High | Advertised MAUI DevFlow feature failed, was missing, or contradicted docs; no reasonable workaround; repeated sessions hit the same issue |
+| Medium | Workflow eventually worked but required retries, hidden prerequisites, stale guidance, manual fallback, or platform-specific knowledge |
+| Low | Minor confusion, unclear output, noisy guidance, or a one-off workaround with low repeatability |
+| Unknown | Evidence shows friction but not enough to attribute cause |
+
+## Common friction patterns
+
+### Advertised feature did not work
+
+Look for cases where the agent expected a `maui devflow` command, MCP tool, or
+skill workflow to exist or behave a certain way, but it failed. Capture the
+advertised expectation, actual behavior, and whether docs or skill guidance
+caused the expectation.
+
+### Repeated command or tool loop
+
+Count repeated attempts at the same underlying task, not just identical command
+strings. Three or more failed attempts at connection, selection, query, action,
+recording, logging, WebView/CDP, or setup are usually worth reporting.
+
+### Workaround chain
+
+Record the failed approaches before the workaround. A useful report explains why
+the successful approach was not obvious:
+
+- broker discovery failed, direct `--agent-port` worked
+- Android registration failed until `adb reverse tcp:19223 tcp:19223`
+- Android CLI-to-agent traffic failed until `adb forward tcp:<port> tcp:<port>`
+- targeted query failed, shallow tree plus manual element selection worked
+- platform setup docs missed a package, entitlement, or debug-only guard
+- a recording or screenshot was needed because structured state was unavailable
+
+### Broker, discovery, and port confusion
+
+High-signal evidence includes repeated switching between broker discovery,
+`localhost:9223`, `19223`, `maui devflow list`, `maui devflow wait`,
+`maui devflow agent status`, and explicit host/port overrides without clear
+success criteria.
+
+### Platform package or version mismatch
+
+Look for mismatch between `Microsoft.Maui.Cli`, embedded DevFlow package
+versions, target app framework versions, or runtime platform. Examples: missing
+GTK package, missing Blazor package, Mac Catalyst entitlement gaps, old direct
+port configuration, or package names that changed.
+
+### Missing stable identifiers or observability
+
+Report when DevFlow could connect but the workflow became brittle because the
+app had no stable `AutomationId`, route, DevFlow Action, log, network entry,
+storage root, profiler data, or assertion point.
+
+### AI-host or model/tool mismatch
+
+Capture when the AI host did not expose the expected session history, MCP tools,
+model metadata, or filesystem access. This may not be a DevFlow bug, but it is
+useful product feedback if DevFlow guidance assumes capabilities that are not
+available in common hosts.
+
+## Confidence
+
+| Confidence | Use when |
+| --- | --- |
+| Confirmed | Multiple evidence points agree, or the same DevFlow failure reproduced in-session |
+| Likely | Session evidence strongly suggests DevFlow friction but one variable is missing |
+| Possible | DevFlow was involved, but app code, environment, or AI host could also explain the issue |
+| Unknown | Evidence is insufficient; include as a question or omit from issue filing |
+
+## Outcome labels
+
+- **Solved**: the session reached the intended DevFlow-assisted result.
+- **Worked around**: the original DevFlow path failed, but another path
+  succeeded.
+- **Unresolved**: the session stopped before success.
+- **Unknown**: the transcript does not show the final state.
+
+## Stop signals
+
+- You have identified the top actionable friction points.
+- Additional candidates repeat the same pattern without adding new evidence.
+- The issue is likely app-specific and not useful MAUI DevFlow product feedback.
+- Confidence remains unknown after checking the approved evidence.

--- a/.claude/skills/maui-devflow-session-review/references/reporting.md
+++ b/.claude/skills/maui-devflow-session-review/references/reporting.md
@@ -1,0 +1,119 @@
+# Reporting and GitHub issues
+
+Default to a markdown report. File GitHub issues only when the user asks and the
+agent has access to `dotnet/maui-labs`.
+
+Before sending, saving, or filing any output, perform a PII scrub. Reports and
+issues must not contain session IDs, transcript IDs, local file paths, artifact
+paths, names, usernames, emails, machine names, private URLs, credentials,
+tokens, request bodies, screenshots, or user-specific private text.
+
+## Markdown report template
+
+```markdown
+# MAUI DevFlow session review
+
+## Summary
+
+{One paragraph with scope, session count, and top findings.}
+
+## Environment
+
+- Host OS/platform: {value}
+- AI tool/host: {value}
+- Model: {value}
+- MAUI CLI: {value}
+- App framework(s): {value}
+- Target platform(s): {value}
+- MAUI DevFlow package/reference versions: {value}
+- Review scope: {current session/recent sessions/date range/platform/feature}
+
+## Findings
+
+### 1. {short title}
+
+- Severity: {High/Medium/Low/Unknown}
+- Confidence: {Confirmed/Likely/Possible/Unknown}
+- Outcome: {Solved/Worked around/Unresolved/Unknown}
+- Symptom: {what happened}
+- Evidence: {sanitized behavior summary, no identifiers or paths}
+- Attempts: {failed attempts, retries, detours}
+- Workaround or success route: {final working approach, if any}
+- Product feedback: {what MAUI DevFlow could improve}
+
+## Suggested GitHub issues
+
+{List issue titles or say "None requested".}
+```
+
+## GitHub issue template
+
+Use this shape when the user asks to file issues:
+
+```markdown
+## Summary
+
+{A concise product-facing description of the friction.}
+
+## Environment
+
+- Host OS/platform: {value}
+- AI tool/host: {value}
+- Model: {value}
+- MAUI CLI: {value}
+- App framework(s): {value}
+- Target platform(s): {value}
+- MAUI DevFlow package/reference versions: {value}
+
+## What happened
+
+{Observed symptom and user/agent goal.}
+
+## Attempts and workarounds
+
+1. {attempt}
+2. {attempt}
+3. {workaround or final state}
+
+## Expected behavior
+
+{What MAUI DevFlow advertised or should reasonably do.}
+
+## Actual behavior
+
+{What happened instead.}
+
+## Outcome
+
+{Solved, worked around, unresolved, or unknown. Include workaround if present.}
+
+## Scope
+
+{High-level review scope only, with no session IDs or file paths.}
+```
+
+## Filing guidance
+
+- Ask before filing. Markdown-only is the default.
+- Check that `gh` is authenticated and has access to `dotnet/maui-labs`.
+- Prefer one issue per distinct MAUI DevFlow product problem.
+- Merge repeated evidence into one issue when multiple sessions hit the same
+  symptom.
+- Do not include private transcript excerpts, secrets, screenshots, request
+  bodies, session IDs, file paths, or user-specific data.
+- If access fails, keep the issue body in the markdown report for manual filing.
+
+## Title patterns
+
+Good issue titles are product-facing and specific:
+
+- `Broker discovery loop when agent is registered but maui devflow wait times out`
+- `Android agent registration guidance missed adb reverse for broker port`
+- `maui_query failure required full tree workaround for stable AutomationId`
+- `Blazor WebView CDP guidance lacked fallback when webview list was empty`
+
+Avoid titles that blame the AI host without evidence:
+
+- `Copilot failed`
+- `Session was bad`
+- `DevFlow is broken`

--- a/.claude/skills/maui-devflow-session-review/references/session-sources.md
+++ b/.claude/skills/maui-devflow-session-review/references/session-sources.md
@@ -1,0 +1,104 @@
+# Session sources
+
+Use the narrowest source that can answer the user's request. The review is
+opt-in; do not broaden from the approved scope to unrelated history without
+asking.
+
+## Source order
+
+1. **User-approved scope**: current session, recent sessions, date range, target
+   platform, feature, command family, or DevFlow workflow.
+2. **Current session context**: useful when the review is prompted because the
+   current DevFlow workflow was stuck.
+3. **Session history tools**: use when available to search recent sessions by
+   MAUI DevFlow-specific signals.
+4. **Already-provided sanitized material**: use only if the user has already
+   supplied it. Do not ask for session IDs, transcript paths, log paths, artifact
+   paths, or local file names.
+
+Do not recursively scan a home directory or cloud-synced folder just because it
+might contain session logs.
+
+## Session history query strategy
+
+When a session-store query tool is available:
+
+- Start with a time bound and `LIMIT`.
+- Search for DevFlow-specific terms first: `maui devflow`,
+  `Microsoft.Maui.DevFlow`, `AddMauiDevFlowAgent`, `maui_wait`, `maui_tree`,
+  `maui_query`, `maui devflow wait`, `maui devflow ui tree`, `recording`,
+  `broker`, `9223`, or `19223`.
+- Prefer finding candidate sessions within the scoped search, then inspect only
+  those sessions. If a tool exposes internal handles, use them only
+  transiently; never ask the user for them or include them in output.
+- Include exact filters such as agent/tool fields when available.
+- Widen the time window only if the first query finds too little evidence.
+
+Example intent, not a required exact query:
+
+```sql
+-- Find recent candidate sessions with MAUI DevFlow-specific text.
+SELECT timestamp, user_message, assistant_response
+FROM turns
+WHERE timestamp > now() - INTERVAL '14 days'
+  AND (
+    COALESCE(user_message, '') ILIKE '%maui devflow%'
+    OR COALESCE(assistant_response, '') ILIKE '%maui devflow%'
+    OR COALESCE(assistant_response, '') ILIKE '%Microsoft.Maui.DevFlow%'
+    OR COALESCE(assistant_response, '') ILIKE '%maui_wait%'
+    OR COALESCE(assistant_response, '') ILIKE '%maui_tree%'
+    OR COALESCE(assistant_response, '') ILIKE '%AddMauiDevFlowAgent%'
+  )
+LIMIT 50
+```
+
+After selecting candidate sessions, look for retry patterns and outcomes in the
+same session rather than scanning every historical turn.
+
+## Provided material fallback
+
+If no session-store tool is available, work from the current conversation or
+material the user already provided. Do not ask for local paths or identifiers.
+Collect only non-PII facts:
+
+- relevant time window, turn number, or command family
+- command/tool attempts and results
+- final answer or stopping point
+
+If the user provides a transcript that includes private material, summarize the
+safe pattern and avoid quoting sensitive text.
+
+## Evidence to preserve
+
+For each finding, preserve the smallest useful evidence set:
+
+- sanitized evidence summary
+- turn/time range or command sequence without local identifiers
+- observed failure or repeated attempt
+- workaround attempts
+- final successful command or unresolved blocker
+- environment metadata source type, such as CLI output or package manifest,
+  without local file paths
+
+Do not preserve session IDs, file paths, full transcripts, screenshots, tokens,
+request bodies, private URLs, usernames, emails, machine names, or private user
+text in the report.
+
+## Output scrub
+
+Before sending, saving, or filing anything, scan the summary for PII and local
+identifiers. Remove or generalize:
+
+- names, usernames, emails, handles, or account IDs
+- session IDs, transcript IDs, file paths, artifact paths, machine names, and
+  home-directory fragments
+- private hostnames, internal URLs, tokens, credentials, request bodies, or
+  screenshots
+- user-authored private text copied from a transcript
+
+## Stop signals
+
+- You have enough evidence to explain the top actionable findings.
+- Candidate sessions are unrelated to MAUI DevFlow after a quick scan.
+- Further investigation would require private or out-of-scope history.
+- The output would become a transcript dump instead of product feedback.

--- a/src/MauiSherpa.LinuxGtk/MauiSherpa.LinuxGtk.csproj
+++ b/src/MauiSherpa.LinuxGtk/MauiSherpa.LinuxGtk.csproj
@@ -32,8 +32,8 @@
     <PackageReference Include="Microsoft.Maui.Platforms.Linux.Gtk4.BlazorWebView" Version="0.1.0-preview.12.26378.2" />
     <PackageReference Include="Microsoft.Maui.Platforms.Linux.Gtk4.Essentials" Version="0.1.0-preview.12.26378.2" />
     <!-- DevFlow GTK packages are still disabled until the Linux app head wires the GTK agent startup path. -->
-    <!-- <PackageReference Include="Microsoft.Maui.DevFlow.Agent.Gtk" Version="0.1.0-preview.7.26230.1" Condition="'$(Configuration)' == 'Debug'" /> -->
-    <!-- <PackageReference Include="Microsoft.Maui.DevFlow.Blazor.Gtk" Version="0.1.0-preview.7.26230.1" Condition="'$(Configuration)' == 'Debug'" /> -->
+    <!-- <PackageReference Include="Microsoft.Maui.DevFlow.Agent.Gtk" Version="0.1.0-preview.12.26421.1" Condition="'$(Configuration)' == 'Debug'" /> -->
+    <!-- <PackageReference Include="Microsoft.Maui.DevFlow.Blazor.Gtk" Version="0.1.0-preview.12.26421.1" Condition="'$(Configuration)' == 'Debug'" /> -->
     <PackageReference Include="Sentry.Maui" Version="6.8.0" />
     <PackageReference Include="Shiny.Mediator.Caching.MicrosoftMemoryCache" Version="6.8.0" />
     <PackageReference Include="Shiny.Mediator.Maui" Version="6.8.0" />

--- a/src/MauiSherpa.MacOS/MauiSherpa.MacOS.csproj
+++ b/src/MauiSherpa.MacOS/MauiSherpa.MacOS.csproj
@@ -27,9 +27,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Maui.Platforms.MacOS" Version="0.1.0-preview.8.26256.5" />
-    <PackageReference Include="Microsoft.Maui.Platforms.MacOS.BlazorWebView" Version="0.1.0-preview.8.26256.5" />
-    <PackageReference Include="Microsoft.Maui.Platforms.MacOS.Essentials" Version="0.1.0-preview.8.26256.5" />
+    <PackageReference Include="Microsoft.Maui.Platforms.MacOS" Version="0.1.0-preview.12.26421.1" />
+    <PackageReference Include="Microsoft.Maui.Platforms.MacOS.BlazorWebView" Version="0.1.0-preview.12.26421.1" />
+    <PackageReference Include="Microsoft.Maui.Platforms.MacOS.Essentials" Version="0.1.0-preview.12.26421.1" />
     <PackageReference Include="Blazorise.Icons.FontAwesome" Version="1.7.2" />
     <!-- Reference the SDK directly so its build targets run with the AppKit publish RID
          instead of inheriting the build-host architecture from MauiSherpa.Core. -->
@@ -44,8 +44,8 @@
     <PackageReference Include="Shiny.Mediator.Caching.MicrosoftMemoryCache" Version="6.6.2" />
     <PackageReference Include="Shiny.Mediator.Blazor" Version="6.6.2" />
     <PackageReference Include="Shiny.Mediator.Maui" Version="6.6.2" />
-    <PackageReference Include="Microsoft.Maui.DevFlow.Agent" Version="0.1.0-preview.7.26230.1" Condition="'$(Configuration)' == 'Debug'" />
-    <PackageReference Include="Microsoft.Maui.DevFlow.Blazor" Version="0.1.0-preview.7.26230.1" Condition="'$(Configuration)' == 'Debug'" />
+    <PackageReference Include="Microsoft.Maui.DevFlow.Agent" Version="0.1.0-preview.12.26421.1" Condition="'$(Configuration)' == 'Debug'" />
+    <PackageReference Include="Microsoft.Maui.DevFlow.Blazor" Version="0.1.0-preview.12.26421.1" Condition="'$(Configuration)' == 'Debug'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MauiSherpa.ProfilingSample/MauiSherpa.ProfilingSample.csproj
+++ b/src/MauiSherpa.ProfilingSample/MauiSherpa.ProfilingSample.csproj
@@ -35,8 +35,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="10.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
     <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.31" />
-    <PackageReference Include="Microsoft.Maui.DevFlow.Agent" Version="0.1.0-preview.7.26230.1" Condition="'$(Configuration)' == 'Debug'" />
-    <PackageReference Include="Microsoft.Maui.DevFlow.Blazor" Version="0.1.0-preview.7.26230.1" Condition="'$(Configuration)' == 'Debug'" />
+    <PackageReference Include="Microsoft.Maui.DevFlow.Agent" Version="0.1.0-preview.12.26421.1" Condition="'$(Configuration)' == 'Debug'" />
+    <PackageReference Include="Microsoft.Maui.DevFlow.Blazor" Version="0.1.0-preview.12.26421.1" Condition="'$(Configuration)' == 'Debug'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MauiSherpa/MauiSherpa.csproj
+++ b/src/MauiSherpa/MauiSherpa.csproj
@@ -52,8 +52,8 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
     <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.60" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Maui.DevFlow.Agent" Version="0.1.0-preview.7.26230.1" Condition="'$(Configuration)' == 'Debug'" />
-    <PackageReference Include="Microsoft.Maui.DevFlow.Blazor" Version="0.1.0-preview.7.26230.1" Condition="'$(Configuration)' == 'Debug'" />
+    <PackageReference Include="Microsoft.Maui.DevFlow.Agent" Version="0.1.0-preview.12.26421.1" Condition="'$(Configuration)' == 'Debug'" />
+    <PackageReference Include="Microsoft.Maui.DevFlow.Blazor" Version="0.1.0-preview.12.26421.1" Condition="'$(Configuration)' == 'Debug'" />
     <PackageReference Include="Sentry.Maui" Version="6.4.0" />
     <PackageReference Include="Shiny.Mediator.Caching.MicrosoftMemoryCache" Version="6.6.2" />
     <PackageReference Include="Shiny.Mediator.Blazor" Version="6.6.2" />


### PR DESCRIPTION
## Summary
- update MAUI DevFlow agent and Blazor packages to `0.1.0-preview.12.26421.1`
- align macOS platform packages required by the newer DevFlow agent
- refresh the project DevFlow skills and add the session review skill

## Validation
- built the macOS AppKit head successfully
- ran the Infisical provider tests
- connected to the updated DevFlow agent and captured the running app