### PR TITLE
Use hybrid modal for Xcode installation

### DIFF
--- a/src/MauiSherpa/Pages/XcodeManagement.razor
+++ b/src/MauiSherpa/Pages/XcodeManagement.razor
@@ -443,129 +443,6 @@ else
         }
     }
 
-    @* ====== DOWNLOAD/INSTALL MODAL ====== *@
-    @if (showInstallModal)
-    {
-        <div class="modal-overlay">
-            <div class="modal modal-wide">
-                <div class="modal-header">
-                    <h3><i class="fas fa-download"></i> Installing Xcode @downloadingRelease?.Version</h3>
-                </div>
-                <div class="modal-body">
-                    <div class="install-steps">
-                        <div class="install-step @GetStepClass(InstallStep.Download)">
-                            <div class="step-icon">
-                                @if (currentInstallStep == InstallStep.Download)
-                                {
-                                    <i class="fas fa-spinner fa-spin"></i>
-                                }
-                                else if (currentInstallStep > InstallStep.Download)
-                                {
-                                    <i class="fas fa-check-circle text-success"></i>
-                                }
-                                else
-                                {
-                                    <i class="fas fa-circle"></i>
-                                }
-                            </div>
-                            <div class="step-content">
-                                <div class="step-title">Download</div>
-                                @if (currentInstallStep == InstallStep.Download && downloadProgress != null)
-                                {
-                                    <div class="progress-bar">
-                                        <div class="progress-fill" style="width: @(downloadProgressPercent)%"></div>
-                                    </div>
-                                    <div class="step-detail">
-                                        @FormatBytes(downloadProgress.BytesReceived) / @(downloadProgress.TotalBytes.HasValue ? FormatBytes(downloadProgress.TotalBytes.Value) : "?")
-                                        — @FormatSpeed(downloadProgress.BytesPerSecond)
-                                        @if (downloadProgress.EstimatedTimeRemaining.HasValue)
-                                        {
-                                            <text> — ETA: @FormatTimeSpan(downloadProgress.EstimatedTimeRemaining.Value)</text>
-                                        }
-                                    </div>
-                                }
-                            </div>
-                        </div>
-                        <div class="install-step @GetStepClass(InstallStep.Extract)">
-                            <div class="step-icon">
-                                @if (currentInstallStep == InstallStep.Extract)
-                                {
-                                    <i class="fas fa-spinner fa-spin"></i>
-                                }
-                                else if (currentInstallStep > InstallStep.Extract)
-                                {
-                                    <i class="fas fa-check-circle text-success"></i>
-                                }
-                                else
-                                {
-                                    <i class="fas fa-circle"></i>
-                                }
-                            </div>
-                            <div class="step-content">
-                                <div class="step-title">Extract &amp; Install</div>
-                                @if (currentInstallStep == InstallStep.Extract && !string.IsNullOrEmpty(installStepMessage))
-                                {
-                                    <div class="step-detail">@installStepMessage</div>
-                                }
-                            </div>
-                        </div>
-                        <div class="install-step @GetStepClass(InstallStep.FirstLaunch)">
-                            <div class="step-icon">
-                                @if (currentInstallStep == InstallStep.FirstLaunch)
-                                {
-                                    <i class="fas fa-spinner fa-spin"></i>
-                                }
-                                else if (currentInstallStep > InstallStep.FirstLaunch)
-                                {
-                                    <i class="fas fa-check-circle text-success"></i>
-                                }
-                                else
-                                {
-                                    <i class="fas fa-circle"></i>
-                                }
-                            </div>
-                            <div class="step-content">
-                                <div class="step-title">First Launch Setup</div>
-                                @if (currentInstallStep == InstallStep.FirstLaunch && !string.IsNullOrEmpty(installStepMessage))
-                                {
-                                    <div class="step-detail">@installStepMessage</div>
-                                }
-                            </div>
-                        </div>
-                        <div class="install-step @GetStepClass(InstallStep.Complete)">
-                            <div class="step-icon">
-                                @if (currentInstallStep >= InstallStep.Complete)
-                                {
-                                    <i class="fas fa-check-circle text-success"></i>
-                                }
-                                else
-                                {
-                                    <i class="fas fa-circle"></i>
-                                }
-                            </div>
-                            <div class="step-content">
-                                <div class="step-title">Complete</div>
-                            </div>
-                        </div>
-                    </div>
-                    @if (!string.IsNullOrEmpty(installError))
-                    {
-                        <div class="auth-error" style="margin-top: 1rem;"><i class="fas fa-exclamation-circle"></i> @installError</div>
-                    }
-                </div>
-                <div class="modal-footer">
-                    @if (currentInstallStep >= InstallStep.Complete || !string.IsNullOrEmpty(installError))
-                    {
-                        <button class="btn btn-primary" @onclick="CloseInstallModal">Done</button>
-                    }
-                    else
-                    {
-                        <button class="btn btn-danger-outline" @onclick="CancelDownload">Cancel</button>
-                    }
-                </div>
-            </div>
-        </div>
-    }
 }
 
 <style>
