### PR TITLE
Fix Doctor setup guidance and JS teardown

### DIFF
--- a/src/MauiSherpa.Core/Services/DoctorService.cs
+++ b/src/MauiSherpa.Core/Services/DoctorService.cs
@@ -794,7 +794,7 @@ public class DoctorService : IDoctorService
         var status = installedVersion != null ? DependencyStatusType.Ok : DependencyStatusType.Error;
         var message = installedVersion != null 
             ? $"JDK {installedVersion} found"
-            : "JDK not found. Required for Android development.";
+            : "JDK not found. Download and run the Microsoft OpenJDK installer, then run Doctor again.";
         
         dependencies.Add(new DependencyStatus(
             "JDK",

--- a/src/MauiSherpa/Components/BackgroundTaskCenter.razor
+++ b/src/MauiSherpa/Components/BackgroundTaskCenter.razor
@@ -441,6 +441,11 @@
         catch (JSDisconnectedException)
         {
         }
+        catch (JSException ex) when (ex.Message.Contains(
+            "does not exist (has it been disposed?)",
+            StringComparison.Ordinal))
+        {
+        }
 
         _dotNetReference?.Dispose();
     }

--- a/src/MauiSherpa/Components/SecretProviderPicker.razor
+++ b/src/MauiSherpa/Components/SecretProviderPicker.razor
@@ -432,6 +432,11 @@
         catch (JSDisconnectedException)
         {
         }
+        catch (JSException ex) when (ex.Message.Contains(
+            "does not exist (has it been disposed?)",
+            StringComparison.Ordinal))
+        {
+        }
 
         _dotNetReference?.Dispose();
     }

--- a/src/MauiSherpa/Pages/Doctor.razor
+++ b/src/MauiSherpa/Pages/Doctor.razor
@@ -375,10 +375,19 @@
                                         <span class="dep-message">@dep.Message</span>
                                     }
                                 </div>
-                                @if (dep.IsFixable)
+                                @if (IsMissingJdk(dep))
+                                {
+                                    <button class="btn btn-sm btn-fix"
+                                            @onclick="DownloadMicrosoftOpenJdk"
+                                            disabled="@isLoading">
+                                        <i class="fas fa-download"></i>
+                                        Download Microsoft OpenJDK
+                                    </button>
+                                }
+                                else if (dep.IsFixable)
                                 {
                                     <button class="btn btn-sm btn-fix" @onclick="@(() => FixDependency(dep))" disabled="@isLoading">
-                                        Fix
+                                        @GetDependencyActionLabel(dep)
                                     </button>
                                 }
                             </div>
@@ -1181,6 +1190,18 @@ else
         DependencyStatusType.Error => "status-error",
         _ => "status-unknown"
     };
+
+    private static bool IsMissingJdk(DependencyStatus dependency) =>
+        dependency.Category == DependencyCategory.Jdk &&
+        dependency.Status == DependencyStatusType.Error;
+
+    private static string GetDependencyActionLabel(DependencyStatus dependency) =>
+        dependency.FixAction == "install-android-sdk"
+            ? "Install Android SDK"
+            : "Fix";
+
+    private Task DownloadMicrosoftOpenJdk() =>
+        OpenUrl("https://learn.microsoft.com/java/openjdk/download");
 
     private string GetCategoryName(DependencyCategory category) => category switch
     {


### PR DESCRIPTION
## Summary
- ignore the Blazor WebView's specific already-disposed JS module error during popover teardown
- add an official Microsoft OpenJDK download action when Doctor cannot find a JDK
- label the existing Android SDK remediation action clearly
- improve missing-JDK guidance to explain installation and rerunning Doctor

## Validation
- `dotnet build src/MauiSherpa.MacOS/MauiSherpa.MacOS.csproj -f net10.0-macos -p:ValidateXcodeVersion=false --verbosity quiet`
- launched the macOS app under .NET 11 for local DevFlow inspection and confirmed clean teardown