### PR TITLE
Fix macOS keystore create and import dialogs

### DIFF
--- a/src/MauiSherpa/Pages/Forms/FormPage.cs
+++ b/src/MauiSherpa/Pages/Forms/FormPage.cs
@@ -81,14 +81,17 @@ public abstract class FormPage<TResult> : ContentPage, IFormPage<TResult>, IForm
 
         var formContent = BuildFormContent();
         formContent.Margin = new Thickness(28, 16, 28, 16);
-        var formScrollView = new ScrollView
-        {
-            Content = formContent,
-            VerticalScrollBarVisibility = ScrollBarVisibility.Default,
-            VerticalOptions = LayoutOptions.Fill,
-        };
+        View formBody = formContent;
         if (FormBodyHeightRequest > 0)
-            formScrollView.HeightRequest = FormBodyHeightRequest;
+        {
+            formBody = new ScrollView
+            {
+                Content = formContent,
+                HeightRequest = FormBodyHeightRequest,
+                VerticalScrollBarVisibility = ScrollBarVisibility.Default,
+                VerticalOptions = LayoutOptions.Fill,
+            };
+        }
 
         // Footer separator — full width
         var footerSeparator = new BoxView { HeightRequest = 1, Opacity = 0.2 };
@@ -145,7 +148,7 @@ public abstract class FormPage<TResult> : ContentPage, IFormPage<TResult>, IForm
             {
                 new RowDefinition(GridLength.Auto),
                 new RowDefinition(GridLength.Auto),
-                new RowDefinition(GridLength.Star),
+                new RowDefinition(FormBodyHeightRequest > 0 ? GridLength.Star : GridLength.Auto),
                 new RowDefinition(GridLength.Auto),
                 new RowDefinition(GridLength.Auto),
             },
@@ -156,13 +159,13 @@ public abstract class FormPage<TResult> : ContentPage, IFormPage<TResult>, IForm
 
         Grid.SetRow(titleLabel, 0);
         Grid.SetRow(headerSeparator, 1);
-        Grid.SetRow(formScrollView, 2);
+        Grid.SetRow(formBody, 2);
         Grid.SetRow(footerSeparator, 3);
         Grid.SetRow(footerLayout, 4);
 
         grid.Children.Add(titleLabel);
         grid.Children.Add(headerSeparator);
-        grid.Children.Add(formScrollView);
+        grid.Children.Add(formBody);
         grid.Children.Add(footerSeparator);
         grid.Children.Add(footerLayout);
 

--- a/src/MauiSherpa/Services/DialogService.cs
+++ b/src/MauiSherpa/Services/DialogService.cs
@@ -271,6 +271,35 @@ public class DialogService : IDialogService
         });
 
         return await tcs.Task;
+#elif MACOSAPP
+        var tcs = new TaskCompletionSource<string?>();
+
+        await Dispatcher.DispatchAsync(() =>
+        {
+            var panel = new NSOpenPanel
+            {
+                Title = title,
+                CanChooseFiles = true,
+                CanChooseDirectories = false,
+                AllowsMultipleSelection = false,
+            };
+
+            var allowedFileTypes = extensions?
+                .Select(extension => extension.TrimStart('.', '*'))
+                .Where(extension => !string.IsNullOrWhiteSpace(extension))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            if (allowedFileTypes is { Length: > 0 })
+                panel.AllowedFileTypes = allowedFileTypes;
+
+            var result = panel.RunModal();
+            if (result == 1 && panel.Url?.Path is string path)
+                tcs.TrySetResult(path);
+            else
+                tcs.TrySetResult(null);
+        });
+
+        return await tcs.Task;
 #elif LINUXGTK
         if (_filePicker == null) return null;
         try


### PR DESCRIPTION
## Summary

- restore intrinsic sizing and input handling for content-sized native forms
- keep scrollable bodies for forms that explicitly request a fixed height
- use an AppKit `NSOpenPanel` for filtered keystore imports on macOS

## Validation

- built the patched v0.15 macOS AppKit application
- confirmed the create-keystore fields render and accept input
- imported a generated valid `.keystore` file and confirmed the password prompt and list entry
- ran all 592 `MauiSherpa.Core.Tests`

Closes #252
Closes #253