@@ -976,149 +853,6 @@ else
         color: var(--text-muted);
     }
 
-    /* Modal Styles */
-    .modal-overlay {
-        position: fixed;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background: rgba(0, 0, 0, 0.5);
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        z-index: 1000;
-    }
-    .modal {
-        background: var(--card-bg);
-        border-radius: 0.75rem;
-        border: 1px solid var(--border-color);
-        width: 420px;
-        max-width: 90vw;
-        box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
-    }
-    .modal.modal-wide { width: 520px; }
-    .modal-header {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        padding: 1.25rem 1.5rem 0.75rem;
-        border-bottom: 1px solid var(--border-color);
-    }
-    .modal-header h3 {
-        font-size: 1.125rem;
-        font-weight: 600;
-        color: var(--text-primary);
-        display: flex;
-        align-items: center;
-        gap: 0.5rem;
-        margin: 0;
-    }
-    .modal-close {
-        background: transparent;
-        border: none;
-        color: var(--text-muted);
-        cursor: pointer;
-        font-size: 1rem;
-        padding: 0.25rem;
-    }
-    .modal-close:hover { color: var(--text-primary); }
-    .modal-body { padding: 1.25rem 1.5rem; }
-    .modal-footer {
-        display: flex;
-        justify-content: flex-end;
-        gap: 0.75rem;
-        padding: 0.75rem 1.5rem 1.25rem;
-    }
-
-    /* Auth Form */
-    .auth-description {
-        font-size: 0.875rem;
-        color: var(--text-muted);
-        margin-bottom: 1.25rem;
-    }
-    .form-group {
-        margin-bottom: 1rem;
-    }
-    .form-group label {
-        display: block;
-        font-size: 0.8125rem;
-        font-weight: 600;
-        color: var(--text-primary);
-        margin-bottom: 0.375rem;
-    }
-    .form-group input, .form-group select {
-        width: 100%;
-        padding: 0.625rem 0.75rem;
-        border: 1px solid var(--border-color);
-        border-radius: 0.375rem;
-        background: var(--bg-secondary);
-        color: var(--text-primary);
-        font-size: 0.875rem;
-        box-sizing: border-box;
-    }
-    .form-group input:focus, .form-group select:focus {
-        outline: none;
-        border-color: var(--accent-primary);
-        box-shadow: 0 0 0 2px rgba(66, 153, 225, 0.2);
-    }
-    .code-input {
-        font-family: monospace;
-        font-size: 1.5rem !important;
-        letter-spacing: 0.5rem;
-        text-align: center;
-    }
-    .auth-error {
-        padding: 0.625rem 0.875rem;
-        background: var(--status-error-bg);
-        border: 1px solid var(--accent-danger);
-        border-radius: 0.375rem;
-        color: var(--accent-danger);
-        font-size: 0.8125rem;
-        display: flex;
-        align-items: center;
-        gap: 0.5rem;
-    }
-
-    /* Install Steps */
-    .install-steps {
-        display: flex;
-        flex-direction: column;
-        gap: 0;
-    }
-    .install-step {
-        display: flex;
-        gap: 1rem;
-        padding: 0.875rem 0;
-        border-bottom: 1px solid var(--border-color);
-        opacity: 0.5;
-    }
-    .install-step:last-child { border-bottom: none; }
-    .install-step.active { opacity: 1; }
-    .install-step.completed { opacity: 0.8; }
-    .step-icon {
-        font-size: 1.125rem;
-        width: 1.5rem;
-        text-align: center;
-        flex-shrink: 0;
-        color: var(--text-muted);
-    }
-    .install-step.active .step-icon { color: var(--accent-primary); }
-    .install-step.completed .step-icon { color: var(--accent-success); }
-    .step-content { flex: 1; }
-    .step-title {
-        font-weight: 600;
-        font-size: 0.9375rem;
-        color: var(--text-primary);
-        margin-bottom: 0.25rem;
-    }
-    .step-detail {
-        font-size: 0.8125rem;
-        color: var(--text-muted);
-        margin-top: 0.25rem;
-    }
-
-    .text-success { color: var(--accent-success); }
 </style>
 
 @code {
@@ -1131,16 +865,9 @@ else
     // Download/Install state
     private XcodeRelease? downloadingRelease;
     private XcodeDownloadProgress? downloadProgress;
-    private CancellationTokenSource? downloadCts;
-    private bool showInstallModal;
-    private InstallStep currentInstallStep = InstallStep.Download;
-    private string? installStepMessage;
-    private string? installError;
 
     // Runtime state
     private string? installingDownloadableRuntimeBuild;
-
-    private enum InstallStep { Download, Extract, FirstLaunch, Complete }
 
     private double downloadProgressPercent =>
         downloadProgress?.TotalBytes > 0
@@ -1340,82 +1067,83 @@ else
 
         downloadingRelease = release;
         downloadProgress = null;
-        downloadCts = new CancellationTokenSource();
-        showInstallModal = true;
-        currentInstallStep = InstallStep.Download;
-        installStepMessage = null;
-        installError = null;
         StateHasChanged();
 
         try
         {
-            var tempPath = Path.Combine(Path.GetTempPath(), $"Xcode_{release.Version}_{release.BuildNumber}.xip");
-            var progress = new Progress<XcodeDownloadProgress>(p =>
-            {
-                downloadProgress = p;
-                InvokeAsync(StateHasChanged);
-            });
+            await OperationModal.RunAsync(
+                $"Install Xcode {release.Version}",
+                $"Downloading and installing Xcode {release.Version} (build {release.BuildNumber})...",
+                async ctx =>
+                {
+                    var tempPath = Path.Combine(Path.GetTempPath(), $"Xcode_{release.Version}_{release.BuildNumber}.xip");
+                    ctx.LogInfo($"Downloading Xcode {release.Version} ({release.BuildNumber})");
+                    ctx.SetStatus("Preparing download...");
 
-            var downloadOk = await XcodeService.DownloadXcodeAsync(release, tempPath, progress, downloadCts.Token);
-            if (!downloadOk)
-            {
-                installError = "Download failed. You may need to sign in again.";
-                return;
-            }
+                    var progress = new Progress<XcodeDownloadProgress>(p =>
+                    {
+                        downloadProgress = p;
+                        var total = p.TotalBytes.HasValue ? FormatBytes(p.TotalBytes.Value) : "?";
+                        var status = $"{FormatBytes(p.BytesReceived)} / {total} — {FormatSpeed(p.BytesPerSecond)}";
+                        if (p.EstimatedTimeRemaining.HasValue)
+                            status += $" — ETA: {FormatTimeSpan(p.EstimatedTimeRemaining.Value)}";
 
-            currentInstallStep = InstallStep.Extract;
-            installStepMessage = "Extracting and moving to /Applications...";
-            StateHasChanged();
+                        ctx.SetStatus(status);
+                        ctx.SetProgress(p.TotalBytes > 0
+                            ? (int)Math.Clamp(Math.Round((double)p.BytesReceived / p.TotalBytes.Value * 100), 0, 100)
+                            : null);
+                        InvokeAsync(StateHasChanged);
+                    });
 
-            var installProgress = new Progress<string>(msg =>
-            {
-                installStepMessage = msg;
-                if (msg.Contains("first launch", StringComparison.OrdinalIgnoreCase))
-                    currentInstallStep = InstallStep.FirstLaunch;
-                InvokeAsync(StateHasChanged);
-            });
+                    var downloadOk = await XcodeService.DownloadXcodeAsync(
+                        release,
+                        tempPath,
+                        progress,
+                        ctx.CancellationToken);
+                    if (!downloadOk)
+                    {
+                        ctx.LogError("Download failed. You may need to sign in again.");
+                        return false;
+                    }
 
-            var installOk = await XcodeService.InstallXcodeAsync(tempPath, null, installProgress, downloadCts.Token);
-            if (!installOk)
-            {
-                installError = "Installation failed. The Xcode .xip file has been preserved in your temp directory.";
-                return;
-            }
+                    ctx.LogSuccess("Download complete");
+                    ctx.SetProgress(null);
+                    ctx.SetStatus("Extracting and moving to /Applications...");
 
-            currentInstallStep = InstallStep.Complete;
-            installStepMessage = null;
-            await ViewModel.LoadInstalledAsync();
-        }
-        catch (OperationCanceledException)
-        {
-            installError = "Installation cancelled.";
-        }
-        catch (Exception ex)
-        {
-            installError = $"Error: {ex.Message}";
+                    var installProgress = new Progress<string>(message =>
+                    {
+                        ctx.LogInfo(message);
+                        ctx.SetStatus(message);
+                    });
+
+                    var installOk = await XcodeService.InstallXcodeAsync(
+                        tempPath,
+                        null,
+                        installProgress,
+                        ctx.CancellationToken);
+                    if (!installOk)
+                    {
+                        ctx.LogError("Installation failed. The Xcode .xip file has been preserved in your temp directory.");
+                        return false;
+                    }
+
+                    ctx.SetProgress(100);
+                    ctx.SetStatus("Refreshing installed Xcode versions...");
+                    await ViewModel.LoadInstalledAsync();
+                    return true;
+                });
         }
         finally
         {
             downloadingRelease = null;
             downloadProgress = null;
-            downloadCts?.Dispose();
-            downloadCts = null;
             StateHasChanged();
         }
     }
 
     private void CancelDownload()
     {
-        downloadCts?.Cancel();
-    }
-
-    private void CloseInstallModal()
-    {
-        showInstallModal = false;
-        downloadingRelease = null;
-        downloadProgress = null;
-        installError = null;
-        StateHasChanged();
+        OperationModal.RequestCancellation();
     }
 
     // ---- Runtimes ----
@@ -1548,13 +1276,6 @@ else
         catch { }
     }
 
-    private string GetStepClass(InstallStep step)
-    {
-        if (currentInstallStep == step) return "active";
-        if (currentInstallStep > step) return "completed";
-        return "";
-    }
-
     private static string GetRuntimeIcon(string? platformIdentifier) => FriendlyPlatform(platformIdentifier) switch
     {
         "iOS" => "fas fa-mobile-alt",
@@ -1670,7 +1391,7 @@ else
     {
         if (bytes < 1024) return $"{bytes} B";
         if (bytes < 1024 * 1024) return $"{bytes / 1024.0:F1} KB";
-        if (bytes < 1024L * 1024 * 1024) return $"{bytes / (1024.0 * 1024):F1} MB";
+        if (bytes < 1024L * 1024 * 1024) return $"{bytes / (1024.0 * 1024):F0} MB";
         return $"{bytes / (1024.0 * 1024 * 1024):F2} GB";
     }
 


### PR DESCRIPTION
Xcode downloads previously used a pure Blazor overlay, making the install experience inconsistent with the app's native hybrid dialogs and causing rapidly changing fractional MB values.

This moves Xcode download and installation into the shared hybrid operation modal, including native sheet actions, cancellation, progress status, activity logs, and completion state. Download sizes now display whole MB values and switch to two decimal places for GB.

Build validation was not available because `dotnet` was not present in the session environment.